### PR TITLE
change type names to be more human readable

### DIFF
--- a/zingo-memo/src/lib.rs
+++ b/zingo-memo/src/lib.rs
@@ -57,7 +57,7 @@ pub fn read_wallet_internal_memo(memo: [u8; 511]) -> io::Result<ParsedMemo> {
 
 /// A helper function to encode a UA as a CompactSize specifying the number
 /// of receivers, followed by the UA's raw encoding as specified in
-/// https://zips.z.cash/zip-0316#encoding-of-unified-addresses
+/// <https://zips.z.cash/zip-0316#encoding-of-unified-addresses>
 pub fn write_unified_address_to_raw_encoding<W: Write>(
     ua: &UnifiedAddress,
     writer: W,
@@ -81,7 +81,7 @@ pub fn write_unified_address_to_raw_encoding<W: Write>(
 
 /// A helper function to decode a UA from a CompactSize specifying the number of
 /// receivers, followed by the UA's raw encoding as specified in
-/// https://zips.z.cash/zip-0316#encoding-of-unified-addresses
+/// <https://zips.z.cash/zip-0316#encoding-of-unified-addresses>
 pub fn read_unified_address_from_raw_encoding<R: Read>(reader: R) -> io::Result<UnifiedAddress> {
     let receivers = Vector::read(reader, |mut r| {
         let typecode: usize = CompactSize::read_t(&mut r)?;

--- a/zingo-memo/src/lib.rs
+++ b/zingo-memo/src/lib.rs
@@ -18,7 +18,7 @@ pub enum ParsedMemo {
 /// Note that a UA's raw representation is 1 byte for length, +21 for a T-receiver,
 /// +44 for a Sapling receiver, and +44 for an Orchard receiver. This totals a maximum
 /// of 110 bytes per UA, and attempting to write more than 510 bytes will cause an error.
-pub fn create_wallet_internal_memo_version_0(uas: &[UnifiedAddress]) -> io::Result<[u8; 511]> {
+pub fn pack_with_uas(uas: &[UnifiedAddress]) -> io::Result<[u8; 511]> {
     let mut uas_bytes_vec = Vec::new();
     CompactSize::write(&mut uas_bytes_vec, 0usize)?;
     Vector::write(&mut uas_bytes_vec, uas, |mut w, ua| {
@@ -37,7 +37,7 @@ pub fn create_wallet_internal_memo_version_0(uas: &[UnifiedAddress]) -> io::Resu
 }
 
 /// Attempts to parse the 511 bytes of an arbitrary data memo
-pub fn read_wallet_internal_memo(memo: [u8; 511]) -> io::Result<ParsedMemo> {
+pub fn read_plaintext(memo: [u8; 511]) -> io::Result<ParsedMemo> {
     let mut reader: &[u8] = &memo;
     match CompactSize::read(&mut reader)? {
         0 => Ok(ParsedMemo::Version0 {

--- a/zingocli/Cargo.toml
+++ b/zingocli/Cargo.toml
@@ -12,7 +12,7 @@ json = "0.12.4"
 http = "0.2.8"
 tokio =  { version = "1.24.2", features = ["full"] }
 
-zingolib = { path = "../zingolib/" }
+zingolib = { path = "../zingolib/", features = ["integration_test"] }
 zingoconfig = { path = "../zingoconfig/" }
 zingtaddrfix = { git = "https://github.com/zingolabs/zingolib", package = "zingolib", rev = "f8fb624237fd4923512cc065620b55230676ab82", optional = true }
 

--- a/zingocli/tests/utils/mod.rs
+++ b/zingocli/tests/utils/mod.rs
@@ -66,7 +66,7 @@ pub mod scenarios {
         pub struct ScenarioBuilder {
             pub test_env: TestEnvironmentGenerator,
             pub regtest_manager: RegtestManager,
-            pub client_builder: ClientBuilder,
+            pub client_builder: ClientManager,
             pub child_process_handler: Option<ChildProcessHandler>,
         }
         impl ScenarioBuilder {
@@ -83,7 +83,7 @@ pub mod scenarios {
                 let server_id = zingoconfig::construct_server_uri(Some(format!(
                     "http://127.0.0.1:{lightwalletd_port}"
                 )));
-                let client_builder = ClientBuilder::new(
+                let client_builder = ClientManager::new(
                     server_id,
                     regtest_manager.zingo_datadir.clone(),
                     data::seeds::ABANDON_ART_SEED,
@@ -116,24 +116,24 @@ pub mod scenarios {
 
         /// Internally (and perhaps in wider scopes) we say "Sprout" to mean
         /// take a seed, and generate a client from the seed (planted in the chain).
-        pub struct ClientBuilder {
+        pub struct ClientManager {
             server_id: http::Uri,
             zingo_datadir: PathBuf,
             seed: String,
             client_number: u8,
         }
-        impl ClientBuilder {
+        impl ClientManager {
             pub fn new(server_id: http::Uri, zingo_datadir: PathBuf, seed: &str) -> Self {
                 let seed = seed.to_string();
                 let client_number = 0;
-                ClientBuilder {
+                ClientManager {
                     server_id,
                     zingo_datadir,
                     seed,
                     client_number,
                 }
             }
-            fn make_config(&mut self) -> (zingoconfig::ZingoConfig, u64) {
+            fn make_new_zing_configdir(&mut self) -> (zingoconfig::ZingoConfig, u64) {
                 //! Each client requires a unique data_dir, we use the
                 //! client_number counter for this.
                 self.client_number += 1;
@@ -142,18 +142,16 @@ pub mod scenarios {
                     self.zingo_datadir.to_string_lossy().to_string(),
                     self.client_number
                 );
-                dbg!(&conf_path);
                 std::fs::create_dir(&conf_path).unwrap();
-
                 zingolib::create_zingoconf_from_datadir(self.server_id.clone(), Some(conf_path))
                     .unwrap()
             }
-            pub fn build_unfunded_client(&mut self, birthday: u64) -> LightClient {
-                let (zingo_config, _) = self.make_config();
+            pub fn build_new_unfunded_client(&mut self, birthday: u64) -> LightClient {
+                let (zingo_config, _) = self.make_new_zing_configdir();
                 LightClient::new(&zingo_config, birthday).unwrap()
             }
-            pub fn build_funded_client(&mut self, birthday: u64, overwrite: bool) -> LightClient {
-                let (zingo_config, _) = self.make_config();
+            pub fn build_new_faucet(&mut self, birthday: u64, overwrite: bool) -> LightClient {
+                let (zingo_config, _) = self.make_new_zing_configdir();
                 LightClient::create_with_seedorkey_wallet(
                     self.seed.clone(),
                     &zingo_config,
@@ -169,7 +167,7 @@ pub mod scenarios {
                 birthday: u64,
                 overwrite: bool,
             ) -> LightClient {
-                let (zingo_config, _) = self.make_config();
+                let (zingo_config, _) = self.make_new_zing_configdir();
                 LightClient::create_with_seedorkey_wallet(seed, &zingo_config, birthday, overwrite)
                     .unwrap()
             }
@@ -204,8 +202,6 @@ pub mod scenarios {
             }
             pub(crate) fn create_unfunded_zcash_conf(&self) -> PathBuf {
                 //! Side effect only fn, writes to FS.
-                dbg!(&self.zcashd_rpcservice_port);
-                dbg!(&self.lightwalletd_rpcservice_port);
                 self.write_contents_and_return_path(
                     "zcash",
                     data::config_template_fillers::zcashd::basic(&self.zcashd_rpcservice_port, ""),
@@ -255,7 +251,7 @@ pub mod scenarios {
     /// and zcashd (in regtest mode). This setup is intended to produce the most basic  
     /// of scenarios.  As scenarios with even less requirements
     /// become interesting (e.g. without experimental features, or txindices) we'll create more setups.
-    pub fn sapling_funded_client() -> (RegtestManager, ChildProcessHandler, setup::ClientBuilder) {
+    pub fn sapling_funded_client() -> (RegtestManager, ChildProcessHandler, setup::ClientManager) {
         let mut sb = setup::ScenarioBuilder::new();
         //tracing_subscriber::fmt::init();
         sb.test_env
@@ -309,10 +305,10 @@ pub mod scenarios {
         LightClient,
         LightClient,
         ChildProcessHandler,
-        setup::ClientBuilder,
+        setup::ClientManager,
     ) {
         let (regtest_manager, child_process_handler, mut client_builder) = sapling_funded_client();
-        let client_one = client_builder.build_funded_client(0, false);
+        let client_one = client_builder.build_new_faucet(0, false);
         let seed_phrase_of_two = zcash_primitives::zip339::Mnemonic::from_entropy([1; 32])
             .unwrap()
             .to_string();
@@ -373,7 +369,7 @@ pub mod scenarios {
         (
             scenario_builder.regtest_manager,
             scenario_builder.child_process_handler.unwrap(),
-            scenario_builder.client_builder.build_unfunded_client(0),
+            scenario_builder.client_builder.build_new_unfunded_client(0),
         )
     }
 }

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [features]
 default = ["embed_params"]
+integration_test = []
 embed_params = []
 
 [dependencies]

--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -6,10 +6,10 @@
 use crate::{
     compact_formats::{CompactBlock, CompactTx},
     wallet::{
-        data::{PoolNullifier, TransactionMetadata},
+        data::{PoolNullifier, WalletTransaction},
         keys::unified::UnifiedSpendCapability,
         traits::{CompactOutput as _, DomainWalletExt, ReceivedNoteAndMetadata as _},
-        transactions::TransactionMetadataSet,
+        transactions::WalletTransactions,
         MemoDownloadOption,
     },
 };
@@ -36,7 +36,7 @@ use super::syncdata::BlazeSyncData;
 
 pub struct TrialDecryptions {
     usc: Arc<RwLock<UnifiedSpendCapability>>,
-    transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
+    transaction_metadata_set: Arc<RwLock<WalletTransactions>>,
     config: Arc<ZingoConfig>,
 }
 
@@ -44,7 +44,7 @@ impl TrialDecryptions {
     pub fn new(
         config: Arc<ZingoConfig>,
         usc: Arc<RwLock<UnifiedSpendCapability>>,
-        transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
+        transaction_metadata_set: Arc<RwLock<WalletTransactions>>,
     ) -> Self {
         Self {
             config,
@@ -148,7 +148,7 @@ impl TrialDecryptions {
         bsync_data: Arc<RwLock<BlazeSyncData>>,
         sapling_ivk: SaplingIvk,
         orchard_ivk: OrchardIvk,
-        transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
+        transaction_metadata_set: Arc<RwLock<WalletTransactions>>,
         transaction_size_filter: Option<u32>,
         detected_transaction_id_sender: UnboundedSender<(
             TxId,
@@ -213,7 +213,7 @@ impl TrialDecryptions {
                 // Note the memos are immediately discarded.
                 // Perhaps this obfuscates the memos of interest?
                 if !transaction_metadata && download_memos == MemoDownloadOption::AllMemos {
-                    let transaction_id = TransactionMetadata::new_txid(&compact_transaction.hash);
+                    let transaction_id = WalletTransaction::new_txid(&compact_transaction.hash);
                     let (transmitter, receiver) = oneshot::channel();
                     full_transaction_fetcher
                         .send((transaction_id, transmitter))
@@ -252,7 +252,7 @@ impl TrialDecryptions {
         config: &zingoconfig::ZingoConfig,
         usc: &Arc<RwLock<UnifiedSpendCapability>>,
         bsync_data: &Arc<RwLock<BlazeSyncData>>,
-        transaction_metadata_set: &Arc<RwLock<TransactionMetadataSet>>,
+        transaction_metadata_set: &Arc<RwLock<WalletTransactions>>,
         detected_transaction_id_sender: &UnboundedSender<(
             TxId,
             PoolNullifier,
@@ -306,7 +306,7 @@ impl TrialDecryptions {
                         )
                         .await?;
 
-                    let transaction_id = TransactionMetadata::new_txid(&compact_transaction.hash);
+                    let transaction_id = WalletTransaction::new_txid(&compact_transaction.hash);
                     let nullifier = D::WalletNote::get_nullifier_from_note_fvk_and_witness_position(
                         &note,
                         &fvk,

--- a/zingolib/src/blaze/update_notes.rs
+++ b/zingolib/src/blaze/update_notes.rs
@@ -1,8 +1,8 @@
 use crate::wallet::traits::{DomainWalletExt, ReceivedNoteAndMetadata};
 use crate::wallet::MemoDownloadOption;
 use crate::wallet::{
-    data::{PoolNullifier, TransactionMetadata},
-    transactions::TransactionMetadataSet,
+    data::{PoolNullifier, WalletTransaction},
+    transactions::WalletTransactions,
 };
 use std::sync::Arc;
 
@@ -30,11 +30,11 @@ use super::syncdata::BlazeSyncData;
 /// If No, then:
 ///    - Update the witness for this note
 pub struct UpdateNotes {
-    transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
+    transaction_metadata_set: Arc<RwLock<WalletTransactions>>,
 }
 
 impl UpdateNotes {
-    pub fn new(wallet_txns: Arc<RwLock<TransactionMetadataSet>>) -> Self {
+    pub fn new(wallet_txns: Arc<RwLock<WalletTransactions>>) -> Self {
         Self {
             transaction_metadata_set: wallet_txns,
         }
@@ -42,7 +42,7 @@ impl UpdateNotes {
 
     async fn update_witnesses(
         bsync_data: Arc<RwLock<BlazeSyncData>>,
-        wallet_txns: Arc<RwLock<TransactionMetadataSet>>,
+        wallet_txns: Arc<RwLock<WalletTransactions>>,
         txid: TxId,
         nullifier: PoolNullifier,
         output_num: Option<u32>,
@@ -73,7 +73,7 @@ impl UpdateNotes {
 
     async fn update_witnesses_inner<D: DomainWalletExt>(
         bsync_data: Arc<RwLock<BlazeSyncData>>,
-        wallet_txns: Arc<RwLock<TransactionMetadataSet>>,
+        wallet_txns: Arc<RwLock<WalletTransactions>>,
         txid: TxId,
         nullifier: <D::WalletNote as ReceivedNoteAndMetadata>::Nullifier,
         output_num: Option<u32>,
@@ -202,7 +202,7 @@ impl UpdateNotes {
                             .await;
 
                         let spent_transaction_id =
-                            TransactionMetadata::new_txid(&compact_transaction.hash);
+                            WalletTransaction::new_txid(&compact_transaction.hash);
                         let spent_at_height = BlockHeight::from_u32(spent_height as u32);
 
                         // Mark this note as being spent

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -249,6 +249,20 @@ impl LightClient {
         }
     }
 }
+
+#[cfg(feature = "integration_test")]
+impl LightClient {
+    pub fn create_with_wallet(wallet: LightWallet, config: ZingoConfig) -> Self {
+        LightClient {
+            wallet,
+            config: config.clone(),
+            mempool_monitor: std::sync::RwLock::new(None),
+            sync_lock: Mutex::new(()),
+            bsync_data: Arc::new(RwLock::new(BlazeSyncData::new(&config))),
+            interrupt_sync: Arc::new(RwLock::new(false)),
+        }
+    }
+}
 impl LightClient {
     pub fn create_unconnected(
         config: &ZingoConfig,

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -8,7 +8,7 @@ use crate::{
     compact_formats::RawTransaction,
     grpc_connector::GrpcConnector,
     wallet::{
-        data::TransactionMetadata,
+        data::WalletTransaction,
         keys::{
             address_from_pubkeyhash,
             unified::{ReceiverSelection, UnifiedSpendCapability},
@@ -1043,7 +1043,7 @@ impl LightClient {
 
     fn add_wallet_notes_in_transaction_to_list<'a, 'b, 'c>(
         &'a self,
-        transaction_metadata: &'b TransactionMetadata,
+        transaction_metadata: &'b WalletTransaction,
         include_memo_hex: &'b bool,
         unified_spend_auth: &'c UnifiedSpendCapability,
     ) -> impl Iterator<Item = JsonValue> + 'b
@@ -1067,7 +1067,7 @@ impl LightClient {
 
     fn add_wallet_notes_in_transaction_to_list_inner<'a, 'b, 'c, D>(
         &'a self,
-        transaction_metadata: &'b TransactionMetadata,
+        transaction_metadata: &'b WalletTransaction,
         include_memo_hex: &'b bool,
         unified_spend_auth: &'c UnifiedSpendCapability,
     ) -> impl Iterator<Item = JsonValue> + 'b
@@ -1236,7 +1236,7 @@ impl LightClient {
                                 BlockHeight::from_u32(rtransaction.height as u32),
                                 true,
                                 now() as u32,
-                                TransactionMetadata::get_price(now(), &price),
+                                WalletTransaction::get_price(now(), &price),
                             )
                             .await;
                         }

--- a/zingolib/src/lightclient/test_server.rs
+++ b/zingolib/src/lightclient/test_server.rs
@@ -11,7 +11,7 @@ use crate::compact_formats::{
     LightdInfo, PingResponse, RawTransaction, SendResponse, TransparentAddressBlockFilter,
     TreeState, TxFilter,
 };
-use crate::wallet::data::TransactionMetadata;
+use crate::wallet::data::WalletTransaction;
 use futures::{FutureExt, Stream};
 use rand::rngs::OsRng;
 use rand::Rng;
@@ -560,7 +560,7 @@ impl CompactTxStreamer for TestGRPCService {
     ) -> Result<Response<RawTransaction>, Status> {
         Self::wait_random().await;
 
-        let transaction_id = TransactionMetadata::new_txid(&request.into_inner().hash);
+        let transaction_id = WalletTransaction::new_txid(&request.into_inner().hash);
         match self.data.read().await.transactions.get(&transaction_id) {
             Some((_taddrs, transaction)) => Ok(Response::new(transaction.clone())),
             None => Err(Status::invalid_argument(format!(

--- a/zingolib/src/lightclient/tests.rs
+++ b/zingolib/src/lightclient/tests.rs
@@ -27,7 +27,7 @@ use crate::lightclient::test_server::{
     clean_shutdown, create_test_server, mine_numblocks_each_with_two_sap_txs, mine_pending_blocks,
 };
 use crate::lightclient::LightClient;
-use crate::wallet::data::{ReceivedSaplingNoteAndMetadata, TransactionMetadata};
+use crate::wallet::data::{ReceivedSaplingNoteAndMetadata, WalletTransaction};
 use crate::wallet::keys::unified::get_transparent_secretkey_pubkey_taddr;
 use crate::wallet::traits::ReadableWriteable;
 
@@ -1032,7 +1032,7 @@ async fn aborted_resync(scenario: NBlockFCBLScenario) {
         .read()
         .await
         .current
-        .get(&TransactionMetadata::new_txid(
+        .get(&WalletTransaction::new_txid(
             &hex::decode(sent_transaction_id.clone())
                 .unwrap()
                 .into_iter()
@@ -1065,7 +1065,7 @@ async fn aborted_resync(scenario: NBlockFCBLScenario) {
         .read()
         .await
         .current
-        .get(&TransactionMetadata::new_txid(
+        .get(&WalletTransaction::new_txid(
             &hex::decode(sent_transaction_id)
                 .unwrap()
                 .into_iter()

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -258,10 +258,7 @@ impl LightWallet {
     /// some source ("external") and which is represented as a source-code constant
     /// ("internal").
 
-    pub(crate) async fn read_internal<R: Read>(
-        mut reader: R,
-        config: &ZingoConfig,
-    ) -> io::Result<Self> {
+    pub async fn read_internal<R: Read>(mut reader: R, config: &ZingoConfig) -> io::Result<Self> {
         let external_version = reader.read_u64::<LittleEndian>()?;
         if external_version > Self::serialized_version() {
             let e = format!(

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -493,7 +493,7 @@ impl OutgoingTxMetadata {
     }
 }
 
-pub struct TransactionMetadata {
+pub struct WalletTransaction {
     // Block in which this tx was included
     pub block_height: BlockHeight,
 
@@ -541,7 +541,7 @@ pub struct TransactionMetadata {
     pub zec_price: Option<f64>,
 }
 
-impl TransactionMetadata {
+impl WalletTransaction {
     pub fn serialized_version() -> u64 {
         return 23;
     }
@@ -585,7 +585,7 @@ impl TransactionMetadata {
         transaction_id: &TxId,
         unconfirmed: bool,
     ) -> Self {
-        TransactionMetadata {
+        WalletTransaction {
             block_height: height,
             unconfirmed,
             datetime,

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -140,6 +140,9 @@ impl TransactionMetadataSet {
                 .current
                 .iter()
                 .collect::<Vec<(&TxId, &TransactionMetadata)>>();
+            // Don't write down metadata for transactions in the mempool, we'll rediscover
+            // it on reload
+            transaction_metadatas.retain(|metadata| !metadata.1.unconfirmed);
             transaction_metadatas.sort_by(|a, b| a.0.partial_cmp(b.0).unwrap());
 
             Vector::write(&mut writer, &transaction_metadatas, |w, (k, v)| {


### PR DESCRIPTION
@jarys

This naming scheme seems easier to parse and understand to me.   I certainly had a hand in the previous names, but after more experience I feel like they're unwieldy and not really more explicit.
For the moment I left the local variables with 'metadata' containing idents.  I'm not sure that's a bad thing.   Obviously this PR might be irritating due to conflicts, so I will leave it draft.