### PR TITLE
Save per batch

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -427,14 +427,8 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         );
         recipient.do_seed_phrase().await.unwrap()
     });
-    let server_id = recipient.get_server_uri(); // Last use of original recipient
+    let (config, _height) = utils::derive_client(&recipient, &regtest_manager);
     drop(recipient); // Discard original to ensure subsequent data is fresh.
-
-    let zingo_datadir = regtest_manager
-        .zingo_data_dir
-        .to_str()
-        .map(ToString::to_string);
-    let (config, _height) = create_zingoconf_with_datadir(server_id, zingo_datadir).unwrap();
     let mut expected_unspent_sapling_notes_after_restore_from_seed =
         expected_unspent_sapling_notes.clone();
     expected_unspent_sapling_notes_after_restore_from_seed["address"] = JsonValue::String(

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -10,13 +10,14 @@ use utils::setup::{
 };
 #[test]
 fn create_network_disconnected_client() {
-    let (_regtest_manager_1, _child_process_handler_1, _client_1) =
+    let (_regtest_manager_1, _child_process_handler_1, _client_builder) =
         saplingcoinbasebacked_spendcapable();
 }
 
 #[test]
 fn zcashd_sapling_commitment_tree() {
-    let (regtest_manager, _child_process_handler, _client) = saplingcoinbasebacked_spendcapable();
+    let (regtest_manager, _child_process_handler, _client_builder) =
+        saplingcoinbasebacked_spendcapable();
     let trees = regtest_manager
         .get_cli_handle()
         .args(["z_gettreestate", "1"])
@@ -76,8 +77,9 @@ fn actual_empty_zcashd_sapling_commitment_tree() {
 
 #[test]
 fn mine_sapling_to_self() {
-    let (regtest_manager, _child_process_handler, client) = saplingcoinbasebacked_spendcapable();
-
+    let (regtest_manager, _child_process_handler, mut client_builder) =
+        saplingcoinbasebacked_spendcapable();
+    let client = client_builder.new_sameseed_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
 
@@ -88,7 +90,9 @@ fn mine_sapling_to_self() {
 
 #[test]
 fn send_mined_sapling_to_orchard() {
-    let (regtest_manager, _child_process_handler, client) = saplingcoinbasebacked_spendcapable();
+    let (regtest_manager, _child_process_handler, mut client_builder) =
+        saplingcoinbasebacked_spendcapable();
+    let client = client_builder.new_sameseed_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
 
@@ -112,7 +116,6 @@ fn extract_value_as_u64(input: &JsonValue) -> u64 {
     note.clone()
 }
 use zcash_primitives::transaction::components::amount::DEFAULT_FEE;
-use zingolib::{create_zingoconf_with_datadir, lightclient::LightClient};
 #[test]
 fn note_selection_order() {
     //! In order to fund a transaction multiple notes may be selected and consumed.
@@ -120,7 +123,7 @@ fn note_selection_order() {
     //! In addition to testing the order in which notes are selected this test:
     //!   * sends to a sapling address
     //!   * sends back to the original sender's UA
-    let (regtest_manager, client_1, client_2, child_process_handler) =
+    let (regtest_manager, client_1, client_2, child_process_handler, _) =
         two_clients_one_saplingcoinbase_backed();
 
     Runtime::new().unwrap().block_on(async {
@@ -220,7 +223,7 @@ fn note_selection_order() {
 
 #[test]
 fn send_orchard_back_and_forth() {
-    let (regtest_manager, client_a, client_b, child_process_handler) =
+    let (regtest_manager, client_a, client_b, child_process_handler, _) =
         two_clients_one_saplingcoinbase_backed();
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client_a, 5).await;
@@ -262,7 +265,7 @@ fn send_orchard_back_and_forth() {
 
 #[test]
 fn diversified_addresses_receive_funds_in_best_pool() {
-    let (regtest_manager, client_a, client_b, child_process_handler) =
+    let (regtest_manager, client_a, client_b, child_process_handler, _) =
         two_clients_one_saplingcoinbase_backed();
     Runtime::new().unwrap().block_on(async {
         client_b.do_new_address("o").await.unwrap();
@@ -303,7 +306,7 @@ fn diversified_addresses_receive_funds_in_best_pool() {
 
 #[test]
 fn rescan_still_have_outgoing_metadata() {
-    let (regtest_manager, client_one, client_two, child_process_handler) =
+    let (regtest_manager, client_one, client_two, child_process_handler, _) =
         two_clients_one_saplingcoinbase_backed();
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client_one, 5).await;
@@ -329,7 +332,9 @@ fn rescan_still_have_outgoing_metadata() {
 ///
 #[test]
 fn rescan_still_have_outgoing_metadata_with_sends_to_self() {
-    let (regtest_manager, child_process_handler, client) = saplingcoinbasebacked_spendcapable();
+    let (regtest_manager, child_process_handler, mut client_builder) =
+        saplingcoinbasebacked_spendcapable();
+    let client = client_builder.new_sameseed_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
         let sapling_addr = client.do_new_address("tz").await.unwrap();
@@ -374,7 +379,7 @@ fn rescan_still_have_outgoing_metadata_with_sends_to_self() {
 /// the previous diversifier list.
 #[test]
 fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
-    let (regtest_manager, sender, recipient, child_process_handler) =
+    let (regtest_manager, sender, recipient, child_process_handler, mut client_builder) =
         two_clients_one_saplingcoinbase_backed();
     let mut expected_unspent_sapling_notes = json::object! {
 
@@ -427,7 +432,6 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         );
         recipient.do_seed_phrase().await.unwrap()
     });
-    let (config, _height) = utils::setup::get_config_and_height(&recipient, &regtest_manager);
     drop(recipient); // Discard original to ensure subsequent data is fresh.
     let mut expected_unspent_sapling_notes_after_restore_from_seed =
         expected_unspent_sapling_notes.clone();
@@ -435,13 +439,11 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         "Diversifier not in wallet. Perhaps you restored from seed and didn't restore addresses"
             .to_string(),
     );
-    let recipient_restored = LightClient::create_with_seedorkey_wallet(
+    let recipient_restored = client_builder.new_plantedseed_client(
         seed_of_recipient["seed"].as_str().unwrap().to_string(),
-        &config,
         0,
         true,
-    )
-    .unwrap();
+    );
     let seed_of_recipient_restored = Runtime::new().unwrap().block_on(async {
         recipient_restored.do_sync(true).await.unwrap();
         let restored_addresses = recipient_restored.do_addresses().await;
@@ -486,27 +488,12 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
 
 #[test]
 fn ensure_taddrs_from_old_seeds_work() {
-    let (regtest_manager, child_process_handler, client_a) = saplingcoinbasebacked_spendcapable();
-
-    let client_b_zingoconf_path = format!(
-        "{}_two",
-        regtest_manager.zingo_data_dir.to_string_lossy().to_string()
-    );
-    std::fs::create_dir(&client_b_zingoconf_path).unwrap();
-    let (client_b_config, _height) =
-        create_zingoconf_with_datadir(client_a.get_server_uri(), Some(client_b_zingoconf_path))
-            .unwrap();
-
+    let (_regtest_manager, child_process_handler, mut client_builder) =
+        saplingcoinbasebacked_spendcapable();
     // The first taddr generated on commit 9e71a14eb424631372fd08503b1bd83ea763c7fb
     let transparent_address = "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i";
 
-    let client_b = LightClient::create_with_seedorkey_wallet(
-        TEST_SEED.to_string(),
-        &client_b_config,
-        0,
-        false,
-    )
-    .unwrap();
+    let client_b = client_builder.new_plantedseed_client(TEST_SEED.to_string(), 0, false);
 
     Runtime::new().unwrap().block_on(async {
         client_b.do_new_address("zt").await.unwrap();

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -368,6 +368,10 @@ fn rescan_still_have_outgoing_metadata_with_sends_to_self() {
     });
 }
 
+/// An arbitrary number of diversified addresses may be generated
+/// from a seed.  If the wallet is subsequently lost-or-destroyed
+/// wallet-regeneration-from-seed (sprouting) doesn't regenerate
+/// the previous diversifier list.
 #[test]
 fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
     let (regtest_manager, client_a, client_b, child_process_handler) =

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -415,7 +415,7 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         assert_eq!(
             note,
             &expected_unspent_sapling_notes,
-            "Expected: {}\nActual: {}",
+            "\nExpected:\n{}\n===\nActual:\n{}\n",
             json::stringify_pretty(expected_unspent_sapling_notes.clone(), 4),
             json::stringify_pretty(note.clone(), 4)
         );

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -421,14 +421,12 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         );
         recipient.do_seed_phrase().await.unwrap()
     });
-    let (config, _height) = create_zingoconf_with_datadir(
-        recipient.get_server_uri(),
-        regtest_manager
-            .zingo_data_dir
-            .to_str()
-            .map(ToString::to_string),
-    )
-    .unwrap();
+    let server_id = recipient.get_server_uri();
+    let zingo_datadir = regtest_manager
+        .zingo_data_dir
+        .to_str()
+        .map(ToString::to_string);
+    let (config, _height) = create_zingoconf_with_datadir(server_id, zingo_datadir).unwrap();
     drop(recipient);
     let mut expected_unspent_sapling_notes_after_restore_from_seed =
         expected_unspent_sapling_notes.clone();
@@ -459,7 +457,8 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
             json::stringify_pretty(note.clone(), 4)
         );
 
-        //The first address in a wallet should always contain all three currently extant receiver types
+        //The first address in a wallet should always contain all three currently extant
+        //receiver types.
         let sender_address = &sender.do_addresses().await[0]["address"];
         recipient_restored
             .do_send(vec![(sender_address.as_str().unwrap(), 4_000, None)])
@@ -467,7 +466,7 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
             .unwrap();
         utils::increase_height_and_sync_client(&regtest_manager, &sender, 5).await;
 
-        //Ensure that client_b_restored was still able to spend the note, despite not having the
+        //Ensure that recipient_restored was still able to spend the note, despite not having the
         //diversified address associated with it
         assert_eq!(
             sender.do_balance().await["spendable_orchard_balance"],

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -427,7 +427,7 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         );
         recipient.do_seed_phrase().await.unwrap()
     });
-    let (config, _height) = utils::derive_client(&recipient, &regtest_manager);
+    let (config, _height) = utils::setup::get_config_and_height(&recipient, &regtest_manager);
     drop(recipient); // Discard original to ensure subsequent data is fresh.
     let mut expected_unspent_sapling_notes_after_restore_from_seed =
         expected_unspent_sapling_notes.clone();

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -391,7 +391,10 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
             "unconfirmed_spent" =>  JsonValue::Null,
 
     };
-    let original_recipient_address = "uregtest1qtqr46fwkhmdn336uuyvvxyrv0l7trgc0z9clpryx6vtladnpyt4wvq99p59f4rcyuvpmmd0hm4k5vv6j8edj6n8ltk45sdkptlk7rtzlm4uup4laq8ka8vtxzqemj3yhk6hqhuypupzryhv66w65lah9ms03xa8nref7gux2zzhjnfanxnnrnwscmz6szv2ghrurhu3jsqdx25y2yh";
+    let original_recipient_address = "\
+        uregtest1qtqr46fwkhmdn336uuyvvxyrv0l7trgc0z9clpryx6vtladnpyt4wvq99p59f4rcyuvpmmd0hm4k5vv6j\
+        8edj6n8ltk45sdkptlk7rtzlm4uup4laq8ka8vtxzqemj3yhk6hqhuypupzryhv66w65lah9ms03xa8nref7gux2zz\
+        hjnfanxnnrnwscmz6szv2ghrurhu3jsqdx25y2yh";
     let seed_of_recipient = Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &sender, 5).await;
         let addresses = recipient.do_addresses().await;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -443,7 +443,7 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         true,
     )
     .unwrap();
-    Runtime::new().unwrap().block_on(async {
+    let seed_of_recipient_restored = Runtime::new().unwrap().block_on(async {
         recipient_restored.do_sync(true).await.unwrap();
         let notes = recipient_restored.do_list_notes(true).await;
         assert_eq!(notes["unspent_sapling_notes"].members().len(), 1);
@@ -473,7 +473,9 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
             sender.do_balance().await["spendable_orchard_balance"],
             4_000
         );
+        recipient_restored.do_seed_phrase().await.unwrap()
     });
+    assert_eq!(seed_of_recipient, seed_of_recipient_restored);
     drop(child_process_handler);
 }
 

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -29,18 +29,6 @@ pub async fn increase_height_and_sync_client(
 async fn check_wallet_chainheight_value(client: &LightClient, target: u32) -> bool {
     get_synced_wallet_height(&client).await != target
 }
-pub fn derive_client(
-    reference_client: &LightClient,
-    regtest_manager: &RegtestManager,
-) -> (zingoconfig::ZingoConfig, u64) {
-    let server_id = reference_client.get_server_uri(); // Last use of original recipient
-    let zingo_datadir = regtest_manager
-        .zingo_data_dir
-        .to_str()
-        .map(ToString::to_string);
-
-    zingolib::create_zingoconf_with_datadir(server_id, zingo_datadir).unwrap()
-}
 pub mod setup {
     use crate::data;
     use std::path::PathBuf;
@@ -48,6 +36,26 @@ pub mod setup {
     use zingo_cli::regtest::{ChildProcessHandler, RegtestManager};
     use zingolib::{create_zingoconf_with_datadir, lightclient::LightClient};
 
+    struct ClientBuilder {
+        server_id: String,
+        zingo_datadir: String,
+        seed: Option<String>,
+    }
+    impl ClientBuilder {
+        pub fn get_config_and_height(
+            reference_client: &LightClient,
+            regtest_manager: &RegtestManager,
+        ) -> (zingoconfig::ZingoConfig, u64) {
+            let server_id = reference_client.get_server_uri(); // Last use of original recipient
+            let zingo_datadir = regtest_manager
+                .zingo_data_dir
+                .to_str()
+                .map(ToString::to_string);
+
+            zingolib::create_zingoconf_with_datadir(server_id, zingo_datadir).unwrap()
+        }
+    }
+    //pub fn add_nonprimary_client() -> LightClient {}
     ///  Test setup involves common configurations files.  Contents and locations
     ///  are variable.
     ///   Locations:

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -29,6 +29,18 @@ pub async fn increase_height_and_sync_client(
 async fn check_wallet_chainheight_value(client: &LightClient, target: u32) -> bool {
     get_synced_wallet_height(&client).await != target
 }
+pub fn derive_client(
+    reference_client: &LightClient,
+    regtest_manager: &RegtestManager,
+) -> (zingoconfig::ZingoConfig, u64) {
+    let server_id = reference_client.get_server_uri(); // Last use of original recipient
+    let zingo_datadir = regtest_manager
+        .zingo_data_dir
+        .to_str()
+        .map(ToString::to_string);
+
+    zingolib::create_zingoconf_with_datadir(server_id, zingo_datadir).unwrap()
+}
 pub mod setup {
     use crate::data;
     use std::path::PathBuf;


### PR DESCRIPTION
So far this is just minor tweaks to:

`handling_of_nonregenerated_diversified_addresses_after_seed_restore`

Which I intend to plagiarize to test save-during after successful batch sync.

I chose it because:
(a) It calls `do_sync`
(b) It has bearing on the consistency of addresses across restore operations