### PR TITLE
Set reorg buffer to 1

### DIFF
--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -140,13 +140,6 @@ fn send_mined_sapling_to_orchard() {
         let balance = client.do_balance().await;
         // We send change to orchard now, so we should have the full value of the note
         // we spent, minus the transaction fee
-        assert_eq!(
-            balance["unverified_orchard_balance"],
-            625_000_000 - u64::from(DEFAULT_FEE)
-        );
-        assert_eq!(balance["verified_orchard_balance"], 0);
-        utils::increase_height_and_sync_client(&regtest_manager, &client, 1).await;
-        let balance = client.do_balance().await;
         assert_eq!(balance["unverified_orchard_balance"], 0);
         assert_eq!(
             balance["verified_orchard_balance"],

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -27,7 +27,7 @@ pub const DEFAULT_SERVER: &str = "https://mainnet.lightwalletd.com:9067";
 pub const MAX_REORG: usize = 100;
 pub const WALLET_NAME: &str = "zingo-wallet.dat";
 pub const LOGFILE_NAME: &str = "zingo-wallet.debug.log";
-pub const REORG_BUFFER_OFFSET: u32 = 4;
+pub const REORG_BUFFER_OFFSET: u32 = 1;
 pub const GAP_RULE_UNUSED_ADDRESSES: usize = if cfg!(any(target_os = "ios", target_os = "android"))
 {
     0
@@ -72,7 +72,7 @@ impl ZingoConfig {
             server_uri: Arc::new(RwLock::new(http::Uri::default())),
             chain,
             monitor_mempool: false,
-            reorg_buffer_offset: 4,
+            reorg_buffer_offset: REORG_BUFFER_OFFSET,
             data_dir: dir,
         }
     }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -27,7 +27,7 @@ pub const DEFAULT_SERVER: &str = "https://mainnet.lightwalletd.com:9067";
 pub const MAX_REORG: usize = 100;
 pub const WALLET_NAME: &str = "zingo-wallet.dat";
 pub const LOGFILE_NAME: &str = "zingo-wallet.debug.log";
-pub const REORG_BUFFER_OFFSET: u32 = 1;
+pub const REORG_BUFFER_OFFSET: u32 = 0;
 pub const GAP_RULE_UNUSED_ADDRESSES: usize = if cfg!(any(target_os = "ios", target_os = "android"))
 {
     0

--- a/lib/src/lightclient/test_server.rs
+++ b/lib/src/lightclient/test_server.rs
@@ -803,8 +803,11 @@ impl CompactTxStreamer for TestGRPCService {
         todo!()
     }
 }
-apply_scenario! {check_anchor_offset 10}
-async fn check_anchor_offset(scenario: NBlockFCBLScenario) {
+apply_scenario! {check_reorg_buffer_offset 10}
+async fn check_reorg_buffer_offset(scenario: NBlockFCBLScenario) {
     let NBlockFCBLScenario { lightclient, .. } = scenario;
-    assert_eq!(lightclient.wallet.get_anchor_height().await, 10 - 4);
+    assert_eq!(
+        lightclient.wallet.get_anchor_height().await,
+        10 - zingoconfig::REORG_BUFFER_OFFSET
+    );
 }

--- a/lib/src/wallet.rs
+++ b/lib/src/wallet.rs
@@ -361,7 +361,6 @@ impl LightWallet {
             Vec::new()
         };
 
-        //TODO: Rework read/write interface, given the opportunity to make breaking changes
         let seed_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
         let mnemonic = Mnemonic::from_entropy(seed_bytes)
             .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
@@ -633,13 +632,12 @@ impl LightWallet {
             .unwrap_or_default()
     }
 
-    // TODO:   Understand how this is used.. is it correct to add one?
-    async fn get_latest_wallet_height_plus_one(&self) -> Option<u32> {
+    async fn get_latest_wallet_height(&self) -> Option<u32> {
         self.blocks
             .read()
             .await
             .first()
-            .map(|block| block.height as u32 + 1)
+            .map(|block| block.height as u32)
     }
 
     /// Determines the target height for a transaction, and the offset from which to
@@ -1177,7 +1175,7 @@ impl LightWallet {
         println!("{}: Selecting notes", now() - start_time);
 
         let target_amount = (Amount::from_u64(total_value).unwrap() + DEFAULT_FEE).unwrap();
-        let last_height = match self.get_latest_wallet_height_plus_one().await {
+        let latest_wallet_height = match self.get_latest_wallet_height().await {
             Some(h) => BlockHeight::from_u32(h),
             None => return Err("No blocks in wallet to target, please sync first".to_string()),
         };
@@ -1209,7 +1207,9 @@ impl LightWallet {
         }
         println!("Selected notes worth {}", u64::from(selected_value));
 
-        let orchard_anchor = self.get_orchard_anchor(&orchard_notes, last_height).await?;
+        let orchard_anchor = self
+            .get_orchard_anchor(&orchard_notes, latest_wallet_height)
+            .await?;
         let mut builder = Builder::with_orchard_anchor(
             self.transaction_context.config.chain,
             submission_height,
@@ -1447,7 +1447,8 @@ impl LightWallet {
                     .iter_mut()
                     .find(|nd| nd.nullifier == selected.nullifier)
                     .unwrap();
-                spent_note.unconfirmed_spent = Some((transaction.txid(), u32::from(last_height)));
+                spent_note.unconfirmed_spent =
+                    Some((transaction.txid(), u32::from(submission_height)));
             }
             // Mark orchard notes as unconfirmed spent
             for selected in orchard_notes {
@@ -1459,7 +1460,8 @@ impl LightWallet {
                     .iter_mut()
                     .find(|nd| nd.nullifier == selected.nullifier)
                     .unwrap();
-                spent_note.unconfirmed_spent = Some((transaction.txid(), u32::from(last_height)));
+                spent_note.unconfirmed_spent =
+                    Some((transaction.txid(), u32::from(submission_height)));
             }
 
             // Mark this utxo as unconfirmed spent
@@ -1472,7 +1474,8 @@ impl LightWallet {
                     .iter_mut()
                     .find(|u| utxo.txid == u.txid && utxo.output_index == u.output_index)
                     .unwrap();
-                spent_utxo.unconfirmed_spent = Some((transaction.txid(), u32::from(last_height)));
+                spent_utxo.unconfirmed_spent =
+                    Some((transaction.txid(), u32::from(submission_height)));
             }
         }
 
@@ -1483,7 +1486,7 @@ impl LightWallet {
             self.transaction_context
                 .scan_full_tx(
                     transaction,
-                    last_height.into(),
+                    submission_height.into(),
                     true,
                     now() as u32,
                     TransactionMetadata::get_price(now(), &price),
@@ -1576,8 +1579,8 @@ mod test {
             assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.3);
         }
 
-        crate::apply_scenario! {insufficient_funds_1_present_needed_1 10}
-        async fn insufficient_funds_1_present_needed_1(scenario: NBlockFCBLScenario) {
+        crate::apply_scenario! {sufficient_funds_1_present_needed_1 10}
+        async fn sufficient_funds_1_present_needed_1(scenario: NBlockFCBLScenario) {
             let NBlockFCBLScenario {
                 lightclient,
                 data,
@@ -1601,10 +1604,10 @@ mod test {
                 .wallet
                 .select_notes_and_utxos(Amount::from_u64(1).unwrap(), false, false, false)
                 .await;
-            assert_eq!(Amount::from_u64(0).unwrap(), sufficient_funds.3);
+            assert_eq!(Amount::from_u64(1).unwrap(), sufficient_funds.3);
         }
-        crate::apply_scenario! {insufficient_funds_1_plus_txfee_present_needed_1 10}
-        async fn insufficient_funds_1_plus_txfee_present_needed_1(scenario: NBlockFCBLScenario) {
+        crate::apply_scenario! {sufficient_funds_1_plus_txfee_present_needed_1 10}
+        async fn sufficient_funds_1_plus_txfee_present_needed_1(scenario: NBlockFCBLScenario) {
             let NBlockFCBLScenario {
                 lightclient,
                 data,


### PR DESCRIPTION
Setting the buffer to 0 causes us an attempt to fetch orchard anchors from above the chain. It seems this number is 1-indexed. I'm not sure what's happening with that, exactly. Needs to be investigated. 