### PR TITLE
Fix duplicate transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,6 +3894,7 @@ dependencies = [
  "bech32 0.9.1",
  "clap",
  "http",
+ "itertools",
  "json",
  "log",
  "orchard",

--- a/zingocli/Cargo.toml
+++ b/zingocli/Cargo.toml
@@ -27,8 +27,9 @@ orchard = "0.2.0"
 zcash_address = { git = "https://github.com/zingolabs/librustzcash", rev = "d66f7f70516e6da5c24008874a926d41221b1346"}
 zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash", rev = "d66f7f70516e6da5c24008874a926d41221b1346"}
 zcash_primitives = { git = "https://github.com/zingolabs/librustzcash", rev = "d66f7f70516e6da5c24008874a926d41221b1346", features = ["transparent-inputs", "test-dependencies"] }
+itertools = "0.10.5"
 
 [features]
 default = ["local_env"]
-cross_version = [ "dep:zingtaddrfix" ]
+cross_version = ["dep:zingtaddrfix"]
 local_env =[]

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -2,7 +2,6 @@
 #![cfg(feature = "local_env")]
 mod data;
 mod utils;
-use itertools::Itertools;
 use std::fs::File;
 
 use data::seeds::HOSPITAL_MUSEUM_SEED;
@@ -1181,7 +1180,7 @@ async fn self_send_to_t_displays_as_one_transaction() {
     let mut txids = transactions
         .members()
         .map(|transaction| transaction["txid"].as_str());
-    assert!(txids.all_unique());
+    assert!(itertools::Itertools::all_unique(&mut txids));
     drop(child_process_handler);
 }
 

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -1130,9 +1130,29 @@ async fn self_send_to_t_displays_as_one_transaction() {
         .unwrap();
     utils::increase_height_and_sync_client(&regtest_manager, &recipient, 1).await;
     let recipient_taddr = get_base_address!(recipient, "transparent");
+    let recipient_zaddr = get_base_address!(recipient, "sapling");
     let sent_to_taddr_value = 5_000;
+    let sent_to_zaddr_value = 11_000;
+    let sent_to_self_orchard_value = 1_000;
     recipient
         .do_send(vec![(recipient_taddr.as_str(), sent_to_taddr_value, None)])
+        .await
+        .unwrap();
+    utils::increase_height_and_sync_client(&regtest_manager, &recipient, 1).await;
+    recipient
+        .do_send(vec![
+            (recipient_taddr.as_str(), sent_to_taddr_value, None),
+            (
+                recipient_zaddr.as_str(),
+                sent_to_zaddr_value,
+                Some("foo".to_string()),
+            ),
+            (
+                recipient_unified_address.as_str(),
+                sent_to_self_orchard_value,
+                Some("bar".to_string()),
+            ),
+        ])
         .await
         .unwrap();
     utils::increase_height_and_sync_client(&regtest_manager, &recipient, 1).await;

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -1155,6 +1155,23 @@ async fn self_send_to_t_displays_as_one_transaction() {
         ])
         .await
         .unwrap();
+    faucet.do_sync(false).await.unwrap();
+    faucet
+        .do_send(vec![
+            (recipient_taddr.as_str(), sent_to_taddr_value, None),
+            (
+                recipient_zaddr.as_str(),
+                sent_to_zaddr_value,
+                Some("foo2".to_string()),
+            ),
+            (
+                recipient_unified_address.as_str(),
+                sent_to_self_orchard_value,
+                Some("bar2".to_string()),
+            ),
+        ])
+        .await
+        .unwrap();
     utils::increase_height_and_sync_client(&regtest_manager, &recipient, 1).await;
     println!(
         "{}",

--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -120,7 +120,8 @@ impl TransactionContext {
         // Collect our t-addresses for easy checking
         let taddrs_set = self.key.read().await.get_all_taddrs(&self.config);
         // Process t-address outputs
-        // we need to grab all transparent outputs as the outgoing metadata
+        // If this transaction in outgoing, i.e., we recieved sent some money in this transaction, then we need to grab all transparent outputs
+        // that don't belong to us as the outgoing metadata
         if self
             .transaction_metadata_set
             .read()
@@ -144,21 +145,21 @@ impl TransactionContext {
         )
         .await;
         // Post process scan results
-        if let Some(t_bundle) = transaction.transparent_bundle() {
-            for vout in &t_bundle.vout {
-                if let Some(taddr) =
-                    address_from_pubkeyhash(&self.config, vout.script_pubkey.address())
-                {
-                    outgoing_metadatas.push(OutgoingTxMetadata {
-                        to_address: taddr,
-                        value: vout.value.into(),
-                        memo: Memo::Empty,
-                        ua: None,
-                    });
+        if is_outgoing_transaction {
+            if let Some(t_bundle) = transaction.transparent_bundle() {
+                for vout in &t_bundle.vout {
+                    if let Some(taddr) =
+                        address_from_pubkeyhash(&self.config, vout.script_pubkey.address())
+                    {
+                        outgoing_metadatas.push(OutgoingTxMetadata {
+                            to_address: taddr,
+                            value: vout.value.into(),
+                            memo: Memo::Empty,
+                            ua: None,
+                        });
+                    }
                 }
             }
-        }
-        if is_outgoing_transaction {
             // Also, if this is an outgoing transaction, then mark all the *incoming* sapling notes to this transaction as change.
             // Note that this is also done in `WalletTxns::add_new_spent`, but that doesn't take into account transparent spends,
             // so we'll do it again here.

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1008,13 +1008,7 @@ impl LightClient {
                 let amount = total_transparent_received as i64 - wallet_transaction.total_transparent_value_spent as i64;
                 let address = wallet_transaction.utxos.iter().map(|u| u.address.clone()).collect::<Vec<String>>().join(",");
                 if total_transparent_received > wallet_transaction.total_transparent_value_spent {
-                    if let Some(transaction) = transactions.iter_mut().find(|transaction| transaction["txid"] == wallet_transaction.txid.to_string()) {
-                        let old_address = transaction.remove("address");
-                        transaction.insert("address", match old_address {
-                            JsonValue::String(addr) => [addr, address].join(","),
-                            _ => address
-                        }).unwrap();
-                    } else {
+                    if  transactions.iter_mut().find(|transaction| transaction["txid"] == wallet_transaction.txid.to_string()).is_none() {
                     // Create an input transaction for the transparent value as well.
                     let block_height: u32 = wallet_transaction.block_height.into();
                     transactions.push(object! {

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1026,8 +1026,9 @@ impl LightClient {
                             "amount"       => wallet_transparent_value_delta,
                             "zec_price"    => wallet_transaction.zec_price.map(|p| (p * 100.0).round() / 100.0),
                             "address"      => address,
-                            "memo"         => None::<String>
-                    })}
+                            "memo"         => None::<String> 
+                        })
+                    }
                 }
 
                 transactions

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1011,7 +1011,7 @@ impl LightClient {
                     if let Some(transaction) = transactions.iter_mut().find(|transaction| transaction["txid"] == wallet_transaction.txid.to_string()) {
                         // If this transaction is outgoing:
                         // Then we've already accounted for the entire balance.
-                        
+
                         if !wallet_transaction.is_outgoing_transaction() {
                             // If not, we've added sapling/orchard, and need to add transparent
                             let old_amount = transaction.remove("amount").as_i64().unwrap();

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1016,17 +1016,17 @@ impl LightClient {
                             transaction.insert("amount", old_amount + wallet_transparent_value_delta).unwrap();
                         }
                     } else {
-                    // Create an input transaction for the transparent value as well.
-                    let block_height: u32 = wallet_transaction.block_height.into();
-                    transactions.push(object! {
-                        "block_height" => block_height,
-                        "unconfirmed" => wallet_transaction.unconfirmed,
-                        "datetime"     => wallet_transaction.datetime,
-                        "txid"         => format!("{}", wallet_transaction.txid),
-                        "amount"       => wallet_transparent_value_delta,
-                        "zec_price"    => wallet_transaction.zec_price.map(|p| (p * 100.0).round() / 100.0),
-                        "address"      => address,
-                        "memo"         => None::<String>
+                        // Create an input transaction for the transparent value as well.
+                        let block_height: u32 = wallet_transaction.block_height.into();
+                        transactions.push(object! {
+                            "block_height" => block_height,
+                            "unconfirmed"  => wallet_transaction.unconfirmed,
+                            "datetime"     => wallet_transaction.datetime,
+                            "txid"         => format!("{}", wallet_transaction.txid),
+                            "amount"       => wallet_transparent_value_delta,
+                            "zec_price"    => wallet_transaction.zec_price.map(|p| (p * 100.0).round() / 100.0),
+                            "address"      => address,
+                            "memo"         => None::<String>
                     })}
                 }
 

--- a/zingolib/src/lightclient/tests.rs
+++ b/zingolib/src/lightclient/tests.rs
@@ -545,24 +545,17 @@ async fn multiple_incoming_same_transaction(scenario: NBlockFCBLScenario) {
         panic!("unspent notes not found");
     }
 
-    if let JsonValue::Array(mut sorted_transactions) = transactions.clone() {
-        sorted_transactions.sort_by_cached_key(|t| t["amount"].as_u64().unwrap());
-
-        for i in 0..4 {
-            //assert_eq!(sorted_transactions[i]["txid"], transaction.txid().to_string());
-            assert_eq!(sorted_transactions[i]["block_height"].as_u64().unwrap(), 11);
-            assert_eq!(
-                sorted_transactions[i]["address"],
-                lightclient.do_addresses().await[0]["address"]
-            );
-            assert_eq!(
-                sorted_transactions[i]["amount"].as_u64().unwrap(),
-                value + i as u64
-            );
-        }
-    } else {
-        panic!("transactions is not array");
-    }
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(transactions[0]["block_height"].as_u64().unwrap(), 11);
+    assert_eq!(
+        transactions[0]["address"],
+        lightclient.do_addresses().await[0]["address"]
+    );
+    assert_eq!(
+        transactions[0]["amount"].as_u64().unwrap(),
+        // 4 values + 0 + 1 + 2 + 3
+        value * 4 + 6
+    );
 
     // 3. Send a big transaction, so all the value is spent
     let sent_value = value * 3 + u64::from(DEFAULT_FEE);
@@ -591,24 +584,24 @@ async fn multiple_incoming_same_transaction(scenario: NBlockFCBLScenario) {
             17
         );
     }
-    assert_eq!(transactions[4]["txid"], sent_transaction_id);
-    assert_eq!(transactions[4]["block_height"], 17 as u32);
+    assert_eq!(transactions[1]["txid"], sent_transaction_id);
+    assert_eq!(transactions[1]["block_height"], 17 as u32);
     assert_eq!(
-        transactions[4]["amount"].as_i64().unwrap(),
+        transactions[1]["amount"].as_i64().unwrap(),
         -(sent_value as i64) - i64::from(DEFAULT_FEE)
     );
     assert_eq!(
-        transactions[4]["outgoing_metadata"][0]["address"],
+        transactions[1]["outgoing_metadata"][0]["address"],
         EXT_ZADDR.to_string()
     );
     assert_eq!(
-        transactions[4]["outgoing_metadata"][0]["value"]
+        transactions[1]["outgoing_metadata"][0]["value"]
             .as_u64()
             .unwrap(),
         sent_value
     );
     assert_eq!(
-        transactions[4]["outgoing_metadata"][0]["memo"].is_null(),
+        transactions[1]["outgoing_metadata"][0]["memo"].is_null(),
         true
     );
 }

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -554,6 +554,9 @@ impl TransactionMetadata {
     pub fn total_value_spent(&self) -> u64 {
         self.value_spent_by_pool().iter().sum()
     }
+    pub fn is_outgoing_transaction(&self) -> bool {
+        self.total_value_spent() > 0
+    }
     pub fn value_spent_by_pool(&self) -> [u64; 3] {
         [
             self.total_transparent_value_spent,


### PR DESCRIPTION
@zancas This PR should fix the duplicate transaction bug, could you take a look at the test here? I'm not sure it's comprehensive enough, and I've changed the way that transactions are displayed (transparent sends-to-self now show up in metadata, and when we detect transparent pool stuff we check to see if we already have the transaction listed...but we seem to already have everythind handled in that case, which I'm suspicious of.