### PR TITLE
Set the rust toolchain to nightly.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This PR provides a `rust-toolchain.toml` that ensures `nightly` is used, regardless of the developer's default / ambient toolchain.

## Problem

I attempted to follow the [compiling from source](https://github.com/zingolabs/zingolib/blob/dev/README.md#compiling-from-source) README instructions and got error messages about experimental nightly features. My ambient / default rust toolchain is stable.

## Solution Verification

After placing this file in the repository root, `cargo build` succeeds.