### PR TITLE
checks for ready zcashd and lwd daemons in regtest mode

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod regtest;
 use log::error;
+use tokio::runtime::Runtime;
 use zingo_cli::{
     attempt_recover_seed, configure_clapapp, report_permission_error, start_interactive, startup,
     version::VERSION,
@@ -55,8 +56,13 @@ pub fn main() {
 
     let regtest_mode_enabled = matches.is_present("regtest");
     if regtest_mode_enabled {
-        regtest::launch()
-        // do the regtest
+        regtest::git_check();
+        let runtime = Runtime::new().expect("problem creating runtime");
+        runtime.block_on(async {
+            regtest::launch()
+                .await
+                .expect("regtest::launch() errored out");
+        });
     }
 
     let server = ZingoConfig::get_server_or_default(maybe_server);

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -136,21 +136,21 @@ pub(crate) fn launch() {
     }
 
     println!("zcashd is starting in regtest mode, please standby...");
-    let half_second = time::Duration::from_millis(500);
-    thread::sleep(half_second);
+    let check_interval = time::Duration::from_millis(100);
 
-    let mut alt = File::open(&zcashd_stdout_log).expect("can't open zcashd log");
+    let mut zcashd_log_open = File::open(&zcashd_stdout_log).expect("can't open zcashd log");
     let mut zcashd_logfile_state = String::new();
     //now enter loop to find string that indicates daemon is ready for next step
     loop {
-        alt.read_to_string(&mut zcashd_logfile_state)
+        zcashd_log_open
+            .read_to_string(&mut zcashd_logfile_state)
             .expect("problem reading zcashd_logfile into rust string"); // returns result
         if zcashd_logfile_state.contains("Error:") {
             panic!("zcashd reporting ERROR! exiting with panic. you may have to shut the daemon down manually.");
         } else if zcashd_logfile_state.contains("init message: Done loading") {
             break;
         } else {
-            thread::sleep(half_second);
+            thread::sleep(check_interval);
         }
     }
 
@@ -233,17 +233,17 @@ pub(crate) fn launch() {
 
     println!("lightwalletd is now started in regtest mode, please standby...");
 
-    let mut lwd_alt = File::open(&lwd_stdout_log).expect("can't open lwd log");
+    let mut lwd_log_opened = File::open(&lwd_stdout_log).expect("can't open lwd log");
     let mut lwd_logfile_state = String::new();
     //now enter loop to find string that indicates daemon is ready for next step
     loop {
-        lwd_alt
+        lwd_log_opened
             .read_to_string(&mut lwd_logfile_state)
             .expect("problem reading lwd_logfile into rust string");
         if lwd_logfile_state.contains("Starting insecure no-TLS (plaintext) server") {
             break;
         } else {
-            thread::sleep(half_second);
+            thread::sleep(check_interval);
         }
     }
     println!("lwd start section completed, lightwalletd should be running!");


### PR DESCRIPTION
Chasing #34 and #36 - probably a WIP. This no longer has a hard coded waiting duration for the daemons to start, instead there is a check every half second against the log files. I considered several more exotic solutions, for example, splitting the stdout into multiple outputs like `tee` in the shell, and I would like to move toward an async solution, but this is working for me.

I also added a simple error check for `zcashd`, which only works in regtest mode, and logging for `lightwalletd`'s `stdout`into a file.

Implementing async could or will be a further refinement, with a timeout of the attempts and so on. I'd also like to have more consideration of error detection, including if that should be ported to other "modes" like mainnet usage.

See also #27 .