### PR TITLE
Factor out zingoconfig crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,16 @@ dependencies = [
  "log",
  "rustyline",
  "shellwords",
+ "zingoconfig",
  "zingolib",
+]
+
+[[package]]
+name = "zingoconfig"
+version = "0.1.0"
+dependencies = [
+ "zcash_address",
+ "zcash_primitives",
 ]
 
 [[package]]
@@ -3459,4 +3468,5 @@ dependencies = [
  "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash?rev=73d9395c9d3c5fa81fc7becd363a2c1a51772a76)",
  "zcash_primitives",
  "zcash_proofs",
+ "zingoconfig",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "lib",
     "cli",
+    "config"
 ]
 
 [profile.release]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,3 +12,4 @@ json = "0.12.4"
 http = "0.2.8"
 
 zingolib = { path = "../lib/" }
+zingoconfig = { path = "../config/" }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -65,14 +65,21 @@ macro_rules! configure_clapapp {
 pub fn report_permission_error() {
     let user = std::env::var("USER").expect("Unexpected error reading value of $USER!");
     let home = std::env::var("HOME").expect("Unexpected error reading value of $HOME!");
-    let current_executable = std::env::current_exe().expect("Unexpected error reporting executable path!");
+    let current_executable =
+        std::env::current_exe().expect("Unexpected error reporting executable path!");
     eprintln!("USER: {}", user);
     eprintln!("HOME: {}", home);
     eprintln!("Executable: {}", current_executable.display());
     if home == "/" {
-        eprintln!("User {} must have permission to write to '{}.zcash/' .", user, home);
+        eprintln!(
+            "User {} must have permission to write to '{}.zcash/' .",
+            user, home
+        );
     } else {
-        eprintln!("User {} must have permission to write to '{}/.zcash/' .", user, home);
+        eprintln!(
+            "User {} must have permission to write to '{}/.zcash/' .",
+            user, home
+        );
     }
 }
 
@@ -85,17 +92,23 @@ pub fn startup(
     print_updates: bool,
 ) -> io::Result<(Sender<(String, Vec<String>)>, Receiver<String>)> {
     // Try to get the configuration
-    let (config, latest_block_height) = LightClientConfig::create_on_data_dir(server.clone(), data_dir)?;
+    let (config, latest_block_height) =
+        LightClientConfig::create_on_data_dir(server.clone(), data_dir)?;
 
     let lightclient = match seed {
-        Some(phrase) => Arc::new(LightClient::new_from_phrase(phrase, &config, birthday, false)?),
+        Some(phrase) => Arc::new(LightClient::new_from_phrase(
+            phrase, &config, birthday, false,
+        )?),
         None => {
             if config.wallet_exists() {
                 Arc::new(LightClient::read_from_disk(&config)?)
             } else {
                 println!("Creating a new wallet");
                 // Create a wallet with height - 100, to protect against reorgs
-                Arc::new(LightClient::new(&config, latest_block_height.saturating_sub(100))?)
+                Arc::new(LightClient::new(
+                    &config,
+                    latest_block_height.saturating_sub(100),
+                )?)
             }
         }
     };
@@ -126,7 +139,10 @@ pub fn startup(
     Ok((command_transmitter, resp_receiver))
 }
 
-pub fn start_interactive(command_transmitter: Sender<(String, Vec<String>)>, resp_receiver: Receiver<String>) {
+pub fn start_interactive(
+    command_transmitter: Sender<(String, Vec<String>)>,
+    resp_receiver: Receiver<String>,
+) {
     // `()` can be used when no completer is required
     let mut rl = rustyline::Editor::<()>::new();
 
@@ -146,15 +162,25 @@ pub fn start_interactive(command_transmitter: Sender<(String, Vec<String>)>, res
     };
 
     let info = send_command("info".to_string(), vec![]);
-    let chain_name = json::parse(&info).unwrap()["chain_name"].as_str().unwrap().to_string();
+    let chain_name = json::parse(&info).unwrap()["chain_name"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     loop {
         // Read the height first
-        let height = json::parse(&send_command("height".to_string(), vec!["false".to_string()])).unwrap()["height"]
+        let height = json::parse(&send_command(
+            "height".to_string(),
+            vec!["false".to_string()],
+        ))
+        .unwrap()["height"]
             .as_i64()
             .unwrap();
 
-        let readline = rl.readline(&format!("({}) Block:{} (type 'help') >> ", chain_name, height));
+        let readline = rl.readline(&format!(
+            "({}) Block:{} (type 'help') >> ",
+            chain_name, height
+        ));
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str());
@@ -201,7 +227,9 @@ pub fn start_interactive(command_transmitter: Sender<(String, Vec<String>)>, res
     }
 }
 
-pub fn command_loop(lightclient: Arc<LightClient>) -> (Sender<(String, Vec<String>)>, Receiver<String>) {
+pub fn command_loop(
+    lightclient: Arc<LightClient>,
+) -> (Sender<(String, Vec<String>)>, Receiver<String>) {
     let (command_transmitter, command_receiver) = channel::<(String, Vec<String>)>();
     let (resp_transmitter, resp_receiver) = channel::<String>();
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use log::{error, info};
 
+use zingoconfig::Network;
 use zingolib::lightclient::lightclient_config::LightClientConfig;
 use zingolib::{commands, lightclient::LightClient};
 
@@ -232,7 +233,7 @@ pub fn attempt_recover_seed(_password: Option<String>) {
     // Create a Light Client Config in an attempt to recover the file.
     let _config = LightClientConfig {
         server: "0.0.0.0:0".parse().unwrap(),
-        chain: zingolib::lightclient::lightclient_config::Network::Mainnet,
+        chain: zingoconfig::Network::Mainnet,
         monitor_mempool: false,
         anchor_offset: [0u32; 5],
         data_dir: None,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 use log::error;
 use zingo_cli::{
-    attempt_recover_seed, configure_clapapp, report_permission_error, start_interactive, startup, version::VERSION,
+    attempt_recover_seed, configure_clapapp, report_permission_error, start_interactive, startup,
+    version::VERSION,
 };
 use zingolib::lightclient::{self, lightclient_config::LightClientConfig};
 
@@ -33,7 +34,9 @@ pub fn main() {
 
     if seed.is_some() && maybe_birthday.is_none() {
         eprintln!("ERROR!");
-        eprintln!("Please specify the wallet birthday (eg. '--birthday 600000') to restore from seed.");
+        eprintln!(
+            "Please specify the wallet birthday (eg. '--birthday 600000') to restore from seed."
+        );
         eprintln!("This should be the block height where the wallet was created. If you don't remember the block height, you can pass '--birthday 0' to scan from the start of the blockchain.");
         return;
     }
@@ -41,7 +44,10 @@ pub fn main() {
     let birthday = match maybe_birthday.unwrap_or("0").parse::<u64>() {
         Ok(b) => b,
         Err(e) => {
-            eprintln!("Couldn't parse birthday. This should be a block number. Error={}", e);
+            eprintln!(
+                "Couldn't parse birthday. This should be a block number. Error={}",
+                e
+            );
             return;
         }
     };
@@ -59,7 +65,14 @@ pub fn main() {
 
     let nosync = matches.is_present("nosync");
 
-    let startup_chan = startup(server, seed, birthday, maybe_data_dir, !nosync, command.is_none());
+    let startup_chan = startup(
+        server,
+        seed,
+        birthday,
+        maybe_data_dir,
+        !nosync,
+        command.is_none(),
+    );
     let (command_transmitter, resp_receiver) = match startup_chan {
         Ok(c) => c,
         Err(e) => {
@@ -82,7 +95,10 @@ pub fn main() {
         command_transmitter
             .send((
                 command.unwrap().to_string(),
-                params.iter().map(|s| s.to_string()).collect::<Vec<String>>(),
+                params
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<String>>(),
             ))
             .unwrap();
 
@@ -96,7 +112,9 @@ pub fn main() {
         }
 
         // Save before exit
-        command_transmitter.send(("save".to_string(), vec![])).unwrap();
+        command_transmitter
+            .send(("save".to_string(), vec![]))
+            .unwrap();
         resp_receiver.recv().unwrap();
     }
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "zingoconfig"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76", features = ["transparent-inputs", "test-dependencies"] }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76"}

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -47,7 +47,10 @@ impl std::fmt::Display for Network {
 }
 
 impl Parameters for Network {
-    fn activation_height(&self, nu: NetworkUpgrade) -> Option<zcash_primitives::consensus::BlockHeight> {
+    fn activation_height(
+        &self,
+        nu: NetworkUpgrade,
+    ) -> Option<zcash_primitives::consensus::BlockHeight> {
         use Network::*;
         match self {
             Mainnet => MAIN_NETWORK.activation_height(nu),

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,0 +1,127 @@
+use zcash_primitives::{
+    consensus::{BlockHeight, NetworkUpgrade, Parameters, MAIN_NETWORK, TEST_NETWORK},
+    constants,
+};
+pub const MAX_REORG: usize = 100;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Network {
+    Testnet,
+    Mainnet,
+    FakeMainnet,
+}
+
+impl Network {
+    pub fn hrp_orchard_spending_key(&self) -> &str {
+        match self {
+            Network::Mainnet => "secret-orchard-sk-main",
+            Network::Testnet => "secret-orchard-sk-test",
+            Network::FakeMainnet => "secret-orchard-sk-main",
+        }
+    }
+    pub fn hrp_unified_full_viewing_key(&self) -> &str {
+        match self {
+            Network::Mainnet => "uview",
+            Network::Testnet => "uviewtest",
+            Network::FakeMainnet => "uview",
+        }
+    }
+    pub fn to_zcash_address_network(&self) -> zcash_address::Network {
+        match self {
+            Network::Testnet => zcash_address::Network::Test,
+            _ => zcash_address::Network::Main,
+        }
+    }
+}
+
+impl std::fmt::Display for Network {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Network::*;
+        let name = match self {
+            Mainnet => "main",
+            Testnet => "test",
+            FakeMainnet => "regtest",
+        };
+        write!(f, "{name}")
+    }
+}
+
+impl Parameters for Network {
+    fn activation_height(&self, nu: NetworkUpgrade) -> Option<zcash_primitives::consensus::BlockHeight> {
+        use Network::*;
+        match self {
+            Mainnet => MAIN_NETWORK.activation_height(nu),
+            Testnet => TEST_NETWORK.activation_height(nu),
+            FakeMainnet => {
+                //Tests don't need to worry about NU5 yet
+                match nu {
+                    NetworkUpgrade::Nu5 => None,
+                    _ => Some(BlockHeight::from_u32(1)),
+                }
+            }
+        }
+    }
+
+    fn coin_type(&self) -> u32 {
+        use Network::*;
+        match self {
+            Mainnet => constants::mainnet::COIN_TYPE,
+            Testnet => constants::testnet::COIN_TYPE,
+            FakeMainnet => constants::mainnet::COIN_TYPE,
+        }
+    }
+
+    fn hrp_sapling_extended_spending_key(&self) -> &str {
+        use Network::*;
+        match self {
+            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
+            Testnet => constants::testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
+            FakeMainnet => constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
+        }
+    }
+
+    fn hrp_sapling_extended_full_viewing_key(&self) -> &str {
+        use Network::*;
+        match self {
+            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            Testnet => constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            FakeMainnet => constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+        }
+    }
+
+    fn hrp_sapling_payment_address(&self) -> &str {
+        use Network::*;
+        match self {
+            Mainnet => constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+            Testnet => constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS,
+            FakeMainnet => constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+        }
+    }
+
+    fn b58_pubkey_address_prefix(&self) -> [u8; 2] {
+        use Network::*;
+        match self {
+            Mainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
+            Testnet => constants::testnet::B58_PUBKEY_ADDRESS_PREFIX,
+            FakeMainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
+        }
+    }
+
+    fn b58_script_address_prefix(&self) -> [u8; 2] {
+        use Network::*;
+        match self {
+            Mainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
+            Testnet => constants::testnet::B58_SCRIPT_ADDRESS_PREFIX,
+            FakeMainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,6 +57,7 @@ zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "7
 zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76", features = ["multicore"]}
 zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76"}
 zcash_note_encryption = { git = "https://github.com/zcash/librustzcash", rev = "73d9395c9d3c5fa81fc7becd363a2c1a51772a76", features = ["pre-zip-212"]}
+zingoconfig = { path = "../config" }
 
 [dev-dependencies]
 portpicker = "0.1.0"

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -1,7 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
-        .build_server(true)
-        .compile(&["proto/service.proto", "proto/compact_formats.proto"], &["proto"])?;
+    tonic_build::configure().build_server(true).compile(
+        &["proto/service.proto", "proto/compact_formats.proto"],
+        &["proto"],
+    )?;
     println!("cargo:rerun-if-changed=proto/service.proto");
     Ok(())
 }

--- a/lib/src/blaze/block_witness_data.rs
+++ b/lib/src/blaze/block_witness_data.rs
@@ -73,7 +73,11 @@ impl BlockAndWitnessData {
         s
     }
 
-    pub async fn setup_sync(&mut self, existing_blocks: Vec<BlockData>, verified_tree: Option<TreeState>) {
+    pub async fn setup_sync(
+        &mut self,
+        existing_blocks: Vec<BlockData>,
+        verified_tree: Option<TreeState>,
+    ) {
         if !existing_blocks.is_empty() {
             if existing_blocks.first().unwrap().height < existing_blocks.last().unwrap().height {
                 panic!("Blocks are in wrong order");
@@ -102,7 +106,11 @@ impl BlockAndWitnessData {
         }
     }
 
-    pub async fn get_ctx_for_nf_at_height(&self, nullifier: &Nullifier, height: u64) -> (CompactTx, u32) {
+    pub async fn get_ctx_for_nf_at_height(
+        &self,
+        nullifier: &Nullifier,
+        height: u64,
+    ) -> (CompactTx, u32) {
         self.wait_for_block(height).await;
 
         let cb = {
@@ -150,14 +158,18 @@ impl BlockAndWitnessData {
         let mut start_trees = vec![];
 
         // Collect all the checkpoints
-        start_trees.extend(get_all_main_checkpoints().into_iter().map(|(h, hash, tree)| {
-            let mut tree_state = TreeState::default();
-            tree_state.height = h;
-            tree_state.hash = hash.to_string();
-            tree_state.tree = tree.to_string();
+        start_trees.extend(
+            get_all_main_checkpoints()
+                .into_iter()
+                .map(|(h, hash, tree)| {
+                    let mut tree_state = TreeState::default();
+                    tree_state.height = h;
+                    tree_state.hash = hash.to_string();
+                    tree_state.tree = tree.to_string();
 
-            tree_state
-        }));
+                    tree_state
+                }),
+        );
 
         // Add all the verification trees as verified, so they can be used as starting points. If any of them fails to verify, then we will
         // fail the whole thing anyway.
@@ -181,9 +193,11 @@ impl BlockAndWitnessData {
             .into_iter()
             .filter_map(|vt| {
                 let height = vt.height;
-                let closest_tree = start_trees
-                    .iter()
-                    .fold(None, |ct, st| if st.height < height { Some(st) } else { ct });
+                let closest_tree =
+                    start_trees.iter().fold(
+                        None,
+                        |ct, st| if st.height < height { Some(st) } else { ct },
+                    );
 
                 if closest_tree.is_some() {
                     Some((vt, closest_tree.unwrap().clone()))
@@ -205,7 +219,8 @@ impl BlockAndWitnessData {
                     if ct.height == vt.height {
                         return true;
                     }
-                    let mut tree = CommitmentTree::<Node>::read(&hex::decode(ct.tree).unwrap()[..]).unwrap();
+                    let mut tree =
+                        CommitmentTree::<Node>::read(&hex::decode(ct.tree).unwrap()[..]).unwrap();
 
                     {
                         let blocks = blocks.read().await;
@@ -239,7 +254,10 @@ impl BlockAndWitnessData {
             })
             .collect();
 
-        let results = join_all(handles).await.into_iter().collect::<Result<Vec<_>, _>>();
+        let results = join_all(handles)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>();
         // If errored out, return false
         if results.is_err() {
             return (false, None);
@@ -266,7 +284,10 @@ impl BlockAndWitnessData {
         }
 
         // Remove all wallet transactions at the height
-        wallet_transactions.write().await.remove_txns_at_height(reorg_height);
+        wallet_transactions
+            .write()
+            .await
+            .remove_txns_at_height(reorg_height);
     }
 
     /// Start a new sync where we ingest all the blocks
@@ -276,7 +297,10 @@ impl BlockAndWitnessData {
         end_block: u64,
         wallet_transactions: Arc<RwLock<WalletTxns>>,
         reorg_transmitter: UnboundedSender<Option<u64>>,
-    ) -> (JoinHandle<Result<u64, String>>, UnboundedSender<CompactBlock>) {
+    ) -> (
+        JoinHandle<Result<u64, String>>,
+        UnboundedSender<CompactBlock>,
+    ) {
         //info!("Starting node and witness sync");
         let batch_size = self.batch_size;
 
@@ -333,8 +357,12 @@ impl BlockAndWitnessData {
 
                     // If there was a reorg, then we need to invalidate the block and its associated transactions
                     if let Some(reorg_height) = reorg_block {
-                        Self::invalidate_block(reorg_height, existing_blocks.clone(), wallet_transactions.clone())
-                            .await;
+                        Self::invalidate_block(
+                            reorg_height,
+                            existing_blocks.clone(),
+                            wallet_transactions.clone(),
+                        )
+                        .await;
                         last_block_expecting = reorg_height;
                     }
                     reorg_transmitter.send(reorg_block).unwrap();
@@ -356,7 +384,9 @@ impl BlockAndWitnessData {
         // Handle: Final
         // Join all the handles
         let h = tokio::spawn(async move {
-            let earliest_block = h0.await.map_err(|e| format!("Error processing blocks: {}", e))??;
+            let earliest_block = h0
+                .await
+                .map_err(|e| format!("Error processing blocks: {}", e))??;
 
             // Return the earlist block that was synced, accounting for all reorgs
             return Ok(earliest_block);
@@ -550,7 +580,9 @@ impl BlockAndWitnessData {
 
             let cb = &blocks.get(pos as usize).unwrap().cb();
             for compact_transaction in &cb.vtx {
-                if !transaction_id_found && WalletTx::new_txid(&compact_transaction.hash) == *transaction_id {
+                if !transaction_id_found
+                    && WalletTx::new_txid(&compact_transaction.hash) == *transaction_id
+                {
                     transaction_id_found = true;
                 }
                 for j in 0..compact_transaction.outputs.len() as u32 {
@@ -857,8 +889,14 @@ mod test {
 
         // Verify the hashes
         for i in 0..(finished_blks.len() - 1) {
-            assert_eq!(finished_blks[i].cb().prev_hash, finished_blks[i + 1].cb().hash);
-            assert_eq!(finished_blks[i].hash(), finished_blks[i].cb().hash().to_string());
+            assert_eq!(
+                finished_blks[i].cb().prev_hash,
+                finished_blks[i + 1].cb().hash
+            );
+            assert_eq!(
+                finished_blks[i].hash(),
+                finished_blks[i].cb().hash().to_string()
+            );
         }
     }
 }

--- a/lib/src/blaze/block_witness_data.rs
+++ b/lib/src/blaze/block_witness_data.rs
@@ -1,15 +1,13 @@
 use crate::{
     compact_formats::{CompactBlock, CompactTx, TreeState},
     grpc_connector::GrpcConnector,
-    lightclient::{
-        checkpoints::get_all_main_checkpoints,
-        lightclient_config::{LightClientConfig, MAX_REORG},
-    },
+    lightclient::{checkpoints::get_all_main_checkpoints, lightclient_config::LightClientConfig},
     wallet::{
         data::{BlockData, WalletTx, WitnessCache},
         transactions::WalletTxns,
     },
 };
+use zingoconfig::MAX_REORG;
 
 use futures::future::join_all;
 use http::Uri;
@@ -588,7 +586,6 @@ mod test {
     use std::sync::Arc;
 
     use crate::blaze::sync_status::SyncStatus;
-    use crate::lightclient::lightclient_config::Network;
     use crate::wallet::transactions::WalletTxns;
     use crate::{
         blaze::test_utils::{FakeCompactBlock, FakeCompactBlockList},
@@ -601,6 +598,7 @@ mod test {
     use tokio::sync::RwLock;
     use tokio::{sync::mpsc::unbounded_channel, task::JoinHandle};
     use zcash_primitives::block::BlockHash;
+    use zingoconfig::Network;
 
     use super::BlockAndWitnessData;
 

--- a/lib/src/blaze/fetch_compact_blocks.rs
+++ b/lib/src/blaze/fetch_compact_blocks.rs
@@ -1,7 +1,8 @@
 use std::{cmp::max, sync::Arc};
 
 use crate::{
-    compact_formats::CompactBlock, grpc_connector::GrpcConnector, lightclient::lightclient_config::LightClientConfig,
+    compact_formats::CompactBlock, grpc_connector::GrpcConnector,
+    lightclient::lightclient_config::LightClientConfig,
 };
 use log::info;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
@@ -12,7 +13,9 @@ pub struct FetchCompactBlocks {
 
 impl FetchCompactBlocks {
     pub fn new(config: &LightClientConfig) -> Self {
-        Self { config: config.clone() }
+        Self {
+            config: config.clone(),
+        }
     }
 
     async fn fetch_blocks_range(
@@ -53,12 +56,14 @@ impl FetchCompactBlocks {
         }
 
         //info!("Starting fetch compact blocks");
-        self.fetch_blocks_range(&senders, start_block, end_block).await?;
+        self.fetch_blocks_range(&senders, start_block, end_block)
+            .await?;
 
         // After fetching all the normal blocks, we actually wait to see if any re-org'd blocks are recieved
         while let Some(Some(reorg_block)) = reorg_receiver.recv().await {
             // Fetch the additional block.
-            self.fetch_blocks_range(&senders, reorg_block, reorg_block).await?;
+            self.fetch_blocks_range(&senders, reorg_block, reorg_block)
+                .await?;
         }
 
         //info!("Finished fetch compact blocks, closing channels");

--- a/lib/src/blaze/fetch_taddr_transactions.rs
+++ b/lib/src/blaze/fetch_taddr_transactions.rs
@@ -258,7 +258,7 @@ mod test {
                 1,
                 taddr_fetcher_transmitter,
                 full_transaction_scanner_transmitter,
-                crate::lightclient::lightclient_config::Network::FakeMainnet,
+                zingoconfig::Network::FakeMainnet,
             )
             .await;
         //Todo: Add regtest support

--- a/lib/src/blaze/fixed_size_buffer.rs
+++ b/lib/src/blaze/fixed_size_buffer.rs
@@ -14,7 +14,11 @@ impl<T> FixedSizeBuffer<T> {
 
         let mut buf = Vec::<T>::new();
         buf.reserve_exact(capacity);
-        Self { buf, pos: 0, capacity }
+        Self {
+            buf,
+            pos: 0,
+            capacity,
+        }
     }
 
     pub fn push(&mut self, item: T) {

--- a/lib/src/blaze/syncdata.rs
+++ b/lib/src/blaze/syncdata.rs
@@ -52,7 +52,9 @@ impl BlazeSyncData {
 
         self.wallet_options = wallet_options;
 
-        self.block_data.setup_sync(existing_blocks, verified_tree).await;
+        self.block_data
+            .setup_sync(existing_blocks, verified_tree)
+            .await;
     }
 
     // Finish up the sync

--- a/lib/src/blaze/update_notes.rs
+++ b/lib/src/blaze/update_notes.rs
@@ -90,7 +90,8 @@ impl UpdateNotes {
         let download_memos = bsync_data.read().await.wallet_options.download_memos;
 
         // Create a new channel where we'll be notified of TxIds that are to be processed
-        let (transmitter, mut receiver) = unbounded_channel::<(TxId, Nullifier, BlockHeight, Option<u32>)>();
+        let (transmitter, mut receiver) =
+            unbounded_channel::<(TxId, Nullifier, BlockHeight, Option<u32>)>();
 
         // Aside from the incoming Txns, we also need to update the notes that are currently in the wallet
         let wallet_transactions = self.wallet_txns.clone();
@@ -111,7 +112,12 @@ impl UpdateNotes {
                 .get_notes_for_updating(earliest_block - 1);
             for (transaction_id, nf) in notes {
                 transmitter_existing
-                    .send((transaction_id, nf, BlockHeight::from(earliest_block as u32), None))
+                    .send((
+                        transaction_id,
+                        nf,
+                        BlockHeight::from(earliest_block as u32),
+                        None,
+                    ))
                     .map_err(|e| format!("Error sending note for updating: {}", e))?;
             }
 
@@ -170,7 +176,9 @@ impl UpdateNotes {
 
                         // Send the future transaction to be fetched too, in case it has only spent nullifiers and not recieved any change
                         if download_memos != MemoDownloadOption::NoMemos {
-                            fetch_full_sender.send((spent_transaction_id, spent_at_height)).unwrap();
+                            fetch_full_sender
+                                .send((spent_transaction_id, spent_at_height))
+                                .unwrap();
                         }
                     } else {
                         //info!("Note was NOT spent, update its witnesses for TxId {}", txid);

--- a/lib/src/commands.rs
+++ b/lib/src/commands.rs
@@ -1339,7 +1339,7 @@ pub mod tests {
             .unwrap()
             .block_on(LightClient::test_new(
                 &LightClientConfig::create_unconnected(
-                    crate::lightclient::lightclient_config::Network::FakeMainnet,
+                    zingoconfig::Network::FakeMainnet,
                     None,
                 ),
                 Some(TEST_SEED.to_string()),

--- a/lib/src/commands.rs
+++ b/lib/src/commands.rs
@@ -293,7 +293,9 @@ impl Command for LastTxIdCommand {
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
-        RT.block_on(async move { format!("{}", lightclient.do_last_transaction_id().await.pretty(2)) })
+        RT.block_on(
+            async move { format!("{}", lightclient.do_last_transaction_id().await.pretty(2)) },
+        )
     }
 }
 
@@ -349,7 +351,9 @@ impl Command for ExportCommand {
         h.push("Usage:");
         h.push("export [t-address or z-address]");
         h.push("");
-        h.push("If no address is passed, private key for all addresses in the wallet are exported.");
+        h.push(
+            "If no address is passed, private key for all addresses in the wallet are exported.",
+        );
         h.push("");
         h.push("Example:");
         h.push("export ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d");
@@ -389,7 +393,9 @@ impl Command for EncryptCommand {
         h.push("Note 1: This will encrypt the seed and the sapling and transparent private keys.");
         h.push("        Use 'unlock' to temporarily unlock the wallet for spending or 'decrypt' ");
         h.push("        to permanatly remove the encryption");
-        h.push("Note 2: If you forget the password, the only way to recover the wallet is to restore");
+        h.push(
+            "Note 2: If you forget the password, the only way to recover the wallet is to restore",
+        );
         h.push("        from the seed phrase.");
         h.push("Usage:");
         h.push("encrypt password");
@@ -652,7 +658,10 @@ impl Command for EncryptMessageCommand {
 
             (to, memo.unwrap())
         } else {
-            return format!("Wrong number of arguments. Was expecting 1 or 2\n{}", self.help());
+            return format!(
+                "Wrong number of arguments. Was expecting 1 or 2\n{}",
+                self.help()
+            );
         };
 
         if let Ok(m) = memo.try_into() {
@@ -687,7 +696,12 @@ impl Command for DecryptMessageCommand {
             return self.help();
         }
 
-        RT.block_on(async move { lightclient.do_decrypt_message(args[0].to_string()).await.pretty(2) })
+        RT.block_on(async move {
+            lightclient
+                .do_decrypt_message(args[0].to_string())
+                .await
+                .pretty(2)
+        })
     }
 }
 
@@ -697,7 +711,9 @@ impl Command for SendCommand {
         let mut h = vec![];
         h.push("Send ZEC to a given address(es)");
         h.push("Usage:");
-        h.push("send <address> <amount in zatoshis || \"entire-verified-zbalance\"> \"optional_memo\"");
+        h.push(
+            "send <address> <amount in zatoshis || \"entire-verified-zbalance\"> \"optional_memo\"",
+        );
         h.push("OR");
         h.push("send '[{'address': <address>, 'amount': <amount in zatoshis>, 'memo': <optional memo>}, ...]'");
         h.push("");
@@ -739,7 +755,11 @@ impl Command for SendCommand {
                 }
 
                 let fee = u64::from(DEFAULT_FEE);
-                let all_zbalance = lightclient.wallet.verified_zbalance(None).await.checked_sub(fee);
+                let all_zbalance = lightclient
+                    .wallet
+                    .verified_zbalance(None)
+                    .await
+                    .checked_sub(fee);
 
                 let maybe_send_args = json_args
                     .members()
@@ -758,7 +778,10 @@ impl Command for SendCommand {
                                     amt,
                                     j["memo"].as_str().map(|s| s.to_string().clone()),
                                 )),
-                                None => Err(format!("Not enough in wallet to pay transaction fee of {}", fee)),
+                                None => Err(format!(
+                                    "Not enough in wallet to pay transaction fee of {}",
+                                    fee
+                                )),
                             }
                         }
                     })
@@ -779,9 +802,19 @@ impl Command for SendCommand {
                     Err(e) => {
                         if args[1] == "entire-verified-zbalance" {
                             let fee = u64::from(DEFAULT_FEE);
-                            match lightclient.wallet.verified_zbalance(None).await.checked_sub(fee) {
+                            match lightclient
+                                .wallet
+                                .verified_zbalance(None)
+                                .await
+                                .checked_sub(fee)
+                            {
                                 Some(amt) => amt,
-                                None => return format!("Not enough in wallet to pay transaction fee of {}", fee),
+                                None => {
+                                    return format!(
+                                        "Not enough in wallet to pay transaction fee of {}",
+                                        fee
+                                    )
+                                }
                             }
                         } else {
                             return format!("Couldn't parse amount: {}", e);
@@ -914,13 +947,25 @@ impl Command for TransactionsCommand {
             if args[0] == "allmemos" || args[0] == "true" || args[0] == "yes" {
                 true
             } else {
-                return format!("Couldn't understand first argument '{}'\n{}", args[0], self.help());
+                return format!(
+                    "Couldn't understand first argument '{}'\n{}",
+                    args[0],
+                    self.help()
+                );
             }
         } else {
             false
         };
 
-        RT.block_on(async move { format!("{}", lightclient.do_list_transactions(include_memo_hex).await.pretty(2)) })
+        RT.block_on(async move {
+            format!(
+                "{}",
+                lightclient
+                    .do_list_transactions(include_memo_hex)
+                    .await
+                    .pretty(2)
+            )
+        })
     }
 }
 
@@ -959,15 +1004,30 @@ impl Command for SetOptionCommand {
         RT.block_on(async move {
             match option_name {
                 "download_memos" => match option_value {
-                    "none" => lightclient.wallet.set_download_memo(MemoDownloadOption::NoMemos).await,
+                    "none" => {
+                        lightclient
+                            .wallet
+                            .set_download_memo(MemoDownloadOption::NoMemos)
+                            .await
+                    }
                     "wallet" => {
                         lightclient
                             .wallet
                             .set_download_memo(MemoDownloadOption::WalletMemos)
                             .await
                     }
-                    "all" => lightclient.wallet.set_download_memo(MemoDownloadOption::AllMemos).await,
-                    _ => return format!("Error: Couldn't understand {} value {}", option_name, option_value),
+                    "all" => {
+                        lightclient
+                            .wallet
+                            .set_download_memo(MemoDownloadOption::AllMemos)
+                            .await
+                    }
+                    _ => {
+                        return format!(
+                            "Error: Couldn't understand {} value {}",
+                            option_name, option_value
+                        )
+                    }
                 },
                 _ => return format!("Error: Couldn't understand {}", option_name),
             }
@@ -1005,7 +1065,13 @@ impl Command for GetOptionCommand {
 
         RT.block_on(async move {
             let value = match option_name {
-                "download_memos" => match lightclient.wallet.wallet_options.read().await.download_memos {
+                "download_memos" => match lightclient
+                    .wallet
+                    .wallet_options
+                    .read()
+                    .await
+                    .download_memos
+                {
                     MemoDownloadOption::NoMemos => "none",
                     MemoDownloadOption::WalletMemos => "wallet",
                     MemoDownloadOption::AllMemos => "all",
@@ -1241,13 +1307,20 @@ impl Command for NotesCommand {
         let all_notes = if args.len() == 1 {
             match args[0] {
                 "all" => true,
-                a => return format!("Invalid argument \"{}\". Specify 'all' to include unspent notes", a),
+                a => {
+                    return format!(
+                        "Invalid argument \"{}\". Specify 'all' to include unspent notes",
+                        a
+                    )
+                }
             }
         } else {
             false
         };
 
-        RT.block_on(async move { format!("{}", lightclient.do_list_notes(all_notes).await.pretty(2)) })
+        RT.block_on(
+            async move { format!("{}", lightclient.do_list_notes(all_notes).await.pretty(2)) },
+        )
     }
 }
 
@@ -1282,9 +1355,18 @@ pub fn get_commands() -> Box<HashMap<String, Box<dyn Command>>> {
 
     map.insert("sync".to_string(), Box::new(SyncCommand {}));
     map.insert("syncstatus".to_string(), Box::new(SyncStatusCommand {}));
-    map.insert("encryptionstatus".to_string(), Box::new(EncryptionStatusCommand {}));
-    map.insert("encryptmessage".to_string(), Box::new(EncryptMessageCommand {}));
-    map.insert("decryptmessage".to_string(), Box::new(DecryptMessageCommand {}));
+    map.insert(
+        "encryptionstatus".to_string(),
+        Box::new(EncryptionStatusCommand {}),
+    );
+    map.insert(
+        "encryptmessage".to_string(),
+        Box::new(EncryptMessageCommand {}),
+    );
+    map.insert(
+        "decryptmessage".to_string(),
+        Box::new(DecryptMessageCommand {}),
+    );
     map.insert("rescan".to_string(), Box::new(RescanCommand {}));
     map.insert("clear".to_string(), Box::new(ClearCommand {}));
     map.insert("help".to_string(), Box::new(HelpCommand {}));
@@ -1319,7 +1401,10 @@ pub fn get_commands() -> Box<HashMap<String, Box<dyn Command>>> {
 pub fn do_user_command(cmd: &str, args: &Vec<&str>, lightclient: &LightClient) -> String {
     match get_commands().get(&cmd.to_ascii_lowercase()) {
         Some(cmd) => cmd.exec(args, lightclient),
-        None => format!("Unknown command : {}. Type 'help' for a list of commands", cmd),
+        None => format!(
+            "Unknown command : {}. Type 'help' for a list of commands",
+            cmd
+        ),
     }
 }
 
@@ -1338,10 +1423,7 @@ pub mod tests {
         let lc = Runtime::new()
             .unwrap()
             .block_on(LightClient::test_new(
-                &LightClientConfig::create_unconnected(
-                    zingoconfig::Network::FakeMainnet,
-                    None,
-                ),
+                &LightClientConfig::create_unconnected(zingoconfig::Network::FakeMainnet, None),
                 Some(TEST_SEED.to_string()),
                 0,
             ))

--- a/lib/src/lightclient.rs
+++ b/lib/src/lightclient.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     compact_formats::RawTransaction,
     grpc_connector::GrpcConnector,
-    lightclient::lightclient_config::MAX_REORG,
     wallet::{self, data::WalletTx, keys::Keys, message::Message, now, LightWallet},
 };
 use futures::future::join_all;
@@ -38,6 +37,7 @@ use zcash_primitives::{
     transaction::{components::amount::DEFAULT_FEE, Transaction, TxId},
 };
 use zcash_proofs::prover::LocalTxProver;
+use zingoconfig::MAX_REORG;
 
 pub(crate) mod checkpoints;
 pub mod lightclient_config;

--- a/lib/src/lightclient/checkpoints.rs
+++ b/lib/src/lightclient/checkpoints.rs
@@ -1,6 +1,9 @@
 use zingoconfig::Network;
 
-pub fn get_closest_checkpoint(chain: &Network, height: u64) -> Option<(u64, &'static str, &'static str)> {
+pub fn get_closest_checkpoint(
+    chain: &Network,
+    height: u64,
+) -> Option<(u64, &'static str, &'static str)> {
     log::info!("Trying to get checkpoint closest to block {}", height);
     match chain {
         Network::Testnet => get_test_checkpoint(height),
@@ -103,7 +106,10 @@ fn find_checkpoint(
     heights.sort();
 
     match get_first_lower_than(height, heights) {
-        Some(closest_height) => chkpts.iter().find(|(h, _, _)| *h == closest_height).map(|t| *t),
+        Some(closest_height) => chkpts
+            .iter()
+            .find(|(h, _, _)| *h == closest_height)
+            .map(|t| *t),
         None => None,
     }
 }

--- a/lib/src/lightclient/checkpoints.rs
+++ b/lib/src/lightclient/checkpoints.rs
@@ -1,4 +1,4 @@
-use super::lightclient_config::Network;
+use zingoconfig::Network;
 
 pub fn get_closest_checkpoint(chain: &Network, height: u64) -> Option<(u64, &'static str, &'static str)> {
     log::info!("Trying to get checkpoint closest to block {}", height);

--- a/lib/src/lightclient/lightclient_config.rs
+++ b/lib/src/lightclient/lightclient_config.rs
@@ -6,7 +6,9 @@ use std::{
 use log::{error, info, LevelFilter};
 use log4rs::{
     append::rolling_file::{
-        policy::compound::{roll::fixed_window::FixedWindowRoller, trigger::size::SizeTrigger, CompoundPolicy},
+        policy::compound::{
+            roll::fixed_window::FixedWindowRoller, trigger::size::SizeTrigger, CompoundPolicy,
+        },
         RollingFileAppender,
     },
     config::{Appender, Root},
@@ -27,7 +29,8 @@ pub const DEFAULT_SERVER: &str = "https://lwdv3.zecwallet.co";
 pub const WALLET_NAME: &str = "zingo-wallet.dat";
 pub const LOGFILE_NAME: &str = "zingo-wallet.debug.log";
 pub const ANCHOR_OFFSET: [u32; 5] = [4, 0, 0, 0, 0];
-pub const GAP_RULE_UNUSED_ADDRESSES: usize = if cfg!(any(target_os = "ios", target_os = "android")) {
+pub const GAP_RULE_UNUSED_ADDRESSES: usize = if cfg!(any(target_os = "ios", target_os = "android"))
+{
     0
 } else {
     5
@@ -56,10 +59,16 @@ impl LightClientConfig {
 
     //Convenience wrapper
     pub fn sapling_activation_height(&self) -> u64 {
-        self.chain.activation_height(NetworkUpgrade::Sapling).unwrap().into()
+        self.chain
+            .activation_height(NetworkUpgrade::Sapling)
+            .unwrap()
+            .into()
     }
 
-    pub fn create_on_data_dir(server: http::Uri, data_dir: Option<String>) -> io::Result<(LightClientConfig, u64)> {
+    pub fn create_on_data_dir(
+        server: http::Uri,
+        data_dir: Option<String>,
+    ) -> io::Result<(LightClientConfig, u64)> {
         use std::net::ToSocketAddrs;
 
         let lc = Runtime::new().unwrap().block_on(async move {
@@ -112,7 +121,8 @@ impl LightClientConfig {
             .unwrap();
         let size_limit = 5 * 1024 * 1024; // 5MB as max log file size to roll
         let size_trigger = SizeTrigger::new(size_limit);
-        let compound_policy = CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller));
+        let compound_policy =
+            CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller));
 
         Config::builder()
             .appender(
@@ -127,7 +137,11 @@ impl LightClientConfig {
                         ),
                     ),
             )
-            .build(Root::builder().appender("logfile").build(LevelFilter::Debug))
+            .build(
+                Root::builder()
+                    .appender("logfile")
+                    .build(LevelFilter::Debug),
+            )
             .map_err(|e| Error::new(ErrorKind::Other, format!("{}", e)))
     }
 
@@ -141,13 +155,15 @@ impl LightClientConfig {
                 zcash_data_location = PathBuf::from(&self.data_dir.as_ref().unwrap());
             } else {
                 if cfg!(target_os = "macos") || cfg!(target_os = "windows") {
-                    zcash_data_location = dirs::data_dir().expect("Couldn't determine app data directory!");
+                    zcash_data_location =
+                        dirs::data_dir().expect("Couldn't determine app data directory!");
                     zcash_data_location.push("Zcash");
                 } else {
                     if dirs::home_dir().is_none() {
                         info!("Couldn't determine home dir!");
                     }
-                    zcash_data_location = dirs::home_dir().expect("Couldn't determine home directory!");
+                    zcash_data_location =
+                        dirs::home_dir().expect("Couldn't determine home directory!");
                     zcash_data_location.push(".zcash");
                 };
 
@@ -223,7 +239,10 @@ impl LightClientConfig {
         let mut backup_file_path = self.get_zcash_data_path().into_path_buf();
         backup_file_path.push(&format!(
             "zingo-wallet.backup.{}.dat",
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
         ));
 
         let backup_file_str = backup_file_path.to_string_lossy().to_string();
@@ -245,7 +264,10 @@ impl LightClientConfig {
             return None;
         }
 
-        info!("Getting sapling tree from LightwalletD at height {}", height);
+        info!(
+            "Getting sapling tree from LightwalletD at height {}",
+            height
+        );
         match GrpcConnector::get_sapling_tree(self.server.clone(), height).await {
             Ok(tree_state) => {
                 let hash = tree_state.hash.clone();
@@ -253,9 +275,14 @@ impl LightClientConfig {
                 Some((tree_state.height, hash, tree))
             }
             Err(e) => {
-                error!("Error getting sapling tree:{}\nWill return checkpoint instead.", e);
+                error!(
+                    "Error getting sapling tree:{}\nWill return checkpoint instead.",
+                    e
+                );
                 match checkpoints::get_closest_checkpoint(&self.chain, height) {
-                    Some((height, hash, tree)) => Some((height, hash.to_string(), tree.to_string())),
+                    Some((height, hash, tree)) => {
+                        Some((height, hash.to_string(), tree.to_string()))
+                    }
                     None => None,
                 }
             }

--- a/lib/src/lightclient/lightclient_config.rs
+++ b/lib/src/lightclient/lightclient_config.rs
@@ -21,130 +21,17 @@ use zcash_primitives::{
 };
 
 use crate::{grpc_connector::GrpcConnector, lightclient::checkpoints};
+use zingoconfig::Network;
 
 pub const DEFAULT_SERVER: &str = "https://lwdv3.zecwallet.co";
 pub const WALLET_NAME: &str = "zingo-wallet.dat";
 pub const LOGFILE_NAME: &str = "zingo-wallet.debug.log";
 pub const ANCHOR_OFFSET: [u32; 5] = [4, 0, 0, 0, 0];
-pub const MAX_REORG: usize = 100;
 pub const GAP_RULE_UNUSED_ADDRESSES: usize = if cfg!(any(target_os = "ios", target_os = "android")) {
     0
 } else {
     5
 };
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Network {
-    Testnet,
-    Mainnet,
-    FakeMainnet,
-}
-
-impl std::fmt::Display for Network {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use Network::*;
-        let name = match self {
-            Mainnet => "main",
-            Testnet => "test",
-            FakeMainnet => "regtest",
-        };
-        write!(f, "{name}")
-    }
-}
-
-impl Network {
-    pub fn hrp_orchard_spending_key(&self) -> &str {
-        match self {
-            Network::Mainnet => "secret-orchard-sk-main",
-            Network::Testnet => "secret-orchard-sk-test",
-            Network::FakeMainnet => "secret-orchard-sk-main",
-        }
-    }
-    pub fn hrp_unified_full_viewing_key(&self) -> &str {
-        match self {
-            Network::Mainnet => "uview",
-            Network::Testnet => "uviewtest",
-            Network::FakeMainnet => "uview",
-        }
-    }
-    pub fn to_zcash_address_network(&self) -> zcash_address::Network {
-        match self {
-            Network::Testnet => zcash_address::Network::Test,
-            _ => zcash_address::Network::Main,
-        }
-    }
-}
-
-impl Parameters for Network {
-    fn activation_height(&self, nu: NetworkUpgrade) -> Option<zcash_primitives::consensus::BlockHeight> {
-        use Network::*;
-        match self {
-            Mainnet => MAIN_NETWORK.activation_height(nu),
-            Testnet => TEST_NETWORK.activation_height(nu),
-            FakeMainnet => {
-                //Tests don't need to worry about NU5 yet
-                match nu {
-                    NetworkUpgrade::Nu5 => None,
-                    _ => Some(BlockHeight::from_u32(1)),
-                }
-            }
-        }
-    }
-
-    fn coin_type(&self) -> u32 {
-        use Network::*;
-        match self {
-            Mainnet => constants::mainnet::COIN_TYPE,
-            Testnet => constants::testnet::COIN_TYPE,
-            FakeMainnet => constants::mainnet::COIN_TYPE,
-        }
-    }
-
-    fn hrp_sapling_extended_spending_key(&self) -> &str {
-        use Network::*;
-        match self {
-            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            Testnet => constants::testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            FakeMainnet => constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-        }
-    }
-
-    fn hrp_sapling_extended_full_viewing_key(&self) -> &str {
-        use Network::*;
-        match self {
-            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            Testnet => constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            FakeMainnet => constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-        }
-    }
-
-    fn hrp_sapling_payment_address(&self) -> &str {
-        use Network::*;
-        match self {
-            Mainnet => constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
-            Testnet => constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS,
-            FakeMainnet => constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
-        }
-    }
-
-    fn b58_pubkey_address_prefix(&self) -> [u8; 2] {
-        use Network::*;
-        match self {
-            Mainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
-            Testnet => constants::testnet::B58_PUBKEY_ADDRESS_PREFIX,
-            FakeMainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
-        }
-    }
-
-    fn b58_script_address_prefix(&self) -> [u8; 2] {
-        use Network::*;
-        match self {
-            Mainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
-            Testnet => constants::testnet::B58_SCRIPT_ADDRESS_PREFIX,
-            FakeMainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
-        }
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct LightClientConfig {

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -6,7 +6,7 @@ use crate::compact_formats::{
     GetAddressUtxosArg, GetAddressUtxosReply, GetAddressUtxosReplyList, LightdInfo, PingResponse, PriceRequest,
     PriceResponse, RawTransaction, SendResponse, TransparentAddressBlockFilter, TreeState, TxFilter,
 };
-use crate::lightclient::lightclient_config::Network;
+use zingoconfig::Network;
 use crate::wallet::data::WalletTx;
 use crate::wallet::now;
 use futures::{FutureExt, Stream};

--- a/lib/src/lightclient/testmocks.rs
+++ b/lib/src/lightclient/testmocks.rs
@@ -12,16 +12,17 @@ pub fn new_transactiondata() -> TransactionData<zcash_primitives::transaction::A
         value_balance: Amount::zero(),
         authorization,
     };
-    let td: TransactionData<zcash_primitives::transaction::Authorized> = TransactionData::from_parts(
-        TxVersion::Sapling,
-        BranchId::Sapling,
-        0,
-        0u32.into(),
-        None,
-        None,
-        Some(sapling_bundle),
-        None,
-    );
+    let td: TransactionData<zcash_primitives::transaction::Authorized> =
+        TransactionData::from_parts(
+            TxVersion::Sapling,
+            BranchId::Sapling,
+            0,
+            0u32.into(),
+            None,
+            None,
+            Some(sapling_bundle),
+            None,
+        );
 
     td
 }

--- a/lib/src/lightclient/tests.rs
+++ b/lib/src/lightclient/tests.rs
@@ -31,7 +31,8 @@ use crate::lightclient::LightClient;
 use crate::wallet::data::{SaplingNoteData, WalletTx};
 
 use super::checkpoints;
-use super::lightclient_config::{LightClientConfig, Network};
+use super::lightclient_config::LightClientConfig;
+use zingoconfig::Network;
 
 #[test]
 fn new_wallet_from_phrase() {

--- a/lib/src/lightclient/tests.rs
+++ b/lib/src/lightclient/tests.rs
@@ -26,7 +26,9 @@ use crate::blaze::test_utils::{FakeCompactBlockList, FakeTransaction};
 use crate::lightclient::testmocks;
 
 use crate::compact_formats::{CompactOutput, CompactTx, Empty};
-use crate::lightclient::test_server::{clean_shutdown, create_test_server, mine_pending_blocks, mine_random_blocks};
+use crate::lightclient::test_server::{
+    clean_shutdown, create_test_server, mine_pending_blocks, mine_random_blocks,
+};
 use crate::lightclient::LightClient;
 use crate::wallet::data::{SaplingNoteData, WalletTx};
 
@@ -68,7 +70,8 @@ fn new_wallet_from_phrase() {
         let addresses = lc.do_address().await;
 
         assert_eq!(
-            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg".to_string(),
+            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg"
+                .to_string(),
             addresses["z_addresses"][0]
         );
         assert_eq!(
@@ -98,7 +101,8 @@ fn new_wallet_from_sapling_esk() {
         assert_eq!(addresses["z_addresses"].len(), 1);
         assert_eq!(addresses["t_addresses"].len(), 1);
         assert_eq!(
-            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg".to_string(),
+            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg"
+                .to_string(),
             addresses["z_addresses"][0]
         );
 
@@ -108,7 +112,8 @@ fn new_wallet_from_sapling_esk() {
         let addresses = lc.do_address().await;
         assert_eq!(addresses["z_addresses"].len(), 2);
         assert_ne!(
-            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg".to_string(),
+            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg"
+                .to_string(),
             addresses["z_addresses"][1]
         );
     });
@@ -134,7 +139,8 @@ fn import_orchard_spending_key() {
         let new_address = lc
             .wallet
             .add_imported_orchard_spending_key(
-                "secret-orchard-sk-main10vj29mt2ezeyc8y5ut6knfcdptg3umdsjk4v8zge6fdmt2kepycqs6j2g8".to_string(),
+                "secret-orchard-sk-main10vj29mt2ezeyc8y5ut6knfcdptg3umdsjk4v8zge6fdmt2kepycqs6j2g8"
+                    .to_string(),
                 0,
             )
             .await;
@@ -162,7 +168,8 @@ fn new_wallet_from_zvk() {
         assert_eq!(addresses["z_addresses"].len(), 1);
         assert_eq!(addresses["t_addresses"].len(), 1);
         assert_eq!(
-            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg".to_string(),
+            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg"
+                .to_string(),
             addresses["z_addresses"][0]
         );
 
@@ -172,7 +179,8 @@ fn new_wallet_from_zvk() {
         let addresses = lc.do_address().await;
         assert_eq!(addresses["z_addresses"].len(), 2);
         assert_ne!(
-            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg".to_string(),
+            "zs1q6xk3q783t5k92kjqt2rkuuww8pdw2euzy5rk6jytw97enx8fhpazdv3th4xe7vsk6e9sfpawfg"
+                .to_string(),
             addresses["z_addresses"][1]
         );
     });
@@ -241,8 +249,14 @@ async fn z_incoming_z_outgoing() {
             lc.wallet.keys().read().await.get_all_zaddresses()[0]
         );
         assert_eq!(b["z_addresses"][0]["zbalance"].as_u64().unwrap(), value);
-        assert_eq!(b["z_addresses"][0]["unverified_zbalance"].as_u64().unwrap(), value);
-        assert_eq!(b["z_addresses"][0]["spendable_zbalance"].as_u64().unwrap(), 0);
+        assert_eq!(
+            b["z_addresses"][0]["unverified_zbalance"].as_u64().unwrap(),
+            value
+        );
+        assert_eq!(
+            b["z_addresses"][0]["spendable_zbalance"].as_u64().unwrap(),
+            0
+        );
 
         let list = lc.do_list_transactions(false).await;
         if let JsonValue::Array(list) = list {
@@ -251,7 +265,10 @@ async fn z_incoming_z_outgoing() {
 
             assert_eq!(jv["txid"], txid.to_string());
             assert_eq!(jv["amount"].as_u64().unwrap(), value);
-            assert_eq!(jv["address"], lc.wallet.keys().read().await.get_all_zaddresses()[0]);
+            assert_eq!(
+                jv["address"],
+                lc.wallet.keys().read().await.get_all_zaddresses()[0]
+            );
             assert_eq!(jv["block_height"].as_u64().unwrap(), 11);
         } else {
             panic!("Expecting an array");
@@ -264,8 +281,14 @@ async fn z_incoming_z_outgoing() {
         assert_eq!(b["unverified_zbalance"].as_u64().unwrap(), 0);
         assert_eq!(b["spendable_zbalance"].as_u64().unwrap(), value);
         assert_eq!(b["z_addresses"][0]["zbalance"].as_u64().unwrap(), value);
-        assert_eq!(b["z_addresses"][0]["spendable_zbalance"].as_u64().unwrap(), value);
-        assert_eq!(b["z_addresses"][0]["unverified_zbalance"].as_u64().unwrap(), 0);
+        assert_eq!(
+            b["z_addresses"][0]["spendable_zbalance"].as_u64().unwrap(),
+            value
+        );
+        assert_eq!(
+            b["z_addresses"][0]["unverified_zbalance"].as_u64().unwrap(),
+            0
+        );
 
         // 5. Send z-to-z transaction to external z address with a memo
         let sent_value = 2000;
@@ -282,13 +305,25 @@ async fn z_incoming_z_outgoing() {
         let notes = lc.do_list_notes(true).await;
         // Has a new (unconfirmed) unspent note (the change)
         assert_eq!(notes["unspent_notes"].len(), 1);
-        assert_eq!(notes["unspent_notes"][0]["created_in_txid"], sent_transaction_id);
-        assert_eq!(notes["unspent_notes"][0]["unconfirmed"].as_bool().unwrap(), true);
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_txid"],
+            sent_transaction_id
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["unconfirmed"].as_bool().unwrap(),
+            true
+        );
 
         assert_eq!(notes["spent_notes"].len(), 0);
         assert_eq!(notes["pending_notes"].len(), 1);
-        assert_eq!(notes["pending_notes"][0]["created_in_txid"], txid.to_string());
-        assert_eq!(notes["pending_notes"][0]["unconfirmed_spent"], sent_transaction_id);
+        assert_eq!(
+            notes["pending_notes"][0]["created_in_txid"],
+            txid.to_string()
+        );
+        assert_eq!(
+            notes["pending_notes"][0]["unconfirmed_spent"],
+            sent_transaction_id
+        );
         assert_eq!(notes["pending_notes"][0]["spent"].is_null(), true);
         assert_eq!(notes["pending_notes"][0]["spent_at_height"].is_null(), true);
 
@@ -296,7 +331,10 @@ async fn z_incoming_z_outgoing() {
         let list = lc.do_list_transactions(false).await;
 
         assert_eq!(list.len(), 2);
-        let jv = list.members().find(|jv| jv["txid"] == sent_transaction_id).unwrap();
+        let jv = list
+            .members()
+            .find(|jv| jv["txid"] == sent_transaction_id)
+            .unwrap();
 
         assert_eq!(jv["txid"], sent_transaction_id);
         assert_eq!(
@@ -308,7 +346,10 @@ async fn z_incoming_z_outgoing() {
 
         assert_eq!(jv["outgoing_metadata"][0]["address"], EXT_ZADDR.to_string());
         assert_eq!(jv["outgoing_metadata"][0]["memo"], outgoing_memo);
-        assert_eq!(jv["outgoing_metadata"][0]["value"].as_u64().unwrap(), sent_value);
+        assert_eq!(
+            jv["outgoing_metadata"][0]["value"].as_u64().unwrap(),
+            sent_value
+        );
 
         // 7. Mine the sent transaction
         fcbl.add_pending_sends(&data).await;
@@ -317,7 +358,10 @@ async fn z_incoming_z_outgoing() {
         let list = lc.do_list_transactions(false).await;
 
         assert_eq!(list.len(), 2);
-        let jv = list.members().find(|jv| jv["txid"] == sent_transaction_id).unwrap();
+        let jv = list
+            .members()
+            .find(|jv| jv["txid"] == sent_transaction_id)
+            .unwrap();
 
         assert_eq!(jv.contains("unconfirmed"), false);
         assert_eq!(jv["block_height"].as_u64().unwrap(), 17);
@@ -325,22 +369,50 @@ async fn z_incoming_z_outgoing() {
         // 8. Check the notes to see that we have one spent note and one unspent note (change)
         let notes = lc.do_list_notes(true).await;
         assert_eq!(notes["unspent_notes"].len(), 1);
-        assert_eq!(notes["unspent_notes"][0]["created_in_block"].as_u64().unwrap(), 17);
-        assert_eq!(notes["unspent_notes"][0]["created_in_txid"], sent_transaction_id);
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_block"]
+                .as_u64()
+                .unwrap(),
+            17
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_txid"],
+            sent_transaction_id
+        );
         assert_eq!(
             notes["unspent_notes"][0]["value"].as_u64().unwrap(),
             value - sent_value - u64::from(DEFAULT_FEE)
         );
-        assert_eq!(notes["unspent_notes"][0]["is_change"].as_bool().unwrap(), true);
-        assert_eq!(notes["unspent_notes"][0]["spendable"].as_bool().unwrap(), false); // Not yet spendable
+        assert_eq!(
+            notes["unspent_notes"][0]["is_change"].as_bool().unwrap(),
+            true
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["spendable"].as_bool().unwrap(),
+            false
+        ); // Not yet spendable
 
         assert_eq!(notes["spent_notes"].len(), 1);
-        assert_eq!(notes["spent_notes"][0]["created_in_block"].as_u64().unwrap(), 11);
+        assert_eq!(
+            notes["spent_notes"][0]["created_in_block"]
+                .as_u64()
+                .unwrap(),
+            11
+        );
         assert_eq!(notes["spent_notes"][0]["value"].as_u64().unwrap(), value);
-        assert_eq!(notes["spent_notes"][0]["is_change"].as_bool().unwrap(), false);
-        assert_eq!(notes["spent_notes"][0]["spendable"].as_bool().unwrap(), false); // Already spent
+        assert_eq!(
+            notes["spent_notes"][0]["is_change"].as_bool().unwrap(),
+            false
+        );
+        assert_eq!(
+            notes["spent_notes"][0]["spendable"].as_bool().unwrap(),
+            false
+        ); // Already spent
         assert_eq!(notes["spent_notes"][0]["spent"], sent_transaction_id);
-        assert_eq!(notes["spent_notes"][0]["spent_at_height"].as_u64().unwrap(), 17);
+        assert_eq!(
+            notes["spent_notes"][0]["spent_at_height"].as_u64().unwrap(),
+            17
+        );
 
         // Shutdown everything cleanly
         clean_shutdown(stop_transmitter, h1).await;
@@ -402,7 +474,11 @@ async fn multiple_incoming_same_transaction() {
                 cmu: note.cmu(),
                 ephemeral_key: EphemeralKeyBytes::from(encryptor.epk().to_bytes()),
                 enc_ciphertext: encryptor.encrypt_note_plaintext(),
-                out_ciphertext: encryptor.encrypt_outgoing_plaintext(&cv.commitment().into(), &cmu, &mut rng),
+                out_ciphertext: encryptor.encrypt_outgoing_plaintext(
+                    &cv.commitment().into(),
+                    &cmu,
+                    &mut rng,
+                ),
                 zkproof: [0; GROTH_PROOF_SIZE],
             };
 
@@ -424,8 +500,10 @@ async fn multiple_incoming_same_transaction() {
         compact_transaction.hash = transaction.txid().clone().as_ref().to_vec();
 
         // Add and mine the block
-        fcbl.transactions.push((transaction, fcbl.next_height, vec![]));
-        fcbl.add_empty_block().add_transactions(vec![compact_transaction]);
+        fcbl.transactions
+            .push((transaction, fcbl.next_height, vec![]));
+        fcbl.add_empty_block()
+            .add_transactions(vec![compact_transaction]);
         mine_pending_blocks(&mut fcbl, &data, &lc).await;
         assert_eq!(lc.wallet.last_scanned_height().await, 11);
 
@@ -438,7 +516,10 @@ async fn multiple_incoming_same_transaction() {
 
             for i in 0..4 {
                 assert_eq!(unspent_notes[i]["created_in_block"].as_u64().unwrap(), 11);
-                assert_eq!(unspent_notes[i]["value"].as_u64().unwrap(), value + i as u64);
+                assert_eq!(
+                    unspent_notes[i]["value"].as_u64().unwrap(),
+                    value + i as u64
+                );
                 assert_eq!(unspent_notes[i]["is_change"].as_bool().unwrap(), false);
                 assert_eq!(
                     unspent_notes[i]["address"],
@@ -459,7 +540,10 @@ async fn multiple_incoming_same_transaction() {
                     sorted_transactions[i]["address"],
                     lc.wallet.keys().read().await.get_all_zaddresses()[0]
                 );
-                assert_eq!(sorted_transactions[i]["amount"].as_u64().unwrap(), value + i as u64);
+                assert_eq!(
+                    sorted_transactions[i]["amount"].as_u64().unwrap(),
+                    value + i as u64
+                );
             }
         } else {
             panic!("transactions is not array");
@@ -468,7 +552,10 @@ async fn multiple_incoming_same_transaction() {
         // 3. Send a big transaction, so all the value is spent
         let sent_value = value * 3 + u64::from(DEFAULT_FEE);
         mine_random_blocks(&mut fcbl, &data, &lc, 5).await; // make the funds spentable
-        let sent_transaction_id = lc.test_do_send(vec![(EXT_ZADDR, sent_value, None)]).await.unwrap();
+        let sent_transaction_id = lc
+            .test_do_send(vec![(EXT_ZADDR, sent_value, None)])
+            .await
+            .unwrap();
 
         // 4. Mine the sent transaction
         fcbl.add_pending_sends(&data).await;
@@ -479,7 +566,10 @@ async fn multiple_incoming_same_transaction() {
         let transactions = lc.do_list_transactions(false).await;
         for i in 0..4 {
             assert_eq!(notes["spent_notes"][i]["spent"], sent_transaction_id);
-            assert_eq!(notes["spent_notes"][i]["spent_at_height"].as_u64().unwrap(), 17);
+            assert_eq!(
+                notes["spent_notes"][i]["spent_at_height"].as_u64().unwrap(),
+                17
+            );
         }
         assert_eq!(transactions[4]["txid"], sent_transaction_id);
         assert_eq!(transactions[4]["block_height"], 17 as u32);
@@ -492,10 +582,15 @@ async fn multiple_incoming_same_transaction() {
             EXT_ZADDR.to_string()
         );
         assert_eq!(
-            transactions[4]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
+            transactions[4]["outgoing_metadata"][0]["value"]
+                .as_u64()
+                .unwrap(),
             sent_value
         );
-        assert_eq!(transactions[4]["outgoing_metadata"][0]["memo"].is_null(), true);
+        assert_eq!(
+            transactions[4]["outgoing_metadata"][0]["memo"].is_null(),
+            true
+        );
 
         // Shutdown everything cleanly
         clean_shutdown(stop_transmitter, h1).await;
@@ -594,7 +689,9 @@ async fn z_to_z_scan_together() {
         let witness = IncrementalWitness::from_tree(&tree);
         let nf = note.nf(&extfvk1.fvk.vk, witness.position() as u64);
 
-        let pa = if let Some(RecipientAddress::Shielded(pa)) = RecipientAddress::decode(&config.chain, EXT_ZADDR) {
+        let pa = if let Some(RecipientAddress::Shielded(pa)) =
+            RecipientAddress::decode(&config.chain, EXT_ZADDR)
+        {
             pa
         } else {
             panic!("Couldn't parse address")
@@ -615,8 +712,14 @@ async fn z_to_z_scan_together() {
         assert_eq!(list[1]["block_height"].as_u64().unwrap(), 12);
         assert_eq!(list[1]["txid"], spent_txid.to_string());
         assert_eq!(list[1]["amount"].as_i64().unwrap(), -(value as i64));
-        assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_ZADDR.to_string());
-        assert_eq!(list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(), spent_value);
+        assert_eq!(
+            list[1]["outgoing_metadata"][0]["address"],
+            EXT_ZADDR.to_string()
+        );
+        assert_eq!(
+            list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
+            spent_value
+        );
 
         // Shutdown everything cleanly
         clean_shutdown(stop_transmitter, h1).await;
@@ -641,7 +744,8 @@ async fn z_incoming_viewkey() {
         // 2. Create a new Viewkey and import it
         let iextsk = ExtendedSpendingKey::master(&[1u8; 32]);
         let iextfvk = ExtendedFullViewingKey::from(&iextsk);
-        let iaddr = encode_payment_address(config.hrp_sapling_address(), &iextfvk.default_address().1);
+        let iaddr =
+            encode_payment_address(config.hrp_sapling_address(), &iextfvk.default_address().1);
         let addrs = lc
             .do_import_sapling_full_view_key(
                 encode_extended_full_viewing_key(config.hrp_sapling_viewing_key(), &iextfvk),
@@ -661,7 +765,12 @@ async fn z_incoming_viewkey() {
         // 3. Test that we have the transaction
         let list = lc.do_list_transactions(false).await;
         assert_eq!(lc.do_balance().await["zbalance"].as_u64().unwrap(), value);
-        assert_eq!(lc.do_balance().await["spendable_zbalance"].as_u64().unwrap(), 0);
+        assert_eq!(
+            lc.do_balance().await["spendable_zbalance"]
+                .as_u64()
+                .unwrap(),
+            0
+        );
         assert_eq!(list[0]["txid"], txid.to_string());
         assert_eq!(list[0]["amount"].as_u64().unwrap(), value);
         assert_eq!(list[0]["address"], iaddr);
@@ -672,7 +781,12 @@ async fn z_incoming_viewkey() {
         // Test all the same values
         let list = lc.do_list_transactions(false).await;
         assert_eq!(lc.do_balance().await["zbalance"].as_u64().unwrap(), value);
-        assert_eq!(lc.do_balance().await["spendable_zbalance"].as_u64().unwrap(), 0);
+        assert_eq!(
+            lc.do_balance().await["spendable_zbalance"]
+                .as_u64()
+                .unwrap(),
+            0
+        );
         assert_eq!(list[0]["txid"], txid.to_string());
         assert_eq!(list[0]["amount"].as_u64().unwrap(), value);
         assert_eq!(list[0]["address"], iaddr);
@@ -688,12 +802,22 @@ async fn z_incoming_viewkey() {
 
         assert_eq!(sk_addr[0], iaddr);
         assert_eq!(lc.do_balance().await["zbalance"].as_u64().unwrap(), value);
-        assert_eq!(lc.do_balance().await["spendable_zbalance"].as_u64().unwrap(), 0);
+        assert_eq!(
+            lc.do_balance().await["spendable_zbalance"]
+                .as_u64()
+                .unwrap(),
+            0
+        );
 
         // 6. Rescan to make the funds spendable (i.e., update witnesses)
         lc.do_rescan().await.unwrap();
         assert_eq!(lc.do_balance().await["zbalance"].as_u64().unwrap(), value);
-        assert_eq!(lc.do_balance().await["spendable_zbalance"].as_u64().unwrap(), value);
+        assert_eq!(
+            lc.do_balance().await["spendable_zbalance"]
+                .as_u64()
+                .unwrap(),
+            value
+        );
 
         // 7. Spend funds from the now-imported private key.
         let sent_value = 3000;
@@ -713,8 +837,14 @@ async fn z_incoming_viewkey() {
             list[1]["amount"].as_i64().unwrap(),
             -((sent_value + u64::from(DEFAULT_FEE)) as i64)
         );
-        assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_ZADDR.to_string());
-        assert_eq!(list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(), sent_value);
+        assert_eq!(
+            list[1]["outgoing_metadata"][0]["address"],
+            EXT_ZADDR.to_string()
+        );
+        assert_eq!(
+            list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
+            sent_value
+        );
 
         // Shutdown everything cleanly
         clean_shutdown(stop_transmitter, h1).await;
@@ -755,7 +885,10 @@ async fn t_incoming_t_outgoing() {
 
         // 4. We can spend the funds immediately, since this is a taddr
         let sent_value = 20_000;
-        let sent_transaction_id = lc.test_do_send(vec![(EXT_TADDR, sent_value, None)]).await.unwrap();
+        let sent_transaction_id = lc
+            .test_do_send(vec![(EXT_TADDR, sent_value, None)])
+            .await
+            .unwrap();
 
         // 5. Test the unconfirmed send.
         let list = lc.do_list_transactions(false).await;
@@ -767,21 +900,43 @@ async fn t_incoming_t_outgoing() {
         );
         assert_eq!(list[1]["unconfirmed"].as_bool().unwrap(), true);
         assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_TADDR);
-        assert_eq!(list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(), sent_value);
+        assert_eq!(
+            list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
+            sent_value
+        );
 
         // 7. Mine the sent transaction
         fcbl.add_pending_sends(&data).await;
         mine_pending_blocks(&mut fcbl, &data, &lc).await;
 
         let notes = lc.do_list_notes(true).await;
-        assert_eq!(notes["spent_utxos"][0]["created_in_block"].as_u64().unwrap(), 11);
-        assert_eq!(notes["spent_utxos"][0]["spent_at_height"].as_u64().unwrap(), 12);
+        assert_eq!(
+            notes["spent_utxos"][0]["created_in_block"]
+                .as_u64()
+                .unwrap(),
+            11
+        );
+        assert_eq!(
+            notes["spent_utxos"][0]["spent_at_height"].as_u64().unwrap(),
+            12
+        );
         assert_eq!(notes["spent_utxos"][0]["spent"], sent_transaction_id);
 
         // Change shielded note
-        assert_eq!(notes["unspent_notes"][0]["created_in_block"].as_u64().unwrap(), 12);
-        assert_eq!(notes["unspent_notes"][0]["created_in_txid"], sent_transaction_id);
-        assert_eq!(notes["unspent_notes"][0]["is_change"].as_bool().unwrap(), true);
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_block"]
+                .as_u64()
+                .unwrap(),
+            12
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_txid"],
+            sent_transaction_id
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["is_change"].as_bool().unwrap(),
+            true
+        );
         assert_eq!(
             notes["unspent_notes"][0]["value"].as_u64().unwrap(),
             value - sent_value - u64::from(DEFAULT_FEE)
@@ -793,7 +948,10 @@ async fn t_incoming_t_outgoing() {
         assert_eq!(list[1]["txid"], sent_transaction_id);
         assert_eq!(list[1]["unconfirmed"].as_bool().unwrap(), false);
         assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_TADDR);
-        assert_eq!(list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(), sent_value);
+        assert_eq!(
+            list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
+            sent_value
+        );
 
         // Make sure everything is fine even after the rescan
 
@@ -804,13 +962,27 @@ async fn t_incoming_t_outgoing() {
         assert_eq!(list[1]["txid"], sent_transaction_id);
         assert_eq!(list[1]["unconfirmed"].as_bool().unwrap(), false);
         assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_TADDR);
-        assert_eq!(list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(), sent_value);
+        assert_eq!(
+            list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
+            sent_value
+        );
 
         let notes = lc.do_list_notes(true).await;
         // Change shielded note
-        assert_eq!(notes["unspent_notes"][0]["created_in_block"].as_u64().unwrap(), 12);
-        assert_eq!(notes["unspent_notes"][0]["created_in_txid"], sent_transaction_id);
-        assert_eq!(notes["unspent_notes"][0]["is_change"].as_bool().unwrap(), true);
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_block"]
+                .as_u64()
+                .unwrap(),
+            12
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_txid"],
+            sent_transaction_id
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["is_change"].as_bool().unwrap(),
+            true
+        );
         assert_eq!(
             notes["unspent_notes"][0]["value"].as_u64().unwrap(),
             value - sent_value - u64::from(DEFAULT_FEE)
@@ -871,8 +1043,16 @@ async fn mixed_transaction() {
 
         // 5. Check everything
         assert_eq!(notes["unspent_notes"].len(), 1);
-        assert_eq!(notes["unspent_notes"][0]["created_in_block"].as_u64().unwrap(), 18);
-        assert_eq!(notes["unspent_notes"][0]["is_change"].as_bool().unwrap(), true);
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_block"]
+                .as_u64()
+                .unwrap(),
+            18
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["is_change"].as_bool().unwrap(),
+            true
+        );
         assert_eq!(
             notes["unspent_notes"][0]["value"].as_u64().unwrap(),
             tvalue + zvalue - sent_tvalue - sent_zvalue - u64::from(DEFAULT_FEE)
@@ -900,11 +1080,15 @@ async fn mixed_transaction() {
             list[2]["amount"].as_i64().unwrap(),
             0 - (sent_tvalue + sent_zvalue + u64::from(DEFAULT_FEE)) as i64
         );
-        assert_eq!(list[2]["txid"], notes["unspent_notes"][0]["created_in_txid"]);
+        assert_eq!(
+            list[2]["txid"],
+            notes["unspent_notes"][0]["created_in_txid"]
+        );
         assert_eq!(
             list[2]["outgoing_metadata"]
                 .members()
-                .find(|j| j["address"].to_string() == EXT_ZADDR && j["value"].as_u64().unwrap() == sent_zvalue)
+                .find(|j| j["address"].to_string() == EXT_ZADDR
+                    && j["value"].as_u64().unwrap() == sent_zvalue)
                 .unwrap()["memo"]
                 .to_string(),
             sent_zmemo
@@ -1015,7 +1199,11 @@ async fn aborted_resync() {
             .await
             .current
             .get(&WalletTx::new_txid(
-                &hex::decode(sent_transaction_id).unwrap().into_iter().rev().collect(),
+                &hex::decode(sent_transaction_id)
+                    .unwrap()
+                    .into_iter()
+                    .rev()
+                    .collect(),
             ))
             .unwrap()
             .notes
@@ -1030,10 +1218,18 @@ async fn aborted_resync() {
         assert_eq!(witness_before.len(), witness_after.len());
         for i in 0..witness_before.len() {
             let mut before_bytes = vec![];
-            witness_before.get(i).unwrap().write(&mut before_bytes).unwrap();
+            witness_before
+                .get(i)
+                .unwrap()
+                .write(&mut before_bytes)
+                .unwrap();
 
             let mut after_bytes = vec![];
-            witness_after.get(i).unwrap().write(&mut after_bytes).unwrap();
+            witness_after
+                .get(i)
+                .unwrap()
+                .write(&mut after_bytes)
+                .unwrap();
 
             assert_eq!(hex::encode(before_bytes), hex::encode(after_bytes));
         }
@@ -1143,7 +1339,14 @@ async fn recover_at_checkpoint() {
 
         // Check the trees
         assert_eq!(
-            lc.wallet.blocks.read().await.first().map(|b| b.clone()).unwrap().height,
+            lc.wallet
+                .blocks
+                .read()
+                .await
+                .first()
+                .map(|b| b.clone())
+                .unwrap()
+                .height,
             1220110
         );
 
@@ -1163,7 +1366,14 @@ async fn recover_at_checkpoint() {
 
         // Check the trees
         assert_eq!(
-            lc.wallet.blocks.read().await.first().map(|b| b.clone()).unwrap().height,
+            lc.wallet
+                .blocks
+                .read()
+                .await
+                .first()
+                .map(|b| b.clone())
+                .unwrap()
+                .height,
             1220110
         );
         // assert_eq!(
@@ -1315,7 +1525,10 @@ async fn mempool_clearing() {
         let orig_transaction_id = transaction.txid().to_string();
         mine_pending_blocks(&mut fcbl, &data, &lc).await;
         mine_random_blocks(&mut fcbl, &data, &lc, 5).await;
-        assert_eq!(lc.do_last_transaction_id().await["last_txid"], orig_transaction_id);
+        assert_eq!(
+            lc.do_last_transaction_id().await["last_txid"],
+            orig_transaction_id
+        );
 
         // 3. Send z-to-z transaction to external z address with a memo
         let sent_value = 2000;
@@ -1327,8 +1540,16 @@ async fn mempool_clearing() {
             .unwrap();
 
         // 4. The transaction is not yet sent, it is just sitting in the test GRPC server, so remove it from there to make sure it doesn't get mined.
-        assert_eq!(lc.do_last_transaction_id().await["last_txid"], sent_transaction_id);
-        let mut sent_transactions = data.write().await.sent_transactions.drain(..).collect::<Vec<_>>();
+        assert_eq!(
+            lc.do_last_transaction_id().await["last_txid"],
+            sent_transaction_id
+        );
+        let mut sent_transactions = data
+            .write()
+            .await
+            .sent_transactions
+            .drain(..)
+            .collect::<Vec<_>>();
         assert_eq!(sent_transactions.len(), 1);
         let sent_transaction = sent_transactions.remove(0);
 
@@ -1383,8 +1604,14 @@ async fn mempool_clearing() {
 
         // There is 1 unspent note, which is the unconfirmed transaction
         assert_eq!(notes["unspent_notes"].len(), 1);
-        assert_eq!(notes["unspent_notes"][0]["created_in_txid"], sent_transaction_id);
-        assert_eq!(notes["unspent_notes"][0]["unconfirmed"].as_bool().unwrap(), true);
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_txid"],
+            sent_transaction_id
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["unconfirmed"].as_bool().unwrap(),
+            true
+        );
         assert_eq!(transactions.len(), 2);
 
         // 7. Mine 100 blocks, so the mempool expires
@@ -1396,8 +1623,14 @@ async fn mempool_clearing() {
 
         // There is now again 1 unspent note, but it is the original (confirmed) note.
         assert_eq!(notes["unspent_notes"].len(), 1);
-        assert_eq!(notes["unspent_notes"][0]["created_in_txid"], orig_transaction_id);
-        assert_eq!(notes["unspent_notes"][0]["unconfirmed"].as_bool().unwrap(), false);
+        assert_eq!(
+            notes["unspent_notes"][0]["created_in_txid"],
+            orig_transaction_id
+        );
+        assert_eq!(
+            notes["unspent_notes"][0]["unconfirmed"].as_bool().unwrap(),
+            false
+        );
         assert_eq!(notes["pending_notes"].len(), 0);
         assert_eq!(transactions.len(), 1);
 
@@ -1511,12 +1744,17 @@ async fn read_write_block_data() {
         let block_bytes: &mut [u8] = &mut [];
         let cb = crate::wallet::data::BlockData::new(block.block);
         cb.write(&mut *block_bytes).unwrap();
-        assert_eq!(cb, crate::wallet::data::BlockData::read(&*block_bytes).unwrap());
+        assert_eq!(
+            cb,
+            crate::wallet::data::BlockData::read(&*block_bytes).unwrap()
+        );
     }
     clean_shutdown(stop_transmitter, h1).await;
 }
 
 pub const EXT_TADDR: &str = "t1NoS6ZgaUTpmjkge2cVpXGcySasdYDrXqh";
-pub const EXT_ZADDR: &str = "zs1va5902apnzlhdu0pw9r9q7ca8s4vnsrp2alr6xndt69jnepn2v2qrj9vg3wfcnjyks5pg65g9dc";
-pub const EXT_ZADDR2: &str = "zs1fxgluwznkzm52ux7jkf4st5znwzqay8zyz4cydnyegt2rh9uhr9458z0nk62fdsssx0cqhy6lyv";
+pub const EXT_ZADDR: &str =
+    "zs1va5902apnzlhdu0pw9r9q7ca8s4vnsrp2alr6xndt69jnepn2v2qrj9vg3wfcnjyks5pg65g9dc";
+pub const EXT_ZADDR2: &str =
+    "zs1fxgluwznkzm52ux7jkf4st5znwzqay8zyz4cydnyegt2rh9uhr9458z0nk62fdsssx0cqhy6lyv";
 pub const TEST_SEED: &str = "chimney better bulb horror rebuild whisper improve intact letter giraffe brave rib appear bulk aim burst snap salt hill sad merge tennis phrase raise";

--- a/lib/src/wallet/keys.rs
+++ b/lib/src/wallet/keys.rs
@@ -21,6 +21,7 @@ use zcash_primitives::{
     sapling::PaymentAddress,
     zip32::{ChildIndex, ExtendedFullViewingKey, ExtendedSpendingKey},
 };
+use zingoconfig::Network;
 
 use crate::{
     lightclient::lightclient_config::{LightClientConfig, GAP_RULE_UNUSED_ADDRESSES},
@@ -152,8 +153,7 @@ impl Keys {
 
     #[cfg(test)]
     pub fn new_empty() -> Self {
-        let config =
-            LightClientConfig::create_unconnected(crate::lightclient::lightclient_config::Network::FakeMainnet, None);
+        let config = LightClientConfig::create_unconnected(Network::FakeMainnet, None);
         Self {
             config,
             encrypted: false,
@@ -465,9 +465,9 @@ impl Keys {
 
     fn get_network_enum(&self) -> zcash_address::Network {
         match self.config.chain {
-            crate::lightclient::lightclient_config::Network::Mainnet => zcash_address::Network::Main,
-            crate::lightclient::lightclient_config::Network::Testnet => zcash_address::Network::Test,
-            crate::lightclient::lightclient_config::Network::FakeMainnet => zcash_address::Network::Main,
+            Network::Mainnet => zcash_address::Network::Main,
+            Network::Testnet => zcash_address::Network::Test,
+            Network::FakeMainnet => zcash_address::Network::Main,
         }
     }
 
@@ -625,9 +625,9 @@ impl Keys {
 
         use zcash_address::unified::Encoding as _;
         newkey.unified_address.encode(&match self.config.chain {
-            crate::lightclient::lightclient_config::Network::Mainnet => zcash_address::Network::Main,
-            crate::lightclient::lightclient_config::Network::Testnet => zcash_address::Network::Test,
-            crate::lightclient::lightclient_config::Network::FakeMainnet => zcash_address::Network::Main,
+            Network::Mainnet => zcash_address::Network::Main,
+            Network::Testnet => zcash_address::Network::Test,
+            Network::FakeMainnet => zcash_address::Network::Main,
         })
     }
     /// Add a new t address to the wallet. This will derive a new address from the seed

--- a/lib/src/wallet/keys.rs
+++ b/lib/src/wallet/keys.rs
@@ -13,7 +13,9 @@ use sodiumoxide::crypto::secretbox;
 use zcash_address::unified::{Encoding, Ufvk};
 use zcash_client_backend::{
     address,
-    encoding::{encode_extended_full_viewing_key, encode_extended_spending_key, encode_payment_address},
+    encoding::{
+        encode_extended_full_viewing_key, encode_extended_spending_key, encode_payment_address,
+    },
 };
 use zcash_encoding::Vector;
 use zcash_primitives::{
@@ -78,7 +80,12 @@ impl FromBase58Check for str {
     fn from_base58check(&self) -> io::Result<(u8, Vec<u8>)> {
         let mut payload: Vec<u8> = match self.from_base58() {
             Ok(payload) => payload,
-            Err(error) => return Err(io::Error::new(ErrorKind::InvalidData, format!("{:?}", error))),
+            Err(error) => {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("{:?}", error),
+                ))
+            }
         };
         if payload.len() < 5 {
             return Err(io::Error::new(
@@ -91,7 +98,10 @@ impl FromBase58Check for str {
         let provided_checksum = payload.split_off(checksum_index);
         let checksum = double_sha256(&payload)[..4].to_vec();
         if checksum != provided_checksum {
-            return Err(io::Error::new(ErrorKind::InvalidData, format!("Invalid Checksum")));
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid Checksum"),
+            ));
         }
         Ok((payload[0], payload[1..].to_vec()))
     }
@@ -167,7 +177,11 @@ impl Keys {
         }
     }
 
-    pub fn new(config: &LightClientConfig, seed_phrase: Option<String>, num_zaddrs: u32) -> Result<Self, String> {
+    pub fn new(
+        config: &LightClientConfig,
+        seed_phrase: Option<String>,
+        num_zaddrs: u32,
+    ) -> Result<Self, String> {
         let mut seed_bytes = [0u8; 32];
 
         if seed_phrase.is_none() {
@@ -213,8 +227,16 @@ impl Keys {
         })
     }
 
-    pub fn read_old<R: Read>(version: u64, mut reader: R, config: &LightClientConfig) -> io::Result<Self> {
-        let encrypted = if version >= 4 { reader.read_u8()? > 0 } else { false };
+    pub fn read_old<R: Read>(
+        version: u64,
+        mut reader: R,
+        config: &LightClientConfig,
+    ) -> io::Result<Self> {
+        let encrypted = if version >= 4 {
+            reader.read_u8()? > 0
+        } else {
+            false
+        };
 
         let mut enc_seed = [0u8; 48];
         if version >= 4 {
@@ -263,7 +285,10 @@ impl Keys {
                     .map(|(i, (extfvk, payment_address))| {
                         let zk = WalletZKey::new_locked_hdkey(i as u32, extfvk.clone());
                         if zk.zaddress != *payment_address {
-                            Err(io::Error::new(ErrorKind::InvalidData, "Payment address didn't match"))
+                            Err(io::Error::new(
+                                ErrorKind::InvalidData,
+                                "Payment address didn't match",
+                            ))
                         } else {
                             Ok(zk)
                         }
@@ -278,11 +303,17 @@ impl Keys {
                     .map(|(i, (extsk, (extfvk, payment_address)))| {
                         let zk = WalletZKey::new_hdkey(i as u32, extsk);
                         if zk.zaddress != *payment_address {
-                            return Err(io::Error::new(ErrorKind::InvalidData, "Payment address didn't match"));
+                            return Err(io::Error::new(
+                                ErrorKind::InvalidData,
+                                "Payment address didn't match",
+                            ));
                         }
 
                         if zk.extfvk != extfvk {
-                            return Err(io::Error::new(ErrorKind::InvalidData, "Full View key didn't match"));
+                            return Err(io::Error::new(
+                                ErrorKind::InvalidData,
+                                "Full View key didn't match",
+                            ));
                         }
 
                         Ok(zk)
@@ -301,7 +332,8 @@ impl Keys {
             let tkeys = Vector::read(&mut reader, |r| {
                 let mut tpk_bytes = [0u8; 32];
                 r.read_exact(&mut tpk_bytes)?;
-                secp256k1::SecretKey::from_slice(&tpk_bytes).map_err(|e| io::Error::new(ErrorKind::InvalidData, e))
+                secp256k1::SecretKey::from_slice(&tpk_bytes)
+                    .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))
             })?;
 
             let taddresses = if version >= 4 {
@@ -311,7 +343,9 @@ impl Keys {
                 // Calculate the addresses
                 tkeys
                     .iter()
-                    .map(|sk| WalletTKey::address_from_prefix_sk(&config.base58_pubkey_address(), sk))
+                    .map(|sk| {
+                        WalletTKey::address_from_prefix_sk(&config.base58_pubkey_address(), sk)
+                    })
                     .collect()
             };
 
@@ -366,7 +400,8 @@ impl Keys {
             let tkeys = Vector::read(&mut reader, |r| {
                 let mut tpk_bytes = [0u8; 32];
                 r.read_exact(&mut tpk_bytes)?;
-                secp256k1::SecretKey::from_slice(&tpk_bytes).map_err(|e| io::Error::new(ErrorKind::InvalidData, e))
+                secp256k1::SecretKey::from_slice(&tpk_bytes)
+                    .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))
             })?;
 
             let taddresses = Vector::read(&mut reader, |r| utils::read_string(r))?;
@@ -432,7 +467,10 @@ impl Keys {
             return "".to_string();
         }
 
-        Mnemonic::from_entropy(self.seed).unwrap().phrase().to_string()
+        Mnemonic::from_entropy(self.seed)
+            .unwrap()
+            .phrase()
+            .to_string()
     }
 
     pub fn get_all_sapling_extfvks(&self) -> Vec<ExtendedFullViewingKey> {
@@ -443,7 +481,10 @@ impl Keys {
     where
         for<'a> T: TryFrom<&'a WalletOKeyInner>,
     {
-        self.okeys.iter().filter_map(|k| T::try_from(&k.key).ok()).collect()
+        self.okeys
+            .iter()
+            .filter_map(|k| T::try_from(&k.key).ok())
+            .collect()
     }
 
     pub fn get_all_zaddresses(&self) -> Vec<String> {
@@ -480,7 +521,10 @@ impl Keys {
     }
 
     pub fn get_all_taddrs(&self) -> Vec<String> {
-        self.tkeys.iter().map(|tk| tk.address.clone()).collect::<Vec<_>>()
+        self.tkeys
+            .iter()
+            .map(|tk| tk.address.clone())
+            .collect::<Vec<_>>()
     }
 
     pub fn have_sapling_spending_key(&self, extfvk: &ExtendedFullViewingKey) -> bool {
@@ -491,7 +535,10 @@ impl Keys {
             .unwrap_or(false)
     }
 
-    pub fn get_extsk_for_extfvk(&self, extfvk: &ExtendedFullViewingKey) -> Option<ExtendedSpendingKey> {
+    pub fn get_extsk_for_extfvk(
+        &self,
+        extfvk: &ExtendedFullViewingKey,
+    ) -> Option<ExtendedSpendingKey> {
         self.zkeys
             .iter()
             .find(|zk| zk.extfvk == *extfvk)
@@ -617,8 +664,12 @@ impl Keys {
 
         let bip39_seed = &Mnemonic::from_entropy(self.seed).unwrap().to_seed("");
 
-        let spending_key =
-            ::orchard::keys::SpendingKey::from_zip32_seed(bip39_seed, self.config.get_coin_type(), account).unwrap();
+        let spending_key = ::orchard::keys::SpendingKey::from_zip32_seed(
+            bip39_seed,
+            self.config.get_coin_type(),
+            account,
+        )
+        .unwrap();
 
         let newkey = WalletOKey::new_hdkey(account, spending_key);
         self.okeys.push(newkey.clone());
@@ -661,16 +712,17 @@ impl Keys {
             .zkeys
             .iter()
             .map(|k| {
-                let pkey = match k
-                    .extsk
-                    .clone()
-                    .map(|extsk| encode_extended_spending_key(self.config.hrp_sapling_private_key(), &extsk))
-                {
+                let pkey = match k.extsk.clone().map(|extsk| {
+                    encode_extended_spending_key(self.config.hrp_sapling_private_key(), &extsk)
+                }) {
                     Some(pk) => pk,
                     None => "".to_string(),
                 };
 
-                let vkey = encode_extended_full_viewing_key(self.config.hrp_sapling_viewing_key(), &k.extfvk);
+                let vkey = encode_extended_full_viewing_key(
+                    self.config.hrp_sapling_viewing_key(),
+                    &k.extfvk,
+                );
 
                 (
                     encode_payment_address(self.config.hrp_sapling_address(), &k.zaddress),
@@ -702,14 +754,20 @@ impl Keys {
 
                 let vkey = match ::orchard::keys::FullViewingKey::try_from(&k.key) {
                     Ok(viewing_key) => {
-                        Ufvk::try_from_items(vec![zcash_address::unified::Fvk::Orchard(viewing_key.to_bytes())])
-                            .map(|vk| vk.encode(&self.get_network_enum()))
-                            .unwrap_or_else(|e| e.to_string())
+                        Ufvk::try_from_items(vec![zcash_address::unified::Fvk::Orchard(
+                            viewing_key.to_bytes(),
+                        )])
+                        .map(|vk| vk.encode(&self.get_network_enum()))
+                        .unwrap_or_else(|e| e.to_string())
                     }
                     Err(_) => "".to_string(),
                 };
 
-                (k.unified_address.encode(&self.get_network_enum()), pkey, vkey)
+                (
+                    k.unified_address.encode(&self.get_network_enum()),
+                    pkey,
+                    vkey,
+                )
             })
             .collect::<Vec<(String, String, String)>>();
 
@@ -720,13 +778,21 @@ impl Keys {
     pub fn get_t_secret_keys(&self) -> Vec<(String, String)> {
         self.tkeys
             .iter()
-            .map(|sk| (sk.address.clone(), sk.sk_as_string(&self.config).unwrap_or_default()))
+            .map(|sk| {
+                (
+                    sk.address.clone(),
+                    sk.sk_as_string(&self.config).unwrap_or_default(),
+                )
+            })
             .collect::<Vec<(String, String)>>()
     }
 
     pub fn encrypt(&mut self, passwd: String) -> io::Result<()> {
         if self.encrypted {
-            return Err(io::Error::new(ErrorKind::AlreadyExists, "Wallet is already encrypted"));
+            return Err(io::Error::new(
+                ErrorKind::AlreadyExists,
+                "Wallet is already encrypted",
+            ));
         }
 
         // Get the doublesha256 of the password, which is the right length
@@ -757,11 +823,17 @@ impl Keys {
 
     pub fn lock(&mut self) -> io::Result<()> {
         if !self.encrypted {
-            return Err(io::Error::new(ErrorKind::AlreadyExists, "Wallet is not encrypted"));
+            return Err(io::Error::new(
+                ErrorKind::AlreadyExists,
+                "Wallet is not encrypted",
+            ));
         }
 
         if !self.unlocked {
-            return Err(io::Error::new(ErrorKind::AlreadyExists, "Wallet is already locked"));
+            return Err(io::Error::new(
+                ErrorKind::AlreadyExists,
+                "Wallet is already locked",
+            ));
         }
 
         // Empty the seed and the secret keys
@@ -785,11 +857,17 @@ impl Keys {
 
     pub fn unlock(&mut self, passwd: String) -> io::Result<()> {
         if !self.encrypted {
-            return Err(Error::new(ErrorKind::AlreadyExists, "Wallet is not encrypted"));
+            return Err(Error::new(
+                ErrorKind::AlreadyExists,
+                "Wallet is not encrypted",
+            ));
         }
 
         if self.encrypted && self.unlocked {
-            return Err(Error::new(ErrorKind::AlreadyExists, "Wallet is already unlocked"));
+            return Err(Error::new(
+                ErrorKind::AlreadyExists,
+                "Wallet is already unlocked",
+            ));
         }
 
         // Get the doublesha256 of the password, which is the right length
@@ -837,7 +915,10 @@ impl Keys {
     // permanantly removing the encryption
     pub fn remove_encryption(&mut self, passwd: String) -> io::Result<()> {
         if !self.encrypted {
-            return Err(Error::new(ErrorKind::AlreadyExists, "Wallet is not encrypted"));
+            return Err(Error::new(
+                ErrorKind::AlreadyExists,
+                "Wallet is not encrypted",
+            ));
         }
 
         // Unlock the wallet if it's locked

--- a/lib/src/wallet/keys/orchard.rs
+++ b/lib/src/wallet/keys/orchard.rs
@@ -70,8 +70,12 @@ impl TryFrom<&WalletOKeyInner> for OutgoingViewingKey {
         match key {
             WalletOKeyInner::ImportedOutViewKey(k) => Ok(k.clone()),
             WalletOKeyInner::ImportedFullViewKey(k) => Ok(k.to_ovk(Scope::External)),
-            WalletOKeyInner::ImportedInViewKey(k) => Err(format!("Received ivk {k:?} which does not contain an ovk")),
-            _ => Ok(FullViewingKey::try_from(key).unwrap().to_ovk(Scope::External)),
+            WalletOKeyInner::ImportedInViewKey(k) => {
+                Err(format!("Received ivk {k:?} which does not contain an ovk"))
+            }
+            _ => Ok(FullViewingKey::try_from(key)
+                .unwrap()
+                .to_ovk(Scope::External)),
         }
     }
 }

--- a/lib/src/wallet/keys/sapling.rs
+++ b/lib/src/wallet/keys/sapling.rs
@@ -335,7 +335,7 @@ pub mod tests {
     fn get_config() -> LightClientConfig {
         LightClientConfig {
             server: "0.0.0.0:0".parse().unwrap(),
-            chain: crate::lightclient::lightclient_config::Network::FakeMainnet,
+            chain: zingoconfig::Network::FakeMainnet,
             monitor_mempool: false,
             anchor_offset: [0u32; 5],
             data_dir: None,

--- a/lib/src/wallet/keys/transparent.rs
+++ b/lib/src/wallet/keys/transparent.rs
@@ -344,8 +344,7 @@ mod test {
 
     #[test]
     fn tkey_encode_decode() {
-        let config =
-            LightClientConfig::create_unconnected(crate::lightclient::lightclient_config::Network::FakeMainnet, None);
+        let config = LightClientConfig::create_unconnected(zingoconfig::Network::FakeMainnet, None);
 
         for _i in 0..10 {
             let mut b = [0u8; 32];

--- a/lib/src/wallet/message.rs
+++ b/lib/src/wallet/message.rs
@@ -8,7 +8,8 @@ use std::{
     io::{self, ErrorKind, Read},
 };
 use zcash_note_encryption::{
-    EphemeralKeyBytes, NoteEncryption, OutgoingCipherKey, ShieldedOutput, ENC_CIPHERTEXT_SIZE, OUT_CIPHERTEXT_SIZE,
+    EphemeralKeyBytes, NoteEncryption, OutgoingCipherKey, ShieldedOutput, ENC_CIPHERTEXT_SIZE,
+    OUT_CIPHERTEXT_SIZE,
 };
 use zcash_primitives::{
     consensus::{BlockHeight, MainNetwork, MAIN_NETWORK},
@@ -103,7 +104,8 @@ impl Message {
         let mut rng = OsRng;
 
         // Encrypt To address. We're using a 'NONE' OVK here, so the out_ciphertext is not recoverable.
-        let (_ock, _cv, cmu, epk, enc_ciphertext, _out_ciphertext) = self.encrypt_message_to(None, &mut rng)?;
+        let (_ock, _cv, cmu, epk, enc_ciphertext, _out_ciphertext) =
+            self.encrypt_message_to(None, &mut rng)?;
 
         // We'll encode the message on the wire as a series of bytes
         // u8 -> serialized version
@@ -156,14 +158,20 @@ impl Message {
         reader.read_exact(&mut cmu_bytes)?;
         let cmu = bls12_381::Scalar::from_bytes(&cmu_bytes);
         if cmu.is_none().into() {
-            return Err(io::Error::new(ErrorKind::InvalidData, format!("Can't read CMU bytes")));
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("Can't read CMU bytes"),
+            ));
         }
 
         let mut epk_bytes = [0u8; 32];
         reader.read_exact(&mut epk_bytes)?;
         let epk = jubjub::ExtendedPoint::from_bytes(&epk_bytes);
         if epk.is_none().into() {
-            return Err(io::Error::new(ErrorKind::InvalidData, format!("Can't read EPK bytes")));
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("Can't read EPK bytes"),
+            ));
         }
 
         let mut enc_bytes = [0u8; ENC_CIPHERTEXT_SIZE];
@@ -203,10 +211,14 @@ impl Message {
         ) {
             Some((_note, address, memo)) => Ok(Self::new(
                 address,
-                memo.try_into()
-                    .map_err(|_e| io::Error::new(ErrorKind::InvalidData, format!("Failed to decrypt")))?,
+                memo.try_into().map_err(|_e| {
+                    io::Error::new(ErrorKind::InvalidData, format!("Failed to decrypt"))
+                })?,
             )),
-            None => Err(io::Error::new(ErrorKind::InvalidData, format!("Failed to decrypt"))),
+            None => Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("Failed to decrypt"),
+            )),
         }
     }
 }
@@ -300,7 +312,10 @@ pub mod tests {
 
         // Bad version
         let mut bad_enc = enc.clone();
-        bad_enc.splice(magic_len..magic_len + 1, [Message::serialized_version() + 1].to_vec());
+        bad_enc.splice(
+            magic_len..magic_len + 1,
+            [Message::serialized_version() + 1].to_vec(),
+        );
         let dec_success = Message::decrypt(&bad_enc, &ivk);
         assert!(dec_success.is_err());
 

--- a/lib/src/wallet/transactions.rs
+++ b/lib/src/wallet/transactions.rs
@@ -150,7 +150,9 @@ impl WalletTxns {
                 }
 
                 // Remove unconfirmed spends too
-                if nd.unconfirmed_spent.is_some() && txids_to_remove.contains(&nd.unconfirmed_spent.unwrap().0) {
+                if nd.unconfirmed_spent.is_some()
+                    && txids_to_remove.contains(&nd.unconfirmed_spent.unwrap().0)
+                {
                     nd.unconfirmed_spent = None;
                 }
             });
@@ -162,7 +164,9 @@ impl WalletTxns {
                     utxo.spent_at_height = None;
                 }
 
-                if utxo.unconfirmed_spent.is_some() && txids_to_remove.contains(&utxo.unconfirmed_spent.unwrap().0) {
+                if utxo.unconfirmed_spent.is_some()
+                    && txids_to_remove.contains(&utxo.unconfirmed_spent.unwrap().0)
+                {
                     utxo.unconfirmed_spent = None;
                 }
             })
@@ -248,7 +252,11 @@ impl WalletTxns {
             .collect()
     }
 
-    pub(crate) fn get_note_witness(&self, txid: &TxId, nullifier: &Nullifier) -> Option<(WitnessCache, BlockHeight)> {
+    pub(crate) fn get_note_witness(
+        &self,
+        txid: &TxId,
+        nullifier: &Nullifier,
+    ) -> Option<(WitnessCache, BlockHeight)> {
         self.current.get(txid).map(|wtx| {
             wtx.notes
                 .iter()
@@ -257,7 +265,12 @@ impl WalletTxns {
         })?
     }
 
-    pub(crate) fn set_note_witnesses(&mut self, txid: &TxId, nullifier: &Nullifier, witnesses: WitnessCache) {
+    pub(crate) fn set_note_witnesses(
+        &mut self,
+        txid: &TxId,
+        nullifier: &Nullifier,
+        witnesses: WitnessCache,
+    ) {
         self.current
             .get_mut(txid)
             .unwrap()
@@ -274,7 +287,9 @@ impl WalletTxns {
         self.current.iter_mut().for_each(|(_, wtx)| {
             wtx.notes
                 .iter_mut()
-                .filter(|n| !n.witnesses.is_empty() && n.spent.is_some() && n.spent.unwrap().1 < cutoff)
+                .filter(|n| {
+                    !n.witnesses.is_empty() && n.spent.is_some() && n.spent.unwrap().1 < cutoff
+                })
                 .for_each(|n| n.witnesses.clear());
         });
     }
@@ -373,12 +388,22 @@ impl WalletTxns {
     ) {
         // Record this Tx as having spent some funds
         {
-            let wtx = self.get_or_create_tx(&txid, BlockHeight::from(height), unconfirmed, timestamp as u64);
+            let wtx = self.get_or_create_tx(
+                &txid,
+                BlockHeight::from(height),
+                unconfirmed,
+                timestamp as u64,
+            );
 
             // Mark the height correctly, in case this was previously a mempool or unconfirmed tx.
             wtx.block = height;
 
-            if wtx.spent_nullifiers.iter().find(|nf| **nf == nullifier).is_none() {
+            if wtx
+                .spent_nullifiers
+                .iter()
+                .find(|nf| **nf == nullifier)
+                .is_none()
+            {
                 wtx.spent_nullifiers.push(nullifier);
                 wtx.total_sapling_value_spent += value;
             }
@@ -389,12 +414,18 @@ impl WalletTxns {
 
         // Mark the source note's nullifier as spent
         if !unconfirmed {
-            let wtx = self.current.get_mut(&source_txid).expect("Txid should be present");
+            let wtx = self
+                .current
+                .get_mut(&source_txid)
+                .expect("Txid should be present");
 
-            wtx.notes.iter_mut().find(|n| n.nullifier == nullifier).map(|nd| {
-                // Record the spent height
-                nd.spent = Some((txid, height.into()));
-            });
+            wtx.notes
+                .iter_mut()
+                .find(|n| n.nullifier == nullifier)
+                .map(|nd| {
+                    // Record the spent height
+                    nd.spent = Some((txid, height.into()));
+                });
         }
     }
 
@@ -584,7 +615,11 @@ impl WalletTxns {
         });
     }
 
-    pub fn add_outgoing_metadata(&mut self, txid: &TxId, outgoing_metadata: Vec<OutgoingTxMetadata>) {
+    pub fn add_outgoing_metadata(
+        &mut self,
+        txid: &TxId,
+        outgoing_metadata: Vec<OutgoingTxMetadata>,
+    ) {
         if let Some(wtx) = self.current.get_mut(txid) {
             // This is n^2 search, but this is likely very small struct, limited by the protocol, so...
             let new_omd: Vec<_> = outgoing_metadata
@@ -594,7 +629,10 @@ impl WalletTxns {
 
             wtx.outgoing_metadata.extend(new_omd);
         } else {
-            error!("TxId {} should be present while adding metadata, but wasn't", txid);
+            error!(
+                "TxId {} should be present while adding metadata, but wasn't",
+                txid
+            );
         }
     }
 }

--- a/lib/src/wallet/transactions.rs
+++ b/lib/src/wallet/transactions.rs
@@ -15,7 +15,7 @@ use zcash_primitives::{
     zip32::ExtendedFullViewingKey,
 };
 
-use crate::lightclient::lightclient_config::MAX_REORG;
+use zingoconfig::MAX_REORG;
 
 use super::data::{OutgoingTxMetadata, SaplingNoteData, Utxo, WalletTx, WitnessCache};
 

--- a/lib/src/wallet/utils.rs
+++ b/lib/src/wallet/utils.rs
@@ -8,7 +8,8 @@ pub fn read_string<R: Read>(mut reader: R) -> io::Result<String> {
     let mut str_bytes = vec![0; str_len as usize];
     reader.read_exact(&mut str_bytes)?;
 
-    let str = String::from_utf8(str_bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+    let str = String::from_utf8(str_bytes)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
     Ok(str)
 }
@@ -32,5 +33,6 @@ pub fn interpret_memo_string(memo_str: String) -> Result<MemoBytes, String> {
         Vec::from(memo_str.as_bytes())
     };
 
-    MemoBytes::from_bytes(&s_bytes).map_err(|_| format!("Error creating output. Memo '{:?}' is too long", memo_str))
+    MemoBytes::from_bytes(&s_bytes)
+        .map_err(|_| format!("Error creating output. Memo '{:?}' is too long", memo_str))
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
 edition = "2021"
-max_width = 120

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 edition = "2021"
+max_width = 100


### PR DESCRIPTION
Within `wallet` all references to lightclient are via `lightclient_config`.

This defines a separate `zingoconfig` crate.  This has several benefits:
  * decouples `wallet` and `client` (not completely)
  * moves away from (accidental) circular dependencies
  * moves towards building `wallet` as a separate (WASM-able) concern