### PR TITLE
Revert "Keep orcharding"

### DIFF
--- a/lib/src/blaze/block_witness_data.rs
+++ b/lib/src/blaze/block_witness_data.rs
@@ -3,7 +3,7 @@ use crate::{
     grpc_connector::GrpcConnector,
     lightclient::checkpoints::get_all_main_checkpoints,
     wallet::{
-        data::{BlockData, FromBytes, WalletNullifier, WalletTx, WitnessCache},
+        data::{BlockData, FromCommitment, WalletNullifier, WalletTx, WitnessCache},
         transactions::WalletTxns,
     },
 };
@@ -507,7 +507,7 @@ impl BlockAndWitnessData {
     where
         D: Domain,
         Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>,
-        Node: Hashable + FromBytes,
+        Node: Hashable + FromCommitment,
         D::ExtractedCommitmentBytes: Into<[u8; 32]>,
         TreeGetter: Fn(&TreeState) -> &String,
         OutputsFromTransaction: Fn(&CompactTx) -> &Vec<Output>,
@@ -552,7 +552,7 @@ impl BlockAndWitnessData {
                 .iter()
                 .enumerate()
             {
-                let node = Node::from_commitment_bytes(&co.cmstar_bytes().into());
+                let node = Node::from_commitment(&co.cmstar_bytes().into());
                 tree.append(node).unwrap();
                 if t_num == transaction_num && o_num == output_num {
                     return Ok(IncrementalWitness::from_tree(&tree));
@@ -601,7 +601,7 @@ impl BlockAndWitnessData {
     }
 
     // Stream all the outputs start at the block till the highest block available.
-    pub(crate) async fn update_witness_after_block<Node: Hashable + FromBytes>(
+    pub(crate) async fn update_witness_after_block<Node: Hashable + FromCommitment>(
         &self,
         witnesses: WitnessCache<Node>,
     ) -> WitnessCache<Node> {
@@ -628,7 +628,7 @@ impl BlockAndWitnessData {
                 let cb = &blocks.get(i as usize).unwrap().cb();
                 for compact_transaction in &cb.vtx {
                     for co in &compact_transaction.outputs {
-                        let node = Node::from_commitment_bytes(&co.cmu().unwrap().into());
+                        let node = Node::from_commitment(&co.cmu().unwrap().into());
                         w.append(node).unwrap();
                     }
                 }
@@ -650,7 +650,7 @@ impl BlockAndWitnessData {
         return WitnessCache::new(fsb.into_vec(), top_block);
     }
 
-    pub(crate) async fn update_witness_after_pos<Node: Hashable + FromBytes>(
+    pub(crate) async fn update_witness_after_pos<Node: Hashable + FromCommitment>(
         &self,
         height: &BlockHeight,
         transaction_id: &TxId,
@@ -682,7 +682,7 @@ impl BlockAndWitnessData {
                     // If we've already passed the transaction id and output_num, stream the results
                     if transaction_id_found && output_found {
                         let co = compact_transaction.outputs.get(j as usize).unwrap();
-                        let node = Node::from_commitment_bytes(&co.cmu().unwrap().into());
+                        let node = Node::from_commitment(&co.cmu().unwrap().into());
                         w.append(node).unwrap();
                     }
 

--- a/lib/src/blaze/update_notes.rs
+++ b/lib/src/blaze/update_notes.rs
@@ -1,4 +1,4 @@
-use crate::wallet::data::{FromBytes, WitnessCache};
+use crate::wallet::data::{FromCommitment, WitnessCache};
 use crate::wallet::MemoDownloadOption;
 use crate::wallet::{
     data::{WalletNullifier, WalletTx},
@@ -72,7 +72,7 @@ impl UpdateNotes {
         }
     }
 
-    async fn update_witnesses_inner<T, N: Hashable + FromBytes>(
+    async fn update_witnesses_inner<T, N: Hashable + FromCommitment>(
         bsync_data: Arc<RwLock<BlazeSyncData>>,
         wallet_txns: Arc<RwLock<WalletTxns>>,
         txid: TxId,

--- a/lib/src/wallet/data.rs
+++ b/lib/src/wallet/data.rs
@@ -196,8 +196,8 @@ impl<Node: Hashable> WitnessCache<Node> {
     //     return hex::encode(buf);
     // }
 }
-pub(crate) trait FromBytes {
-    fn from_commitment_bytes(from: &[u8; 32]) -> Self;
+pub(crate) trait FromCommitment {
+    fn from_commitment(from: &[u8; 32]) -> Self;
 }
 
 pub(crate) trait ToBytes<const N: usize> {
@@ -216,13 +216,13 @@ impl ToBytes<32> for OrchardNullifier {
     }
 }
 
-impl FromBytes for SaplingNode {
-    fn from_commitment_bytes(from: &[u8; 32]) -> Self {
+impl FromCommitment for SaplingNode {
+    fn from_commitment(from: &[u8; 32]) -> Self {
         Self::new(*from)
     }
 }
-impl FromBytes for MerkleHashOrchard {
-    fn from_commitment_bytes(from: &[u8; 32]) -> Self {
+impl FromCommitment for MerkleHashOrchard {
+    fn from_commitment(from: &[u8; 32]) -> Self {
         Self::from_bytes(from).unwrap()
     }
 }
@@ -245,8 +245,8 @@ pub(crate) trait NoteData {
         is_change: bool,
         have_spending_key: bool,
     ) -> Self;
-    fn get_nullifier(&self) -> Self::Nullifier;
-    fn get_witnesses(&mut self) -> &mut WitnessCache<Self::Node>;
+    fn nullifier(&self) -> Self::Nullifier;
+    fn witnesses(&mut self) -> &mut WitnessCache<Self::Node>;
 }
 
 pub struct SaplingNoteData {
@@ -328,11 +328,11 @@ impl NoteData for SaplingNoteData {
         }
     }
 
-    fn get_nullifier(&self) -> Self::Nullifier {
+    fn nullifier(&self) -> Self::Nullifier {
         self.nullifier
     }
 
-    fn get_witnesses(&mut self) -> &mut WitnessCache<Self::Node> {
+    fn witnesses(&mut self) -> &mut WitnessCache<Self::Node> {
         &mut self.witnesses
     }
 }
@@ -370,10 +370,10 @@ impl NoteData for OrchardNoteData {
         }
     }
 
-    fn get_nullifier(&self) -> Self::Nullifier {
+    fn nullifier(&self) -> Self::Nullifier {
         self.nullifier
     }
-    fn get_witnesses(&mut self) -> &mut WitnessCache<Self::Node> {
+    fn witnesses(&mut self) -> &mut WitnessCache<Self::Node> {
         &mut self.witnesses
     }
 }

--- a/lib/src/wallet/transactions.rs
+++ b/lib/src/wallet/transactions.rs
@@ -763,7 +763,7 @@ impl WalletTxns {
 
         match wtx_notes(wtx)
             .iter_mut()
-            .find(|n| n.get_nullifier() == nullifier)
+            .find(|n| n.nullifier() == nullifier)
         {
             None => {
                 let nd = NoteData::from_parts(
@@ -783,14 +783,14 @@ impl WalletTxns {
 
                 // Also remove any pending notes.
                 use super::data::ToBytes;
-                wtx_notes(wtx).retain(|n| n.get_nullifier().to_bytes() != [0u8; 32]);
+                wtx_notes(wtx).retain(|n| n.nullifier().to_bytes() != [0u8; 32]);
             }
             Some(n) => {
                 // If this note already exists, then just reset the witnesses, because we'll start scanning the witnesses
                 // again after this.
                 // This is likely to happen if the previous wallet wasn't synced properly or was aborted in the middle of a sync,
                 // and has some dangling witnesses
-                *n.get_witnesses() = witnesses;
+                *n.witnesses() = witnesses;
             }
         }
     }


### PR DESCRIPTION
Reverts zingolabs/zingolib#58.

#58 is causing too many rebase conflicts and naming scheme conflicts with my #52. These changes make sense, but let's make them atop #52.