### PR TITLE
Cross version

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,6 @@
+[[language]]
+name = "rust"
+
+[language.config]
+checkOnSave = { command = "check" } 
+cargo = { features = ["cross_version"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,3 +23,6 @@ tempdir = "0.3.7"
 tracing-subscriber = "0.3.15"
 zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash", rev = "d66f7f70516e6da5c24008874a926d41221b1346"}
 zcash_primitives = { git = "https://github.com/zingolabs/librustzcash", rev = "d66f7f70516e6da5c24008874a926d41221b1346", features = ["transparent-inputs", "test-dependencies"] }
+
+[features]
+cross_version = []

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -115,6 +115,10 @@ impl RegtestManager {
         }
     }
 
+    #[cfg(feature = "cross_version")]
+    pub fn get_zingocli_bin(&self) -> PathBuf {
+        self.zingo_cli_bin.clone()
+    }
     pub fn get_cli_handle(&self) -> std::process::Command {
         let config_str = &self
             .zcashd_config

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -132,9 +132,8 @@ impl RegtestManager {
         seed_phrase: &str,
         lightwalletd_port: String,
     ) -> std::process::Command {
-        let lightwalletd_server = &format!("https://127.0.0.1:{lightwalletd_port}");
+        let lightwalletd_server = &format!("http://127.0.0.1:{lightwalletd_port}");
         let mut handle = std::process::Command::new(&self.zingo_cli_bin);
-        dbg!(&lightwalletd_server);
         handle.args([
             "--server",
             lightwalletd_server,

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -126,25 +126,6 @@ impl RegtestManager {
         command
     }
 
-    #[cfg(feature = "cross_version")]
-    pub fn get_zingo_cli_handle(
-        &self,
-        seed_phrase: &str,
-        lightwalletd_port: String,
-    ) -> std::process::Command {
-        let lightwalletd_server = &format!("http://127.0.0.1:{lightwalletd_port}");
-        let mut handle = std::process::Command::new(&self.zingo_cli_bin);
-        handle.args([
-            "--regtest",
-            "--server",
-            lightwalletd_server,
-            "--birthday=1",
-            "--seed",
-            seed_phrase,
-        ]);
-        handle
-    }
-
     pub fn generate_n_blocks(
         &self,
         num_blocks: u32,

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -135,6 +135,7 @@ impl RegtestManager {
         let lightwalletd_server = &format!("http://127.0.0.1:{lightwalletd_port}");
         let mut handle = std::process::Command::new(&self.zingo_cli_bin);
         handle.args([
+            "--regtest",
             "--server",
             lightwalletd_server,
             "--birthday=1",

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -128,9 +128,9 @@ impl RegtestManager {
 
     #[cfg(feature = "cross_version")]
     pub fn get_zingo_cli_handle(&self, seed_phrase: &str) -> std::process::Command {
-        let mut command = std::process::Command::new(&self.zingo_cli_bin);
-        command.args(["--seed", seed_phrase]);
-        command
+        let mut handle = std::process::Command::new(&self.zingo_cli_bin);
+        handle.args(["--regtest", "--birthday=1", "--seed", seed_phrase]);
+        handle
     }
 
     pub fn generate_n_blocks(

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -31,6 +31,7 @@ pub struct RegtestManager {
     confs_dir: PathBuf,
     bin_dir: PathBuf,
     cli_bin: PathBuf,
+    #[cfg(feature = "cross_version")]
     zingo_cli_bin: PathBuf,
     logs_dir: PathBuf,
     data_dir: PathBuf,
@@ -72,6 +73,7 @@ impl RegtestManager {
         std::fs::create_dir_all(&confs_dir).expect("Couldn't create dir.");
         let bin_dir = get_regtest_dir().join("bin");
         std::fs::create_dir_all(&bin_dir).expect("Couldn't create dir.");
+        #[cfg(feature = "cross_version")]
         let zingo_cli_bin = bin_dir.join("zingo-cli");
         let cli_bin = bin_dir.join("zcash-cli");
         let logs_dir = regtest_dir.join("logs");
@@ -95,6 +97,7 @@ impl RegtestManager {
             regtest_dir,
             confs_dir,
             bin_dir,
+            #[cfg(feature = "cross_version")]
             zingo_cli_bin,
             cli_bin,
             logs_dir,
@@ -123,13 +126,9 @@ impl RegtestManager {
         command
     }
 
-    pub fn get_zingo_cli_handle(&self) -> std::process::Command {
-        let config_str = &self
-            .zcashd_config
-            .to_str()
-            .expect("Path to string failure!");
-
-        let mut command = std::process::Command::new(&self.zingo_cli_bin);
+    #[cfg(feature = "cross_version")]
+    pub fn get_zingo_cli_handle(&self, seed_phrase: &str) -> std::process::Command {
+        std::process::Command::new(&self.zingo_cli_bin).args(["--seed", seed_phrase])
     }
 
     pub fn generate_n_blocks(

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -31,6 +31,7 @@ pub struct RegtestManager {
     confs_dir: PathBuf,
     bin_dir: PathBuf,
     cli_bin: PathBuf,
+    zingo_cli_bin: PathBuf,
     logs_dir: PathBuf,
     data_dir: PathBuf,
     zcashd_data_dir: PathBuf,
@@ -71,6 +72,7 @@ impl RegtestManager {
         std::fs::create_dir_all(&confs_dir).expect("Couldn't create dir.");
         let bin_dir = get_regtest_dir().join("bin");
         std::fs::create_dir_all(&bin_dir).expect("Couldn't create dir.");
+        let zingo_cli_bin = bin_dir.join("zingo-cli");
         let cli_bin = bin_dir.join("zcash-cli");
         let logs_dir = regtest_dir.join("logs");
         let data_dir = regtest_dir.join("data");
@@ -93,6 +95,7 @@ impl RegtestManager {
             regtest_dir,
             confs_dir,
             bin_dir,
+            zingo_cli_bin,
             cli_bin,
             logs_dir,
             data_dir,
@@ -119,6 +122,16 @@ impl RegtestManager {
         command.arg(format!("-conf={config_str}"));
         command
     }
+
+    pub fn get_zingo_cli_handle(&self) -> std::process::Command {
+        let config_str = &self
+            .zcashd_config
+            .to_str()
+            .expect("Path to string failure!");
+
+        let mut command = std::process::Command::new(&self.zingo_cli_bin);
+    }
+
     pub fn generate_n_blocks(
         &self,
         num_blocks: u32,

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -128,7 +128,9 @@ impl RegtestManager {
 
     #[cfg(feature = "cross_version")]
     pub fn get_zingo_cli_handle(&self, seed_phrase: &str) -> std::process::Command {
-        std::process::Command::new(&self.zingo_cli_bin).args(["--seed", seed_phrase])
+        let mut command = std::process::Command::new(&self.zingo_cli_bin);
+        command.args(["--seed", seed_phrase]);
+        command
     }
 
     pub fn generate_n_blocks(

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -132,8 +132,16 @@ impl RegtestManager {
         seed_phrase: &str,
         lightwalletd_port: String,
     ) -> std::process::Command {
+        let lightwalletd_server = &format!("https://127.0.0.1:{lightwalletd_port}");
         let mut handle = std::process::Command::new(&self.zingo_cli_bin);
-        handle.args(["--birthday=1", "--seed", seed_phrase]);
+        dbg!(&lightwalletd_server);
+        handle.args([
+            "--server",
+            lightwalletd_server,
+            "--birthday=1",
+            "--seed",
+            seed_phrase,
+        ]);
         handle
     }
 

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -68,7 +68,7 @@ pub enum LaunchChildProcessError {
 }
 impl RegtestManager {
     pub fn new(rootpathname: Option<PathBuf>) -> Self {
-        let regtest_dir = dbg!(rootpathname.unwrap_or_else(get_regtest_dir));
+        let regtest_dir = rootpathname.unwrap_or_else(get_regtest_dir);
         let confs_dir = regtest_dir.join("conf");
         std::fs::create_dir_all(&confs_dir).expect("Couldn't create dir.");
         let bin_dir = get_regtest_dir().join("bin");

--- a/cli/src/regtest.rs
+++ b/cli/src/regtest.rs
@@ -127,9 +127,13 @@ impl RegtestManager {
     }
 
     #[cfg(feature = "cross_version")]
-    pub fn get_zingo_cli_handle(&self, seed_phrase: &str) -> std::process::Command {
+    pub fn get_zingo_cli_handle(
+        &self,
+        seed_phrase: &str,
+        lightwalletd_port: String,
+    ) -> std::process::Command {
         let mut handle = std::process::Command::new(&self.zingo_cli_bin);
-        handle.args(["--regtest", "--birthday=1", "--seed", seed_phrase]);
+        handle.args(["--birthday=1", "--seed", seed_phrase]);
         handle
     }
 

--- a/cli/tests/data/mod.rs
+++ b/cli/tests/data/mod.rs
@@ -1,3 +1,8 @@
+//Generate test seed
+pub const TEST_SEED: &str = "hospital museum valve antique skate museum \
+unfold vocal weird milk scale social vessel identify \
+crowd hospital control album rib bulb path oven civil tank";
+
 pub mod config_template_fillers {
     pub mod zcashd {
         pub fn basic(rpcport: &str, extra: &str) -> String {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -522,3 +522,9 @@ fn ensure_taddrs_from_old_seeds_work() {
 //   The incorrectly configured location is still present (and not checked in)
 //   The test-or-scenario that caused this situation has failed/panicked.
 //}
+
+/// TODO: feature gate
+#[cfg(test)]
+mod cross_version {
+    
+}

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -611,8 +611,8 @@ mod cross_version {
             .expect("failed to get seed")
             .stdout;
         let oldclient_seed = dbg!(extract_seed(&rawseedoutput));
-        let zaddr = extract_sapling_address(&addresses);
-        let uaddr = extract_unified_address(&addresses);
+        let _zaddr = extract_sapling_address(&addresses);
+        let _uaddr = extract_unified_address(&addresses);
         tokio::runtime::Runtime::new().unwrap().block_on(async {
             let newclient_seed = sameseed_newclient.do_seed_phrase().await.unwrap();
             assert_eq!(newclient_seed["seed"].to_string(), oldclient_seed);

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -535,6 +535,15 @@ mod cross_version {
     fn cross_compat() {
         let (regtest_manager, client_one, client_two, child_process_handler, client_two_seedphrase) =
             cross_version_setup();
-        let zingo_cli = regtest_manager.get_zingo_cli_handle(&client_two_seedphrase);
+        let mut zingo_cli_handle = regtest_manager.get_zingo_cli_handle(&client_two_seedphrase);
+        let addresses = &zingo_cli_handle
+            .arg("addresses")
+            .output()
+            .expect("unable to create addresses");
+        assert_eq!(
+            std::str::from_utf8(addresses.stdout.as_slice()).unwrap(),
+            "foo"
+        );
+        drop(child_process_handler);
     }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -572,10 +572,15 @@ mod cross_version {
     }
     #[test]
     fn cross_compat() {
-        let (regtest_manager, client_one, client_two, child_process_handler, zingo_cli_handler) =
-            cross_version_setup();
+        let (
+            _regtest_manager,
+            _miner_client,
+            sameseed_newclient,
+            child_process_handler,
+            sameseed_oldcli_client,
+        ) = cross_version_setup();
 
-        let addresses = zingo_cli_handler
+        let addresses = sameseed_oldcli_client
             .build_handle()
             .arg("addresses")
             .output()
@@ -585,7 +590,16 @@ mod cross_version {
         let zaddr = extract_sapling_address(&addresses);
         let uaddr = extract_unified_address(&addresses);
         tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let new_addresses = client_one.do_addresses().await;
+            let newclient_seed = sameseed_newclient.do_seed_phrase();
+            let oldclient_seed = sameseed_oldcli_client
+                .build_handle()
+                .arg("seed")
+                .output()
+                .expect("failed to get seed")
+                .stdout;
+            dbg!(std::str::from_utf8(&oldclient_seed));
+            assert!(1 == 0);
+            let new_addresses = sameseed_newclient.do_addresses().await;
             println!("{}", json::stringify_pretty(new_addresses.clone(), 4));
             assert_eq!(
                 new_addresses[0]["receivers"]["transparent"].to_string(),
@@ -593,6 +607,6 @@ mod cross_version {
             )
         });
         drop(child_process_handler);
-        drop(zingo_cli_handler);
+        drop(sameseed_oldcli_client);
     }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -526,7 +526,7 @@ fn ensure_taddrs_from_old_seeds_work() {
 //}
 
 #[cfg(feature = "cross_version")]
-/// Use test seed to recieve funds from artificial blockchain 
+/// Use test seed to receive funds from local "regtest" blockchain
 /// using zcash-cli and zcashd in regtest mode
 mod cross_version {
     #[test]

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -533,11 +533,8 @@ mod cross_version {
 
     #[test]
     fn cross_compat() {
-        let (regtest_manager, client_one, client_two, child_process_handler) =
+        let (regtest_manager, client_one, client_two, child_process_handler, client_two_seedphrase) =
             cross_version_setup();
-        let seed_phrase = zcash_primitives::zip339::Mnemonic::from_entropy([0; 32])
-            .unwrap()
-            .to_string();
-        let zingo_cli = regtest_manager.get_zingo_cli_handle(&seed_phrase);
+        let zingo_cli = regtest_manager.get_zingo_cli_handle(&client_two_seedphrase);
     }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -539,7 +539,6 @@ mod cross_version {
             .output()
             .expect("unable to create addresses")
             .stdout;
-        dbg!(&raw_output);
         let address_chunk = std::str::from_utf8(&raw_output)
             .unwrap()
             .split_once("{\n  \"result\": \"success\",\n  \"latest_block\": 1,\n  \"total_blocks_synced\": 1\n}\n")

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -555,10 +555,11 @@ mod cross_version {
             .expect("unable to create addresses")
             .stdout;
 
-        let taddr = extract_legacy_address(&raw_output, "transparent");
-        let zaddr = extract_legacy_address(&raw_output, "sapling");
-        assert_eq!(taddr, "tmCMFLcENTAx8pJzvMMRqVmYuQnhoLCgFQF");
-        assert_eq!(zaddr, "foo");
+        //let taddr = extract_legacy_address(&raw_output, "transparent");
+        //let zaddr = extract_legacy_address(&raw_output, "sapling");
+        //assert_eq!(taddr, "tmCMFLcENTAx8pJzvMMRqVmYuQnhoLCgFQF");
+        //assert_eq!(zaddr, "foo");
         drop(child_process_handler);
+        drop(zingo_cli_handle);
     }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -524,7 +524,9 @@ fn ensure_taddrs_from_old_seeds_work() {
 //}
 
 /// TODO: feature gate
-#[cfg(test)]
 mod cross_version {
-    
+    #[test]
+    fn cross_compat() {
+        assert_eq!(0, 0);
+    }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -529,15 +529,15 @@ fn ensure_taddrs_from_old_seeds_work() {
 /// Use test seed to receive funds from local "regtest" blockchain
 /// using zcash-cli and zcashd in regtest mode
 mod cross_version {
-    use crate::utils::setup::two_clients_one_saplingcoinbase_backed;
+    use crate::utils::setup::cross_version_setup;
 
     #[test]
     fn cross_compat() {
+        let (regtest_manager, client_one, client_two, child_process_handler) =
+            cross_version_setup();
         let seed_phrase = zcash_primitives::zip339::Mnemonic::from_entropy([0; 32])
             .unwrap()
             .to_string();
-        let (regtest_manager, client_one, client_two, child_process_handler) =
-            two_clients_one_saplingcoinbase_backed();
         let zingo_cli = regtest_manager.get_zingo_cli_handle(&seed_phrase);
     }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -529,8 +529,15 @@ fn ensure_taddrs_from_old_seeds_work() {
 /// Use test seed to receive funds from local "regtest" blockchain
 /// using zcash-cli and zcashd in regtest mode
 mod cross_version {
+    use crate::utils::setup::two_clients_one_saplingcoinbase_backed;
+
     #[test]
     fn cross_compat() {
-        assert_eq!(0, 0);
+        let seed_phrase = zcash_primitives::zip339::Mnemonic::from_entropy([0; 32])
+            .unwrap()
+            .to_string();
+        let (regtest_manager, client_one, client_two, child_process_handler) =
+            two_clients_one_saplingcoinbase_backed();
+        let zingo_cli = regtest_manager.get_zingo_cli_handle(&seed_phrase);
     }
 }

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -547,9 +547,8 @@ mod cross_version {
     }
     #[test]
     fn cross_compat() {
-        let (regtest_manager, client_one, client_two, child_process_handler, client_two_seedphrase) =
+        let (regtest_manager, client_one, client_two, child_process_handler, mut zingo_cli_handle) =
             cross_version_setup();
-        let mut zingo_cli_handle = regtest_manager.get_zingo_cli_handle(&client_two_seedphrase);
         let raw_output = zingo_cli_handle
             .arg("addresses")
             .output()

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -529,15 +529,23 @@ fn ensure_taddrs_from_old_seeds_work() {
 /// Use test seed to receive funds from local "regtest" blockchain
 /// using zcash-cli and zcashd in regtest mode
 mod cross_version {
+    use std::process::Command;
+
     use crate::utils::setup::cross_version_setup;
 
-    fn extract_legacy_address(raw_output: &Vec<u8>, legacy_addr_type: &str) -> String {
-        let address_chunk = std::str::from_utf8(raw_output)
+    fn extract_transparent_address(zingo_cli_handle: &mut Command) -> String {
+        let raw_output = zingo_cli_handle
+            .arg("addresses")
+            .output()
+            .expect("unable to create addresses")
+            .stdout;
+        dbg!(&raw_output);
+        let address_chunk = std::str::from_utf8(&raw_output)
             .unwrap()
             .split_once("{\n  \"result\": \"success\",\n  \"latest_block\": 1,\n  \"total_blocks_synced\": 1\n}\n")
             .unwrap().1;
         let addresses = json::parse(address_chunk).unwrap();
-        let with_quotes = json::stringify(addresses[0]["receivers"][legacy_addr_type].clone());
+        let with_quotes = json::stringify(addresses[0]["receivers"]["transparent"].clone());
         with_quotes
             .strip_suffix("\"")
             .unwrap()
@@ -549,13 +557,13 @@ mod cross_version {
     fn cross_compat() {
         let (regtest_manager, client_one, client_two, child_process_handler, mut zingo_cli_handle) =
             cross_version_setup();
-        let raw_output = zingo_cli_handle
-            .arg("addresses")
-            .output()
-            .expect("unable to create addresses")
-            .stdout;
+        //std::thread::sleep(std::time::Duration::new(10, 0));
+        dbg!(&zingo_cli_handle);
+        let zingocli_output = zingo_cli_handle.output().unwrap().stderr;
+        dbg!(std::str::from_utf8(&zingocli_output).unwrap());
+        assert!(1 == 0);
 
-        //let taddr = extract_legacy_address(&raw_output, "transparent");
+        //let taddr = extract_transparent_address(&mut zingo_cli_handle);
         //let zaddr = extract_legacy_address(&raw_output, "sapling");
         //assert_eq!(taddr, "tmCMFLcENTAx8pJzvMMRqVmYuQnhoLCgFQF");
         //assert_eq!(zaddr, "foo");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -560,7 +560,6 @@ mod cross_version {
         dbg!(&zingo_cli_handle);
         let zingocli_output = zingo_cli_handle.output().unwrap().stderr;
         dbg!(std::str::from_utf8(&zingocli_output).unwrap());
-        assert!(1 == 0);
 
         //let taddr = extract_transparent_address(&mut zingo_cli_handle);
         //let zaddr = extract_legacy_address(&raw_output, "sapling");

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -526,6 +526,8 @@ fn ensure_taddrs_from_old_seeds_work() {
 //}
 
 #[cfg(feature = "cross_version")]
+/// Use test seed to recieve funds from artificial blockchain 
+/// using zcash-cli and zcashd in regtest mode
 mod cross_version {
     #[test]
     fn cross_compat() {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -2,6 +2,7 @@
 
 mod data;
 mod utils;
+use data::TEST_SEED;
 use json::JsonValue;
 use tokio::runtime::Runtime;
 use utils::setup::{
@@ -486,12 +487,9 @@ fn ensure_taddrs_from_old_seeds_work() {
 
     // The first taddr generated on commit 9e71a14eb424631372fd08503b1bd83ea763c7fb
     let transparent_address = "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i";
-    // Generated from the following seed
-    let seed = "hospital museum valve antique skate museum \
-    unfold vocal weird milk scale social vessel identify \
-    crowd hospital control album rib bulb path oven civil tank";
+
     let client_b =
-        LightClient::create_with_seedorkey_wallet(seed.to_string(), &client_b_config, 0, false)
+        LightClient::create_with_seedorkey_wallet(TEST_SEED.to_string(), &client_b_config, 0, false)
             .unwrap();
 
     Runtime::new().unwrap().block_on(async {

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -488,9 +488,13 @@ fn ensure_taddrs_from_old_seeds_work() {
     // The first taddr generated on commit 9e71a14eb424631372fd08503b1bd83ea763c7fb
     let transparent_address = "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i";
 
-    let client_b =
-        LightClient::create_with_seedorkey_wallet(TEST_SEED.to_string(), &client_b_config, 0, false)
-            .unwrap();
+    let client_b = LightClient::create_with_seedorkey_wallet(
+        TEST_SEED.to_string(),
+        &client_b_config,
+        0,
+        false,
+    )
+    .unwrap();
 
     Runtime::new().unwrap().block_on(async {
         client_b.do_new_address("zt").await.unwrap();
@@ -521,7 +525,7 @@ fn ensure_taddrs_from_old_seeds_work() {
 //   The test-or-scenario that caused this situation has failed/panicked.
 //}
 
-/// TODO: feature gate
+#[cfg(feature = "cross_version")]
 mod cross_version {
     #[test]
     fn cross_compat() {

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -105,7 +105,6 @@ pub mod setup {
                 "lightwalletd" => &self.regtest_manager.lightwalletd_config,
                 _ => panic!("Unepexted configtype!"),
             };
-            dbg!(&loc);
             let mut output = std::fs::File::create(&loc).expect("How could path be missing?");
             std::io::Write::write(&mut output, contents.as_bytes())
                 .expect(&format!("Couldn't write {contents}!"));

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -253,6 +253,35 @@ pub mod setup {
         )
     }
 
+    #[cfg(feature = "cross_version")]
+    struct ZingoCliHandler {
+        lightwalletd_port: String,
+        seed_phrase: &'static str,
+        zingo_cli_bin: PathBuf,
+    }
+    impl ZingoCliHandler {
+        pub fn new(lightwalletd_port: String, seed_phrase: &str, zingo_cli_bin: PathBuf) -> Self {
+            Self {
+                lightwalletd_port,
+                seed_phrase,
+                zingo_cli_bin,
+            }
+        }
+        pub fn build_handle(&self) -> std::process::Command {
+            let lightwalletd_port = self.lightwalletd_port;
+            let lightwalletd_server = &format!("http://127.0.0.1:{lightwalletd_port}");
+            let mut handle = std::process::Command::new(&self.zingo_cli_bin);
+            handle.args([
+                "--regtest",
+                "--server",
+                lightwalletd_server,
+                "--birthday=1",
+                "--seed",
+                self.seed_phrase,
+            ]);
+            handle
+        }
+    }
     /// This creates two so-called "LightClient"s "client_one" controls a spend capability
     /// that has furnished a receiving address in the mineraddress configuration field
     /// of the "generating" regtest-zcashd
@@ -262,7 +291,7 @@ pub mod setup {
         LightClient,
         LightClient,
         ChildProcessHandler,
-        std::process::Command,
+        ZingoCliHandler,
     ) {
         let (regtest_manager, child_process_handler, client_one, lightwalletd_port) =
             saplingcoinbasebacked_spendcapable_cross_version();

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -254,13 +254,13 @@ pub mod setup {
     }
 
     #[cfg(feature = "cross_version")]
-    struct ZingoCliHandler {
+    pub struct ZingoCliHandler {
         lightwalletd_port: String,
-        seed_phrase: &'static str,
+        seed_phrase: String,
         zingo_cli_bin: PathBuf,
     }
     impl ZingoCliHandler {
-        pub fn new(lightwalletd_port: String, seed_phrase: &str, zingo_cli_bin: PathBuf) -> Self {
+        pub fn new(lightwalletd_port: String, seed_phrase: String, zingo_cli_bin: PathBuf) -> Self {
             Self {
                 lightwalletd_port,
                 seed_phrase,
@@ -268,7 +268,7 @@ pub mod setup {
             }
         }
         pub fn build_handle(&self) -> std::process::Command {
-            let lightwalletd_port = self.lightwalletd_port;
+            let lightwalletd_port = &self.lightwalletd_port;
             let lightwalletd_server = &format!("http://127.0.0.1:{lightwalletd_port}");
             let mut handle = std::process::Command::new(&self.zingo_cli_bin);
             handle.args([
@@ -277,7 +277,7 @@ pub mod setup {
                 lightwalletd_server,
                 "--birthday=1",
                 "--seed",
-                self.seed_phrase,
+                &self.seed_phrase,
             ]);
             handle
         }
@@ -315,14 +315,17 @@ pub mod setup {
             false,
         )
         .unwrap();
-        let mut zingo_cli_handle =
-            regtest_manager.get_zingo_cli_handle(&seed_phrase_for_two, lightwalletd_port);
+        let zingo_cli_handler = ZingoCliHandler::new(
+            lightwalletd_port,
+            seed_phrase_for_two,
+            regtest_manager.get_zingocli_bin(),
+        );
         (
             regtest_manager,
             client_one,
             client_two,
             child_process_handler,
-            zingo_cli_handle,
+            zingo_cli_handler,
         )
     }
 

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -238,7 +238,7 @@ pub mod setup {
             .unwrap()
             .to_string();
         let client_two = LightClient::create_with_seedorkey_wallet(
-            seed_phrase_for_two,
+            seed_phrase_for_two.clone(),
             &client_two_config,
             0,
             false,

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -94,9 +94,9 @@ pub mod setup {
         fn create_lightwalletd_conf(&self) -> PathBuf {
             self.write_contents_and_return_path(
                 "lightwalletd",
-                dbg!(data::config_template_fillers::lightwalletd::basic(
-                    &self.lightwalletd_rpcservice_port
-                )),
+                data::config_template_fillers::lightwalletd::basic(
+                    &self.lightwalletd_rpcservice_port,
+                ),
             )
         }
         fn write_contents_and_return_path(&self, configtype: &str, contents: String) -> PathBuf {

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -220,6 +220,7 @@ pub mod setup {
         LightClient,
         LightClient,
         ChildProcessHandler,
+        String,
     ) {
         let (regtest_manager, child_process_handler, client_one) =
             saplingcoinbasebacked_spendcapable();
@@ -233,11 +234,11 @@ pub mod setup {
             Some(client_two_zingoconf_path),
         )
         .unwrap();
-        let seed_phrase_of_two = zcash_primitives::zip339::Mnemonic::from_entropy([1; 32])
+        let seed_phrase_for_two = zcash_primitives::zip339::Mnemonic::from_entropy([1; 32])
             .unwrap()
             .to_string();
         let client_two = LightClient::create_with_seedorkey_wallet(
-            seed_phrase_of_two,
+            seed_phrase_for_two,
             &client_two_config,
             0,
             false,
@@ -248,6 +249,7 @@ pub mod setup {
             client_one,
             client_two,
             child_process_handler,
+            seed_phrase_for_two,
         )
     }
 

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -215,7 +215,7 @@ pub mod setup {
     /// that has furnished a receiving address in the mineraddress configuration field
     /// of the "generating" regtest-zcashd
     #[cfg(feature = "cross_version")]
-    pub fn three_clients() -> (
+    pub fn cross_version_setup() -> (
         RegtestManager,
         LightClient,
         LightClient,

--- a/lib/src/wallet/keys/unified.rs
+++ b/lib/src/wallet/keys/unified.rs
@@ -121,8 +121,6 @@ impl UnifiedSpendCapability {
         };
         let transparent_receiver = if desired_receivers.transparent {
             let key_index = KeyIndex::from_index(self.addresses.len() as u32).unwrap();
-            //let key_index = KeyIndex::Normal(self.addresses.len() as u32);
-            dbg!(&key_index);
             let new_key = self
                 .transparent_parent_key
                 .derive_private_key(key_index)


### PR DESCRIPTION
To run the cross_version test:

Build the `c9a2f03c5e9cfd60f955a411e6a414fd6d7db42c` version of `zingolib` 
in "release" mode and link the binary from the `regtest/bin` directory of the test-code repo..  i.e. this feature's version of the code.

`cargo test --release --features cross_version cross_compat`