### PR TITLE
Scenario macro expt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "concat-idents"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f90860248d75014b7b103db8fee4f291c07bfb41306cdf77a0a5ab7a10d2f"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,6 +3667,7 @@ dependencies = [
  "bls12_381",
  "byteorder",
  "bytes 0.4.12",
+ "concat-idents",
  "ff",
  "futures",
  "group",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -64,6 +64,7 @@ nonempty = "0.7.0"
 [dev-dependencies]
 portpicker = "0.1.0"
 tempfile = "3.3.0"
+concat-idents = "1.1.3"
 
 [build-dependencies]
 tonic-build = "0.7.0"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate rust_embed;
+mod test_framework;
 
 pub mod blaze;
 pub mod commands;

--- a/lib/src/lightclient.rs
+++ b/lib/src/lightclient.rs
@@ -580,7 +580,7 @@ impl LightClient {
         for sapling_address in self.wallet.keys().read().await.get_all_sapling_addresses() {
             sapling_addresses.push(object! {
                 "address"                     => sapling_address.clone(),
-                "sapling_balance"             => self.wallet.sapling_balance(Some(sapling_address.clone())).await,
+                "sapling_balance"             => self.wallet.maybe_verified_sapling_balance(Some(sapling_address.clone())).await,
                 "verified_sapling_balance"    => self.wallet.verified_sapling_balance(Some(sapling_address.clone())).await,
                 "spendable_sapling_balance"   => self.wallet.spendable_sapling_balance(Some(sapling_address.clone())).await,
                 "unverified_sapling_balance"  => self.wallet.unverified_sapling_balance(Some(sapling_address.clone())).await
@@ -591,7 +591,7 @@ impl LightClient {
         for orchard_address in self.wallet.keys().read().await.get_all_orchard_addresses() {
             orchard_addresses.push(object! {
                 "address"                     => orchard_address.clone(),
-                "orchard_balance"             => self.wallet.orchard_balance(Some(orchard_address.clone())).await,
+                "orchard_balance"             => self.wallet.maybe_verified_orchard_balance(Some(orchard_address.clone())).await,
                 "verified_orchard_balance"    => self.wallet.verified_orchard_balance(Some(orchard_address.clone())).await,
                 "spendable_orchard_balance"   => self.wallet.spendable_orchard_balance(Some(orchard_address.clone())).await,
                 "unverified_orchard_balance"  => self.wallet.unverified_orchard_balance(Some(orchard_address.clone())).await
@@ -611,11 +611,11 @@ impl LightClient {
         }
 
         object! {
-            "sapling_balance"                 => self.wallet.sapling_balance(None).await,
+            "sapling_balance"                 => self.wallet.maybe_verified_sapling_balance(None).await,
             "verified_sapling_balance"        => self.wallet.verified_sapling_balance(None).await,
             "spendable_sapling_balance"       => self.wallet.spendable_sapling_balance(None).await,
             "unverified_sapling_balance"      => self.wallet.unverified_sapling_balance(None).await,
-            "orchard_balance"                 => self.wallet.orchard_balance(None).await,
+            "orchard_balance"                 => self.wallet.maybe_verified_orchard_balance(None).await,
             "verified_orchard_balance"        => self.wallet.verified_orchard_balance(None).await,
             "spendable_orchard_balance"       => self.wallet.spendable_orchard_balance(None).await,
             "unverified_orchard_balance"      => self.wallet.unverified_orchard_balance(None).await,

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -773,26 +773,10 @@ impl CompactTxStreamer for TestGRPCService {
         todo!()
     }
 }
-#[macro_export]
-macro_rules! scenario_test {
-    ($scenario:ident,
-     $numblocks:tt,
-     #[tokio::test]
-     async fn $test_name:ident()
-        $implementation:block
-    ) => {
-        #[tokio::test]
-        async fn $test_name() {
-            let $scenario = setup_n_block_fcbl_scenario($numblocks).await;
-            $implementation
-            clean_shutdown($scenario.stop_transmitter, $scenario.test_server_handle).await;
-        }
-    };
-}
 #[cfg(test)]
 mod with_macro {
     use super::*;
-    scenario_test! {
+    crate::scenario_test! {
         scenario_handle,
         10,
         #[tokio::test]

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -776,12 +776,10 @@ impl CompactTxStreamer for TestGRPCService {
 #[cfg(test)]
 mod with_macro {
     use super::*;
-    crate::scenario_test! {
-        scenario_handle,
-        10,
+    crate::scenario_test! { data, stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
         #[tokio::test]
         async fn check_anchor_offset() {
-            assert_eq!(scenario_handle.lightclient.wallet.get_anchor_height().await, 10-4);
+            assert_eq!(lightclient.wallet.get_anchor_height().await, 10-4);
         }
     }
 }

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -779,13 +779,14 @@ impl CompactTxStreamer for TestGRPCService {
 //}
 macro_rules! scenario_test {
     ($scenario:ident,
+     $numblocks:tt,
      #[tokio::test]
      async fn $test_name:ident()
         $implementation:block
     ) => {
         #[tokio::test]
         async fn $test_name() {
-            let $scenario = setup_ten_block_fcbl_scenario(true).await;
+            let $scenario = setup_n_block_fcbl_scenario($numblocks).await;
             $implementation
             clean_shutdown($scenario.stop_transmitter, $scenario.test_server_handle).await;
         }
@@ -796,9 +797,10 @@ mod with_macro {
     use super::*;
     scenario_test! {
         scenario_handle,
+        10,
         #[tokio::test]
         async fn check_anchor_offset() {
-            assert_eq!(scenario_handle.lightclient.wallet.get_anchor_height().await, 1);
+            assert_eq!(scenario_handle.lightclient.wallet.get_anchor_height().await, 10-4);
         }
     }
 }

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -328,7 +328,10 @@ async fn test_direct_grpc_and_lightclient_blockchain_height_agreement() {
         clean_shutdown(stop_transmitter, test_server_handle).await;
     }
 }
-
+/// stop_transmitter: issues the shutdown to the server thread
+/// server_thread_handle: this is Ready when the server thread exits
+/// The first command initiates shutdown the second ensures that the
+/// server thread has exited before the clean_shutdown returns
 pub async fn clean_shutdown(
     stop_transmitter: oneshot::Sender<()>,
     server_thread_handle: JoinHandle<()>,
@@ -776,7 +779,7 @@ impl CompactTxStreamer for TestGRPCService {
 #[cfg(test)]
 mod with_macro {
     use super::*;
-    crate::scenario_test! { data, stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
+    crate::scenario_test! { data, lightclient, fake_compactblock_list, config, 10,
         #[tokio::test]
         async fn check_anchor_offset() {
             assert_eq!(lightclient.wallet.get_anchor_height().await, 10-4);

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -1,3 +1,4 @@
+use crate::apply_scenario;
 use crate::blaze::test_utils::{tree_to_string, FakeCompactBlockList};
 use crate::compact_formats::compact_tx_streamer_server::CompactTxStreamer;
 use crate::compact_formats::compact_tx_streamer_server::CompactTxStreamerServer;
@@ -776,13 +777,8 @@ impl CompactTxStreamer for TestGRPCService {
         todo!()
     }
 }
-#[cfg(test)]
-mod with_macro {
-    use super::*;
-    crate::scenario_test! { data, lightclient, fake_compactblock_list, config, 10,
-        #[tokio::test]
-        async fn check_anchor_offset() {
-            assert_eq!(lightclient.wallet.get_anchor_height().await, 10-4);
-        }
-    }
+apply_scenario! {check_anchor_offset 10}
+async fn check_anchor_offset(scenario: &mut NBlockFCBLScenario) {
+    let NBlockFCBLScenario { lightclient, .. } = scenario;
+    assert_eq!(lightclient.wallet.get_anchor_height().await, 10 - 4);
 }

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -773,10 +773,7 @@ impl CompactTxStreamer for TestGRPCService {
         todo!()
     }
 }
-
-//fn test_name(){
-//    scenario!(numberofblock, testfunction, param1, param2);
-//}
+#[macro_export]
 macro_rules! scenario_test {
     ($scenario:ident,
      $numblocks:tt,

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -773,3 +773,30 @@ impl CompactTxStreamer for TestGRPCService {
         todo!()
     }
 }
+
+//fn test_name(){
+//    scenario!(numberofblock, testfunction, param1, param2);
+//}
+macro_rules! scenario_test {
+    (#[tokio::test]
+     async fn $test_name:ident()
+        $implementation:block
+    ) => {
+        #[tokio::test]
+        async fn $test_name() {
+            let scenario = setup_ten_block_fcbl_scenario(true).await;
+            $implementation
+            clean_shutdown(scenario.stop_transmitter, scenario.test_server_handle).await;
+        }
+    };
+}
+#[cfg(test)]
+mod with_macro {
+    use super::*;
+    scenario_test! {
+        #[tokio::test]
+        async fn check_anchor_offset() {
+            dbg!("foo");
+        }
+    }
+}

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -778,15 +778,16 @@ impl CompactTxStreamer for TestGRPCService {
 //    scenario!(numberofblock, testfunction, param1, param2);
 //}
 macro_rules! scenario_test {
-    (#[tokio::test]
+    ($scenario:ident,
+     #[tokio::test]
      async fn $test_name:ident()
         $implementation:block
     ) => {
         #[tokio::test]
         async fn $test_name() {
-            let scenario = setup_ten_block_fcbl_scenario(true).await;
+            let $scenario = setup_ten_block_fcbl_scenario(true).await;
             $implementation
-            clean_shutdown(scenario.stop_transmitter, scenario.test_server_handle).await;
+            clean_shutdown($scenario.stop_transmitter, $scenario.test_server_handle).await;
         }
     };
 }
@@ -794,9 +795,10 @@ macro_rules! scenario_test {
 mod with_macro {
     use super::*;
     scenario_test! {
+        scenario_handle,
         #[tokio::test]
         async fn check_anchor_offset() {
-            dbg!("foo");
+            assert_eq!(scenario_handle.lightclient.wallet.get_anchor_height().await, 1);
         }
     }
 }

--- a/lib/src/test_framework.rs
+++ b/lib/src/test_framework.rs
@@ -1,0 +1,1 @@
+pub(crate) mod macros;

--- a/lib/src/test_framework/macros.rs
+++ b/lib/src/test_framework/macros.rs
@@ -1,4 +1,13 @@
 #[macro_export]
+macro_rules! apply_scenario {
+    ($test_implementation_fn:ident) => {
+        let scenario = setup_n_block_fcbl_scenario($numblock).await;
+        $test_implementation_fn(&mut scenario).await;
+        clean_shutdown(scenario.stop_transmitter, scenario.test_server_handle).await;
+    };
+}
+
+#[macro_export]
 macro_rules! scenario_test {
     ($($field:ident,)* $numblocks:literal,
      #[tokio::test]

--- a/lib/src/test_framework/macros.rs
+++ b/lib/src/test_framework/macros.rs
@@ -1,0 +1,16 @@
+#[macro_export]
+macro_rules! scenario_test {
+    ($scenario:ident,
+     $numblocks:tt,
+     #[tokio::test]
+     async fn $test_name:ident()
+        $implementation:block
+    ) => {
+        #[tokio::test]
+        async fn $test_name() {
+            let $scenario = setup_n_block_fcbl_scenario($numblocks).await;
+            $implementation
+            clean_shutdown($scenario.stop_transmitter, $scenario.test_server_handle).await;
+        }
+    };
+}

--- a/lib/src/test_framework/macros.rs
+++ b/lib/src/test_framework/macros.rs
@@ -25,4 +25,28 @@ macro_rules! scenario_test {
             clean_shutdown($stop_transmitter, $test_server_handle).await;
         }
     };
+    ($stop_transmitter:ident,
+     $test_server_handle:ident,
+     $lightclient:ident,
+     $fake_compactblock_list:ident,
+     $config:ident,
+     $numblocks:tt,
+     #[tokio::test]
+     async fn $test_name:ident()
+        $implementation:block
+    ) => {
+        #[tokio::test]
+        async fn $test_name() {
+            let NBlockFCBLScenario {
+                $stop_transmitter,
+                $test_server_handle,
+                $lightclient,
+                $fake_compactblock_list,
+                $config,
+                ..
+            } = setup_n_block_fcbl_scenario($numblocks).await;
+            $implementation
+            clean_shutdown($stop_transmitter, $test_server_handle).await;
+        }
+    };
 }

--- a/lib/src/test_framework/macros.rs
+++ b/lib/src/test_framework/macros.rs
@@ -1,6 +1,11 @@
 #[macro_export]
 macro_rules! scenario_test {
-    ($scenario:ident,
+    ($data:ident,
+     $stop_transmitter:ident,
+     $test_server_handle:ident,
+     $lightclient:ident,
+     $fake_compactblock_list:ident,
+     $config:ident,
      $numblocks:tt,
      #[tokio::test]
      async fn $test_name:ident()
@@ -8,9 +13,16 @@ macro_rules! scenario_test {
     ) => {
         #[tokio::test]
         async fn $test_name() {
-            let $scenario = setup_n_block_fcbl_scenario($numblocks).await;
+            let NBlockFCBLScenario {
+                $data,
+                $stop_transmitter,
+                $test_server_handle,
+                $lightclient,
+                $fake_compactblock_list,
+                $config
+            } = setup_n_block_fcbl_scenario($numblocks).await;
             $implementation
-            clean_shutdown($scenario.stop_transmitter, $scenario.test_server_handle).await;
+            clean_shutdown($stop_transmitter, $test_server_handle).await;
         }
     };
 }

--- a/lib/src/test_framework/macros.rs
+++ b/lib/src/test_framework/macros.rs
@@ -5,9 +5,9 @@ macro_rules! apply_scenario {
             fn_name = scenario_, $test_name {
                 #[tokio::test]
                 async fn fn_name() {
-                    let mut scenario = $crate::lightclient::test_server::setup_n_block_fcbl_scenario($numblocks).await;
-                    $test_name(&mut scenario).await;
-                    clean_shutdown(scenario.stop_transmitter, scenario.test_server_handle).await;
+                    let (scenario, stop_transmitter, test_server_handle) = $crate::lightclient::test_server::setup_n_block_fcbl_scenario($numblocks).await;
+                    $test_name(scenario).await;
+                    clean_shutdown(stop_transmitter, test_server_handle).await;
                 }
             }
         );

--- a/lib/src/test_framework/macros.rs
+++ b/lib/src/test_framework/macros.rs
@@ -1,29 +1,15 @@
 #[macro_export]
 macro_rules! apply_scenario {
-    ($test_implementation_fn:ident) => {
-        let scenario = setup_n_block_fcbl_scenario($numblock).await;
-        $test_implementation_fn(&mut scenario).await;
-        clean_shutdown(scenario.stop_transmitter, scenario.test_server_handle).await;
-    };
-}
-
-#[macro_export]
-macro_rules! scenario_test {
-    ($($field:ident,)* $numblocks:literal,
-     #[tokio::test]
-     async fn $test_name:ident()
-        $implementation:block
-    ) => {
-        #[tokio::test]
-        async fn $test_name() {
-            let NBlockFCBLScenario {
-                stop_transmitter,
-                test_server_handle,
-                $($field,)*
-                ..
-            } = setup_n_block_fcbl_scenario($numblocks).await;
-            $implementation
-            clean_shutdown(stop_transmitter, test_server_handle).await;
-        }
+    ($test_name:ident $numblocks:literal) => {
+        concat_idents::concat_idents!(
+            fn_name = scenario_, $test_name {
+                #[tokio::test]
+                async fn fn_name() {
+                    let mut scenario = $crate::lightclient::test_server::setup_n_block_fcbl_scenario($numblocks).await;
+                    $test_name(&mut scenario).await;
+                    clean_shutdown(scenario.stop_transmitter, scenario.test_server_handle).await;
+                }
+            }
+        );
     };
 }

--- a/lib/src/test_framework/macros.rs
+++ b/lib/src/test_framework/macros.rs
@@ -1,12 +1,6 @@
 #[macro_export]
 macro_rules! scenario_test {
-    ($data:ident,
-     $stop_transmitter:ident,
-     $test_server_handle:ident,
-     $lightclient:ident,
-     $fake_compactblock_list:ident,
-     $config:ident,
-     $numblocks:tt,
+    ($($field:ident,)* $numblocks:literal,
      #[tokio::test]
      async fn $test_name:ident()
         $implementation:block
@@ -14,39 +8,13 @@ macro_rules! scenario_test {
         #[tokio::test]
         async fn $test_name() {
             let NBlockFCBLScenario {
-                $data,
-                $stop_transmitter,
-                $test_server_handle,
-                $lightclient,
-                $fake_compactblock_list,
-                $config
-            } = setup_n_block_fcbl_scenario($numblocks).await;
-            $implementation
-            clean_shutdown($stop_transmitter, $test_server_handle).await;
-        }
-    };
-    ($stop_transmitter:ident,
-     $test_server_handle:ident,
-     $lightclient:ident,
-     $fake_compactblock_list:ident,
-     $config:ident,
-     $numblocks:tt,
-     #[tokio::test]
-     async fn $test_name:ident()
-        $implementation:block
-    ) => {
-        #[tokio::test]
-        async fn $test_name() {
-            let NBlockFCBLScenario {
-                $stop_transmitter,
-                $test_server_handle,
-                $lightclient,
-                $fake_compactblock_list,
-                $config,
+                stop_transmitter,
+                test_server_handle,
+                $($field,)*
                 ..
             } = setup_n_block_fcbl_scenario($numblocks).await;
             $implementation
-            clean_shutdown($stop_transmitter, $test_server_handle).await;
+            clean_shutdown(stop_transmitter, test_server_handle).await;
         }
     };
 }

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -774,12 +774,12 @@ impl LightWallet {
         }
     }
 
-    pub async fn sapling_balance(&self, addr: Option<String>) -> u64 {
+    pub async fn maybe_verified_sapling_balance(&self, addr: Option<String>) -> u64 {
         self.shielded_balance::<SaplingNoteAndMetadata>(addr, &[])
             .await
     }
 
-    pub async fn orchard_balance(&self, addr: Option<String>) -> u64 {
+    pub async fn maybe_verified_orchard_balance(&self, addr: Option<String>) -> u64 {
         self.shielded_balance::<OrchardNoteAndMetadata>(addr, &[])
             .await
     }
@@ -1530,24 +1530,94 @@ mod test {
     mod bench_select_notes_and_utxos {
         use super::*;
         #[tokio::test]
-        async fn funds_0_needed_1() {
-            let TenBlockFCBLScenario { lightclient, .. } =
-                setup_ten_block_fcbl_scenario(true).await;
+        async fn insufficient_funds_0_present_needed_1() {
+            let TenBlockFCBLScenario {
+                lightclient,
+                stop_transmitter,
+                test_server_handle,
+                ..
+            } = setup_ten_block_fcbl_scenario(true).await;
             let sufficient_funds = lightclient
                 .wallet
                 .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
                 .await;
             assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
+            // Shutdown everything cleanly
+            clean_shutdown(stop_transmitter, test_server_handle).await;
         }
         #[tokio::test]
-        async fn funds_1_needed_1() {
-            let TenBlockFCBLScenario { lightclient, .. } =
-                setup_ten_block_fcbl_scenario(true).await;
+        async fn insufficient_funds_1_present_needed_1() {
+            let TenBlockFCBLScenario {
+                lightclient,
+                stop_transmitter,
+                test_server_handle,
+                mut fake_compactblock_list,
+                data,
+                ..
+            } = setup_ten_block_fcbl_scenario(true).await;
+            let extended_fvk = lightclient
+                .wallet
+                .keys()
+                .read()
+                .await
+                .get_all_sapling_extfvks()[0]
+                .clone();
+            let (_, _, _) = fake_compactblock_list.create_coinbase_transaction(&extended_fvk, 1);
+            mine_pending_blocks(&mut fake_compactblock_list, &data, &lightclient).await;
+            assert_eq!(
+                lightclient
+                    .wallet
+                    .maybe_verified_sapling_balance(None)
+                    .await,
+                1
+            );
             let sufficient_funds = lightclient
                 .wallet
                 .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
                 .await;
-            dbg!("{}", sufficient_funds.2);
+            assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
+            // Shutdown everything cleanly
+            clean_shutdown(stop_transmitter, test_server_handle).await;
+        }
+        #[tokio::test]
+        async fn sufficient_funds_1_plus_txfee_present_needed_1() {
+            let TenBlockFCBLScenario {
+                lightclient,
+                stop_transmitter,
+                test_server_handle,
+                mut fake_compactblock_list,
+                data,
+                ..
+            } = setup_ten_block_fcbl_scenario(true).await;
+            let extended_fvk = lightclient
+                .wallet
+                .keys()
+                .read()
+                .await
+                .get_all_sapling_extfvks()[0]
+                .clone();
+            use zcash_primitives::transaction::components::amount::DEFAULT_FEE;
+            let (_, _, _) = fake_compactblock_list
+                .create_coinbase_transaction(&extended_fvk, 1 + u64::from(DEFAULT_FEE));
+            fake_compactblock_list.add_empty_block();
+            fake_compactblock_list.add_empty_block();
+            fake_compactblock_list.add_empty_block();
+            fake_compactblock_list.add_empty_block();
+            mine_pending_blocks(&mut fake_compactblock_list, &data, &lightclient).await;
+            assert_eq!(
+                lightclient
+                    .wallet
+                    .maybe_verified_sapling_balance(None)
+                    .await,
+                1_001
+            );
+            let sufficient_funds = lightclient
+                .wallet
+                .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
+                .await;
+            assert_eq!(Amount::from_u64(1_001).unwrap(), sufficient_funds.2);
+            // Shutdown everything cleanly
+            clean_shutdown(stop_transmitter, test_server_handle).await;
         }
     }
 

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1599,10 +1599,9 @@ mod test {
             use zcash_primitives::transaction::components::amount::DEFAULT_FEE;
             let (_, _, _) = fake_compactblock_list
                 .create_coinbase_transaction(&extended_fvk, 1 + u64::from(DEFAULT_FEE));
-            fake_compactblock_list.add_empty_block();
-            fake_compactblock_list.add_empty_block();
-            fake_compactblock_list.add_empty_block();
-            fake_compactblock_list.add_empty_block();
+            for _ in 0..=3 {
+                fake_compactblock_list.add_empty_block();
+            }
             mine_pending_blocks(&mut fake_compactblock_list, &data, &lightclient).await;
             assert_eq!(
                 lightclient

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1527,6 +1527,30 @@ mod test {
         },
     };
 
+    mod bench_select_notes_and_utxos {
+        use super::*;
+        #[tokio::test]
+        async fn funds_0_needed_1() {
+            let TenBlockFCBLScenario { lightclient, .. } =
+                setup_ten_block_fcbl_scenario(true).await;
+            let sufficient_funds = lightclient
+                .wallet
+                .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
+                .await;
+            assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
+        }
+        #[tokio::test]
+        async fn funds_1_needed_1() {
+            let TenBlockFCBLScenario { lightclient, .. } =
+                setup_ten_block_fcbl_scenario(true).await;
+            let sufficient_funds = lightclient
+                .wallet
+                .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
+                .await;
+            dbg!("{}", sufficient_funds.2);
+        }
+    }
+
     #[tokio::test]
     async fn z_t_note_selection() {
         let NBlockFCBLScenario {

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1530,21 +1530,17 @@ mod test {
 
     mod bench_select_notes_and_utxos {
         use super::*;
-        scenario_test! {
-            scenario_handle,
-            10,
+        crate::scenario_test! { data, stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
             #[tokio::test]
             async fn insufficient_funds_0_present_needed_1() {
-                let sufficient_funds = scenario_handle.lightclient
+                let sufficient_funds = lightclient
                     .wallet
                     .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
                     .await;
                 assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
             }
         }
-        scenario_test! {
-            scenario_handle,
-            10,
+        crate::scenario_test! { data, stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
         #[tokio::test]
         async fn insufficient_funds_1_present_needed_1() {
             let NBlockFCBLScenario {

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1525,26 +1525,26 @@ mod test {
             clean_shutdown, mine_numblocks_each_with_two_sap_txs, mine_pending_blocks,
             setup_n_block_fcbl_scenario, NBlockFCBLScenario,
         },
+        scenario_test,
     };
 
     mod bench_select_notes_and_utxos {
         use super::*;
-        #[tokio::test]
-        async fn insufficient_funds_0_present_needed_1() {
-            let NBlockFCBLScenario {
-                lightclient,
-                stop_transmitter,
-                test_server_handle,
-                ..
-            } = setup_n_block_fcbl_scenario(10).await;
-            let sufficient_funds = lightclient
-                .wallet
-                .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
-                .await;
-            assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
-            // Shutdown everything cleanly
-            clean_shutdown(stop_transmitter, test_server_handle).await;
+        scenario_test! {
+            scenario_handle,
+            10,
+            #[tokio::test]
+            async fn insufficient_funds_0_present_needed_1() {
+                let sufficient_funds = scenario_handle.lightclient
+                    .wallet
+                    .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
+                    .await;
+                assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
+            }
         }
+        scenario_test! {
+            scenario_handle,
+            10,
         #[tokio::test]
         async fn insufficient_funds_1_present_needed_1() {
             let NBlockFCBLScenario {
@@ -1576,8 +1576,7 @@ mod test {
                 .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
                 .await;
             assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
-            // Shutdown everything cleanly
-            clean_shutdown(stop_transmitter, test_server_handle).await;
+           }
         }
         #[tokio::test]
         async fn sufficient_funds_1_plus_txfee_present_needed_1() {

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1531,12 +1531,12 @@ mod test {
         use super::*;
         #[tokio::test]
         async fn insufficient_funds_0_present_needed_1() {
-            let TenBlockFCBLScenario {
+            let NBlockFCBLScenario {
                 lightclient,
                 stop_transmitter,
                 test_server_handle,
                 ..
-            } = setup_ten_block_fcbl_scenario(true).await;
+            } = setup_n_block_fcbl_scenario(10).await;
             let sufficient_funds = lightclient
                 .wallet
                 .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false)
@@ -1547,14 +1547,14 @@ mod test {
         }
         #[tokio::test]
         async fn insufficient_funds_1_present_needed_1() {
-            let TenBlockFCBLScenario {
+            let NBlockFCBLScenario {
                 lightclient,
                 stop_transmitter,
                 test_server_handle,
                 mut fake_compactblock_list,
                 data,
                 ..
-            } = setup_ten_block_fcbl_scenario(true).await;
+            } = setup_n_block_fcbl_scenario(10).await;
             let extended_fvk = lightclient
                 .wallet
                 .keys()
@@ -1581,14 +1581,14 @@ mod test {
         }
         #[tokio::test]
         async fn sufficient_funds_1_plus_txfee_present_needed_1() {
-            let TenBlockFCBLScenario {
+            let NBlockFCBLScenario {
                 lightclient,
                 stop_transmitter,
                 test_server_handle,
                 mut fake_compactblock_list,
                 data,
                 ..
-            } = setup_ten_block_fcbl_scenario(true).await;
+            } = setup_n_block_fcbl_scenario(10).await;
             let extended_fvk = lightclient
                 .wallet
                 .keys()

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1530,7 +1530,7 @@ mod test {
 
     mod bench_select_notes_and_utxos {
         use super::*;
-        crate::scenario_test! { stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
+        crate::scenario_test! { lightclient, fake_compactblock_list, config, 10,
             #[tokio::test]
             async fn insufficient_funds_0_present_needed_1() {
                 let sufficient_funds = lightclient
@@ -1540,7 +1540,7 @@ mod test {
                 assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
             }
         }
-        crate::scenario_test! { stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
+        crate::scenario_test! { lightclient, fake_compactblock_list, config, 10,
         #[tokio::test]
         async fn insufficient_funds_1_present_needed_1() {
             let NBlockFCBLScenario {

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -1530,7 +1530,7 @@ mod test {
 
     mod bench_select_notes_and_utxos {
         use super::*;
-        crate::scenario_test! { data, stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
+        crate::scenario_test! { stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
             #[tokio::test]
             async fn insufficient_funds_0_present_needed_1() {
                 let sufficient_funds = lightclient
@@ -1540,7 +1540,7 @@ mod test {
                 assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.2);
             }
         }
-        crate::scenario_test! { data, stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
+        crate::scenario_test! { stop_transmitter, test_server_handle, lightclient, fake_compactblock_list, config, 10,
         #[tokio::test]
         async fn insufficient_funds_1_present_needed_1() {
             let NBlockFCBLScenario {


### PR DESCRIPTION
Scenario tests require a test server, which should be shutdown in all cases (except for tests of the scenario framework itself).

This is an experiment with the use of a macro to bind setup-and-teardown for this kind of test.