### PR TITLE
[#267] debug output leaking into CLI non-interactive calls

### DIFF
--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -429,12 +429,14 @@ pub fn startup(
         }
     };
 
-    // Print startup Messages
-    info!(""); // Blank line
-    info!("Starting Zingo-CLI");
-    info!("Light Client config {:?}", config);
+    if filled_template.command.is_none() {
+        // Print startup Messages
+        info!(""); // Blank line
+        info!("Starting Zingo-CLI");
+        info!("Light Client config {:?}", config);
 
-    println!("Lightclient connecting to {}", config.get_server_uri());
+        info!("Lightclient connecting to {}", config.get_server_uri());
+    }
 
     // At startup, run a sync.
     if filled_template.sync {

--- a/zingoconfig/src/lib.rs
+++ b/zingoconfig/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use log::{info, LevelFilter};
+use log::LevelFilter;
 use log4rs::{
     append::rolling_file::{
         policy::compound::{
@@ -150,7 +150,7 @@ impl ZingoConfig {
                 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
                 {
                     if dirs::home_dir().is_none() {
-                        info!("Couldn't determine home dir!");
+                        log::info!("Couldn't determine home dir!");
                     }
                     zcash_data_location =
                         dirs::home_dir().expect("Couldn't determine home directory!");

--- a/zingolib/src/grpc_connector.rs
+++ b/zingolib/src/grpc_connector.rs
@@ -358,14 +358,13 @@ impl GrpcConnector {
     }
 
     pub async fn get_info(uri: http::Uri) -> Result<LightdInfo, String> {
-        let client = Arc::new(GrpcConnector::new(dbg!(uri.clone())));
+        let client = Arc::new(GrpcConnector::new(uri.clone()));
 
         let mut client = client
             .get_client()
             .await
             .map_err(|e| format!("Error getting client: {:?}", e))?;
 
-        dbg!(&client);
         let request = Request::new(Empty {});
 
         let response = client


### PR DESCRIPTION
This checks that the CLI has been invoked in interactive mode before printing informational strings on startup.

Non-Interactive invocations will have not initial output.

Also removes dbg! call dangling when creating a GRPC connection and removes dbg call from GrpcConnecto constructor
Closes #267