### PR TITLE
WIP : Add regtest mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Zingo-CLI does automatic note and utxo management, which means it doesn't allow 
 
 ```
 git clone https://github.com/zingolabs/zingolib.git
+cd zingolib
 cargo build --release
 ./target/release/zingo-cli
 ```

--- a/README.md
+++ b/README.md
@@ -65,3 +65,46 @@ Here are some CLI arguments you can pass to `zingo-cli`. Please run `zingo-cli -
  * `--recover`: Attempt to recover the seed phrase from a corrupted wallet
  * `--data-dir`: uses the specified path as data directory.
     * Example: `./zingo-cli --server 127.0.0.1:9067 --data-dir /Users/ZingoRocks/my-test-wallet` will use the provided directory to store `zingo-wallet.dat` and logs. If the provided directory does not exist, it will create it.
+
+## Regtest
+This documentation to run regtest "manually" is a placeholder until the `--regtest` flag is fully functional.
+
+The CLI can work in regtest, by locally running a `zcashd` and `lightwalletd`.
+
+Create the directories `~/.zcash/zd/` and `~/.zcash/ld`
+`zcashd` works in regtest with the following invocation, run from your `zcash` directory (explicit path, substitute your own username):
+`./src/zcashd --printtoconsole -conf=/home/username/.zcash/zd/zcash.conf --datadir=/home/username/.zcash/zd/`
+and the following in a `zcash.conf` file in the specified directory:
+```
+regtest=1
+nuparams=5ba81b19:1 # Overwinter
+nuparams=76b809bb:1 # Sapling
+nuparams=2bb40e60:1 # Blossom
+nuparams=f5b9230b:1 # Heartwood
+nuparams=e9ff75a6:1 # Canopy
+nuparams=c2d6d0b4:1 # NU5
+
+txindex=1
+insightexplorer=1
+experimentalfeatures=1
+rpcuser=xxxxxx
+rpcpassword=xxxxxx
+
+rpcport=18232
+rpcallowip=0.0.0.0
+```
+
+In another terminal instance, navigate to your `lightwalletd` directory, and run
+`./lightwalletd --no-tls-very-insecure --zcash-conf-path ~/.zcash/zd/zcash.conf --data-dir ~/.zcash/zd/ --log-file ~/.zcash/ld/lwd-log --log-level 7`
+`lightwalletd`'s terminal output will not have clear success, but the log file will show something like:
+`{"app":"lightwalletd","level":"info","msg":"Got sapling height 1 block height 0 chain regtest ..."}`
+
+Now you will need to add blocks to your regtest chain if you have not done so previously.
+In still another terminal instance in the `zcash` directory, you can run `./src/zcash-cli -regtest generate 11` to generate 11 blocks.
+Please note that by adding more than 100 blocks it is difficult or impossible to rewind the chain. The config means that after the first block all network upgrades should be in place.
+
+Finally, from your `zingolib` directory, with a release build (`cargo build --release`), you can run:
+`./target/release/zingo-cli --regtest --server=127.0.0.1:9067`
+You should see a single line printed out saying `regtest detected and network set correctly!` and the interactive cli application should work with your regtest network!
+
+Tested with `zcash` commit `1e6f46`, `lightwalletd` commit `db2795`, and `zingolib` commit `0b1823`

--- a/README.md
+++ b/README.md
@@ -68,10 +68,16 @@ Here are some CLI arguments you can pass to `zingo-cli`. Please run `zingo-cli -
     * Example: `./zingo-cli --server 127.0.0.1:9067 --data-dir /Users/ZingoRocks/my-test-wallet` will use the provided directory to store `zingo-wallet.dat` and logs. If the provided directory does not exist, it will create it.
 
 ## Regtest
-This documentation to run regtest "manually" is a placeholder until the `--regtest` flag is fully functional.
+Experimental!
+We have recently added support for `Network::Regtest` enum: https://github.com/zcash/librustzcash/blob/main/zcash_primitives/src/constants/regtest.rs
+This has not been sufficiently tested, but now compiles.
 
-The CLI can work in regtest, by locally running a `zcashd` and `lightwalletd`.
+This documentation to run regtest "manually" is a placeholder until flags are more functional.
+We also aim to be able to select any network type with cli flags.
 
+The CLI can work in regtest mode, by locally running a `zcashd` and `lightwalletd`.
+
+For example:
 Create the directories `~/.zcash/zd/` and `~/.zcash/ld`
 `zcashd` works in regtest with the following invocation, run from your `zcash` directory (explicit path, substitute your own username):
 `./src/zcashd --printtoconsole -conf=/home/username/.zcash/zd/zcash.conf --datadir=/home/username/.zcash/zd/`
@@ -108,4 +114,4 @@ Finally, from your `zingolib` directory, with a release build (`cargo build --re
 `./target/release/zingo-cli --regtest --server=127.0.0.1:9067`
 You should see a single line printed out saying `regtest detected and network set correctly!` and the interactive cli application should work with your regtest network!
 
-Tested with `zcash` commit `1e6f46`, `lightwalletd` commit `db2795`, and `zingolib` commit `0b1823`
+Tested with `zcash` commit `1e6f46`, `lightwalletd` commit `db2795`, and `zingolib` commit `8376f6` or better.

--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ Finally, from your `zingolib` directory, with a release build (`cargo build --re
 `./target/release/zingo-cli --regtest --server=127.0.0.1:9067`
 You should see a single line printed out saying `regtest detected and network set correctly!` and the interactive cli application should work with your regtest network!
 
-Tested with `zcash` commit `1e6f46`, `lightwalletd` commit `db2795`, and `zingolib` commit `8376f6` or better.
+Tested with `zcash` commit `1e6f46`, `lightwalletd` commit `db2795`, and `zingolib` commit `252abe` or better.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -101,13 +101,13 @@ pub fn startup(
         LightClientConfig::create_on_data_dir(server.clone(), data_dir)?;
 
     // check for regtest flag and network in config.
-    if regtest && config.chain == Network::FakeMainnet {
+    if regtest && config.chain == Network::Regtest {
         println!("regtest detected and network set correctly!");
-    } else if regtest && config.chain != Network::FakeMainnet {
+    } else if regtest && config.chain != Network::Regtest {
         println!("Regtest flag detected, but unexpected network set! Exiting.");
         panic!("Regtest Network Problem");
-    } else if config.chain == Network::FakeMainnet {
-        println!("WARNING! FakeMainnet (regtest network) in use but no regtest flag recognized!");
+    } else if config.chain == Network::Regtest {
+        println!("WARNING! regtest network in use but no regtest flag recognized!");
     }
 
     let lightclient = match seed {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -48,6 +48,11 @@ macro_rules! configure_clapapp {
                 .value_name("data-dir")
                 .help("Absolute path to use as data directory")
                 .takes_value(true))
+            .arg(Arg::with_name("regtest")
+                .long("regtest")
+                .value_name("regtest")
+                .help("Regtest mode")
+                .takes_value(false))
             .arg(Arg::with_name("COMMAND")
                 .help("Command to execute. If a command is not specified, zingo-cli will start in interactive mode.")
                 .required(false)
@@ -88,10 +93,17 @@ pub fn startup(
     data_dir: Option<String>,
     first_sync: bool,
     print_updates: bool,
+    regtest: bool,
 ) -> std::io::Result<(Sender<(String, Vec<String>)>, Receiver<String>)> {
     // Try to get the configuration
     let (config, latest_block_height) =
         LightClientConfig::create_on_data_dir(server.clone(), data_dir)?;
+
+    if regtest {
+        println!("regtest detected!");
+    } else {
+        println!("no regtest detected...");
+    }
 
     let lightclient = match seed {
         Some(phrase) => Arc::new(LightClient::new_from_phrase(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use log::{error, info};
 
+use zingoconfig::Network;
 use zingolib::lightclient::lightclient_config::LightClientConfig;
 use zingolib::{commands, lightclient::LightClient};
 
@@ -99,10 +100,14 @@ pub fn startup(
     let (config, latest_block_height) =
         LightClientConfig::create_on_data_dir(server.clone(), data_dir)?;
 
-    if regtest {
-        println!("regtest detected!");
-    } else {
-        println!("no regtest detected...");
+    // check for regtest flag and network in config.
+    if regtest && config.chain == Network::FakeMainnet {
+        println!("regtest detected and network set correctly!");
+    } else if regtest && config.chain != Network::FakeMainnet {
+        println!("Regtest flag detected, but unexpected network set! Exiting.");
+        panic!("Regtest Network Problem");
+    } else if config.chain == Network::FakeMainnet {
+        println!("WARNING! FakeMainnet (regtest network) in use but no regtest flag recognized!");
     }
 
     let lightclient = match seed {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,6 +65,8 @@ pub fn main() {
 
     let nosync = matches.is_present("nosync");
 
+    let regtest = matches.is_present("regtest");
+
     let startup_chan = startup(
         server,
         seed,
@@ -72,6 +74,7 @@ pub fn main() {
         maybe_data_dir,
         !nosync,
         command.is_none(),
+        regtest,
     );
     let (command_transmitter, resp_receiver) = match startup_chan {
         Ok(c) => c,

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -1,1 +1,1 @@
-pub const VERSION: &str = "1.7.7";
+pub const VERSION: &str = "0.1.1";

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -9,6 +9,7 @@ pub const MAX_REORG: usize = 100;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Network {
     Testnet,
+    Regtest,
     Mainnet,
     FakeMainnet,
 }
@@ -16,21 +17,24 @@ pub enum Network {
 impl Network {
     pub fn hrp_orchard_spending_key(&self) -> &str {
         match self {
-            Network::Mainnet => "secret-orchard-sk-main",
             Network::Testnet => "secret-orchard-sk-test",
+            Network::Regtest => "secret-orchard-sk-regtest",
+            Network::Mainnet => "secret-orchard-sk-main",
             Network::FakeMainnet => "secret-orchard-sk-main",
         }
     }
     pub fn hrp_unified_full_viewing_key(&self) -> &str {
         match self {
-            Network::Mainnet => "uview",
             Network::Testnet => "uviewtest",
+            Network::Regtest => "uviewregtest",
+            Network::Mainnet => "uview",
             Network::FakeMainnet => "uview",
         }
     }
     pub fn to_zcash_address_network(&self) -> zcash_address::Network {
         match self {
             Network::Testnet => zcash_address::Network::Test,
+            Network::Regtest => zcash_address::Network::Regtest,
             _ => zcash_address::Network::Main,
         }
     }
@@ -40,9 +44,10 @@ impl std::fmt::Display for Network {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use Network::*;
         let name = match self {
-            Mainnet => "main",
             Testnet => "test",
-            FakeMainnet => "regtest",
+            Regtest => "regtest",
+            Mainnet => "main",
+            FakeMainnet => "fakemainnet",
         };
         write!(f, "{name}")
     }
@@ -57,7 +62,7 @@ impl Parameters for Network {
         match self {
             Mainnet => MAIN_NETWORK.activation_height(nu),
             Testnet => TEST_NETWORK.activation_height(nu),
-            FakeMainnet => {
+            _ => {
                 //Tests don't need to worry about NU5 yet
                 match nu {
                     NetworkUpgrade::Nu5 => None,
@@ -70,8 +75,9 @@ impl Parameters for Network {
     fn coin_type(&self) -> u32 {
         use Network::*;
         match self {
-            Mainnet => constants::mainnet::COIN_TYPE,
             Testnet => constants::testnet::COIN_TYPE,
+            Regtest => constants::regtest::COIN_TYPE,
+            Mainnet => constants::mainnet::COIN_TYPE,
             FakeMainnet => constants::mainnet::COIN_TYPE,
         }
     }
@@ -79,8 +85,9 @@ impl Parameters for Network {
     fn hrp_sapling_extended_spending_key(&self) -> &str {
         use Network::*;
         match self {
-            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
             Testnet => constants::testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
+            Regtest => constants::regtest::HRP_SAPLING_EXTENDED_SPENDING_KEY,
+            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
             FakeMainnet => constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
         }
     }
@@ -88,8 +95,9 @@ impl Parameters for Network {
     fn hrp_sapling_extended_full_viewing_key(&self) -> &str {
         use Network::*;
         match self {
-            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
             Testnet => constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            Regtest => constants::regtest::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            Mainnet => constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
             FakeMainnet => constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
         }
     }
@@ -97,8 +105,9 @@ impl Parameters for Network {
     fn hrp_sapling_payment_address(&self) -> &str {
         use Network::*;
         match self {
-            Mainnet => constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
             Testnet => constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS,
+            Regtest => constants::regtest::HRP_SAPLING_PAYMENT_ADDRESS,
+            Mainnet => constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
             FakeMainnet => constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
         }
     }
@@ -106,8 +115,9 @@ impl Parameters for Network {
     fn b58_pubkey_address_prefix(&self) -> [u8; 2] {
         use Network::*;
         match self {
-            Mainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
             Testnet => constants::testnet::B58_PUBKEY_ADDRESS_PREFIX,
+            Regtest => constants::regtest::B58_PUBKEY_ADDRESS_PREFIX,
+            Mainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
             FakeMainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
         }
     }
@@ -115,8 +125,9 @@ impl Parameters for Network {
     fn b58_script_address_prefix(&self) -> [u8; 2] {
         use Network::*;
         match self {
-            Mainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
             Testnet => constants::testnet::B58_SCRIPT_ADDRESS_PREFIX,
+            Regtest => constants::regtest::B58_SCRIPT_ADDRESS_PREFIX,
+            Mainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
             FakeMainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
         }
     }

--- a/lib/src/lightclient/lightclient_config.rs
+++ b/lib/src/lightclient/lightclient_config.rs
@@ -91,7 +91,8 @@ impl LightClientConfig {
                 chain: match info.chain_name.as_str() {
                     "main" => Network::Mainnet,
                     "test" => Network::Testnet,
-                    "regtest" => Network::FakeMainnet,
+                    "regtest" => Network::Regtest,
+                    "fakemainnet" => Network::FakeMainnet,
                     _ => panic!("Unknown network"),
                 },
                 monitor_mempool: true,
@@ -168,9 +169,10 @@ impl LightClientConfig {
                 };
 
                 match &self.chain {
-                    Network::Mainnet => {}
                     Network::Testnet => zcash_data_location.push("testnet3"),
-                    Network::FakeMainnet => zcash_data_location.push("regtest"),
+                    Network::Regtest => zcash_data_location.push("regtest"),
+                    Network::Mainnet => {}
+                    Network::FakeMainnet => zcash_data_location.push("fakemainnet"),
                 };
             }
 
@@ -335,8 +337,8 @@ impl LightClientConfig {
 
     pub fn base58_secretkey_prefix(&self) -> [u8; 1] {
         match self.chain {
+            Network::Testnet | Network::Regtest | Network::FakeMainnet => [0xEF],
             Network::Mainnet => [0x80],
-            Network::Testnet | Network::FakeMainnet => [0xEF],
         }
     }
 }

--- a/lib/src/lightclient/lightclient_config.rs
+++ b/lib/src/lightclient/lightclient_config.rs
@@ -91,6 +91,7 @@ impl LightClientConfig {
                 chain: match info.chain_name.as_str() {
                     "main" => Network::Mainnet,
                     "test" => Network::Testnet,
+                    "regtest" => Network::FakeMainnet,
                     _ => panic!("Unknown network"),
                 },
                 monitor_mempool: true,

--- a/lib/src/wallet/keys.rs
+++ b/lib/src/wallet/keys.rs
@@ -506,8 +506,9 @@ impl Keys {
 
     fn get_network_enum(&self) -> zcash_address::Network {
         match self.config.chain {
-            Network::Mainnet => zcash_address::Network::Main,
             Network::Testnet => zcash_address::Network::Test,
+            Network::Regtest => zcash_address::Network::Regtest,
+            Network::Mainnet => zcash_address::Network::Main,
             Network::FakeMainnet => zcash_address::Network::Main,
         }
     }
@@ -676,8 +677,9 @@ impl Keys {
 
         use zcash_address::unified::Encoding as _;
         newkey.unified_address.encode(&match self.config.chain {
-            Network::Mainnet => zcash_address::Network::Main,
             Network::Testnet => zcash_address::Network::Test,
+            Network::Regtest => zcash_address::Network::Regtest,
+            Network::Mainnet => zcash_address::Network::Main,
             Network::FakeMainnet => zcash_address::Network::Main,
         })
     }


### PR DESCRIPTION
WIP!

Following up on [an older issue](https://github.com/zingolabs/zingolib_original/issues/85).

Solves #6 with first commit. 

<strike>Currently a non-functional flag that is recognized when running the compiled binary (ex, `./target/release/zingo-cli --regtest`).</strike>