### PR TITLE
Allow sync of pre-orchard activation blocks

### DIFF
--- a/lib/src/blaze/trial_decryptions.rs
+++ b/lib/src/blaze/trial_decryptions.rs
@@ -184,7 +184,7 @@ impl TrialDecryptions {
                 let orchard_tree = CommitmentTree::<MerkleHashOrchard>::read(
                     hex::decode(&trees_state.orchard_tree).unwrap().as_slice(),
                 )
-                .unwrap();
+                .unwrap_or(CommitmentTree::empty());
                 anchors.push((Anchor::from(orchard_tree.root()), height.into()));
             }
 


### PR DESCRIPTION
Fixes the failure to sync pre-orchard-activation-height blocks introduced by fetching/storage of orchard anchors.