### PR TITLE
Verify pool upgrade paths

### DIFF
--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -42,7 +42,7 @@ fn verify_old_wallet_uses_server_height_in_send() {
 
         // Without sync push server forward 100 blocks
         utils::increase_server_height(&regtest_manager, 100).await;
-        let orchard_receiver = get_address_string!(client_receiving, "orchard");
+        let orchard_receiver = get_base_address!(client_receiving, "orchard");
         let client_wallet_height = client_sending.do_wallet_last_scanned_height().await;
 
         // Verify that wallet is still back at 6.
@@ -132,11 +132,10 @@ fn send_mined_sapling_to_orchard() {
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
 
-        let o_addr = client.do_addresses().await[0]["address"].take();
         let amount_to_send = 5_000;
         client
             .do_send(vec![(
-                o_addr.to_string().as_str(),
+                get_base_address!(client, "orchard").as_str(),
                 amount_to_send,
                 Some("Scenario test: engage!".to_string()),
             )])
@@ -160,7 +159,7 @@ fn extract_value_as_u64(input: &JsonValue) -> u64 {
     note.clone()
 }
 use zcash_primitives::transaction::components::amount::DEFAULT_FEE;
-use zingolib::get_address_string;
+use zingolib::get_base_address;
 
 #[test]
 fn note_selection_order() {
@@ -175,13 +174,7 @@ fn note_selection_order() {
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client_1, 5).await;
 
-        // Note that do_addresses returns an array, each element is a JSON representation
-        // of a UA.  Legacy addresses can be extracted from the receivers, per:
-        // <https://zips.z.cash/zip-0316>
-        //let client_2_saplingaddress = client_2.do_addresses().await[0]["receivers"]["sapling"]
-        //    .clone()
-        //    .to_string();
-        let client_2_saplingaddress = get_address_string!(client_2, "sapling");
+        let client_2_saplingaddress = get_base_address!(client_2, "sapling");
         // Send three transfers in increasing 1000 zat increments
         // These are sent from the coinbase funded client which will
         // subequently receive funding via it's orchard-packed UA.
@@ -405,7 +398,7 @@ fn rescan_still_have_outgoing_metadata_with_sends_to_self() {
     let client = client_builder.build_funded_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
-        let sapling_addr = get_address_string!(client, "sapling");
+        let sapling_addr = get_base_address!(client, "sapling");
         for memo in [None, Some("foo")] {
             client
                 .do_send(vec![(
@@ -574,9 +567,8 @@ fn ensure_taddrs_from_old_seeds_work() {
     let client_b = client_builder.build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false);
 
     Runtime::new().unwrap().block_on(async {
-        //client_b.do_new_address("zt").await.unwrap();
         assert_eq!(
-            get_address_string!(client_b, "transparent"),
+            get_base_address!(client_b, "transparent"),
             transparent_address
         )
     });

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -279,7 +279,7 @@ fn note_selection_order() {
 }
 
 #[test]
-fn from_t_z_o_tz_to_tzo_to_orchard() {
+fn from_t_z_o_tz_to_zo_tzo_to_orchard() {
     //! Test all possible promoting note source combinations
     let (regtest_manager, child_process_handler, mut client_builder) =
         scenarios::sapling_funded_client();
@@ -292,7 +292,7 @@ fn from_t_z_o_tz_to_tzo_to_orchard() {
         let pmc_unified = get_base_address!(pool_migration_client, "unified");
         // Ensure that the client has confirmed spendable funds
         utils::increase_height_and_sync_client(&regtest_manager, &sapling_fund_source, 5).await;
-        // Test of a send from a taddr only client to its own unified address
+        // 1 t Test of a send from a taddr only client to its own unified address
         sapling_fund_source
             .do_send(vec![(&pmc_taddr, 5_000, None)])
             .await
@@ -319,7 +319,7 @@ fn from_t_z_o_tz_to_tzo_to_orchard() {
             &pool_migration_client.do_balance().await["orchard_balance"],
             4_000
         );
-        // Test of a send from a sapling only client to its own unified address
+        // 2 Test of a send from a sapling only client to its own unified address
         sapling_fund_source
             .do_send(vec![(&pmc_sapling, 5_000, None)])
             .await
@@ -346,7 +346,7 @@ fn from_t_z_o_tz_to_tzo_to_orchard() {
             &pool_migration_client.do_balance().await["orchard_balance"],
             8_000
         );
-        // Test of an orchard-only client to itself
+        // 3 Test of an orchard-only client to itself
         assert_eq!(
             &pool_migration_client.do_balance().await["transparent_balance"],
             0_000
@@ -364,7 +364,7 @@ fn from_t_z_o_tz_to_tzo_to_orchard() {
             &pool_migration_client.do_balance().await["orchard_balance"],
             7_000
         );
-        // transparent and sapling to orchard
+        // 4 tz transparent and sapling to orchard
         pool_migration_client
             .do_send(vec![(&pmc_taddr, 3_000, None), (&pmc_sapling, 3_000, None)])
             .await
@@ -386,7 +386,7 @@ fn from_t_z_o_tz_to_tzo_to_orchard() {
             .do_send(vec![(&pmc_unified, 5_000, None)])
             .await
             .unwrap();
-        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 15).await;
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
         assert_eq!(
             &pool_migration_client.do_balance().await["transparent_balance"],
             0_000
@@ -398,6 +398,103 @@ fn from_t_z_o_tz_to_tzo_to_orchard() {
         assert_eq!(
             &pool_migration_client.do_balance().await["orchard_balance"],
             5_000
+        );
+        pool_migration_client
+            .do_send(vec![(&pmc_taddr, 2_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        // 5 to transparent and orchard to orchard
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            2_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            2_000
+        );
+        pool_migration_client
+            .do_send(vec![(&pmc_unified, 3_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            3_000
+        );
+        // 6 sapling and orchard to orchard
+        sapling_fund_source
+            .do_send(vec![(&pmc_sapling, 2_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            2_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            3_000
+        );
+        pool_migration_client
+            .do_send(vec![(&pmc_unified, 4_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            4_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            0_000
+        );
+        // 7 tzo --> o
+        sapling_fund_source
+            .do_send(vec![(&pmc_taddr, 2_000, None), (&pmc_sapling, 2_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            2_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            2_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            4_000
+        );
+        pool_migration_client
+            .do_send(vec![(&pmc_unified, 7_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            7_000
         );
     });
     drop(child_process_handler);

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -12,7 +12,8 @@ fn zcashd_sapling_commitment_tree() {
     //!  TODO:  Make this test assert something, what is this a test of?
     //!  TODO:  Add doc-comment explaining what constraints this test
     //!  enforces
-    let (regtest_manager, child_process_handler, _client_builder) = scenarios::funded_client();
+    let (regtest_manager, child_process_handler, _client_builder) =
+        scenarios::sapling_funded_client();
     let trees = regtest_manager
         .get_cli_handle()
         .args(["z_gettreestate", "1"])
@@ -32,7 +33,8 @@ fn verify_old_wallet_uses_server_height_in_send() {
     //! interrupting send, it made it immediately obvious that this was
     //! the wrong height to use!  The correct height is the
     //! "mempool height" which is the server_height + 1
-    let (regtest_manager, child_process_handler, mut client_builder) = scenarios::funded_client();
+    let (regtest_manager, child_process_handler, mut client_builder) =
+        scenarios::sapling_funded_client();
     let client_sending = client_builder.build_funded_client(0, false);
     let client_receiving =
         client_builder.build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false);
@@ -72,7 +74,7 @@ fn actual_empty_zcashd_sapling_commitment_tree() {
     // Setup
     let (regtest_manager, child_process_handler, _client) = scenarios::basic_no_spendable();
     // Execution:
-    let trees = regtest_manager
+    let trees = handling_of_nonregenerated_diversified_addresses_after_seed_restore
         .get_cli_handle()
         .args(["z_gettreestate", "1"])
         .output()
@@ -109,7 +111,8 @@ fn actual_empty_zcashd_sapling_commitment_tree() {
 
 #[test]
 fn mine_sapling_to_self() {
-    let (regtest_manager, child_process_handler, mut client_builder) = scenarios::funded_client();
+    let (regtest_manager, child_process_handler, mut client_builder) =
+        scenarios::sapling_funded_client();
     let client = client_builder.build_funded_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
@@ -126,7 +129,8 @@ fn send_mined_sapling_to_orchard() {
     //! debiting unverified_orchard_balance and crediting verified_orchard_balance.  The debit amount is
     //! consistent with all the notes in the relevant block changing state.
     //! NOTE that the balance doesn't give insight into the distribution across notes.
-    let (regtest_manager, child_process_handler, mut client_builder) = scenarios::funded_client();
+    let (regtest_manager, child_process_handler, mut client_builder) =
+        scenarios::sapling_funded_client();
     let client = client_builder.build_funded_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
@@ -275,6 +279,37 @@ fn note_selection_order() {
 }
 
 #[test]
+fn from_t_z_o_tz_to_tzo_to_orchard() {
+    //! Test all possible promoting note source combinations
+    let (regtest_manager, child_process_handler, mut client_builder) =
+        scenarios::sapling_funded_client();
+    let client_sending = client_builder.build_funded_client(0, false);
+    let client_receiving =
+        client_builder.build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false);
+    Runtime::new().unwrap().block_on(async {
+        // Ensure that the client has confirmed spendable funds
+        utils::increase_height_and_sync_client(&regtest_manager, &client_sending, 5).await;
+
+        // Without sync push server forward 100 blocks
+        utils::increase_server_height(&regtest_manager, 100).await;
+        let client_wallet_height = client_sending.do_wallet_last_scanned_height().await;
+
+        // Verify that wallet is still back at 6.
+        assert_eq!(client_wallet_height, 6);
+
+        // Interrupt generating send
+        client_sending
+            .do_send(vec![(
+                &get_base_address!(client_receiving, "unified"),
+                10_000,
+                Some("Interrupting sync!!".to_string()),
+            )])
+            .await
+            .unwrap();
+    });
+    drop(child_process_handler);
+}
+#[test]
 fn send_orchard_back_and_forth() {
     let (regtest_manager, client_a, client_b, child_process_handler, _) =
         scenarios::two_clients_one_saplingcoinbase_backed();
@@ -396,7 +431,8 @@ fn rescan_still_have_outgoing_metadata() {
 
 #[test]
 fn rescan_still_have_outgoing_metadata_with_sends_to_self() {
-    let (regtest_manager, child_process_handler, mut client_builder) = scenarios::funded_client();
+    let (regtest_manager, child_process_handler, mut client_builder) =
+        scenarios::sapling_funded_client();
     let client = client_builder.build_funded_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
@@ -563,7 +599,8 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
 
 #[test]
 fn ensure_taddrs_from_old_seeds_work() {
-    let (_regtest_manager, child_process_handler, mut client_builder) = scenarios::funded_client();
+    let (_regtest_manager, child_process_handler, mut client_builder) =
+        scenarios::sapling_funded_client();
     // The first taddr generated on commit 9e71a14eb424631372fd08503b1bd83ea763c7fb
     let transparent_address = "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i";
 

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -407,11 +407,11 @@ fn rescan_still_have_outgoing_metadata_with_sends_to_self() {
     let client = client_builder.build_funded_client(0, false);
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
-        let sapling_addr = client.do_new_address("tz").await.unwrap();
+        let sapling_addr = get_address_string!(client, "sapling");
         for memo in [None, Some("foo")] {
             client
                 .do_send(vec![(
-                    sapling_addr[0].as_str().unwrap(),
+                    sapling_addr.as_str(),
                     {
                         let balance = client.do_balance().await;
                         balance["spendable_sapling_balance"].as_u64().unwrap()

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -378,10 +378,11 @@ fn rescan_still_have_outgoing_metadata() {
         scenarios::two_clients_one_saplingcoinbase_backed();
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client_one, 5).await;
-        let sapling_addr_of_two = client_two.do_new_address("tz").await.unwrap();
+        let sapling_addr_of_two =
+            client_two.do_addresses().await[0]["receivers"]["sapling"].to_string();
         client_one
             .do_send(vec![(
-                sapling_addr_of_two[0].as_str().unwrap(),
+                sapling_addr_of_two.as_str(),
                 1_000,
                 Some("foo".to_string()),
             )])

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -42,7 +42,7 @@ fn verify_old_wallet_uses_server_height_in_send() {
 
         // Without sync push server forward 100 blocks
         utils::increase_server_height(&regtest_manager, 100).await;
-        let ua = client_receiving.do_new_address("o").await.unwrap()[0].to_string();
+        let orchard_receiver = client_receiving.do_addresses().await[0]["address"].take();
         let client_wallet_height = client_sending.do_wallet_last_scanned_height().await;
 
         // Verify that wallet is still back at 6.
@@ -50,7 +50,11 @@ fn verify_old_wallet_uses_server_height_in_send() {
 
         // Interrupt generating send
         client_sending
-            .do_send(vec![(&ua, 10_000, Some("Interrupting sync!!".to_string()))])
+            .do_send(vec![(
+                &orchard_receiver.to_string().as_str(),
+                10_000,
+                Some("Interrupting sync!!".to_string()),
+            )])
             .await
             .unwrap();
     });
@@ -128,7 +132,7 @@ fn send_mined_sapling_to_orchard() {
     Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &client, 5).await;
 
-        let o_addr = client.do_new_address("o").await.unwrap()[0].take();
+        let o_addr = client.do_addresses().await[0]["address"].take();
         let amount_to_send = 5_000;
         client
             .do_send(vec![(

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -50,7 +50,7 @@ fn verify_old_wallet_uses_server_height_in_send() {
         // Interrupt generating send
         client_sending
             .do_send(vec![(
-                &get_base_address!(client_receiving, "orchard"),
+                &get_base_address!(client_receiving, "unified"),
                 10_000,
                 Some("Interrupting sync!!".to_string()),
             )])
@@ -134,7 +134,7 @@ fn send_mined_sapling_to_orchard() {
         let amount_to_send = 5_000;
         client
             .do_send(vec![(
-                get_base_address!(client, "orchard").as_str(),
+                get_base_address!(client, "unified").as_str(),
                 amount_to_send,
                 Some("Scenario test: engage!".to_string()),
             )])
@@ -193,13 +193,12 @@ fn note_selection_order() {
             .unwrap();
 
         utils::increase_height_and_sync_client(&regtest_manager, &client_2, 5).await;
-        let client_1_orchard = get_base_address!(client_1, "orchard");
         // We know that the largest single note that 2 received from 1 was 3000, for 2 to send
         // 3000 back to 1 it will have to collect funds from two notes to pay the full 3000
         // plus the transaction fee.
         client_2
             .do_send(vec![(
-                &client_1_orchard,
+                &get_base_address!(client_1, "unified"),
                 3000,
                 Some("Sending back, should have 2 inputs".to_string()),
             )])
@@ -284,7 +283,7 @@ fn send_orchard_back_and_forth() {
 
         client_a
             .do_send(vec![(
-                &get_base_address!(client_b, "orchard"),
+                &get_base_address!(client_b, "unified"),
                 10_000,
                 Some("Orcharding".to_string()),
             )])

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -194,13 +194,13 @@ fn note_selection_order() {
             .unwrap();
 
         utils::increase_height_and_sync_client(&regtest_manager, &client_2, 5).await;
-        let client_1_unifiedaddress = client_1.do_addresses().await[0]["address"].clone();
+        let client_1_orchard = get_base_address!(client_1, "orchard");
         // We know that the largest single note that 2 received from 1 was 3000, for 2 to send
         // 3000 back to 1 it will have to collect funds from two notes to pay the full 3000
         // plus the transaction fee.
         client_2
             .do_send(vec![(
-                &client_1_unifiedaddress.to_string(),
+                &client_1_orchard,
                 3000,
                 Some("Sending back, should have 2 inputs".to_string()),
             )])

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -42,9 +42,7 @@ fn verify_old_wallet_uses_server_height_in_send() {
 
         // Without sync push server forward 100 blocks
         utils::increase_server_height(&regtest_manager, 100).await;
-        let orchard_receiver = client_receiving.do_addresses().await[0]["address"]
-            .take()
-            .to_string();
+        let orchard_receiver = get_address_string!(client_receiving, "orchard");
         let client_wallet_height = client_sending.do_wallet_last_scanned_height().await;
 
         // Verify that wallet is still back at 6.
@@ -576,11 +574,9 @@ fn ensure_taddrs_from_old_seeds_work() {
     let client_b = client_builder.build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false);
 
     Runtime::new().unwrap().block_on(async {
-        client_b.do_new_address("zt").await.unwrap();
-        let addresses = client_b.do_addresses().await;
-        println!("{}", json::stringify_pretty(addresses.clone(), 4));
+        //client_b.do_new_address("zt").await.unwrap();
         assert_eq!(
-            addresses[0]["receivers"]["transparent"].to_string(),
+            get_address_string!(client_b, "transparent"),
             transparent_address
         )
     });

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -302,7 +302,7 @@ fn send_orchard_back_and_forth() {
 
         client_b
             .do_send(vec![(
-                &get_base_address!(client_a, "orchard"),
+                &get_base_address!(client_a, "unified"),
                 5_000,
                 Some("Sending back".to_string()),
             )])
@@ -473,7 +473,7 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
     let seed_of_recipient = Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &sender, 5).await;
         assert_eq!(
-            &get_base_address!(recipient, "orchard"),
+            &get_base_address!(recipient, "unified"),
             &original_recipient_address
         );
         let recipient_addr = recipient.do_new_address("tz").await.unwrap();
@@ -540,7 +540,7 @@ fn handling_of_nonregenerated_diversified_addresses_after_seed_restore() {
         //The first address in a wallet should always contain all three currently extant
         //receiver types.
         recipient_restored
-            .do_send(vec![(&get_base_address!(sender, "orchard"), 4_000, None)])
+            .do_send(vec![(&get_base_address!(sender, "unified"), 4_000, None)])
             .await
             .unwrap();
         let sender_balance = sender.do_balance().await;
@@ -755,7 +755,7 @@ fn send_to_ua_saves_full_ua_in_wallet() {
         scenarios::two_clients_one_saplingcoinbase_backed();
     tokio::runtime::Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &sender, 5).await;
-        let recipient_orchard_address = get_base_address!(recipient, "orchard");
+        let recipient_orchard_address = get_base_address!(recipient, "unified");
         let sent_value = 50_000;
         sender
             .do_send(vec![(recipient_orchard_address.as_str(), sent_value, None)])

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -42,7 +42,6 @@ fn verify_old_wallet_uses_server_height_in_send() {
 
         // Without sync push server forward 100 blocks
         utils::increase_server_height(&regtest_manager, 100).await;
-        let orchard_receiver = get_base_address!(client_receiving, "orchard");
         let client_wallet_height = client_sending.do_wallet_last_scanned_height().await;
 
         // Verify that wallet is still back at 6.
@@ -51,7 +50,7 @@ fn verify_old_wallet_uses_server_height_in_send() {
         // Interrupt generating send
         client_sending
             .do_send(vec![(
-                &orchard_receiver.as_str(),
+                &get_base_address!(client_receiving, "orchard"),
                 10_000,
                 Some("Interrupting sync!!".to_string()),
             )])

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -42,7 +42,9 @@ fn verify_old_wallet_uses_server_height_in_send() {
 
         // Without sync push server forward 100 blocks
         utils::increase_server_height(&regtest_manager, 100).await;
-        let orchard_receiver = client_receiving.do_addresses().await[0]["address"].take();
+        let orchard_receiver = client_receiving.do_addresses().await[0]["address"]
+            .take()
+            .to_string();
         let client_wallet_height = client_sending.do_wallet_last_scanned_height().await;
 
         // Verify that wallet is still back at 6.
@@ -51,7 +53,7 @@ fn verify_old_wallet_uses_server_height_in_send() {
         // Interrupt generating send
         client_sending
             .do_send(vec![(
-                &orchard_receiver.to_string().as_str(),
+                &orchard_receiver.as_str(),
                 10_000,
                 Some("Interrupting sync!!".to_string()),
             )])
@@ -160,6 +162,7 @@ fn extract_value_as_u64(input: &JsonValue) -> u64 {
     note.clone()
 }
 use zcash_primitives::transaction::components::amount::DEFAULT_FEE;
+use zingolib::get_address_string;
 
 #[test]
 fn note_selection_order() {
@@ -177,10 +180,10 @@ fn note_selection_order() {
         // Note that do_addresses returns an array, each element is a JSON representation
         // of a UA.  Legacy addresses can be extracted from the receivers, per:
         // <https://zips.z.cash/zip-0316>
-        let client_2_saplingaddress = client_2.do_addresses().await[0]["receivers"]["sapling"]
-            .clone()
-            .to_string();
-
+        //let client_2_saplingaddress = client_2.do_addresses().await[0]["receivers"]["sapling"]
+        //    .clone()
+        //    .to_string();
+        let client_2_saplingaddress = get_address_string!(client_2, "sapling");
         // Send three transfers in increasing 1000 zat increments
         // These are sent from the coinbase funded client which will
         // subequently receive funding via it's orchard-packed UA.
@@ -398,7 +401,6 @@ fn rescan_still_have_outgoing_metadata() {
     });
 }
 
-///
 #[test]
 fn rescan_still_have_outgoing_metadata_with_sends_to_self() {
     let (regtest_manager, child_process_handler, mut client_builder) = scenarios::funded_client();

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -496,6 +496,41 @@ fn from_t_z_o_tz_to_zo_tzo_to_orchard() {
             &pool_migration_client.do_balance().await["orchard_balance"],
             7_000
         );
+        // Send from Sapling into empty Orchard pool
+        pool_migration_client
+            .do_send(vec![(&pmc_sapling, 6_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            6_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            0_000
+        );
+        pool_migration_client
+            .do_send(vec![(&pmc_unified, 5_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            5_000
+        );
     });
     drop(child_process_handler);
 }

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -1017,10 +1017,10 @@ fn send_to_ua_saves_full_ua_in_wallet() {
         scenarios::two_clients_one_saplingcoinbase_backed();
     tokio::runtime::Runtime::new().unwrap().block_on(async {
         utils::increase_height_and_sync_client(&regtest_manager, &sender, 5).await;
-        let recipient_orchard_address = get_base_address!(recipient, "unified");
+        let recipient_unified_address = get_base_address!(recipient, "unified");
         let sent_value = 50_000;
         sender
-            .do_send(vec![(recipient_orchard_address.as_str(), sent_value, None)])
+            .do_send(vec![(recipient_unified_address.as_str(), sent_value, None)])
             .await
             .unwrap();
         utils::increase_height_and_sync_client(&regtest_manager, &sender, 3).await;
@@ -1028,7 +1028,7 @@ fn send_to_ua_saves_full_ua_in_wallet() {
         assert!(list.members().any(|transaction| {
             transaction.entries().any(|(key, value)| {
                 if key == "outgoing_metadata" {
-                    value[0]["address"] == recipient_orchard_address
+                    value[0]["address"] == recipient_unified_address
                 } else {
                     false
                 }
@@ -1039,7 +1039,7 @@ fn send_to_ua_saves_full_ua_in_wallet() {
         assert!(new_list.members().any(|transaction| {
             transaction.entries().any(|(key, value)| {
                 if key == "outgoing_metadata" {
-                    value[0]["address"] == recipient_orchard_address
+                    value[0]["address"] == recipient_unified_address
                 } else {
                     false
                 }

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -364,6 +364,41 @@ fn from_t_z_o_tz_to_tzo_to_orchard() {
             &pool_migration_client.do_balance().await["orchard_balance"],
             7_000
         );
+        // transparent and sapling to orchard
+        pool_migration_client
+            .do_send(vec![(&pmc_taddr, 3_000, None), (&pmc_sapling, 3_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 5).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            3_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            3_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            0_000
+        );
+        pool_migration_client
+            .do_send(vec![(&pmc_unified, 5_000, None)])
+            .await
+            .unwrap();
+        utils::increase_height_and_sync_client(&regtest_manager, &pool_migration_client, 15).await;
+        assert_eq!(
+            &pool_migration_client.do_balance().await["transparent_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["sapling_balance"],
+            0_000
+        );
+        assert_eq!(
+            &pool_migration_client.do_balance().await["orchard_balance"],
+            5_000
+        );
     });
     drop(child_process_handler);
 }

--- a/zingocli/tests/utils/mod.rs
+++ b/zingocli/tests/utils/mod.rs
@@ -255,7 +255,7 @@ pub mod scenarios {
     /// and zcashd (in regtest mode). This setup is intended to produce the most basic  
     /// of scenarios.  As scenarios with even less requirements
     /// become interesting (e.g. without experimental features, or txindices) we'll create more setups.
-    pub fn funded_client() -> (RegtestManager, ChildProcessHandler, setup::ClientBuilder) {
+    pub fn sapling_funded_client() -> (RegtestManager, ChildProcessHandler, setup::ClientBuilder) {
         let mut sb = setup::ScenarioBuilder::new();
         //tracing_subscriber::fmt::init();
         sb.test_env
@@ -311,7 +311,7 @@ pub mod scenarios {
         ChildProcessHandler,
         setup::ClientBuilder,
     ) {
-        let (regtest_manager, child_process_handler, mut client_builder) = funded_client();
+        let (regtest_manager, child_process_handler, mut client_builder) = sapling_funded_client();
         let client_one = client_builder.build_funded_client(0, false);
         let seed_phrase_of_two = zcash_primitives::zip339::Mnemonic::from_entropy([1; 32])
             .unwrap()

--- a/zingolib/src/test_framework/macros.rs
+++ b/zingolib/src/test_framework/macros.rs
@@ -15,8 +15,11 @@ macro_rules! apply_scenario {
     };
 }
 
+// Note that do_addresses returns an array, each element is a JSON representation
+// of a UA.  Legacy addresses can be extracted from the receivers, per:
+// <https://zips.z.cash/zip-0316>
 #[macro_export]
-macro_rules! get_address_string {
+macro_rules! get_base_address {
     ($client:ident, $address_protocol:literal) => {
         match $address_protocol {
             "orchard" => $client.do_addresses().await[0]["address"]

--- a/zingolib/src/test_framework/macros.rs
+++ b/zingolib/src/test_framework/macros.rs
@@ -22,6 +22,7 @@ macro_rules! apply_scenario {
 macro_rules! get_base_address {
     ($client:ident, $address_protocol:literal) => {
         match $address_protocol {
+            "unified" => $client.do_addresses().await[0].clone().to_string(),
             "orchard" => $client.do_addresses().await[0]["address"]
                 .take()
                 .to_string(),

--- a/zingolib/src/test_framework/macros.rs
+++ b/zingolib/src/test_framework/macros.rs
@@ -22,8 +22,7 @@ macro_rules! apply_scenario {
 macro_rules! get_base_address {
     ($client:ident, $address_protocol:literal) => {
         match $address_protocol {
-            "unified" => $client.do_addresses().await[0].clone().to_string(),
-            "orchard" => $client.do_addresses().await[0]["address"]
+            "unified" => $client.do_addresses().await[0]["address"]
                 .take()
                 .to_string(),
             "sapling" => $client.do_addresses().await[0]["receivers"]["sapling"]

--- a/zingolib/src/test_framework/macros.rs
+++ b/zingolib/src/test_framework/macros.rs
@@ -14,3 +14,21 @@ macro_rules! apply_scenario {
         );
     };
 }
+
+#[macro_export]
+macro_rules! get_address_string {
+    ($client:ident, $address_protocol:literal) => {
+        match $address_protocol {
+            "orchard" => $client.do_addresses().await[0]["address"]
+                .take()
+                .to_string(),
+            "sapling" => $client.do_addresses().await[0]["receivers"]["sapling"]
+                .clone()
+                .to_string(),
+            "transparent" => $client.do_addresses().await[0]["receivers"]["transparent"]
+                .clone()
+                .to_string(),
+            _ => "ERROR".to_string(),
+        }
+    };
+}


### PR DESCRIPTION
I think this verifies that all the 7 possible clearances of lower-protocol pools into orchard for self-spends achieves the correct balances.