### PR TITLE
Clippy continuous integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,8 @@ jobs:
         run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./regtest/bin/
       - name: Symlink zcash parameters and rustup files
         run: ln -s /root/.zcash-params /root/.rustup /github/home
+      - name: Reject trailing whitespace
+        run: ./utils/trailing-whitespace.sh reject
       - name: Check formatting of code
         run: cargo fmt --check
       - name: Generate code coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,8 @@ jobs:
         run: ./utils/trailing-whitespace.sh reject
       - name: Check formatting of code
         run: cargo fmt --check
+      - name: Clippy Checks
+        run: cargo clippy
       - name: Generate code coverage
         run: cargo tarpaulin --all-features --verbose --workspace --avoid-cfg-tarpaulin --skip-clean --ignore-tests --release --timeout 300 --out xml
       - name: Upload to codecov.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   pull_request:
   push:
     branches: [main, dev]
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./cobertura.xml
           # fail_ci_if_error:     true
-        
+
   timestamp:
     name: Create timestamp
     runs-on: ubuntu-22.04
@@ -112,7 +112,7 @@ jobs:
         with:
           name: ${{ matrix.arch }}-${{ env.timestamp }}
           path: rust/target/${{ matrix.target }}/release/librust.so
-           
+
   integration_test_android:
     name: Integration test android
     runs-on: macos-12
@@ -145,14 +145,14 @@ jobs:
       - name: AVD cache
         uses: actions/cache@v3
         id: avd-cache
-        with: 
+        with:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.arch }}-api-${{ matrix.api-level }}      
+          key: avd-${{ matrix.arch }}-api-${{ matrix.api-level }}
       - name: Download native rust
         uses: actions/download-artifact@v3
-        with: 
+        with:
           name: ${{ matrix.arch }}-${{ env.timestamp }}
           path: android/app/src/main/jniLibs/${{ matrix.arch }}
       - run: yarn install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,6 +1352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4173,6 +4179,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "incrementalmerkletree",
+ "indoc",
  "json",
  "jubjub",
  "lazy_static",

--- a/docker-ci/Dockerfile
+++ b/docker-ci/Dockerfile
@@ -16,13 +16,14 @@ RUN apt update \
     unzip \
     procps \
     && update-ca-certificates
-    
+
 # Install Rust and Cargo-Tarpaulin
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV HOME=/root
 ENV CARGO_HOME=$HOME/.cargo
 ENV PATH=$PATH:$CARGO_HOME/bin
 RUN rustup toolchain install stable \
+    && rustup component add clippy
     && cargo install cargo-tarpaulin
 
 # Install Zcash and fetch zero-knowledge parameters

--- a/regtest/README.md
+++ b/regtest/README.md
@@ -7,7 +7,7 @@ There are pre-made directories in this repo to support ready use of regtest mode
 
 There are default config files for these binaries already in place in `/zingolib/regtest/conf/` which can also be edited.
 
-Because regtest mode has no ability to cope with an initial `zcashd` state without any blocks, 
+Because regtest mode has no ability to cope with an initial `zcashd` state without any blocks,
 we have included files to produce an initial block height of one, with no variation between runs.
 These files are copied from a 'passive' directory (`zingolib/regtest/data/regtestvectors/`)
 into a newly cleared 'active' data directory at the beginning of each time regtest mode is run.
@@ -46,7 +46,7 @@ at which point the interactive cli application should work with your regtest net
 
 Once regtest mode is running, you can manipulate the simulated chain with `zcash-cli`.
 
-For example, in still another terminal instance in the `zingolib/regtest/bin/` directory, you can run 
+For example, in still another terminal instance in the `zingolib/regtest/bin/` directory, you can run
 `./zcash-cli -regtest -rpcuser=xxxxxx -rpcpassword=xxxxxx generate 11` to generate 11 blocks.
 Please note that by adding more than 100 blocks it is difficult or impossible to rewind the chain. The config means that after the first block all network upgrades should be in place.
 Other `zcash-cli` commands should work similarly.

--- a/utils/git-hook-pre-commit.sh
+++ b/utils/git-hook-pre-commit.sh
@@ -21,3 +21,4 @@ cargo fmt -- --check
 cargo check
 cargo test --bins --lib
 #cargo test --doc # No doc tests yet.
+cargo clippy

--- a/utils/git-hook-pre-commit.sh
+++ b/utils/git-hook-pre-commit.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# zingolib pre-commit hook
+#
+# zingolib devs can ensure consistent commits by using this pre-commit
+# hook. Install with:
+#
+# $ ln -s ../../utils/git-hook-pre-commit.sh .git/hooks/pre-commit
+
+set -efuo pipefail
+
+echo 'Running zingolib pre-commit checks.'
+
+cd "$(git rev-parse --show-toplevel)"
+
+./utils/git-require-clean-worktree.sh
+
+set -x
+./utils/trailing-whitespace.sh reject
+cargo fmt -- --check
+cargo check
+cargo test --bins --lib
+#cargo test --doc # No doc tests yet.

--- a/utils/git-require-clean-worktree.sh
+++ b/utils/git-require-clean-worktree.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -efuo pipefail
+
+echo 'Checking for clean git working tree:'
+
+if ! git status --porcelain | grep '^.[^ ]'
+then
+  echo 'Clean git working tree.'
+  exit 0
+fi
+
+cat <<EOF
+
+↑ dirty working tree ↑
+
+When running checks prior to a git commit, the working tree is tested
+whereas the git commit only includes the index. To ensure pre-commit
+checks are verifying the actual commit contents, the working tree must
+be clean.
+
+Either add unstaged changes, or you can save them for after the commit
+with:
+
+$ git stash -p
+$ git commit …
+$ git stash pop
+
+EOF
+exit 1

--- a/utils/trailing-whitespace.sh
+++ b/utils/trailing-whitespace.sh
@@ -43,7 +43,13 @@ function reject
 function process-well-known-text-files
 {
   find . \
-    \( -type d -name .git -prune \) \
+    \( -type d \
+      \( \
+        -name '.git' \
+        -o -name 'target' \
+      \) \
+      -prune \
+    \) \
     -o \( \
       -type f \
       \( \

--- a/utils/trailing-whitespace.sh
+++ b/utils/trailing-whitespace.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -efuo pipefail
+
+function main
+{
+  [ $# -eq 1 ] || usage-error 'expected a single arg'
+
+  # cd to repo dir:
+  cd "$(git rev-parse --show-toplevel)"
+
+  case "$1" in
+    fix) fix ;;
+    reject) reject ;;
+    *) usage-error "unknown command: $1" ;;
+  esac
+}
+
+function fix
+{
+  process-well-known-text-files sed -i 's/ *$//'
+}
+
+function reject
+{
+  local F="$(mktemp --tmpdir zingolib-trailing-whitespace.XXX)"
+
+  process-well-known-text-files grep -E --with-filename ' +$' \
+    | sed 's/$/\\n/' \
+    | tee "$F"
+
+  local NOISE="$(cat "$F" | wc -l)"
+  rm "$F"
+
+  if [ "$NOISE" -eq 0 ]
+  then
+    echo 'No trailing whitespace detected.'
+  else
+    echo -e '\nRejecting trailing whitespace above.'
+    exit 1
+  fi
+}
+
+function process-well-known-text-files
+{
+  find . \
+    \( -type d -name .git -prune \) \
+    -o \( \
+      -type f \
+      \( \
+        -name '*.rs' \
+        -o -name '*.md' \
+        -o -name '*.toml' \
+        -o -name '*.yaml' \
+      \) \
+      -exec "$@" '{}' \; \
+    \)
+}
+
+function usage-error
+{
+  echo "usage error: $*"
+  echo
+  echo "usage: $0 ( fix | reject )"
+  exit 1
+}
+
+main "$@"

--- a/zingo-memo/src/lib.rs
+++ b/zingo-memo/src/lib.rs
@@ -41,17 +41,13 @@ pub fn parse_zingo_memo(memo: [u8; 511]) -> io::Result<ParsedMemo> {
     let mut reader: &[u8] = &memo;
     match CompactSize::read(&mut reader)? {
         0 => Ok(ParsedMemo::Version0 {
-            uas: Vector::read(&mut reader, |r| {
-                read_unified_address_from_raw_encoding(r)
-            })?,
+            uas: Vector::read(&mut reader, |r| read_unified_address_from_raw_encoding(r))?,
         }),
-        _ => {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Received memo from a future version of this protocol.\n\
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Received memo from a future version of this protocol.\n\
             Please ensure your software is up-to-date",
-            ))
-        }
+        )),
     }
 }
 

--- a/zingo-memo/src/lib.rs
+++ b/zingo-memo/src/lib.rs
@@ -21,8 +21,8 @@ pub enum ParsedMemo {
 pub fn create_wallet_internal_memo_version_0(uas: &[UnifiedAddress]) -> io::Result<[u8; 511]> {
     let mut uas_bytes_vec = Vec::new();
     CompactSize::write(&mut uas_bytes_vec, 0usize)?;
-    Vector::write(&mut uas_bytes_vec, uas, |mut w, ua| {
-        write_unified_address_to_raw_encoding(&ua, &mut w)
+    Vector::write(&mut uas_bytes_vec, uas, |w, ua| {
+        write_unified_address_to_raw_encoding(ua, w)
     })?;
     let mut uas_bytes = [0u8; 511];
     if uas_bytes_vec.len() > 511 {
@@ -41,12 +41,12 @@ pub fn parse_zingo_memo(memo: [u8; 511]) -> io::Result<ParsedMemo> {
     let mut reader: &[u8] = &memo;
     match CompactSize::read(&mut reader)? {
         0 => Ok(ParsedMemo::Version0 {
-            uas: Vector::read(&mut reader, |mut r| {
-                read_unified_address_from_raw_encoding(&mut r)
+            uas: Vector::read(&mut reader, |r| {
+                read_unified_address_from_raw_encoding(r)
             })?,
         }),
         _ => {
-            return Err(io::Error::new(
+            Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Received memo from a future version of this protocol.\n\
             Please ensure your software is up-to-date",

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -1,13 +1,13 @@
 #![forbid(unsafe_code)]
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use log::{error, info};
 
 use clap::{self, Arg};
 use regtest::ChildProcessHandler;
-use zingoconfig::{ChainType, ZingoConfig};
+use zingoconfig::ChainType;
 use zingolib::wallet::WalletBase;
 use zingolib::{commands, lightclient::LightClient, load_clientconfig};
 
@@ -133,7 +133,7 @@ fn start_interactive(
                 let e = format!("Error executing command {}: {}", cmd, e);
                 eprintln!("{}", e);
                 error!("{}", e);
-                return "".to_string();
+                "".to_string()
             }
         }
     };
@@ -214,35 +214,20 @@ pub fn command_loop(
     std::thread::spawn(move || {
         LightClient::start_mempool_monitor(lightclient.clone());
 
-        loop {
-            if let Ok((cmd, args)) = command_receiver.recv() {
-                let args: Vec<_> = args.iter().map(|s| s.as_ref()).collect();
+        while let Ok((cmd, args)) = command_receiver.recv() {
+            let args: Vec<_> = args.iter().map(|s| s.as_ref()).collect();
 
-                let cmd_response = commands::do_user_command(&cmd, &args[..], lightclient.as_ref());
-                resp_transmitter.send(cmd_response).unwrap();
+            let cmd_response = commands::do_user_command(&cmd, &args[..], lightclient.as_ref());
+            resp_transmitter.send(cmd_response).unwrap();
 
-                if cmd == "quit" {
-                    info!("Quit");
-                    break;
-                }
-            } else {
+            if cmd == "quit" {
+                info!("Quit");
                 break;
             }
         }
     });
 
     (command_transmitter, resp_receiver)
-}
-
-pub fn attempt_recover_seed(_password: Option<String>) {
-    // Create a Light Client Config in an attempt to recover the file.
-    ZingoConfig {
-        lightwalletd_uri: Arc::new(RwLock::new("0.0.0.0:0".parse().unwrap())),
-        chain: zingoconfig::ChainType::Mainnet,
-        monitor_mempool: false,
-        reorg_buffer_offset: 0,
-        zingo_wallet_dir: None,
-    };
 }
 
 pub struct ConfigTemplate {
@@ -297,8 +282,7 @@ impl ConfigTemplate {
         let params: Vec<String> = matches
             .values_of("PARAMS")
             .map(|v| v.collect())
-            .or(Some(vec![]))
-            .unwrap()
+            .unwrap_or(vec![])
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -389,12 +373,19 @@ to scan from the start of the blockchain."
         })
     }
 }
+
+/// A (command, args) request
+pub type CommandRequest = (String, Vec<String>);
+
+/// Command responses are strings
+pub type CommandResponse = String;
+
 /// Used by the zingocli crate, and the zingo-mobile application:
 /// <https://github.com/zingolabs/zingolib/tree/dev/cli>
 /// <https://github.com/zingolabs/zingo-mobile>
 pub fn startup(
     filled_template: &ConfigTemplate,
-) -> std::io::Result<(Sender<(String, Vec<String>)>, Receiver<String>)> {
+) -> std::io::Result<(Sender<CommandRequest>, Receiver<CommandResponse>)> {
     // Try to get the configuration
     let config = load_clientconfig(
         filled_template.server.clone(),
@@ -455,7 +446,7 @@ pub fn startup(
 
     // At startup, run a sync.
     if filled_template.sync {
-        let update = commands::do_user_command("sync", &vec![], lightclient.as_ref());
+        let update = commands::do_user_command("sync", &[], lightclient.as_ref());
         println!("{}", update);
     }
 
@@ -475,11 +466,8 @@ fn start_cli_service(
             error!("{}", emsg);
             #[cfg(target_os = "linux")]
             // TODO: Test report_permission_error() for macos and change to target_family = "unix"
-            {
-                match e.raw_os_error() {
-                    Some(13) => report_permission_error(),
-                    _ => {}
-                }
+            if let Some(13) = e.raw_os_error() {
+                report_permission_error()
             }
             panic!();
         }

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -217,9 +217,9 @@ pub fn command_loop(
 
         loop {
             if let Ok((cmd, args)) = command_receiver.recv() {
-                let args = args.iter().map(|s| s.as_ref()).collect();
+                let args: Vec<_> = args.iter().map(|s| s.as_ref()).collect();
 
-                let cmd_response = commands::do_user_command(&cmd, &args, lc.as_ref());
+                let cmd_response = commands::do_user_command(&cmd, &args[..], lc.as_ref());
                 resp_transmitter.send(cmd_response).unwrap();
 
                 if cmd == "quit" {

--- a/zingocli/src/regtest.rs
+++ b/zingocli/src/regtest.rs
@@ -355,19 +355,19 @@ impl RegtestManager {
         .args([
             "--no-tls-very-insecure",
             "--zcash-conf-path",
-            &self.zcashd_config
+            self.zcashd_config
                 .to_str()
                 .expect("zcashd_config PathBuf to str fail!"),
             "--config",
-            &self.lightwalletd_config
+            self.lightwalletd_config
                 .to_str()
                 .expect("lightwalletd_config PathBuf to str fail!"),
             "--data-dir",
-            &self.lightwalletd_data_dir
+            self.lightwalletd_data_dir
                 .to_str()
                 .expect("lightwalletd_datadir PathBuf to str fail!"),
             "--log-file",
-            &self.lightwalletd_log
+            self.lightwalletd_log
                 .to_str()
                 .expect("lightwalletd_stdout_log PathBuf to str fail!"),
         ])

--- a/zingocli/src/regtest.rs
+++ b/zingocli/src/regtest.rs
@@ -222,21 +222,21 @@ impl RegtestManager {
 
         assert_eq!(command.get_args().len(), 4usize);
         assert_eq!(
-            &command.get_args().into_iter().collect::<Vec<&OsStr>>()[0]
+            &command.get_args().collect::<Vec<&OsStr>>()[0]
                 .to_str()
                 .unwrap(),
             &"--printtoconsole"
         );
-        assert!(&command.get_args().into_iter().collect::<Vec<&OsStr>>()[1]
+        assert!(&command.get_args().collect::<Vec<&OsStr>>()[1]
             .to_str()
             .unwrap()
             .starts_with("--conf="));
-        assert!(&command.get_args().into_iter().collect::<Vec<&OsStr>>()[2]
+        assert!(&command.get_args().collect::<Vec<&OsStr>>()[2]
             .to_str()
             .unwrap()
             .starts_with("--datadir="));
         assert_eq!(
-            &command.get_args().into_iter().collect::<Vec<&OsStr>>()[3]
+            &command.get_args().collect::<Vec<&OsStr>>()[3]
                 .to_str()
                 .unwrap(),
             &"-debug=1"

--- a/zingocli/src/regtest.rs
+++ b/zingocli/src/regtest.rs
@@ -150,9 +150,7 @@ impl RegtestManager {
             .output()
     }
     pub fn get_chain_tip(&self) -> Result<std::process::Output, std::io::Error> {
-        self.get_cli_handle()
-            .arg("getchaintips".to_string())
-            .output()
+        self.get_cli_handle().arg("getchaintips").output()
     }
     fn prepare_working_directories(&self) {
         // remove contents of existing data directories

--- a/zingocli/tests/data/mod.rs
+++ b/zingocli/tests/data/mod.rs
@@ -38,7 +38,7 @@ nuparams=c2d6d0b4:1 # NU5
 txindex=1
 # insightexplorer:
 # https://zcash.readthedocs.io/en/latest/rtd_pages/insight_explorer.html?highlight=insightexplorer#additional-getrawtransaction-fields
-insightexplorer=1 
+insightexplorer=1
 experimentalfeatures=1
 
 
@@ -60,7 +60,7 @@ listen=0
                 &format!(
                     "### Zcashd Help provides documentation of the following:
                     mineraddress={mineraddress}
-                    minetolocalwallet=0 # This is set to false so that we can mine to a wallet, other than the zcashd wallet."                   
+                    minetolocalwallet=0 # This is set to false so that we can mine to a wallet, other than the zcashd wallet."
                 )
             )
         }

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -55,8 +55,7 @@ fn get_wallet_nym(nym: &str) -> Result<(String, PathBuf, PathBuf), String> {
         "sap_only" | "orch_only" | "orch_and_sapl" | "tadd_only" => {
             let one_sapling_wallet = format!(
                 "{}/zingocli/tests/data/wallets/v26/202302_release/regtest/{nym}/zingo-wallet.dat",
-                zingo_cli::regtest::get_git_rootdir()
-                    .to_string_lossy()
+                zingo_cli::regtest::get_git_rootdir().to_string_lossy()
             );
             let wallet_path = Path::new(&one_sapling_wallet);
             let wallet_dir = wallet_path.parent().unwrap();
@@ -698,10 +697,7 @@ async fn note_selection_order() {
     assert_eq!(
         client_2_post_transaction_notes["unspent_sapling_notes"]
             .members()
-            .chain(
-                client_2_post_transaction_notes["unspent_orchard_notes"]
-                    .members()
-            )
+            .chain(client_2_post_transaction_notes["unspent_orchard_notes"].members())
             .map(extract_value_as_u64)
             .sum::<u64>(),
         2000u64 // 1000 received and unused + (2000 - 1000 txfee)
@@ -1230,11 +1226,9 @@ async fn t_incoming_t_outgoing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         sent_transaction_id
     );
-    assert!(
-        notes["unspent_orchard_notes"][0]["is_change"]
-            .as_bool()
-            .unwrap()
-    );
+    assert!(notes["unspent_orchard_notes"][0]["is_change"]
+        .as_bool()
+        .unwrap());
     assert_eq!(
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
         value - sent_value - u64::from(DEFAULT_FEE)
@@ -1279,11 +1273,9 @@ async fn t_incoming_t_outgoing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         sent_transaction_id
     );
-    assert!(
-        notes["unspent_orchard_notes"][0]["is_change"]
-            .as_bool()
-            .unwrap()
-    );
+    assert!(notes["unspent_orchard_notes"][0]["is_change"]
+        .as_bool()
+        .unwrap());
     assert_eq!(
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
         value - sent_value - u64::from(DEFAULT_FEE)
@@ -1541,11 +1533,9 @@ async fn mixed_transaction() {
             .unwrap(),
         5
     );
-    assert!(
-        notes["unspent_orchard_notes"][0]["is_change"]
-            .as_bool()
-            .unwrap()
-    );
+    assert!(notes["unspent_orchard_notes"][0]["is_change"]
+        .as_bool()
+        .unwrap());
     assert_eq!(
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
         tvalue + zvalue - sent_tvalue - sent_zvalue - u64::from(DEFAULT_FEE)
@@ -1581,8 +1571,7 @@ async fn mixed_transaction() {
     assert_eq!(
         list[2]["outgoing_metadata"]
             .members()
-            .find(|j| j["address"] == faucet_sapling
-                && j["value"].as_u64().unwrap() == sent_zvalue)
+            .find(|j| j["address"] == faucet_sapling && j["value"].as_u64().unwrap() == sent_zvalue)
             .unwrap()["memo"]
             .to_string(),
         sent_zmemo
@@ -2062,11 +2051,9 @@ async fn mempool_clearing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         orig_transaction_id
     );
-    assert!(
-        !notes["unspent_orchard_notes"][0]["unconfirmed"]
-            .as_bool()
-            .unwrap()
-    );
+    assert!(!notes["unspent_orchard_notes"][0]["unconfirmed"]
+        .as_bool()
+        .unwrap());
     assert_eq!(notes["pending_orchard_notes"].len(), 0);
     assert_eq!(transactions.len(), 1);
     drop(child_process_handler);
@@ -2240,11 +2227,9 @@ async fn sapling_incoming_sapling_outgoing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         sent_transaction_id
     );
-    assert!(
-        notes["unspent_orchard_notes"][0]["unconfirmed"]
-            .as_bool()
-            .unwrap()
-    );
+    assert!(notes["unspent_orchard_notes"][0]["unconfirmed"]
+        .as_bool()
+        .unwrap());
 
     assert_eq!(notes["spent_sapling_notes"].len(), 0);
     assert_eq!(notes["pending_sapling_notes"].len(), 1);
@@ -2257,9 +2242,7 @@ async fn sapling_incoming_sapling_outgoing() {
         sent_transaction_id
     );
     assert!(notes["pending_sapling_notes"][0]["spent"].is_null());
-    assert!(
-        notes["pending_sapling_notes"][0]["spent_at_height"].is_null()
-    );
+    assert!(notes["pending_sapling_notes"][0]["spent_at_height"].is_null());
 
     // Check transaction list
     let list = recipient.do_list_transactions(false).await;
@@ -2320,16 +2303,12 @@ async fn sapling_incoming_sapling_outgoing() {
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
         value - sent_value - u64::from(DEFAULT_FEE)
     );
-    assert!(
-        notes["unspent_orchard_notes"][0]["is_change"]
-            .as_bool()
-            .unwrap()
-    );
-    assert!(
-        notes["unspent_orchard_notes"][0]["spendable"]
-            .as_bool()
-            .unwrap()
-    ); // Spendable
+    assert!(notes["unspent_orchard_notes"][0]["is_change"]
+        .as_bool()
+        .unwrap());
+    assert!(notes["unspent_orchard_notes"][0]["spendable"]
+        .as_bool()
+        .unwrap()); // Spendable
 
     assert_eq!(notes["spent_sapling_notes"].len(), 1);
     assert_eq!(
@@ -2342,16 +2321,12 @@ async fn sapling_incoming_sapling_outgoing() {
         notes["spent_sapling_notes"][0]["value"].as_u64().unwrap(),
         value
     );
-    assert!(
-        !notes["spent_sapling_notes"][0]["is_change"]
-            .as_bool()
-            .unwrap()
-    );
-    assert!(
-        !notes["spent_sapling_notes"][0]["spendable"]
-            .as_bool()
-            .unwrap()
-    ); // Already spent
+    assert!(!notes["spent_sapling_notes"][0]["is_change"]
+        .as_bool()
+        .unwrap());
+    assert!(!notes["spent_sapling_notes"][0]["spendable"]
+        .as_bool()
+        .unwrap()); // Already spent
     assert_eq!(
         notes["spent_sapling_notes"][0]["spent"],
         sent_transaction_id

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -57,7 +57,6 @@ fn get_wallet_nym(nym: &str) -> Result<(String, PathBuf, PathBuf), String> {
                 "{}/zingocli/tests/data/wallets/v26/202302_release/regtest/{nym}/zingo-wallet.dat",
                 zingo_cli::regtest::get_git_rootdir()
                     .to_string_lossy()
-                    .to_string()
             );
             let wallet_path = Path::new(&one_sapling_wallet);
             let wallet_dir = wallet_path.parent().unwrap();
@@ -185,13 +184,13 @@ async fn build_fvk_client_capability(
 ) -> (LightClient, WalletCapability) {
     let ufvk = zcash_address::unified::Encoding::encode(
         &<Ufvk as zcash_address::unified::Encoding>::try_from_items(
-            fvks.clone().into_iter().map(|x| x.clone()).collect(),
+            fvks.clone().into_iter().cloned().collect(),
         )
         .unwrap(),
         &zcash_address::Network::Regtest,
     );
     let viewkey_client =
-        LightClient::create_unconnected(&zingoconfig, WalletBase::Ufvk(ufvk), 0).unwrap();
+        LightClient::create_unconnected(zingoconfig, WalletBase::Ufvk(ufvk), 0).unwrap();
     let watch_wc = viewkey_client
         .extract_unified_capability()
         .read()
@@ -212,7 +211,7 @@ fn check_view_capability_bounds(
     notes: &JsonValue,
 ) {
     //Orchard
-    if !fvks.contains(&&ovk) {
+    if !fvks.contains(&ovk) {
         assert!(!watch_wc.orchard.can_view());
         assert_eq!(balance["orchard_balance"], Null);
         assert_eq!(balance["verified_orchard_balance"], Null);
@@ -228,7 +227,7 @@ fn check_view_capability_bounds(
         assert!((1..=2).contains(&orchard_notes_count));
     }
     //Sapling
-    if !fvks.contains(&&svk) {
+    if !fvks.contains(&svk) {
         assert!(!watch_wc.sapling.can_view());
         assert_eq!(balance["sapling_balance"], Null);
         assert_eq!(balance["verified_sapling_balance"], Null);
@@ -241,7 +240,7 @@ fn check_view_capability_bounds(
         assert_eq!(balance["unverified_sapling_balance"], 0);
         assert_eq!(notes["unspent_sapling_notes"].members().count(), 1);
     }
-    if !fvks.contains(&&tvk) {
+    if !fvks.contains(&tvk) {
         assert!(!watch_wc.transparent.can_view());
         assert_eq!(balance["transparent_balance"], Null);
         assert_eq!(notes["utxos"].members().count(), 0);
@@ -592,7 +591,7 @@ async fn send_mined_sapling_to_orchard() {
 
 fn extract_value_as_u64(input: &JsonValue) -> u64 {
     let note = &input["value"].as_fixed_point_u64(0).unwrap();
-    note.clone()
+    *note
 }
 
 #[tokio::test]
@@ -670,7 +669,7 @@ async fn note_selection_order() {
     let non_change_note_values = client_2_notes["unspent_sapling_notes"]
         .members()
         .filter(|note| !note["is_change"].as_bool().unwrap())
-        .map(|x| extract_value_as_u64(x))
+        .map(extract_value_as_u64)
         .collect::<Vec<_>>();
     // client_2 got a total of 3000+2000+1000
     // It sent 3000 to the client_1, and also
@@ -699,13 +698,11 @@ async fn note_selection_order() {
     assert_eq!(
         client_2_post_transaction_notes["unspent_sapling_notes"]
             .members()
-            .into_iter()
             .chain(
                 client_2_post_transaction_notes["unspent_orchard_notes"]
                     .members()
-                    .into_iter()
             )
-            .map(|x| extract_value_as_u64(x))
+            .map(extract_value_as_u64)
             .sum::<u64>(),
         2000u64 // 1000 received and unused + (2000 - 1000 txfee)
     );
@@ -1202,7 +1199,7 @@ async fn t_incoming_t_outgoing() {
         list[1]["amount"].as_i64().unwrap(),
         -(sent_value as i64 + i64::from(DEFAULT_FEE))
     );
-    assert_eq!(list[1]["unconfirmed"].as_bool().unwrap(), false);
+    assert!(!list[1]["unconfirmed"].as_bool().unwrap());
     assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_TADDR);
     assert_eq!(
         list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
@@ -1233,11 +1230,10 @@ async fn t_incoming_t_outgoing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         sent_transaction_id
     );
-    assert_eq!(
+    assert!(
         notes["unspent_orchard_notes"][0]["is_change"]
             .as_bool()
-            .unwrap(),
-        true
+            .unwrap()
     );
     assert_eq!(
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
@@ -1249,7 +1245,7 @@ async fn t_incoming_t_outgoing() {
 
     assert_eq!(list[1]["block_height"].as_u64().unwrap(), 3);
     assert_eq!(list[1]["txid"], sent_transaction_id);
-    assert_eq!(list[1]["unconfirmed"].as_bool().unwrap(), false);
+    assert!(!list[1]["unconfirmed"].as_bool().unwrap());
     assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_TADDR);
     assert_eq!(
         list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
@@ -1264,7 +1260,7 @@ async fn t_incoming_t_outgoing() {
     println!("{}", json::stringify_pretty(list.clone(), 4));
     assert_eq!(list[1]["block_height"].as_u64().unwrap(), 3);
     assert_eq!(list[1]["txid"], sent_transaction_id);
-    assert_eq!(list[1]["unconfirmed"].as_bool().unwrap(), false);
+    assert!(!list[1]["unconfirmed"].as_bool().unwrap());
     assert_eq!(list[1]["outgoing_metadata"][0]["address"], EXT_TADDR);
     assert_eq!(
         list[1]["outgoing_metadata"][0]["value"].as_u64().unwrap(),
@@ -1283,11 +1279,10 @@ async fn t_incoming_t_outgoing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         sent_transaction_id
     );
-    assert_eq!(
+    assert!(
         notes["unspent_orchard_notes"][0]["is_change"]
             .as_bool()
-            .unwrap(),
-        true
+            .unwrap()
     );
     assert_eq!(
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
@@ -1546,11 +1541,10 @@ async fn mixed_transaction() {
             .unwrap(),
         5
     );
-    assert_eq!(
+    assert!(
         notes["unspent_orchard_notes"][0]["is_change"]
             .as_bool()
-            .unwrap(),
-        true
+            .unwrap()
     );
     assert_eq!(
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
@@ -1587,7 +1581,7 @@ async fn mixed_transaction() {
     assert_eq!(
         list[2]["outgoing_metadata"]
             .members()
-            .find(|j| j["address"].to_string() == faucet_sapling
+            .find(|j| j["address"] == faucet_sapling
                 && j["value"].as_u64().unwrap() == sent_zvalue)
             .unwrap()["memo"]
             .to_string(),
@@ -1596,7 +1590,7 @@ async fn mixed_transaction() {
     assert_eq!(
         list[2]["outgoing_metadata"]
             .members()
-            .find(|j| j["address"].to_string() == faucet_transparent)
+            .find(|j| j["address"] == faucet_transparent)
             .unwrap()["value"]
             .as_u64()
             .unwrap(),
@@ -2050,7 +2044,7 @@ async fn mempool_clearing() {
         note["value"].as_u64().unwrap(),
         value - sent_value - u64::from(DEFAULT_FEE)
     );
-    assert_eq!(note["unconfirmed"].as_bool().unwrap(), true);
+    assert!(note["unconfirmed"].as_bool().unwrap());
     assert_eq!(transactions.len(), 2);
 
     // 7. Mine 100 blocks, so the mempool expires
@@ -2068,11 +2062,10 @@ async fn mempool_clearing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         orig_transaction_id
     );
-    assert_eq!(
-        notes["unspent_orchard_notes"][0]["unconfirmed"]
+    assert!(
+        !notes["unspent_orchard_notes"][0]["unconfirmed"]
             .as_bool()
-            .unwrap(),
-        false
+            .unwrap()
     );
     assert_eq!(notes["pending_orchard_notes"].len(), 0);
     assert_eq!(transactions.len(), 1);
@@ -2247,11 +2240,10 @@ async fn sapling_incoming_sapling_outgoing() {
         notes["unspent_orchard_notes"][0]["created_in_txid"],
         sent_transaction_id
     );
-    assert_eq!(
+    assert!(
         notes["unspent_orchard_notes"][0]["unconfirmed"]
             .as_bool()
-            .unwrap(),
-        true
+            .unwrap()
     );
 
     assert_eq!(notes["spent_sapling_notes"].len(), 0);
@@ -2264,10 +2256,9 @@ async fn sapling_incoming_sapling_outgoing() {
         notes["pending_sapling_notes"][0]["unconfirmed_spent"],
         sent_transaction_id
     );
-    assert_eq!(notes["pending_sapling_notes"][0]["spent"].is_null(), true);
-    assert_eq!(
-        notes["pending_sapling_notes"][0]["spent_at_height"].is_null(),
-        true
+    assert!(notes["pending_sapling_notes"][0]["spent"].is_null());
+    assert!(
+        notes["pending_sapling_notes"][0]["spent_at_height"].is_null()
     );
 
     // Check transaction list
@@ -2284,12 +2275,12 @@ async fn sapling_incoming_sapling_outgoing() {
         send_transaction["amount"].as_i64().unwrap(),
         -(sent_value as i64 + i64::from(DEFAULT_FEE))
     );
-    assert_eq!(send_transaction["unconfirmed"].as_bool().unwrap(), true);
+    assert!(send_transaction["unconfirmed"].as_bool().unwrap());
     assert_eq!(send_transaction["block_height"].as_u64().unwrap(), 3);
 
     assert_eq!(
         send_transaction["outgoing_metadata"][0]["address"],
-        get_base_address!(faucet, "sapling").to_string()
+        get_base_address!(faucet, "sapling")
     );
     assert_eq!(
         send_transaction["outgoing_metadata"][0]["memo"],
@@ -2307,7 +2298,7 @@ async fn sapling_incoming_sapling_outgoing() {
         .await
         .unwrap();
 
-    assert_eq!(send_transaction.contains("unconfirmed"), false);
+    assert!(!send_transaction.contains("unconfirmed"));
     assert_eq!(send_transaction["block_height"].as_u64().unwrap(), 3);
 
     // 7. Check the notes to see that we have one spent sapling note and one unspent orchard note (change)
@@ -2329,17 +2320,15 @@ async fn sapling_incoming_sapling_outgoing() {
         notes["unspent_orchard_notes"][0]["value"].as_u64().unwrap(),
         value - sent_value - u64::from(DEFAULT_FEE)
     );
-    assert_eq!(
+    assert!(
         notes["unspent_orchard_notes"][0]["is_change"]
             .as_bool()
-            .unwrap(),
-        true
+            .unwrap()
     );
-    assert_eq!(
+    assert!(
         notes["unspent_orchard_notes"][0]["spendable"]
             .as_bool()
-            .unwrap(),
-        true
+            .unwrap()
     ); // Spendable
 
     assert_eq!(notes["spent_sapling_notes"].len(), 1);
@@ -2353,17 +2342,15 @@ async fn sapling_incoming_sapling_outgoing() {
         notes["spent_sapling_notes"][0]["value"].as_u64().unwrap(),
         value
     );
-    assert_eq!(
-        notes["spent_sapling_notes"][0]["is_change"]
+    assert!(
+        !notes["spent_sapling_notes"][0]["is_change"]
             .as_bool()
-            .unwrap(),
-        false
+            .unwrap()
     );
-    assert_eq!(
-        notes["spent_sapling_notes"][0]["spendable"]
+    assert!(
+        !notes["spent_sapling_notes"][0]["spendable"]
             .as_bool()
-            .unwrap(),
-        false
+            .unwrap()
     ); // Already spent
     assert_eq!(
         notes["spent_sapling_notes"][0]["spent"],

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -2393,11 +2393,12 @@ async fn aborted_resync() {
         .await
         .current
         .get(&zingolib::wallet::data::TransactionMetadata::new_txid(
-            &hex::decode(sent_transaction_id.clone())
+            hex::decode(sent_transaction_id.clone())
                 .unwrap()
                 .into_iter()
                 .rev()
-                .collect(),
+                .collect::<Vec<_>>()
+                .as_slice(),
         ))
         .unwrap()
         .orchard_notes
@@ -2426,11 +2427,12 @@ async fn aborted_resync() {
         .await
         .current
         .get(&TransactionMetadata::new_txid(
-            &hex::decode(sent_transaction_id)
+            hex::decode(sent_transaction_id)
                 .unwrap()
                 .into_iter()
                 .rev()
-                .collect(),
+                .collect::<Vec<_>>()
+                .as_slice(),
         ))
         .unwrap()
         .orchard_notes

--- a/zingocli/tests/utils/mod.rs
+++ b/zingocli/tests/utils/mod.rs
@@ -341,8 +341,8 @@ pub mod scenarios {
     /// This key is registered to receive block rewards by corresponding to the
     /// address registered as the "mineraddress" field in zcash.conf
     ///
-    /// The general scenario framework requires instances of zingo-cli, lightwalletd,  
-    /// and zcashd (in regtest mode). This setup is intended to produce the most basic  
+    /// The general scenario framework requires instances of zingo-cli, lightwalletd,
+    /// and zcashd (in regtest mode). This setup is intended to produce the most basic
     /// of scenarios.  As scenarios with even less requirements
     /// become interesting (e.g. without experimental features, or txindices) we'll create more setups.
     pub async fn faucet() -> (RegtestManager, ChildProcessHandler, LightClient) {

--- a/zingocli/tests/utils/mod.rs
+++ b/zingocli/tests/utils/mod.rs
@@ -22,13 +22,13 @@ fn poll_server_height(manager: &RegtestManager) -> JsonValue {
 }
 // This function _DOES NOT SYNC THE CLIENT/WALLET_.
 pub async fn increase_server_height(manager: &RegtestManager, n: u32) {
-    let start_height = poll_server_height(&manager).as_fixed_point_u64(2).unwrap();
+    let start_height = poll_server_height(manager).as_fixed_point_u64(2).unwrap();
     let target = start_height + n as u64;
     manager
         .generate_n_blocks(n)
         .expect("Called for side effect, failed!");
     let mut count = 0;
-    while poll_server_height(&manager).as_fixed_point_u64(2).unwrap() < target {
+    while poll_server_height(manager).as_fixed_point_u64(2).unwrap() < target {
         sleep(Duration::from_millis(50)).await;
         count = dbg!(count + 1);
     }
@@ -67,18 +67,18 @@ pub async fn increase_height_and_sync_client(
     client: &LightClient,
     n: u32,
 ) -> Result<(), String> {
-    let start_height = get_synced_wallet_height(&client).await?;
+    let start_height = get_synced_wallet_height(client).await?;
     let target = start_height + n;
     manager
         .generate_n_blocks(n)
         .expect("Called for side effect, failed!");
-    while check_wallet_chainheight_value(&client, target).await? {
+    while check_wallet_chainheight_value(client, target).await? {
         sleep(Duration::from_millis(50)).await;
     }
     Ok(())
 }
 async fn check_wallet_chainheight_value(client: &LightClient, target: u32) -> Result<bool, String> {
-    Ok(get_synced_wallet_height(&client).await? != target)
+    Ok(get_synced_wallet_height(client).await? != target)
 }
 #[cfg(test)]
 pub mod scenarios {
@@ -199,7 +199,7 @@ pub mod scenarios {
                 self.client_number += 1;
                 let conf_path = format!(
                     "{}_client_{}",
-                    self.zingo_datadir.to_string_lossy().to_string(),
+                    self.zingo_datadir.to_string_lossy(),
                     self.client_number
                 );
                 self.create_clientconfig(PathBuf::from(conf_path))
@@ -314,9 +314,9 @@ pub mod scenarios {
                     "lightwalletd" => &self.regtest_manager.lightwalletd_config,
                     _ => panic!("Unepexted configtype!"),
                 };
-                let mut output = std::fs::File::create(&loc).expect("How could path be missing?");
+                let mut output = std::fs::File::create(loc).expect("How could path be missing?");
                 std::io::Write::write(&mut output, contents.as_bytes())
-                    .expect(&format!("Couldn't write {contents}!"));
+                    .unwrap_or_else(|_| panic!("Couldn't write {contents}!"));
                 loc.clone()
             }
             pub(crate) fn get_lightwalletd_uri(&self) -> http::Uri {
@@ -375,7 +375,7 @@ pub mod scenarios {
         let txid = faucet
             .do_send(vec![(
                 &get_base_address!(recipient, "unified"),
-                value.into(),
+                value,
                 None,
             )])
             .await

--- a/zingoconfig/src/lib.rs
+++ b/zingoconfig/src/lib.rs
@@ -45,7 +45,7 @@ pub fn construct_lightwalletd_uri(server: Option<String>) -> http::Uri {
             };
             let uri: http::Uri = s.parse().unwrap();
             if uri.port().is_none() {
-                s = s + ":9067";
+                s += ":9067";
             }
             s
         }
@@ -227,7 +227,7 @@ impl ZingoConfig {
     }
 
     pub fn wallet_exists(&self) -> bool {
-        return self.get_wallet_path().exists();
+        self.get_wallet_path().exists()
     }
 
     pub fn backup_existing_wallet(&self) -> Result<String, String> {

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -65,6 +65,7 @@ zingo-memo = { path = "../zingo-memo" }
 nonempty = "0.7.0"
 tracing-subscriber = "0.3.15"
 tracing = "0.1.36"
+indoc = "2.0.1"
 
 [dev-dependencies]
 portpicker = "0.1.0"

--- a/zingolib/src/blaze/block_witness_data.rs
+++ b/zingolib/src/blaze/block_witness_data.rs
@@ -225,11 +225,7 @@ impl BlockAndWitnessData {
                     }
                 });
 
-                if closest_tree.is_some() {
-                    Some((candidate, closest_tree.unwrap().clone()))
-                } else {
-                    None
-                }
+                closest_tree.map(|t| (candidate, t.clone()))
             })
             .collect::<Vec<_>>();
 

--- a/zingolib/src/blaze/block_witness_data.rs
+++ b/zingolib/src/blaze/block_witness_data.rs
@@ -991,7 +991,7 @@ mod test {
             .start(
                 start_block,
                 end_block,
-                Arc::new(RwLock::new(TransactionMetadataSet::new())),
+                Arc::new(RwLock::new(TransactionMetadataSet::default())),
                 reorg_transmitter,
             )
             .await;
@@ -1042,7 +1042,7 @@ mod test {
             .start(
                 start_block,
                 end_block,
-                Arc::new(RwLock::new(TransactionMetadataSet::new())),
+                Arc::new(RwLock::new(TransactionMetadataSet::default())),
                 reorg_transmitter,
             )
             .await;
@@ -1140,7 +1140,7 @@ mod test {
             .start(
                 start_block,
                 end_block,
-                Arc::new(RwLock::new(TransactionMetadataSet::new())),
+                Arc::new(RwLock::new(TransactionMetadataSet::default())),
                 reorg_transmitter,
             )
             .await;

--- a/zingolib/src/blaze/block_witness_data.rs
+++ b/zingolib/src/blaze/block_witness_data.rs
@@ -93,7 +93,9 @@ impl BlockAndWitnessData {
         existing_blocks: Vec<BlockData>,
         verified_tree: Option<TreeState>,
     ) {
-        if !existing_blocks.is_empty() && existing_blocks.first().unwrap().height < existing_blocks.last().unwrap().height {
+        if !existing_blocks.is_empty()
+            && existing_blocks.first().unwrap().height < existing_blocks.last().unwrap().height
+        {
             panic!("Blocks are in wrong order");
         }
         self.unverified_treestates.write().await.clear();
@@ -190,8 +192,7 @@ impl BlockAndWitnessData {
         unverified_tree_states.dedup_by_key(|treestate| treestate.height);
 
         // Remember the highest tree that will be verified, and return that.
-        let highest_tree = unverified_tree_states
-            .last().cloned();
+        let highest_tree = unverified_tree_states.last().cloned();
 
         let mut start_trees = vec![];
 
@@ -1091,7 +1092,8 @@ mod test {
         let num_reorged = 5;
         let mut reorged_blocks = existing_blocks
             .iter()
-            .take(num_reorged).cloned()
+            .take(num_reorged)
+            .cloned()
             .collect::<Vec<_>>();
 
         // Reset the hashes

--- a/zingolib/src/blaze/block_witness_data.rs
+++ b/zingolib/src/blaze/block_witness_data.rs
@@ -114,7 +114,7 @@ impl BlockAndWitnessData {
     ///   self.blocks.len() >= num all existing_blocks are discarded
     ///   self.blocks.len() < num the new self.blocks is:
     ///    self.blocks_original + ((the `num` - self.blocks_original.len()) highest
-    ///     self.existing_blocks.  
+    ///     self.existing_blocks.
     pub async fn drain_existingblocks_into_blocks_with_truncation(
         &self,
         num: usize,

--- a/zingolib/src/blaze/fetch_compact_blocks.rs
+++ b/zingolib/src/blaze/fetch_compact_blocks.rs
@@ -29,7 +29,7 @@ impl FetchCompactBlocks {
             let start = b;
             let end = max((b as i64) - (STEP as i64) + 1, end_block as i64) as u64;
             if start < end {
-                return Err(format!("Wrong block order"));
+                return Err("Wrong block order".to_string());
             }
 
             debug!("Fetching blocks {}-{}", start, end);
@@ -49,7 +49,7 @@ impl FetchCompactBlocks {
         mut reorg_receiver: UnboundedReceiver<Option<u64>>,
     ) -> Result<(), String> {
         if start_block < end_block {
-            return Err(format!("Expected blocks in reverse order"));
+            return Err("Expected blocks in reverse order".to_string());
         }
 
         //debug!("Starting fetch compact blocks");

--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -266,31 +266,28 @@ impl TransactionContext {
         // Scan all transparent outputs to see if we recieved any money
         if let Some(t_bundle) = transaction.transparent_bundle() {
             for (n, vout) in t_bundle.vout.iter().enumerate() {
-                match vout.recipient_address() {
-                    Some(TransparentAddress::PublicKey(hash)) => {
-                        let output_taddr =
-                            hash.to_base58check(&self.config.base58_pubkey_address(), &[]);
-                        if taddrs_set.contains(&output_taddr) {
-                            // This is our address. Add this as an output to the txid
-                            self.transaction_metadata_set
-                                .write()
-                                .await
-                                .add_new_taddr_output(
-                                    transaction.txid(),
-                                    output_taddr.clone(),
-                                    height.into(),
-                                    unconfirmed,
-                                    block_time as u64,
-                                    vout,
-                                    n as u32,
-                                );
+                if let Some(TransparentAddress::PublicKey(hash)) = vout.recipient_address() {
+                    let output_taddr =
+                        hash.to_base58check(&self.config.base58_pubkey_address(), &[]);
+                    if taddrs_set.contains(&output_taddr) {
+                        // This is our address. Add this as an output to the txid
+                        self.transaction_metadata_set
+                            .write()
+                            .await
+                            .add_new_taddr_output(
+                                transaction.txid(),
+                                output_taddr.clone(),
+                                height.into(),
+                                unconfirmed,
+                                block_time as u64,
+                                vout,
+                                n as u32,
+                            );
 
-                            // Ensure that we add any new HD addresses
-                            // TODO: I don't think we need to do this anymore
-                            // self.keys.write().await.ensure_hd_taddresses(&output_taddr);
-                        }
+                        // Ensure that we add any new HD addresses
+                        // TODO: I don't think we need to do this anymore
+                        // self.keys.write().await.ensure_hd_taddresses(&output_taddr);
                     }
-                    _ => {}
                 }
             }
         }

--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -713,7 +713,8 @@ pub async fn start(
     let h = tokio::spawn(async move {
         join_all(vec![h1, h2])
             .await
-            .into_iter().try_for_each(|r| r.map_err(|e| format!("{}", e))?)
+            .into_iter()
+            .try_for_each(|r| r.map_err(|e| format!("{}", e))?)
     });
 
     (h, transaction_id_transmitter, transaction_transmitter)

--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -65,6 +65,7 @@ impl TransactionContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn execute_bundlescans_internal(
         &self,
         transaction: &Transaction,
@@ -357,6 +358,7 @@ impl TransactionContext {
             );
         }
     }
+    #[allow(clippy::too_many_arguments)]
     async fn scan_sapling_bundle(
         &self,
         transaction: &Transaction,
@@ -378,6 +380,7 @@ impl TransactionContext {
         )
         .await
     }
+    #[allow(clippy::too_many_arguments)]
     async fn scan_orchard_bundle(
         &self,
         transaction: &Transaction,
@@ -405,6 +408,7 @@ impl TransactionContext {
     /// In Sapling the components are "Spends" and "Outputs"
     /// In Orchard the components are "Actions", each of which
     /// _IS_ 1 Spend and 1 Output.
+    #[allow(clippy::too_many_arguments)]
     async fn scan_bundle<D>(
         &self,
         transaction: &Transaction,

--- a/zingolib/src/blaze/fetch_taddr_transactions.rs
+++ b/zingolib/src/blaze/fetch_taddr_transactions.rs
@@ -23,6 +23,12 @@ pub struct FetchTaddrTransactions {
     config: Arc<ZingoConfig>,
 }
 
+/// A request to fetch taddrs between a start/end height: `(taddrs, start, end)`
+pub type FetchTaddrRequest = (Vec<String>, u64, u64);
+
+/// A reponse for a particular taddr
+pub type FetchTaddrResponse = Result<RawTransaction, String>;
+
 impl FetchTaddrTransactions {
     pub fn new(wc: Arc<RwLock<WalletCapability>>, config: Arc<ZingoConfig>) -> Self {
         Self { wc, config }
@@ -33,8 +39,8 @@ impl FetchTaddrTransactions {
         start_height: u64,
         end_height: u64,
         taddr_fetcher: oneshot::Sender<(
-            (Vec<String>, u64, u64),
-            oneshot::Sender<Vec<UnboundedReceiver<Result<RawTransaction, String>>>>,
+            FetchTaddrRequest,
+            oneshot::Sender<Vec<UnboundedReceiver<FetchTaddrResponse>>>,
         )>,
         full_transaction_scanner: UnboundedSender<(Transaction, BlockHeight)>,
         network: impl Parameters + Send + Copy + 'static,

--- a/zingolib/src/blaze/test_utils.rs
+++ b/zingolib/src/blaze/test_utils.rs
@@ -25,16 +25,16 @@ pub fn trees_from_cblocks(
         let mut sapling_tree = sapling_trees
             .last()
             .map(Clone::clone)
-            .unwrap_or_else(|| CommitmentTree::empty());
+            .unwrap_or_else(CommitmentTree::empty);
         let mut orchard_tree = orchard_trees
             .last()
             .map(Clone::clone)
-            .unwrap_or_else(|| CommitmentTree::empty());
+            .unwrap_or_else(CommitmentTree::empty);
         for compact_transaction in &fake_compact_block.block.vtx {
             update_trees_with_compact_transaction(
                 &mut sapling_tree,
                 &mut orchard_tree,
-                &compact_transaction,
+                compact_transaction,
             )
         }
         sapling_trees.push(sapling_tree);
@@ -106,7 +106,7 @@ impl FakeCompactBlock {
     pub fn add_random_sapling_transaction(&mut self, num_outputs: usize) {
         let xsk_m = ExtendedSpendingKey::master(&[1u8; 32]);
         let dfvk = xsk_m.to_diversifiable_full_viewing_key();
-        let fvk = zcash_primitives::zip32::sapling::DiversifiableFullViewingKey::from(dfvk);
+        let fvk = dfvk;
 
         let to = fvk.default_address().1;
         let value = Amount::from_u64(1).unwrap();

--- a/zingolib/src/blaze/test_utils.rs
+++ b/zingolib/src/blaze/test_utils.rs
@@ -61,19 +61,6 @@ pub fn node_to_string<Node: Hashable>(n: &Node) -> String {
     hex::encode(b1)
 }
 
-///TODO: Is this used? This is probably covered by
-/// block_witness_data::update_tree_with_compact_transaction, consider deletion
-pub fn list_all_witness_nodes(cb: &CompactBlock) -> Vec<sapling::Node> {
-    let mut nodes = vec![];
-    for transaction in &cb.vtx {
-        for co in &transaction.outputs {
-            nodes.push(sapling::Node::from_scalar(co.cmu().unwrap()))
-        }
-    }
-
-    nodes
-}
-
 use super::block_witness_data::update_trees_with_compact_transaction;
 
 pub struct FakeCompactBlock {

--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -133,7 +133,7 @@ impl TrialDecryptions {
             }
         });
 
-        return (management_thread_handle, transmitter);
+        (management_thread_handle, transmitter)
     }
 
     /// Trial decryption is invoked by spend-or-view key holders to detect
@@ -183,7 +183,7 @@ impl TrialDecryptions {
                         SaplingDomain<zingoconfig::ChainType>,
                     >(
                         &mut transaction_metadata,
-                        &compact_transaction,
+                        compact_transaction,
                         transaction_num,
                         &compact_block,
                         zcash_primitives::sapling::note_encryption::PreparedIncomingViewingKey::new(
@@ -202,7 +202,7 @@ impl TrialDecryptions {
                 if let Some(ref orchard_ivk) = orchard_ivk {
                     Self::trial_decrypt_domain_specific_outputs::<OrchardDomain>(
                         &mut transaction_metadata,
-                        &compact_transaction,
+                        compact_transaction,
                         transaction_num,
                         &compact_block,
                         orchard::keys::PreparedIncomingViewingKey::new(orchard_ivk),
@@ -274,8 +274,8 @@ impl TrialDecryptions {
         <D as Domain>::Note: PartialEq + Send + 'static + Clone,
         [u8; 32]: From<<D as Domain>::ExtractedCommitmentBytes>,
     {
-        let outputs = D::CompactOutput::from_compact_transaction(&compact_transaction)
-            .into_iter()
+        let outputs = D::CompactOutput::from_compact_transaction(compact_transaction)
+            .iter()
             .map(|output| (output.domain(config.chain, height), output.clone()))
             .collect::<Vec<_>>();
         let maybe_decrypted_outputs =
@@ -294,7 +294,7 @@ impl TrialDecryptions {
 
                 workers.push(tokio::spawn(async move {
                     let wc = wc.read().await;
-                    let Ok(fvk) = D::wc_to_fvk(&*wc) else {
+                    let Ok(fvk) = D::wc_to_fvk(&wc) else {
                         // skip any scanning if the wallet doesn't have viewing capability
                         return Ok::<_, String>(());
                     };
@@ -321,7 +321,7 @@ impl TrialDecryptions {
 
                     let spend_nullifier = transaction_metadata_set.write().await.add_new_note::<D>(
                         &fvk,
-                        transaction_id.clone(),
+                        transaction_id,
                         height,
                         false,
                         timestamp,

--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -141,6 +141,7 @@ impl TrialDecryptions {
     /// In the case that the User has requested Memos, and transaction_metadata
     /// remains false throughout domain-specific decryptions, a memo-specific
     /// thread is spawned.
+    #[allow(clippy::too_many_arguments)]
     async fn trial_decrypt_batch(
         config: Arc<ZingoConfig>,
         compact_blocks: Vec<CompactBlock>,
@@ -250,6 +251,7 @@ impl TrialDecryptions {
         // Return a nothing-value
         Ok::<(), String>(())
     }
+    #[allow(clippy::too_many_arguments)]
     fn trial_decrypt_domain_specific_outputs<D>(
         transaction_metadata: &mut bool,
         compact_transaction: &CompactTx,

--- a/zingolib/src/blaze/update_notes.rs
+++ b/zingolib/src/blaze/update_notes.rs
@@ -82,7 +82,7 @@ impl UpdateNotes {
         D::Recipient: crate::wallet::traits::Recipient,
     {
         // Get the data first, so we don't hold on to the lock
-        let wtn = D::WalletNote::GET_NOTE_WITNESSES(&*wallet_txns.read().await, &txid, &nullifier);
+        let wtn = D::WalletNote::get_note_witnesses(&*wallet_txns.read().await, &txid, &nullifier);
 
         if let Some((witnesses, created_height)) = wtn {
             if witnesses.is_empty() {
@@ -117,7 +117,7 @@ impl UpdateNotes {
 
             //info!("Finished updating witnesses for {}", txid);
 
-            D::WalletNote::SET_NOTE_WITNESSES(
+            D::WalletNote::set_note_witnesses(
                 &mut *(*wallet_txns).write().await,
                 &txid,
                 &nullifier,

--- a/zingolib/src/blaze/update_notes.rs
+++ b/zingolib/src/blaze/update_notes.rs
@@ -85,7 +85,7 @@ impl UpdateNotes {
         let wtn = D::WalletNote::GET_NOTE_WITNESSES(&*wallet_txns.read().await, &txid, &nullifier);
 
         if let Some((witnesses, created_height)) = wtn {
-            if witnesses.len() == 0 {
+            if witnesses.is_empty() {
                 // No witnesses, likely a Viewkey or we don't have spending key, so don't bother
                 return;
             }
@@ -265,6 +265,6 @@ impl UpdateNotes {
             r1.map_err(|e| format!("{}", e))
         });
 
-        return (h, blocks_done_transmitter, transmitter);
+        (h, blocks_done_transmitter, transmitter)
     }
 }

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::wallet::keys::is_shielded_address;
 use crate::wallet::MemoDownloadOption;
 use crate::{lightclient::LightClient, wallet::utils};
+use indoc::indoc;
 use json::object;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
@@ -28,15 +29,15 @@ pub trait ShortCircuitedCommand {
 struct ChangeServerCommand {}
 impl Command for ChangeServerCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Change the lightwalletd server to receive blockchain data from");
-        h.push("Usage:");
-        h.push("changeserver [server_uri]");
-        h.push("");
-        h.push("Example:");
-        h.push("changeserver https://mainnet.lightwalletd.com:9067");
+        indoc! {r#"
+            Change the lightwalletd server to receive blockchain data from
+            Usage:
+            changeserver [server_uri]
 
-        h.join("\n")
+            Example:
+            changeserver https://mainnet.lightwalletd.com:9067
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -89,13 +90,15 @@ impl Command for InterruptCommand {
 struct ParseCommand {}
 impl Command for ParseCommand {
     fn help(&self) -> String {
-        "Parse an address\n\
-        Usage:\n\
-        parse [address]\n\
-        \n\
-        Example\n\
-        parse tmSwk8bjXdCgBvpS8Kybk5nUyE21QFcDqre"
-            .to_string()
+        indoc! {r#"
+            Parse an address
+            Usage:
+            parse [address]
+
+            Example
+            parse tmSwk8bjXdCgBvpS8Kybk5nUyE21QFcDqre
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -166,13 +169,13 @@ impl Command for ParseCommand {
 struct SyncCommand {}
 impl Command for SyncCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Sync the light client with the server");
-        h.push("Usage:");
-        h.push("sync");
-        h.push("");
+        indoc! {r#"
+            Sync the light client with the server
+            Usage:
+            sync
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -192,13 +195,13 @@ impl Command for SyncCommand {
 struct SyncStatusCommand {}
 impl Command for SyncStatusCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Get the sync status of the wallet");
-        h.push("Usage:");
-        h.push("syncstatus");
-        h.push("");
+        indoc! {r#"
+            Get the sync status of the wallet
+            Usage:
+            syncstatus
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -240,12 +243,12 @@ impl Command for SyncStatusCommand {
 struct SendProgressCommand {}
 impl Command for SendProgressCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Get the progress of any send transactions that are currently computing");
-        h.push("Usage:");
-        h.push("sendprogress");
-
-        h.join("\n")
+        indoc! {r#"
+            Get the progress of any send transactions that are currently computing
+            Usage:
+            sendprogress
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -265,15 +268,14 @@ impl Command for SendProgressCommand {
 struct RescanCommand {}
 impl Command for RescanCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Rescan the wallet, rescanning all blocks for new transactions");
-        h.push("Usage:");
-        h.push("rescan");
-        h.push("");
-        h.push("This command will download all blocks since the intial block again from the light client server");
-        h.push("and attempt to scan each block for transactions belonging to the wallet.");
+        indoc! {r#"
+            Rescan the wallet, rescanning all blocks for new transactions
+            Usage:
+            rescan
 
-        h.join("\n")
+            This command will download all blocks since the intial block again from the light client server
+            and attempt to scan each block for transactions belonging to the wallet.
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -293,14 +295,13 @@ impl Command for RescanCommand {
 struct ClearCommand {}
 impl Command for ClearCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Clear the wallet state, rolling back the wallet to an empty state.");
-        h.push("Usage:");
-        h.push("clear");
-        h.push("");
-        h.push("This command will clear all notes, utxos and transactions from the wallet, setting up the wallet to be synced from scratch.");
+        indoc! {r#"
+            Clear the wallet state, rolling back the wallet to an empty state.
+            Usage:
+            clear
 
-        h.join("\n")
+            This command will clear all notes, utxos and transactions from the wallet, setting up the wallet to be synced from scratch.
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -320,17 +321,17 @@ impl Command for ClearCommand {
 pub struct HelpCommand {}
 impl Command for HelpCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("List all available commands");
-        h.push("Usage:");
-        h.push("help [command_name]");
-        h.push("");
-        h.push("If no \"command_name\" is specified, a list of all available commands is returned");
-        h.push("Example:");
-        h.push("help send");
-        h.push("");
+        indoc! {r#"
+            List all available commands
+            Usage:
+            help [command_name]
 
-        h.join("\n")
+            If no "command_name" is specified, a list of all available commands is returned
+            Example:
+            help send
+
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -385,13 +386,13 @@ impl ShortCircuitedCommand for HelpCommand {
 struct InfoCommand {}
 impl Command for InfoCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Get info about the lightwalletd we're connected to");
-        h.push("Usage:");
-        h.push("info");
-        h.push("");
+        indoc! {r#"
+            Get info about the lightwalletd we're connected to
+            Usage:
+            info
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -406,14 +407,14 @@ impl Command for InfoCommand {
 struct UpdateCurrentPriceCommand {}
 impl Command for UpdateCurrentPriceCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Get the latest ZEC price from Gemini exchange's API.");
-        h.push("Currently using USD.");
-        h.push("Usage:");
-        h.push("zecprice");
-        h.push("");
+        indoc! {r#"
+            Get the latest ZEC price from Gemini exchange's API.
+            Currently using USD.
+            Usage:
+            zecprice
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -428,14 +429,14 @@ impl Command for UpdateCurrentPriceCommand {
 struct BalanceCommand {}
 impl Command for BalanceCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Show the current ZEC balance in the wallet");
-        h.push("Usage:");
-        h.push("balance");
-        h.push("");
-        h.push("Transparent and Shielded balances, along with the addresses they belong to are displayed");
+        indoc! {r#"
+            Show the current ZEC balance in the wallet
+            Usage:
+            balance
 
-        h.join("\n")
+            Transparent and Shielded balances, along with the addresses they belong to are displayed
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -450,13 +451,13 @@ impl Command for BalanceCommand {
 struct AddressCommand {}
 impl Command for AddressCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("List current addresses in the wallet");
-        h.push("Usage:");
-        h.push("address");
-        h.push("");
+        indoc! {r#"
+            List current addresses in the wallet
+            Usage:
+            address
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -471,20 +472,18 @@ impl Command for AddressCommand {
 struct ExportCommand {}
 impl Command for ExportCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Export private key for an individual wallet addresses.");
-        h.push("Note: To backup the whole wallet, use the 'seed' command insted");
-        h.push("Usage:");
-        h.push("export [t-address or z-address]");
-        h.push("");
-        h.push(
-            "If no address is passed, private key for all addresses in the wallet are exported.",
-        );
-        h.push("");
-        h.push("Example:");
-        h.push("export ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d");
+        indoc! {r#"
+            Export private key for an individual wallet addresses.
+            Note: To backup the whole wallet, use the 'seed' command insted
+            Usage:
+            export [t-address or z-address]
 
-        h.join("\n")
+            If no address is passed, private key for all addresses in the wallet are exported.
+
+            Example:
+            export ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -500,17 +499,16 @@ impl Command for ExportCommand {
 struct ShieldCommand {}
 impl Command for ShieldCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Shield all your transparent funds");
-        h.push("Usage:");
-        h.push("shield [optional address]");
-        h.push("");
-        h.push("NOTE: The fee required to send this transaction (currently ZEC 0.0001) is additionally deducted from your balance.");
-        h.push("Example:");
-        h.push("shield");
-        h.push("");
+        indoc! {r#"
+            Shield all your transparent funds
+            Usage:
+            shield [optional address]
 
-        h.join("\n")
+            NOTE: The fee required to send this transaction (currently ZEC 0.0001) is additionally deducted from your balance.
+            Example:
+            shield
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -541,19 +539,18 @@ impl Command for ShieldCommand {
 struct EncryptMessageCommand {}
 impl Command for EncryptMessageCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Encrypt a memo to be sent to a z-address offline");
-        h.push("Usage:");
-        h.push("encryptmessage <address> \"memo\"");
-        h.push("OR");
-        h.push("encryptmessage \"{'address': <address>, 'memo': <memo>}\" ");
-        h.push("");
-        h.push("NOTE: This command only returns the encrypted payload. It does not broadcast it. You are expected to send the encrypted payload to the recipient offline");
-        h.push("Example:");
-        h.push("encryptmessage ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d \"Hello from the command line\"");
-        h.push("");
+        indoc! {r#"
+            Encrypt a memo to be sent to a z-address offline
+            Usage:
+            encryptmessage <address> "memo"
+            OR
+            encryptmessage "{'address': <address>, 'memo': <memo>}"
 
-        h.join("\n")
+            NOTE: This command only returns the encrypted payload. It does not broadcast it. You are expected to send the encrypted payload to the recipient offline
+            Example:
+            encryptmessage ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d "Hello from the command line"
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -615,16 +612,16 @@ impl Command for EncryptMessageCommand {
 struct DecryptMessageCommand {}
 impl Command for DecryptMessageCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Attempt to decrypt a message with all the view keys in the wallet.");
-        h.push("Usage:");
-        h.push("decryptmessage \"encrypted_message_base64\"");
-        h.push("");
-        h.push("Example:");
-        h.push("decryptmessage RW5jb2RlIGFyYml0cmFyeSBvY3RldHMgYXMgYmFzZTY0LiBSZXR1cm5zIGEgU3RyaW5nLg==");
-        h.push("");
+        indoc! {r#"
+            Attempt to decrypt a message with all the view keys in the wallet.
+            Usage:
+            decryptmessage "encrypted_message_base64"
 
-        h.join("\n")
+            Example:
+            decryptmessage RW5jb2RlIGFyYml0cmFyeSBvY3RldHMgYXMgYmFzZTY0LiBSZXR1cm5zIGEgU3RyaW5nLg==
+
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -648,19 +645,18 @@ impl Command for DecryptMessageCommand {
 struct SendCommand {}
 impl Command for SendCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Send ZEC to a given address(es)");
-        h.push("Usage:");
-        h.push("send <address> <amount in zatoshis> \"optional_memo\"");
-        h.push("OR");
-        h.push("send '[{'address': <address>, 'amount': <amount in zatoshis>, 'memo': <optional memo>}, ...]'");
-        h.push("");
-        h.push("NOTE: The fee required to send this transaction (currently ZEC 0.0001) is additionally deducted from your balance.");
-        h.push("Example:");
-        h.push("send ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d 200000 \"Hello from the command line\"");
-        h.push("");
+        indoc! {r#"
+            Send ZEC to a given address(es)
+            Usage:
+            send <address> <amount in zatoshis> "optional_memo"
+            OR
+            send '[{'address': <address>, 'amount': <amount in zatoshis>, 'memo': <optional memo>}, ...]'
 
-        h.join("\n")
+            NOTE: The fee required to send this transaction (currently ZEC 0.0001) is additionally deducted from your balance.
+            Example:
+            send ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d 200000 "Hello from the command line"
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -786,15 +782,15 @@ fn wallet_saver(lightclient: &LightClient) -> String {
 struct SaveCommand {}
 impl Command for SaveCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Save the wallet to disk");
-        h.push("Usage:");
-        h.push("save");
-        h.push("");
-        h.push("The wallet is saved to disk. The wallet is periodically saved to disk (and also saved upon exit)");
-        h.push("but you can use this command to explicitly save it to disk");
+        indoc! {r#"
+            Save the wallet to disk
+            Usage:
+            save
 
-        h.join("\n")
+            The wallet is saved to disk. The wallet is periodically saved to disk (and also saved upon exit)
+            but you can use this command to explicitly save it to disk
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -809,14 +805,14 @@ impl Command for SaveCommand {
 struct SeedCommand {}
 impl Command for SeedCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Show the wallet's seed phrase");
-        h.push("Usage:");
-        h.push("seed");
-        h.push("");
-        h.push("Your wallet is entirely recoverable from the seed phrase. Please save it carefully and don't share it with anyone");
+        indoc! {r#"
+            Show the wallet's seed phrase
+            Usage:
+            seed
 
-        h.join("\n")
+            Your wallet is entirely recoverable from the seed phrase. Please save it carefully and don't share it with anyone
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -837,14 +833,15 @@ impl Command for SeedCommand {
 struct TransactionsCommand {}
 impl Command for TransactionsCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("List all incoming and outgoing transactions from this wallet");
-        h.push("Usage:");
-        h.push("list [allmemos]");
-        h.push("");
-        h.push("If you include the 'allmemos' argument, all memos are returned in their raw hex format");
+        indoc! {r#"
+            List all incoming and outgoing transactions from this wallet
+            Usage:
+            list [allmemos]
 
-        h.join("\n")
+            If you include the 'allmemos' argument, all memos are returned in their raw hex format
+
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -885,14 +882,15 @@ impl Command for TransactionsCommand {
 struct SetOptionCommand {}
 impl Command for SetOptionCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Set a wallet option");
-        h.push("Usage:");
-        h.push("setoption <optionname>=<optionvalue>");
-        h.push("List of available options:");
-        h.push("download_memos : none | wallet | all");
+        indoc! {r#"
+            Set a wallet option
+            Usage:
+            setoption <optionname>=<optionvalue>
+            List of available options:
+            download_memos : none | wallet | all
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -968,12 +966,13 @@ impl Command for SetOptionCommand {
 struct GetOptionCommand {}
 impl Command for GetOptionCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Get a wallet option");
-        h.push("Usage:");
-        h.push("getoption <optionname>");
+        indoc! {r#"
+            Get a wallet option
+            Usage:
+            getoption <optionname>
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -1023,17 +1022,17 @@ impl Command for GetOptionCommand {
 struct ImportCommand {}
 impl Command for ImportCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Import an external spending or viewing key into the wallet");
-        h.push("Usage:");
-        h.push("import <spending_key | viewing_key> <birthday> [norescan]");
-        h.push("OR");
-        h.push("import '{'key': <spending_key or viewing_key>, 'birthday': <birthday>, 'norescan': <true>}'");
-        h.push("");
-        h.push("Birthday is the earliest block number that has transactions belonging to the imported key. Rescanning will start from this block. If not sure, you can specify '0', which will start rescanning from the first sapling block.");
-        h.push("Note that you can import only the full spending (private) key or the full viewing key.");
+        indoc! {r#"
+            Import an external spending or viewing key into the wallet
+            Usage:
+            import <spending_key | viewing_key> <birthday> [norescan]
+            OR
+            import '{'key': <spending_key or viewing_key>, 'birthday': <birthday>, 'norescan': <true>}'
 
-        h.join("\n")
+            Birthday is the earliest block number that has transactions belonging to the imported key. Rescanning will start from this block. If not sure, you can specify '0', which will start rescanning from the first sapling block.
+            Note that you can import only the full spending (private) key or the full viewing key.
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -1048,14 +1047,14 @@ impl Command for ImportCommand {
 struct HeightCommand {}
 impl Command for HeightCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Get the latest block height that the wallet is at.");
-        h.push("Usage:");
-        h.push("height");
-        h.push("");
-        h.push("Pass 'true' (default) to sync to the server to get the latest block height. Pass 'false' to get the latest height in the wallet without checking with the server.");
+        indoc! {r#"
+            Get the latest block height that the wallet is at.
+            Usage:
+            height
 
-        h.join("\n")
+            Pass 'true' (default) to sync to the server to get the latest block height. Pass 'false' to get the latest height in the wallet without checking with the server.
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -1075,14 +1074,15 @@ impl Command for HeightCommand {
 struct DefaultFeeCommand {}
 impl Command for DefaultFeeCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Returns the default fee in zats for outgoing transactions");
-        h.push("Usage:");
-        h.push("defaultfee <optional_block_height>");
-        h.push("");
-        h.push("Example:");
-        h.push("defaultfee");
-        h.join("\n")
+        indoc! {r#"
+            Returns the default fee in zats for outgoing transactions
+            Usage:
+            defaultfee <optional_block_height>
+
+            Example:
+            defaultfee
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -1104,15 +1104,16 @@ impl Command for DefaultFeeCommand {
 struct NewAddressCommand {}
 impl Command for NewAddressCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Create a new address in this wallet");
-        h.push("Usage:");
-        h.push("new [z | t | o]");
-        h.push("");
-        h.push("Example:");
-        h.push("To create a new z address:");
-        h.push("new z");
-        h.join("\n")
+        indoc! {r#"
+            Create a new address in this wallet
+            Usage:
+            new [z | t | o]
+
+            Example:
+            To create a new z address:
+            new z
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {
@@ -1137,16 +1138,14 @@ impl Command for NewAddressCommand {
 struct NotesCommand {}
 impl Command for NotesCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Show all sapling notes and utxos in this wallet");
-        h.push("Usage:");
-        h.push("notes [all]");
-        h.push("");
-        h.push(
-            "If you supply the \"all\" parameter, all previously spent sapling notes and spent utxos are also included",
-        );
+        indoc! {r#"
+            Show all sapling notes and utxos in this wallet
+            Usage:
+            notes [all]
 
-        h.join("\n")
+            If you supply the "all" parameter, all previously spent sapling notes and spent utxos are also included
+
+        "#}.to_string()
     }
 
     fn short_help(&self) -> String {
@@ -1183,13 +1182,13 @@ impl Command for NotesCommand {
 struct QuitCommand {}
 impl Command for QuitCommand {
     fn help(&self) -> String {
-        let mut h = vec![];
-        h.push("Save the wallet to disk and quit");
-        h.push("Usage:");
-        h.push("quit");
-        h.push("");
+        indoc! {r#"
+            Save the wallet to disk and quit
+            Usage:
+            quit
 
-        h.join("\n")
+        "#}
+        .to_string()
     }
 
     fn short_help(&self) -> String {

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1219,7 +1219,7 @@ impl Command for QuitCommand {
     }
 }
 
-pub fn get_commands() -> Box<HashMap<String, Box<dyn Command>>> {
+pub fn get_commands() -> HashMap<String, Box<dyn Command>> {
     let mut map: HashMap<String, Box<dyn Command>> = HashMap::new();
 
     map.insert("sync".to_string(), Box::new(SyncCommand {}));
@@ -1264,7 +1264,7 @@ pub fn get_commands() -> Box<HashMap<String, Box<dyn Command>>> {
     map.insert("defaultfee".to_string(), Box::new(DefaultFeeCommand {}));
     map.insert("seed".to_string(), Box::new(SeedCommand {}));
 
-    Box::new(map)
+    map
 }
 
 pub fn do_user_command(cmd: &str, args: &Vec<&str>, lightclient: &LightClient) -> String {

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -369,7 +369,7 @@ impl ShortCircuitedCommand for HelpCommand {
                 responses.sort();
                 responses.join("\n")
             }
-            1 => match get_commands().get(&args[0]) {
+            1 => match get_commands().get(args[0].as_str()) {
                 Some(cmd) => cmd.help().to_string(),
                 None => format!("Command {} not found", args[0]),
             },
@@ -1219,56 +1219,44 @@ impl Command for QuitCommand {
     }
 }
 
-pub fn get_commands() -> HashMap<String, Box<dyn Command>> {
-    let mut map: HashMap<String, Box<dyn Command>> = HashMap::new();
+pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
+    let mut map: HashMap<&'static str, Box<dyn Command>> = HashMap::new();
 
-    map.insert("sync".to_string(), Box::new(SyncCommand {}));
-    map.insert("syncstatus".to_string(), Box::new(SyncStatusCommand {}));
-    map.insert(
-        "encryptmessage".to_string(),
-        Box::new(EncryptMessageCommand {}),
-    );
-    map.insert(
-        "decryptmessage".to_string(),
-        Box::new(DecryptMessageCommand {}),
-    );
-    map.insert("parse".to_string(), Box::new(ParseCommand {}));
-    map.insert(
-        "interrupt_sync_after_batch".to_string(),
-        Box::new(InterruptCommand {}),
-    );
-    map.insert("changeserver".to_string(), Box::new(ChangeServerCommand {}));
-    map.insert("rescan".to_string(), Box::new(RescanCommand {}));
-    map.insert("clear".to_string(), Box::new(ClearCommand {}));
-    map.insert("help".to_string(), Box::new(HelpCommand {}));
-    map.insert("balance".to_string(), Box::new(BalanceCommand {}));
-    map.insert("addresses".to_string(), Box::new(AddressCommand {}));
-    map.insert("height".to_string(), Box::new(HeightCommand {}));
-    map.insert("sendprogress".to_string(), Box::new(SendProgressCommand {}));
-    map.insert("setoption".to_string(), Box::new(SetOptionCommand {}));
-    map.insert("getoption".to_string(), Box::new(GetOptionCommand {}));
-    map.insert("import".to_string(), Box::new(ImportCommand {}));
-    map.insert("export".to_string(), Box::new(ExportCommand {}));
-    map.insert("info".to_string(), Box::new(InfoCommand {}));
-    map.insert(
-        "updatecurrentprice".to_string(),
-        Box::new(UpdateCurrentPriceCommand {}),
-    );
-    map.insert("send".to_string(), Box::new(SendCommand {}));
-    map.insert("shield".to_string(), Box::new(ShieldCommand {}));
-    map.insert("save".to_string(), Box::new(SaveCommand {}));
-    map.insert("quit".to_string(), Box::new(QuitCommand {}));
-    map.insert("list".to_string(), Box::new(TransactionsCommand {}));
-    map.insert("notes".to_string(), Box::new(NotesCommand {}));
-    map.insert("new".to_string(), Box::new(NewAddressCommand {}));
-    map.insert("defaultfee".to_string(), Box::new(DefaultFeeCommand {}));
-    map.insert("seed".to_string(), Box::new(SeedCommand {}));
+    map.insert("sync", Box::new(SyncCommand {}));
+    map.insert("syncstatus", Box::new(SyncStatusCommand {}));
+    map.insert("encryptmessage", Box::new(EncryptMessageCommand {}));
+    map.insert("decryptmessage", Box::new(DecryptMessageCommand {}));
+    map.insert("parse", Box::new(ParseCommand {}));
+    map.insert("interrupt_sync_after_batch", Box::new(InterruptCommand {}));
+    map.insert("changeserver", Box::new(ChangeServerCommand {}));
+    map.insert("rescan", Box::new(RescanCommand {}));
+    map.insert("clear", Box::new(ClearCommand {}));
+    map.insert("help", Box::new(HelpCommand {}));
+    map.insert("balance", Box::new(BalanceCommand {}));
+    map.insert("addresses", Box::new(AddressCommand {}));
+    map.insert("height", Box::new(HeightCommand {}));
+    map.insert("sendprogress", Box::new(SendProgressCommand {}));
+    map.insert("setoption", Box::new(SetOptionCommand {}));
+    map.insert("getoption", Box::new(GetOptionCommand {}));
+    map.insert("import", Box::new(ImportCommand {}));
+    map.insert("export", Box::new(ExportCommand {}));
+    map.insert("info", Box::new(InfoCommand {}));
+    map.insert("updatecurrentprice", Box::new(UpdateCurrentPriceCommand {}));
+    map.insert("send", Box::new(SendCommand {}));
+    map.insert("shield", Box::new(ShieldCommand {}));
+    map.insert("save", Box::new(SaveCommand {}));
+    map.insert("quit", Box::new(QuitCommand {}));
+    map.insert("list", Box::new(TransactionsCommand {}));
+    map.insert("notes", Box::new(NotesCommand {}));
+    map.insert("new", Box::new(NewAddressCommand {}));
+    map.insert("defaultfee", Box::new(DefaultFeeCommand {}));
+    map.insert("seed", Box::new(SeedCommand {}));
 
     map
 }
 
 pub fn do_user_command(cmd: &str, args: &Vec<&str>, lightclient: &LightClient) -> String {
-    match get_commands().get(&cmd.to_ascii_lowercase()) {
+    match get_commands().get(cmd.to_ascii_lowercase().as_str()) {
         Some(cmd) => cmd.exec(args, lightclient),
         None => format!(
             "Unknown command : {}. Type 'help' for a list of commands",

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1220,39 +1220,39 @@ impl Command for QuitCommand {
 }
 
 pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
-    let mut map: HashMap<&'static str, Box<dyn Command>> = HashMap::new();
+    let entries: [(&'static str, Box<dyn Command>); 29] = [
+        ("sync", Box::new(SyncCommand {})),
+        ("syncstatus", Box::new(SyncStatusCommand {})),
+        ("encryptmessage", Box::new(EncryptMessageCommand {})),
+        ("decryptmessage", Box::new(DecryptMessageCommand {})),
+        ("parse", Box::new(ParseCommand {})),
+        ("interrupt_sync_after_batch", Box::new(InterruptCommand {})),
+        ("changeserver", Box::new(ChangeServerCommand {})),
+        ("rescan", Box::new(RescanCommand {})),
+        ("clear", Box::new(ClearCommand {})),
+        ("help", Box::new(HelpCommand {})),
+        ("balance", Box::new(BalanceCommand {})),
+        ("addresses", Box::new(AddressCommand {})),
+        ("height", Box::new(HeightCommand {})),
+        ("sendprogress", Box::new(SendProgressCommand {})),
+        ("setoption", Box::new(SetOptionCommand {})),
+        ("getoption", Box::new(GetOptionCommand {})),
+        ("import", Box::new(ImportCommand {})),
+        ("export", Box::new(ExportCommand {})),
+        ("info", Box::new(InfoCommand {})),
+        ("updatecurrentprice", Box::new(UpdateCurrentPriceCommand {})),
+        ("send", Box::new(SendCommand {})),
+        ("shield", Box::new(ShieldCommand {})),
+        ("save", Box::new(SaveCommand {})),
+        ("quit", Box::new(QuitCommand {})),
+        ("list", Box::new(TransactionsCommand {})),
+        ("notes", Box::new(NotesCommand {})),
+        ("new", Box::new(NewAddressCommand {})),
+        ("defaultfee", Box::new(DefaultFeeCommand {})),
+        ("seed", Box::new(SeedCommand {})),
+    ];
 
-    map.insert("sync", Box::new(SyncCommand {}));
-    map.insert("syncstatus", Box::new(SyncStatusCommand {}));
-    map.insert("encryptmessage", Box::new(EncryptMessageCommand {}));
-    map.insert("decryptmessage", Box::new(DecryptMessageCommand {}));
-    map.insert("parse", Box::new(ParseCommand {}));
-    map.insert("interrupt_sync_after_batch", Box::new(InterruptCommand {}));
-    map.insert("changeserver", Box::new(ChangeServerCommand {}));
-    map.insert("rescan", Box::new(RescanCommand {}));
-    map.insert("clear", Box::new(ClearCommand {}));
-    map.insert("help", Box::new(HelpCommand {}));
-    map.insert("balance", Box::new(BalanceCommand {}));
-    map.insert("addresses", Box::new(AddressCommand {}));
-    map.insert("height", Box::new(HeightCommand {}));
-    map.insert("sendprogress", Box::new(SendProgressCommand {}));
-    map.insert("setoption", Box::new(SetOptionCommand {}));
-    map.insert("getoption", Box::new(GetOptionCommand {}));
-    map.insert("import", Box::new(ImportCommand {}));
-    map.insert("export", Box::new(ExportCommand {}));
-    map.insert("info", Box::new(InfoCommand {}));
-    map.insert("updatecurrentprice", Box::new(UpdateCurrentPriceCommand {}));
-    map.insert("send", Box::new(SendCommand {}));
-    map.insert("shield", Box::new(ShieldCommand {}));
-    map.insert("save", Box::new(SaveCommand {}));
-    map.insert("quit", Box::new(QuitCommand {}));
-    map.insert("list", Box::new(TransactionsCommand {}));
-    map.insert("notes", Box::new(NotesCommand {}));
-    map.insert("new", Box::new(NewAddressCommand {}));
-    map.insert("defaultfee", Box::new(DefaultFeeCommand {}));
-    map.insert("seed", Box::new(SeedCommand {}));
-
-    map
+    HashMap::from(entries)
 }
 
 pub fn do_user_command(cmd: &str, args: &Vec<&str>, lightclient: &LightClient) -> String {

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -16,9 +16,9 @@ lazy_static! {
 }
 
 pub trait Command {
-    fn help(&self) -> String;
+    fn help(&self) -> &'static str;
 
-    fn short_help(&self) -> String;
+    fn short_help(&self) -> &'static str;
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String;
 }
@@ -28,7 +28,7 @@ pub trait ShortCircuitedCommand {
 }
 struct ChangeServerCommand {}
 impl Command for ChangeServerCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Change the lightwalletd server to receive blockchain data from
             Usage:
@@ -37,11 +37,10 @@ impl Command for ChangeServerCommand {
             Example:
             changeserver https://mainnet.lightwalletd.com:9067
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Change lightwalletd server".to_string()
+    fn short_help(&self) -> &'static str {
+        "Change lightwalletd server"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
@@ -54,18 +53,18 @@ impl Command for ChangeServerCommand {
                 Err(_) => "invalid server uri",
             }
             .to_string(),
-            _ => self.help(),
+            _ => self.help().to_string(),
         }
     }
 }
 
 struct InterruptCommand {}
 impl Command for InterruptCommand {
-    fn help(&self) -> String {
-        "Toggle the sync interrupt after batch flag.".to_string()
+    fn help(&self) -> &'static str {
+        "Toggle the sync interrupt after batch flag."
     }
-    fn short_help(&self) -> String {
-        "Toggle the sync interrupt after batch flag.".to_string()
+    fn short_help(&self) -> &'static str {
+        "Toggle the sync interrupt after batch flag."
     }
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
         match args.len() {
@@ -79,17 +78,17 @@ impl Command for InterruptCommand {
                         lightclient.interrupt_sync_after_batch(false).await;
                         "false".to_string()
                     }
-                    _ => self.help(),
+                    _ => self.help().to_string(),
                 }
             }),
-            _ => self.help(),
+            _ => self.help().to_string(),
         }
     }
 }
 
 struct ParseCommand {}
 impl Command for ParseCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Parse an address
             Usage:
@@ -98,11 +97,10 @@ impl Command for ParseCommand {
             Example
             parse tmSwk8bjXdCgBvpS8Kybk5nUyE21QFcDqre
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Parse an address".to_string()
+    fn short_help(&self) -> &'static str {
+        "Parse an address"
     }
 
     fn exec(&self, args: &[&str], _lightclient: &LightClient) -> String {
@@ -161,25 +159,24 @@ impl Command for ParseCommand {
                 }),
                 4,
             ),
-            _ => self.help(),
+            _ => self.help().to_string(),
         }
     }
 }
 
 struct SyncCommand {}
 impl Command for SyncCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Sync the light client with the server
             Usage:
             sync
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Download CompactBlocks and sync to the server".to_string()
+    fn short_help(&self) -> &'static str {
+        "Download CompactBlocks and sync to the server"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -194,18 +191,17 @@ impl Command for SyncCommand {
 
 struct SyncStatusCommand {}
 impl Command for SyncStatusCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Get the sync status of the wallet
             Usage:
             syncstatus
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Get the sync status of the wallet".to_string()
+    fn short_help(&self) -> &'static str {
+        "Get the sync status of the wallet"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -242,17 +238,16 @@ impl Command for SyncStatusCommand {
 
 struct SendProgressCommand {}
 impl Command for SendProgressCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Get the progress of any send transactions that are currently computing
             Usage:
             sendprogress
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Get the progress of any send transactions that are currently computing".to_string()
+    fn short_help(&self) -> &'static str {
+        "Get the progress of any send transactions that are currently computing"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -267,7 +262,7 @@ impl Command for SendProgressCommand {
 
 struct RescanCommand {}
 impl Command for RescanCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Rescan the wallet, rescanning all blocks for new transactions
             Usage:
@@ -275,11 +270,11 @@ impl Command for RescanCommand {
 
             This command will download all blocks since the intial block again from the light client server
             and attempt to scan each block for transactions belonging to the wallet.
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Rescan the wallet, downloading and scanning all blocks and transactions".to_string()
+    fn short_help(&self) -> &'static str {
+        "Rescan the wallet, downloading and scanning all blocks and transactions"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -294,18 +289,18 @@ impl Command for RescanCommand {
 
 struct ClearCommand {}
 impl Command for ClearCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Clear the wallet state, rolling back the wallet to an empty state.
             Usage:
             clear
 
             This command will clear all notes, utxos and transactions from the wallet, setting up the wallet to be synced from scratch.
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Clear the wallet state, rolling back the wallet to an empty state.".to_string()
+    fn short_help(&self) -> &'static str {
+        "Clear the wallet state, rolling back the wallet to an empty state."
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -320,7 +315,7 @@ impl Command for ClearCommand {
 
 pub struct HelpCommand {}
 impl Command for HelpCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             List all available commands
             Usage:
@@ -331,11 +326,10 @@ impl Command for HelpCommand {
             help send
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Lists all available commands".to_string()
+    fn short_help(&self) -> &'static str {
+        "Lists all available commands"
     }
 
     fn exec(&self, args: &[&str], _: &LightClient) -> String {
@@ -353,10 +347,10 @@ impl Command for HelpCommand {
                 responses.join("\n")
             }
             1 => match get_commands().get(args[0]) {
-                Some(cmd) => cmd.help(),
+                Some(cmd) => cmd.help().to_string(),
                 None => format!("Command {} not found", args[0]),
             },
-            _ => self.help(),
+            _ => self.help().to_string(),
         }
     }
 }
@@ -376,7 +370,7 @@ impl ShortCircuitedCommand for HelpCommand {
                 responses.join("\n")
             }
             1 => match get_commands().get(&args[0]) {
-                Some(cmd) => cmd.help(),
+                Some(cmd) => cmd.help().to_string(),
                 None => format!("Command {} not found", args[0]),
             },
             _ => panic!("Unexpected number of parameters."),
@@ -385,18 +379,17 @@ impl ShortCircuitedCommand for HelpCommand {
 }
 struct InfoCommand {}
 impl Command for InfoCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Get info about the lightwalletd we're connected to
             Usage:
             info
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Get the lightwalletd server's info".to_string()
+    fn short_help(&self) -> &'static str {
+        "Get the lightwalletd server's info"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -406,7 +399,7 @@ impl Command for InfoCommand {
 
 struct UpdateCurrentPriceCommand {}
 impl Command for UpdateCurrentPriceCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Get the latest ZEC price from Gemini exchange's API.
             Currently using USD.
@@ -414,11 +407,10 @@ impl Command for UpdateCurrentPriceCommand {
             zecprice
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Get the latest ZEC price in the wallet's currency (USD)".to_string()
+    fn short_help(&self) -> &'static str {
+        "Get the latest ZEC price in the wallet's currency (USD)"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -428,7 +420,7 @@ impl Command for UpdateCurrentPriceCommand {
 
 struct BalanceCommand {}
 impl Command for BalanceCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Show the current ZEC balance in the wallet
             Usage:
@@ -436,11 +428,10 @@ impl Command for BalanceCommand {
 
             Transparent and Shielded balances, along with the addresses they belong to are displayed
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Show the current ZEC balance in the wallet".to_string()
+    fn short_help(&self) -> &'static str {
+        "Show the current ZEC balance in the wallet"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -450,18 +441,17 @@ impl Command for BalanceCommand {
 
 struct AddressCommand {}
 impl Command for AddressCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             List current addresses in the wallet
             Usage:
             address
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "List all addresses in the wallet".to_string()
+    fn short_help(&self) -> &'static str {
+        "List all addresses in the wallet"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -471,7 +461,7 @@ impl Command for AddressCommand {
 
 struct ExportCommand {}
 impl Command for ExportCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Export private key for an individual wallet addresses.
             Note: To backup the whole wallet, use the 'seed' command insted
@@ -483,11 +473,10 @@ impl Command for ExportCommand {
             Example:
             export ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Export private key for wallet addresses".to_string()
+    fn short_help(&self) -> &'static str {
+        "Export private key for wallet addresses"
     }
 
     fn exec(&self, _args: &[&str], _lightclient: &LightClient) -> String {
@@ -498,7 +487,7 @@ impl Command for ExportCommand {
 
 struct ShieldCommand {}
 impl Command for ShieldCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Shield all your transparent funds
             Usage:
@@ -508,11 +497,11 @@ impl Command for ShieldCommand {
             Example:
             shield
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Shield your transparent ZEC into a sapling address".to_string()
+    fn short_help(&self) -> &'static str {
+        "Shield your transparent ZEC into a sapling address"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
@@ -538,7 +527,7 @@ impl Command for ShieldCommand {
 
 struct EncryptMessageCommand {}
 impl Command for EncryptMessageCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Encrypt a memo to be sent to a z-address offline
             Usage:
@@ -550,16 +539,16 @@ impl Command for EncryptMessageCommand {
             Example:
             encryptmessage ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d "Hello from the command line"
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Encrypt a memo to be sent to a z-address offline".to_string()
+    fn short_help(&self) -> &'static str {
+        "Encrypt a memo to be sent to a z-address offline"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
         if args.len() < 1 || args.len() > 3 {
-            return self.help();
+            return self.help().to_string();
         }
 
         // Check for a single argument that can be parsed as JSON
@@ -611,7 +600,7 @@ impl Command for EncryptMessageCommand {
 
 struct DecryptMessageCommand {}
 impl Command for DecryptMessageCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Attempt to decrypt a message with all the view keys in the wallet.
             Usage:
@@ -621,16 +610,15 @@ impl Command for DecryptMessageCommand {
             decryptmessage RW5jb2RlIGFyYml0cmFyeSBvY3RldHMgYXMgYmFzZTY0LiBSZXR1cm5zIGEgU3RyaW5nLg==
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Attempt to decrypt a message with all the view keys in the wallet.".to_string()
+    fn short_help(&self) -> &'static str {
+        "Attempt to decrypt a message with all the view keys in the wallet."
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
         if args.len() != 1 {
-            return self.help();
+            return self.help().to_string();
         }
 
         RT.block_on(async move {
@@ -644,7 +632,7 @@ impl Command for DecryptMessageCommand {
 
 struct SendCommand {}
 impl Command for SendCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Send ZEC to a given address(es)
             Usage:
@@ -656,11 +644,11 @@ impl Command for SendCommand {
             Example:
             send ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d 200000 "Hello from the command line"
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Send ZEC to the given address".to_string()
+    fn short_help(&self) -> &'static str {
+        "Send ZEC to the given address"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
@@ -668,7 +656,7 @@ impl Command for SendCommand {
         // 1 - A set of 2(+1 optional) arguments for a single address send representing address, value, memo?
         // 2 - A single argument in the form of a JSON string that is "[{address: address, value: value, memo: memo},...]"
         if args.len() < 1 || args.len() > 3 {
-            return self.help();
+            return self.help().to_string();
         }
 
         RT.block_on(async move {
@@ -740,7 +728,7 @@ impl Command for SendCommand {
 
                 vec![(args[0].to_string(), value, memo)]
             } else {
-                return self.help();
+                return self.help().to_string();
             };
 
             // Convert to the right format. String -> &str.
@@ -781,7 +769,7 @@ fn wallet_saver(lightclient: &LightClient) -> String {
 }
 struct SaveCommand {}
 impl Command for SaveCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Save the wallet to disk
             Usage:
@@ -790,11 +778,11 @@ impl Command for SaveCommand {
             The wallet is saved to disk. The wallet is periodically saved to disk (and also saved upon exit)
             but you can use this command to explicitly save it to disk
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Save wallet file to disk".to_string()
+    fn short_help(&self) -> &'static str {
+        "Save wallet file to disk"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -804,7 +792,7 @@ impl Command for SaveCommand {
 
 struct SeedCommand {}
 impl Command for SeedCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Show the wallet's seed phrase
             Usage:
@@ -812,11 +800,11 @@ impl Command for SeedCommand {
 
             Your wallet is entirely recoverable from the seed phrase. Please save it carefully and don't share it with anyone
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Display the seed phrase".to_string()
+    fn short_help(&self) -> &'static str {
+        "Display the seed phrase"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -832,7 +820,7 @@ impl Command for SeedCommand {
 
 struct TransactionsCommand {}
 impl Command for TransactionsCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             List all incoming and outgoing transactions from this wallet
             Usage:
@@ -841,11 +829,10 @@ impl Command for TransactionsCommand {
             If you include the 'allmemos' argument, all memos are returned in their raw hex format
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "List all transactions in the wallet".to_string()
+    fn short_help(&self) -> &'static str {
+        "List all transactions in the wallet"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
@@ -881,7 +868,7 @@ impl Command for TransactionsCommand {
 
 struct SetOptionCommand {}
 impl Command for SetOptionCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Set a wallet option
             Usage:
@@ -890,11 +877,10 @@ impl Command for SetOptionCommand {
             download_memos : none | wallet | all
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Set a wallet option".to_string()
+    fn short_help(&self) -> &'static str {
+        "Set a wallet option"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
@@ -965,18 +951,17 @@ impl Command for SetOptionCommand {
 
 struct GetOptionCommand {}
 impl Command for GetOptionCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Get a wallet option
             Usage:
             getoption <optionname>
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Get a wallet option".to_string()
+    fn short_help(&self) -> &'static str {
+        "Get a wallet option"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
@@ -1021,7 +1006,7 @@ impl Command for GetOptionCommand {
 
 struct ImportCommand {}
 impl Command for ImportCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Import an external spending or viewing key into the wallet
             Usage:
@@ -1032,11 +1017,11 @@ impl Command for ImportCommand {
             Birthday is the earliest block number that has transactions belonging to the imported key. Rescanning will start from this block. If not sure, you can specify '0', which will start rescanning from the first sapling block.
             Note that you can import only the full spending (private) key or the full viewing key.
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Import spending or viewing keys into the wallet".to_string()
+    fn short_help(&self) -> &'static str {
+        "Import spending or viewing keys into the wallet"
     }
 
     fn exec(&self, _args: &[&str], _lightclient: &LightClient) -> String {
@@ -1046,7 +1031,7 @@ impl Command for ImportCommand {
 
 struct HeightCommand {}
 impl Command for HeightCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Get the latest block height that the wallet is at.
             Usage:
@@ -1054,11 +1039,11 @@ impl Command for HeightCommand {
 
             Pass 'true' (default) to sync to the server to get the latest block height. Pass 'false' to get the latest height in the wallet without checking with the server.
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "Get the latest block height that the wallet is at".to_string()
+    fn short_help(&self) -> &'static str {
+        "Get the latest block height that the wallet is at"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
@@ -1073,7 +1058,7 @@ impl Command for HeightCommand {
 
 struct DefaultFeeCommand {}
 impl Command for DefaultFeeCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Returns the default fee in zats for outgoing transactions
             Usage:
@@ -1082,11 +1067,10 @@ impl Command for DefaultFeeCommand {
             Example:
             defaultfee
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Returns the default fee in zats for outgoing transactions".to_string()
+    fn short_help(&self) -> &'static str {
+        "Returns the default fee in zats for outgoing transactions"
     }
 
     fn exec(&self, args: &[&str], _lightclient: &LightClient) -> String {
@@ -1103,7 +1087,7 @@ impl Command for DefaultFeeCommand {
 
 struct NewAddressCommand {}
 impl Command for NewAddressCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Create a new address in this wallet
             Usage:
@@ -1113,11 +1097,10 @@ impl Command for NewAddressCommand {
             To create a new z address:
             new z
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Create a new address in this wallet".to_string()
+    fn short_help(&self) -> &'static str {
+        "Create a new address in this wallet"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
@@ -1137,7 +1120,7 @@ impl Command for NewAddressCommand {
 
 struct NotesCommand {}
 impl Command for NotesCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Show all sapling notes and utxos in this wallet
             Usage:
@@ -1145,17 +1128,17 @@ impl Command for NotesCommand {
 
             If you supply the "all" parameter, all previously spent sapling notes and spent utxos are also included
 
-        "#}.to_string()
+        "#}
     }
 
-    fn short_help(&self) -> String {
-        "List all sapling notes and utxos in the wallet".to_string()
+    fn short_help(&self) -> &'static str {
+        "List all sapling notes and utxos in the wallet"
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
         // Parse the args.
         if args.len() > 1 {
-            return self.short_help();
+            return self.short_help().to_string();
         }
 
         // Make sure we can parse the amount
@@ -1181,18 +1164,17 @@ impl Command for NotesCommand {
 
 struct QuitCommand {}
 impl Command for QuitCommand {
-    fn help(&self) -> String {
+    fn help(&self) -> &'static str {
         indoc! {r#"
             Save the wallet to disk and quit
             Usage:
             quit
 
         "#}
-        .to_string()
     }
 
-    fn short_help(&self) -> String {
-        "Quit the lightwallet, saving state to disk".to_string()
+    fn short_help(&self) -> &'static str {
+        "Quit the lightwallet, saving state to disk"
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1247,7 +1247,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
     HashMap::from(entries)
 }
 
-pub fn do_user_command(cmd: &str, args: &Vec<&str>, lightclient: &LightClient) -> String {
+pub fn do_user_command(cmd: &str, args: &[&str], lightclient: &LightClient) -> String {
     match get_commands().get(cmd.to_ascii_lowercase().as_str()) {
         Some(cmd) => cmd.exec(args, lightclient),
         None => format!(

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1280,12 +1280,12 @@ pub mod tests {
             .unwrap();
 
         assert_eq!(
-            do_user_command("addresses", &vec![], &lc),
-            do_user_command("AddReSSeS", &vec![], &lc)
+            do_user_command("addresses", &[], &lc),
+            do_user_command("AddReSSeS", &[], &lc)
         );
         assert_eq!(
-            do_user_command("addresses", &vec![], &lc),
-            do_user_command("Addresses", &vec![], &lc)
+            do_user_command("addresses", &[], &lc),
+            do_user_command("Addresses", &[], &lc)
         );
     }
 

--- a/zingolib/src/compact_formats.rs
+++ b/zingolib/src/compact_formats.rs
@@ -139,7 +139,7 @@ impl TryFrom<&CompactOrchardAction> for orchard::note_encryption::CompactAction 
     }
 }
 
-pub(crate) fn vec_to_array<'a, const N: usize>(vec: &'a Vec<u8>) -> &'a [u8; N] {
-    <&[u8; N]>::try_from(&vec[..]).unwrap_or_else(|_| &[0; N])
+pub(crate) fn vec_to_array<const N: usize>(vec: &Vec<u8>) -> &[u8; N] {
+    <&[u8; N]>::try_from(&vec[..]).unwrap_or(&[0; N])
     //todo: This default feels dangerous. Find better solution
 }

--- a/zingolib/src/compact_formats.rs
+++ b/zingolib/src/compact_formats.rs
@@ -139,7 +139,7 @@ impl TryFrom<&CompactOrchardAction> for orchard::note_encryption::CompactAction 
     }
 }
 
-pub(crate) fn vec_to_array<const N: usize>(vec: &Vec<u8>) -> &[u8; N] {
+pub(crate) fn vec_to_array<const N: usize>(vec: &[u8]) -> &[u8; N] {
     <&[u8; N]>::try_from(&vec[..]).unwrap_or(&[0; N])
     //todo: This default feels dangerous. Find better solution
 }

--- a/zingolib/src/compact_formats.rs
+++ b/zingolib/src/compact_formats.rs
@@ -99,24 +99,24 @@ impl CompactSaplingOutput {
 
 impl<P: Parameters> ShieldedOutput<SaplingDomain<P>, COMPACT_NOTE_SIZE> for CompactSaplingOutput {
     fn ephemeral_key(&self) -> EphemeralKeyBytes {
-        EphemeralKeyBytes(*vec_to_array(&self.epk))
+        EphemeralKeyBytes(*slice_to_array(&self.epk))
     }
     fn cmstar_bytes(&self) -> [u8; 32] {
-        *vec_to_array(&self.cmu)
+        *slice_to_array(&self.cmu)
     }
     fn enc_ciphertext(&self) -> &[u8; COMPACT_NOTE_SIZE] {
-        vec_to_array(&self.ciphertext)
+        slice_to_array(&self.ciphertext)
     }
 }
 impl ShieldedOutput<OrchardDomain, COMPACT_NOTE_SIZE> for CompactOrchardAction {
     fn ephemeral_key(&self) -> EphemeralKeyBytes {
-        EphemeralKeyBytes(*vec_to_array(&self.ephemeral_key))
+        EphemeralKeyBytes(*slice_to_array(&self.ephemeral_key))
     }
     fn cmstar_bytes(&self) -> [u8; 32] {
-        *vec_to_array(&self.cmx)
+        *slice_to_array(&self.cmx)
     }
     fn enc_ciphertext(&self) -> &[u8; COMPACT_NOTE_SIZE] {
-        vec_to_array(&self.ciphertext)
+        slice_to_array(&self.ciphertext)
     }
 }
 
@@ -139,7 +139,7 @@ impl TryFrom<&CompactOrchardAction> for orchard::note_encryption::CompactAction 
     }
 }
 
-pub(crate) fn vec_to_array<const N: usize>(vec: &[u8]) -> &[u8; N] {
-    <&[u8; N]>::try_from(&vec[..]).unwrap_or(&[0; N])
+pub(crate) fn slice_to_array<const N: usize>(slice: &[u8]) -> &[u8; N] {
+    <&[u8; N]>::try_from(slice).unwrap_or(&[0; N])
     //todo: This default feels dangerous. Find better solution
 }

--- a/zingolib/src/compact_formats.rs
+++ b/zingolib/src/compact_formats.rs
@@ -1,8 +1,4 @@
-use ff::PrimeField;
-use group::GroupEncoding;
 use orchard::{note::ExtractedNoteCommitment, note_encryption::OrchardDomain};
-use std::convert::TryInto;
-
 use zcash_note_encryption::{EphemeralKeyBytes, ShieldedOutput, COMPACT_NOTE_SIZE};
 use zcash_primitives::{
     block::{BlockHash, BlockHeader},
@@ -67,33 +63,6 @@ impl CompactBlock {
     /// [`CompactBlock.height`]: #structfield.height
     pub fn height(&self) -> BlockHeight {
         BlockHeight::from(self.height as u32)
-    }
-}
-
-impl CompactSaplingOutput {
-    /// Returns the note commitment for this output.
-    ///
-    /// A convenience method that parses [`CompactSaplingOutput.cmu`].
-    ///
-    /// [`CompactSaplingOutput.cmu`]: #structfield.cmu
-    pub fn cmu(&self) -> Result<bls12_381::Scalar, ()> {
-        let mut repr = [0; 32];
-        repr.as_mut().copy_from_slice(&self.cmu[..]);
-        Option::from(bls12_381::Scalar::from_repr(repr)).ok_or(())
-    }
-
-    /// Returns the ephemeral public key for this output.
-    ///
-    /// A convenience method that parses [`CompactSaplingOutput.epk`].
-    ///
-    /// [`CompactSaplingOutput.epk`]: #structfield.epk
-    pub fn epk(&self) -> Result<jubjub::ExtendedPoint, ()> {
-        let p = jubjub::ExtendedPoint::from_bytes(&self.epk[..].try_into().map_err(|_| ())?);
-        if p.is_some().into() {
-            Ok(p.unwrap())
-        } else {
-            Err(())
-        }
     }
 }
 

--- a/zingolib/src/grpc_connector.rs
+++ b/zingolib/src/grpc_connector.rs
@@ -409,7 +409,7 @@ impl GrpcConnector {
             .map_err(|e| format!("Error getting client: {:?}", e))?;
 
         let b = BlockId {
-            height: height as u64,
+            height,
             hash: vec![],
         };
         let response = client
@@ -461,7 +461,7 @@ impl GrpcConnector {
         let sendresponse = response.into_inner();
         if sendresponse.error_code == 0 {
             let mut transaction_id = sendresponse.error_message;
-            if transaction_id.starts_with("\"") && transaction_id.ends_with("\"") {
+            if transaction_id.starts_with('\"') && transaction_id.ends_with('\"') {
                 transaction_id = transaction_id[1..transaction_id.len() - 1].to_string();
             }
 
@@ -474,7 +474,7 @@ impl GrpcConnector {
 
 #[cfg(test)]
 fn add_test_cert_to_roots(roots: &mut RootCertStore) {
-    const TEST_PEMFILE_PATH: &'static str = "test-data/localhost.pem";
+    const TEST_PEMFILE_PATH: &str = "test-data/localhost.pem";
     let fd = std::fs::File::open(TEST_PEMFILE_PATH).unwrap();
     let mut buf = std::io::BufReader::new(&fd);
     let certs = rustls_pemfile::certs(&mut buf).unwrap();

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -376,24 +376,24 @@ impl LightClient {
         const SAPLING_SPEND_HASH: &str =
             "8e48ffd23abb3a5fd9c5589204f32d9c31285a04b78096ba40a79b75677efc13";
 
-        if !sapling_output.is_empty() {
-            if *SAPLING_OUTPUT_HASH != hex::encode(Sha256::digest(sapling_output)) {
-                return Err(format!(
-                    "sapling-output hash didn't match. expected {}, found {}",
-                    SAPLING_OUTPUT_HASH,
-                    hex::encode(Sha256::digest(sapling_output))
-                ));
-            }
+        if !sapling_output.is_empty()
+            && *SAPLING_OUTPUT_HASH != hex::encode(Sha256::digest(sapling_output))
+        {
+            return Err(format!(
+                "sapling-output hash didn't match. expected {}, found {}",
+                SAPLING_OUTPUT_HASH,
+                hex::encode(Sha256::digest(sapling_output))
+            ));
         }
 
-        if !sapling_spend.is_empty() {
-            if *SAPLING_SPEND_HASH != hex::encode(Sha256::digest(sapling_spend)) {
-                return Err(format!(
-                    "sapling-spend hash didn't match. expected {}, found {}",
-                    SAPLING_SPEND_HASH,
-                    hex::encode(Sha256::digest(sapling_spend))
-                ));
-            }
+        if !sapling_spend.is_empty()
+            && *SAPLING_SPEND_HASH != hex::encode(Sha256::digest(sapling_spend))
+        {
+            return Err(format!(
+                "sapling-spend hash didn't match. expected {}, found {}",
+                SAPLING_SPEND_HASH,
+                hex::encode(Sha256::digest(sapling_spend))
+            ));
         }
 
         // Ensure that the sapling params are stored on disk properly as well. Only on desktop

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1004,7 +1004,7 @@ impl LightClient {
                             "amount"       => wallet_transparent_value_delta,
                             "zec_price"    => wallet_transaction.zec_price.map(|p| (p * 100.0).round() / 100.0),
                             "address"      => address,
-                            "memo"         => None::<String> 
+                            "memo"         => None::<String>
                         })
                     }
                 }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1586,9 +1586,7 @@ impl LightClient {
             r1,
         ])
         .await
-        .into_iter()
-        .map(|r| r.map_err(|e| format!("{}", e))?)
-        .collect::<Result<(), String>>()?;
+        .into_iter().try_for_each(|r| r.map_err(|e| format!("{}", e))?)?;
 
         let verify_handle =
             tokio::spawn(async move { block_data.read().await.block_data.verify_trees().await });

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1586,7 +1586,8 @@ impl LightClient {
             r1,
         ])
         .await
-        .into_iter().try_for_each(|r| r.map_err(|e| format!("{}", e))?)?;
+        .into_iter()
+        .try_for_each(|r| r.map_err(|e| format!("{}", e))?)?;
 
         let verify_handle =
             tokio::spawn(async move { block_data.read().await.block_data.verify_trees().await });

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -73,12 +73,6 @@ impl WalletStatus {
     }
 }
 
-impl Default for WalletStatus {
-    fn default() -> Self {
-        WalletStatus::new()
-    }
-}
-
 pub struct LightClient {
     pub(crate) config: ZingoConfig,
     #[cfg(not(feature = "integration_test"))]

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -56,7 +56,7 @@ use zingoconfig::{ChainType, ZingoConfig, MAX_REORG};
 
 static LOG_INIT: std::sync::Once = std::sync::Once::new();
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct WalletStatus {
     pub is_syncing: bool,
     pub total_blocks: u64,

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -279,7 +279,7 @@ impl LightWallet {
         };
 
         wc.new_address(wc.can_view()).unwrap();
-        let transaction_metadata_set = Arc::new(RwLock::new(TransactionMetadataSet::new()));
+        let transaction_metadata_set = Arc::new(RwLock::new(TransactionMetadataSet::default()));
         let transaction_context =
             TransactionContext::new(&config, Arc::new(RwLock::new(wc)), transaction_metadata_set);
         Ok(Self {
@@ -289,7 +289,7 @@ impl LightWallet {
             birthday: AtomicU64::new(height),
             verified_tree: Arc::new(RwLock::new(None)),
             send_progress: Arc::new(RwLock::new(SendProgress::new(0))),
-            price: Arc::new(RwLock::new(WalletZecPriceInfo::new())),
+            price: Arc::new(RwLock::new(WalletZecPriceInfo::default())),
             transaction_context,
         })
     }
@@ -388,7 +388,7 @@ impl LightWallet {
         };
 
         let price = if external_version <= 13 {
-            WalletZecPriceInfo::new()
+            WalletZecPriceInfo::default()
         } else {
             WalletZecPriceInfo::read(&mut reader)?
         };

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -51,7 +51,7 @@ pub struct BlockData {
 
 impl BlockData {
     pub fn serialized_version() -> u64 {
-        return 20;
+        20
     }
 
     pub(crate) fn new_with(height: u64, hash: &str) -> Self {
@@ -325,7 +325,7 @@ pub struct Utxo {
 
 impl Utxo {
     pub fn serialized_version() -> u64 {
-        return 3;
+        3
     }
 
     pub fn to_outpoint(&self) -> OutPoint {
@@ -538,7 +538,7 @@ pub struct TransactionMetadata {
 
 impl TransactionMetadata {
     pub fn serialized_version() -> u64 {
-        return 23;
+        23
     }
 
     pub fn new_txid(txid: &Vec<u8>) -> TxId {
@@ -587,7 +587,7 @@ impl TransactionMetadata {
             block_height: height,
             unconfirmed,
             datetime,
-            txid: transaction_id.clone(),
+            txid: *transaction_id,
             spent_sapling_nullifiers: vec![],
             spent_orchard_nullifiers: vec![],
             sapling_notes: vec![],
@@ -793,7 +793,7 @@ impl WalletZecPriceInfo {
     }
 
     pub fn serialized_version() -> u64 {
-        return 20;
+        20
     }
 
     pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -541,7 +541,7 @@ impl TransactionMetadata {
         23
     }
 
-    pub fn new_txid(txid: &Vec<u8>) -> TxId {
+    pub fn new_txid(txid: &[u8]) -> TxId {
         let mut txid_bytes = [0u8; 32];
         txid_bytes.copy_from_slice(txid);
         TxId::from_bytes(txid_bytes)

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -782,8 +782,8 @@ pub struct WalletZecPriceInfo {
     pub historical_prices_retry_count: u64,
 }
 
-impl WalletZecPriceInfo {
-    pub fn new() -> Self {
+impl Default for WalletZecPriceInfo {
+    fn default() -> Self {
         Self {
             zec_price: None,
             currency: "USD".to_string(), // Only USD is supported right now.
@@ -791,7 +791,9 @@ impl WalletZecPriceInfo {
             historical_prices_retry_count: 0,
         }
     }
+}
 
+impl WalletZecPriceInfo {
     pub fn serialized_version() -> u64 {
         20
     }

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -55,12 +55,16 @@ impl BlockData {
     }
 
     pub(crate) fn new_with(height: u64, hash: &str) -> Self {
-        let mut cb = CompactBlock::default();
-        cb.hash = hex::decode(hash)
+        let hash = hex::decode(hash)
             .unwrap()
             .into_iter()
             .rev()
             .collect::<Vec<_>>();
+
+        let cb = CompactBlock {
+            hash,
+            ..Default::default()
+        };
 
         let mut ecb = vec![];
         cb.encode(&mut ecb).unwrap();

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -124,7 +124,7 @@ pub fn get_zaddr_from_bip39seed(
     (extsk, fvk, address)
 }
 
-pub fn is_shielded_address(addr: &String, config: &ZingoConfig) -> bool {
+pub fn is_shielded_address(addr: &str, config: &ZingoConfig) -> bool {
     match address::RecipientAddress::decode(&config.chain, addr) {
         Some(address::RecipientAddress::Shielded(_))
         | Some(address::RecipientAddress::Unified(_)) => true,

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -23,7 +23,7 @@ pub(crate) mod unified;
 
 /// Sha256(Sha256(value))
 pub fn double_sha256(payload: &[u8]) -> Vec<u8> {
-    let h1 = Sha256::digest(&payload);
+    let h1 = Sha256::digest(payload);
     let h2 = Sha256::digest(&h1);
     h2.to_vec()
 }
@@ -71,7 +71,7 @@ impl FromBase58Check for str {
         if payload.len() < 5 {
             return Err(io::Error::new(
                 ErrorKind::InvalidData,
-                format!("Invalid Checksum length"),
+                "Invalid Checksum length".to_string(),
             ));
         }
 
@@ -81,7 +81,7 @@ impl FromBase58Check for str {
         if checksum != provided_checksum {
             return Err(io::Error::new(
                 ErrorKind::InvalidData,
-                format!("Invalid Checksum"),
+                "Invalid Checksum".to_string(),
             ));
         }
         Ok((payload[0], payload[1..].to_vec()))

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -125,11 +125,10 @@ pub fn get_zaddr_from_bip39seed(
 }
 
 pub fn is_shielded_address(addr: &str, config: &ZingoConfig) -> bool {
-    match address::RecipientAddress::decode(&config.chain, addr) {
-        Some(address::RecipientAddress::Shielded(_))
-        | Some(address::RecipientAddress::Unified(_)) => true,
-        _ => false,
-    }
+    matches!(
+        address::RecipientAddress::decode(&config.chain, addr),
+        Some(address::RecipientAddress::Shielded(_)) | Some(address::RecipientAddress::Unified(_))
+    )
 }
 
 /// STATIC METHODS

--- a/zingolib/src/wallet/keys/extended_transparent.rs
+++ b/zingolib/src/wallet/keys/extended_transparent.rs
@@ -75,7 +75,7 @@ impl ExtendedPrivKey {
         let signature = {
             let signing_key = Key::new(hmac::HMAC_SHA512, b"Bitcoin seed");
             let mut h = Context::with_key(&signing_key);
-            h.update(&seed);
+            h.update(seed);
             h.sign()
         };
         let sig_bytes = signature.as_ref();

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -206,7 +206,9 @@ impl WalletCapability {
                 // other than implementing it ourselves.
                 .map(zcash_primitives::legacy::keys::pubkey_to_address),
         )
-        .ok_or("Invalid receivers requested! At least one of sapling or orchard required".to_string())?;
+        .ok_or(
+            "Invalid receivers requested! At least one of sapling or orchard required".to_string(),
+        )?;
         self.addresses.push(ua.clone());
         Ok(ua)
     }
@@ -458,8 +460,7 @@ impl ReadableWriteable<()> for WalletCapability {
                 ))
             }
         };
-        let receiver_selections =
-            Vector::read(reader, |r| ReceiverSelection::read(r, ()))?;
+        let receiver_selections = Vector::read(reader, |r| ReceiverSelection::read(r, ()))?;
         for rs in receiver_selections {
             wc.new_address(rs)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -108,7 +108,6 @@ impl ReadableWriteable<()> for ReceiverSelection {
 #[test]
 fn read_write_receiver_selections() {
     for (i, receivers_selected) in (0..8)
-        .into_iter()
         .map(|n| ReceiverSelection::read([1, n].as_slice(), ()).unwrap())
         .enumerate()
     {
@@ -207,9 +206,7 @@ impl WalletCapability {
                 // other than implementing it ourselves.
                 .map(zcash_primitives::legacy::keys::pubkey_to_address),
         )
-        .ok_or(format!(
-            "Invalid receivers requested! At least one of sapling or orchard required"
-        ))?;
+        .ok_or("Invalid receivers requested! At least one of sapling or orchard required".to_string())?;
         self.addresses.push(ua.clone());
         Ok(ua)
     }
@@ -237,7 +234,7 @@ impl WalletCapability {
                     };
                     (
                         hash.to_base58check(&config.base58_pubkey_address(), &[]),
-                        key.1.clone(),
+                        key.1,
                     )
                 })
                 .collect())
@@ -302,7 +299,7 @@ impl WalletCapability {
                 Fvk::Orchard(key_bytes) => {
                     wc.orchard = Capability::View(
                         orchard::keys::FullViewingKey::from_bytes(&key_bytes)
-                            .ok_or_else(|| "Orchard FVK deserialization failed")?,
+                            .ok_or("Orchard FVK deserialization failed")?,
                     );
                 }
                 Fvk::Sapling(key_bytes) => {
@@ -316,7 +313,7 @@ impl WalletCapability {
                 }
                 Fvk::P2pkh(key_bytes) => {
                     wc.transparent = Capability::View(ExtendedPubKey {
-                        chain_code: (&key_bytes[0..32]).to_vec(),
+                        chain_code: key_bytes[0..32].to_vec(),
                         public_key: secp256k1::PublicKey::from_slice(&key_bytes[32..65])
                             .map_err(|e| e.to_string())?,
                     });
@@ -338,7 +335,7 @@ impl WalletCapability {
     ) -> Option<UnifiedAddress> {
         self.addresses
             .iter()
-            .find(|ua| ua.transparent() == Some(&receiver))
+            .find(|ua| ua.transparent() == Some(receiver))
             .cloned()
     }
     pub(crate) fn get_all_taddrs(&self, config: &ZingoConfig) -> HashSet<String> {
@@ -462,10 +459,10 @@ impl ReadableWriteable<()> for WalletCapability {
             }
         };
         let receiver_selections =
-            Vector::read(reader, |mut r| ReceiverSelection::read(&mut r, ()))?;
+            Vector::read(reader, |r| ReceiverSelection::read(r, ()))?;
         for rs in receiver_selections {
             wc.new_address(rs)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         }
         Ok(wc)
     }
@@ -475,13 +472,13 @@ impl ReadableWriteable<()> for WalletCapability {
         self.orchard.write(&mut writer)?;
         self.sapling.write(&mut writer)?;
         self.transparent.write(&mut writer)?;
-        Vector::write(&mut writer, &self.addresses, |mut w, address| {
+        Vector::write(&mut writer, &self.addresses, |w, address| {
             ReceiverSelection {
                 orchard: address.orchard().is_some(),
                 sapling: address.sapling().is_some(),
                 transparent: address.transparent().is_some(),
             }
-            .write(&mut w)
+            .write(w)
         })
     }
 }
@@ -510,7 +507,7 @@ impl TryFrom<&WalletCapability> for orchard::keys::SpendingKey {
     type Error = String;
     fn try_from(wc: &WalletCapability) -> Result<Self, String> {
         match &wc.orchard {
-            Capability::Spend(sk) => Ok(sk.clone()),
+            Capability::Spend(sk) => Ok(*sk),
             _ => Err("The wallet is not capable of spending Orchard funds".to_string()),
         }
     }
@@ -548,7 +545,7 @@ impl TryFrom<&WalletCapability> for zcash_primitives::zip32::sapling::Diversifia
         match &wc.sapling {
             Capability::Spend(sk) => {
                 let dfvk = sk.to_diversifiable_full_viewing_key();
-                Ok(zcash_primitives::zip32::sapling::DiversifiableFullViewingKey::from(dfvk))
+                Ok(dfvk)
             }
             Capability::View(fvk) => Ok(fvk.clone()),
             Capability::None => {
@@ -627,7 +624,7 @@ pub async fn get_transparent_secretkey_pubkey_taddr(
             (None, child_ext_pk.map(|x| x.public_key))
         }
         Capability::Spend(_) => {
-            let sk = wc.transparent_child_keys[0].1.clone();
+            let sk = wc.transparent_child_keys[0].1;
             let secp = secp256k1::Secp256k1::new();
             let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
             (Some(sk), Some(pk))

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -33,10 +33,7 @@ pub enum Capability<ViewingKeyType, SpendKeyType> {
 
 impl<V, S> Capability<V, S> {
     pub fn can_spend(&self) -> bool {
-        match self {
-            Capability::Spend(_) => true,
-            _ => false,
-        }
+        matches!(self, Capability::Spend(_))
     }
 
     pub fn can_view(&self) -> bool {

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -417,6 +417,7 @@ pub trait ReceivedNoteAndMetadata: Sized {
         WitnessCache<Self::Node>,
     );
     fn diversifier(&self) -> &Self::Diversifier;
+    #[allow(clippy::too_many_arguments)]
     fn from_parts(
         diversifier: Self::Diversifier,
         note: Self::Note,

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -139,7 +139,7 @@ impl FromBytes<32> for zcash_primitives::sapling::Nullifier {
 impl FromBytes<32> for orchard::note::Nullifier {
     fn from_bytes(bytes: [u8; 32]) -> Self {
         Option::from(orchard::note::Nullifier::from_bytes(&bytes))
-            .expect(&format!("Invalid nullifier {:?}", bytes))
+            .unwrap_or_else(|| panic!("Invalid nullifier {:?}", bytes))
     }
 }
 
@@ -224,7 +224,7 @@ impl Recipient for orchard::Address {
     type Diversifier = orchard::keys::Diversifier;
 
     fn diversifier(&self) -> Self::Diversifier {
-        orchard::Address::diversifier(&self)
+        orchard::Address::diversifier(self)
     }
 
     fn b32encode_for_network(&self, chain: &ChainType) -> String {
@@ -242,7 +242,7 @@ impl Recipient for zcash_primitives::sapling::PaymentAddress {
     type Diversifier = zcash_primitives::sapling::Diversifier;
 
     fn diversifier(&self) -> Self::Diversifier {
-        *zcash_primitives::sapling::PaymentAddress::diversifier(&self)
+        *zcash_primitives::sapling::PaymentAddress::diversifier(self)
     }
 
     fn b32encode_for_network(&self, chain: &ChainType) -> String {
@@ -1127,7 +1127,7 @@ impl ReadableWriteable<(zcash_primitives::sapling::Diversifier, &WalletCapabilit
     fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
         writer.write_u8(Self::VERSION)?;
         writer.write_u64::<LittleEndian>(self.value().inner())?;
-        super::data::write_sapling_rseed(&mut writer, &self.rseed())?;
+        super::data::write_sapling_rseed(&mut writer, self.rseed())?;
         Ok(())
     }
 }

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -10,7 +10,7 @@ use super::{
     transactions::TransactionMetadataSet,
 };
 use crate::compact_formats::{
-    vec_to_array, CompactOrchardAction, CompactSaplingOutput, CompactTx, TreeState,
+    slice_to_array, CompactOrchardAction, CompactSaplingOutput, CompactTx, TreeState,
 };
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use nonempty::NonEmpty;
@@ -267,7 +267,7 @@ impl CompactOutput<SaplingDomain<ChainType>> for CompactSaplingOutput {
     }
 
     fn cmstar(&self) -> &[u8; 32] {
-        vec_to_array(&self.cmu)
+        slice_to_array(&self.cmu)
     }
 
     fn domain(&self, parameters: ChainType, height: BlockHeight) -> SaplingDomain<ChainType> {
@@ -280,12 +280,12 @@ impl CompactOutput<OrchardDomain> for CompactOrchardAction {
         &compact_transaction.actions
     }
     fn cmstar(&self) -> &[u8; 32] {
-        vec_to_array(&self.cmx)
+        slice_to_array(&self.cmx)
     }
 
     fn domain(&self, _parameters: ChainType, _heightt: BlockHeight) -> OrchardDomain {
         OrchardDomain::for_nullifier(
-            orchard::note::Nullifier::from_bytes(vec_to_array(&self.nullifier)).unwrap(),
+            orchard::note::Nullifier::from_bytes(slice_to_array(&self.nullifier)).unwrap(),
         )
     }
 }

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -405,16 +405,16 @@ pub trait ReceivedNoteAndMetadata: Sized {
     type Node: Hashable + FromCommitment + Send;
     type Nullifier: Nullifier;
 
-    const GET_NOTE_WITNESSES: fn(
-        &TransactionMetadataSet,
-        &TxId,
-        &Self::Nullifier,
+    fn get_note_witnesses(
+        tms: &TransactionMetadataSet,
+        txid: &TxId,
+        nullifier: &Self::Nullifier,
     ) -> Option<(WitnessCache<Self::Node>, BlockHeight)>;
-    const SET_NOTE_WITNESSES: fn(
-        &mut TransactionMetadataSet,
-        &TxId,
-        &Self::Nullifier,
-        WitnessCache<Self::Node>,
+    fn set_note_witnesses(
+        tms: &mut TransactionMetadataSet,
+        txid: &TxId,
+        nullifier: &Self::Nullifier,
+        cache: WitnessCache<Self::Node>,
     );
     fn diversifier(&self) -> &Self::Diversifier;
     #[allow(clippy::too_many_arguments)]
@@ -462,20 +462,21 @@ impl ReceivedNoteAndMetadata for ReceivedSaplingNoteAndMetadata {
     type Node = zcash_primitives::sapling::Node;
     type Nullifier = zcash_primitives::sapling::Nullifier;
 
-    /// This (and SET_NOTE_WITNESSES) could be associated functions instead of fn
-    /// constants, but that would require an additional repetition of the fn arguments.
-    const GET_NOTE_WITNESSES: fn(
-        &TransactionMetadataSet,
-        &TxId,
-        &Self::Nullifier,
-    ) -> Option<(WitnessCache<Self::Node>, BlockHeight)> =
-        TransactionMetadataSet::get_sapling_note_witnesses;
-    const SET_NOTE_WITNESSES: fn(
-        &mut TransactionMetadataSet,
-        &TxId,
-        &Self::Nullifier,
-        WitnessCache<Self::Node>,
-    ) = TransactionMetadataSet::set_sapling_note_witnesses;
+    fn get_note_witnesses(
+        tms: &TransactionMetadataSet,
+        txid: &TxId,
+        nullifier: &Self::Nullifier,
+    ) -> Option<(WitnessCache<Self::Node>, BlockHeight)> {
+        TransactionMetadataSet::get_sapling_note_witnesses(tms, txid, nullifier)
+    }
+    fn set_note_witnesses(
+        tms: &mut TransactionMetadataSet,
+        txid: &TxId,
+        nullifier: &Self::Nullifier,
+        cache: WitnessCache<Self::Node>,
+    ) {
+        TransactionMetadataSet::set_sapling_note_witnesses(tms, txid, nullifier, cache)
+    }
 
     fn diversifier(&self) -> &Self::Diversifier {
         &self.diversifier
@@ -578,19 +579,22 @@ impl ReceivedNoteAndMetadata for ReceivedOrchardNoteAndMetadata {
     type Node = MerkleHashOrchard;
     type Nullifier = orchard::note::Nullifier;
 
-    const GET_NOTE_WITNESSES: fn(
-        &TransactionMetadataSet,
-        &TxId,
-        &Self::Nullifier,
-    ) -> Option<(WitnessCache<Self::Node>, BlockHeight)> =
-        TransactionMetadataSet::get_orchard_note_witnesses;
+    fn get_note_witnesses(
+        tms: &TransactionMetadataSet,
+        txid: &TxId,
+        nullifier: &Self::Nullifier,
+    ) -> Option<(WitnessCache<Self::Node>, BlockHeight)> {
+        TransactionMetadataSet::get_orchard_note_witnesses(tms, txid, nullifier)
+    }
 
-    const SET_NOTE_WITNESSES: fn(
-        &mut TransactionMetadataSet,
-        &TxId,
-        &Self::Nullifier,
-        WitnessCache<Self::Node>,
-    ) = TransactionMetadataSet::set_orchard_note_witnesses;
+    fn set_note_witnesses(
+        tms: &mut TransactionMetadataSet,
+        txid: &TxId,
+        nullifier: &Self::Nullifier,
+        cache: WitnessCache<Self::Node>,
+    ) {
+        TransactionMetadataSet::set_orchard_note_witnesses(tms, txid, nullifier, cache)
+    }
 
     fn diversifier(&self) -> &Self::Diversifier {
         &self.diversifier

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -182,7 +182,7 @@ impl TransactionMetadataSet {
         self.remove_domain_specific_txids::<OrchardDomain>(&txids_to_remove);
     }
 
-    fn remove_domain_specific_txids<D: DomainWalletExt>(&mut self, txids_to_remove: &Vec<TxId>)
+    fn remove_domain_specific_txids<D: DomainWalletExt>(&mut self, txids_to_remove: &[TxId])
     where
         <D as Domain>::Recipient: Recipient,
         <D as Domain>::Note: PartialEq + Clone,

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -282,9 +282,7 @@ impl TransactionMetadataSet {
                             {
                                 Some((
                                     *txid,
-                                    PoolNullifier::Orchard(
-                                        orchard_note_description.nullifier,
-                                    ),
+                                    PoolNullifier::Orchard(orchard_note_description.nullifier),
                                 ))
                             } else {
                                 None
@@ -580,17 +578,14 @@ impl TransactionMetadataSet {
         source_txid: TxId,
     ) {
         // Record this Tx as having spent some funds
-        let transaction_metadata = self.get_or_create_transaction_metadata(
-            &txid,
-            height,
-            unconfirmed,
-            timestamp as u64,
-        );
+        let transaction_metadata =
+            self.get_or_create_transaction_metadata(&txid, height, unconfirmed, timestamp as u64);
 
         // Mark the height correctly, in case this was previously a mempool or unconfirmed tx.
         transaction_metadata.block_height = height;
         if !NnMd::Nullifier::get_nullifiers_spent_in_transaction(transaction_metadata)
-            .iter().any(|nf| *nf == nullifier)
+            .iter()
+            .any(|nf| *nf == nullifier)
         {
             transaction_metadata.add_spent_nullifier(nullifier.into(), value)
         }
@@ -607,7 +602,10 @@ impl TransactionMetadataSet {
 
             if let Some(nd) = NnMd::transaction_metadata_notes_mut(transaction_metadata)
                 .iter_mut()
-                .find(|n| n.nullifier() == nullifier) { *nd.spent_mut() = Some((txid, height.into())); }
+                .find(|n| n.nullifier() == nullifier)
+            {
+                *nd.spent_mut() = Some((txid, height.into()));
+            }
         }
     }
 
@@ -619,12 +617,8 @@ impl TransactionMetadataSet {
         timestamp: u64,
         total_transparent_value_spent: u64,
     ) {
-        let transaction_metadata = self.get_or_create_transaction_metadata(
-            &txid,
-            height,
-            unconfirmed,
-            timestamp,
-        );
+        let transaction_metadata =
+            self.get_or_create_transaction_metadata(&txid, height, unconfirmed, timestamp);
         transaction_metadata.total_transparent_value_spent = total_transparent_value_spent;
 
         self.check_notes_mark_change(&txid);
@@ -719,12 +713,8 @@ impl TransactionMetadataSet {
         // Check if this is a change note
         let is_change = self.total_funds_spent_in(&txid) > 0;
 
-        let transaction_metadata = self.get_or_create_transaction_metadata(
-            &txid,
-            height,
-            true,
-            timestamp,
-        );
+        let transaction_metadata =
+            self.get_or_create_transaction_metadata(&txid, height, true, timestamp);
         // Update the block height, in case this was a mempool or unconfirmed tx.
         transaction_metadata.block_height = height;
 
@@ -819,12 +809,8 @@ impl TransactionMetadataSet {
         // Check if this is a change note
         let is_change = self.total_funds_spent_in(&txid) > 0;
 
-        let transaction_metadata = self.get_or_create_transaction_metadata(
-            &txid,
-            height,
-            unconfirmed,
-            timestamp,
-        );
+        let transaction_metadata =
+            self.get_or_create_transaction_metadata(&txid, height, unconfirmed, timestamp);
         // Update the block height, in case this was a mempool or unconfirmed tx.
         transaction_metadata.block_height = height;
 
@@ -881,10 +867,12 @@ impl TransactionMetadataSet {
         note: Nd::Note,
         memo: Memo,
     ) {
-        if let Some(transaction_metadata) = self.current.get_mut(txid) { Nd::transaction_metadata_notes_mut(transaction_metadata)
+        if let Some(transaction_metadata) = self.current.get_mut(txid) {
+            Nd::transaction_metadata_notes_mut(transaction_metadata)
                 .iter_mut()
                 .find(|n| n.note() == &note)
-                .map(|n| *n.memo_mut() = Some(memo)); }
+                .map(|n| *n.memo_mut() = Some(memo));
+        }
     }
 
     pub fn add_outgoing_metadata(&mut self, txid: &TxId, outgoing_metadata: Vec<OutgoingTxData>) {
@@ -895,7 +883,8 @@ impl TransactionMetadataSet {
                 .filter(|om| {
                     !transaction_metadata
                         .outgoing_tx_data
-                        .iter().any(|o| *o == *om)
+                        .iter()
+                        .any(|o| *o == *om)
                 })
                 .collect();
 

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -43,7 +43,7 @@ pub struct TransactionMetadataSet {
 
 impl TransactionMetadataSet {
     pub fn serialized_version() -> u64 {
-        return 21;
+        21
     }
 
     pub fn new() -> Self {
@@ -103,7 +103,7 @@ impl TransactionMetadataSet {
             .values()
             .fold(None, |c: Option<(TxId, BlockHeight)>, w| {
                 if c.is_none() || w.block_height > c.unwrap().1 {
-                    Some((w.txid.clone(), w.block_height))
+                    Some((w.txid, w.block_height))
                 } else {
                     c
                 }
@@ -161,7 +161,7 @@ impl TransactionMetadataSet {
 
     pub fn remove_txids(&mut self, txids_to_remove: Vec<TxId>) {
         for txid in &txids_to_remove {
-            self.current.remove(&txid);
+            self.current.remove(txid);
         }
         self.current.values_mut().for_each(|transaction_metadata| {
             // Update UTXOs to rollback any spent utxos
@@ -217,7 +217,7 @@ impl TransactionMetadataSet {
             .values()
             .filter_map(|transaction_metadata| {
                 if transaction_metadata.block_height >= reorg_height {
-                    Some(transaction_metadata.txid.clone())
+                    Some(transaction_metadata.txid)
                 } else {
                     None
                 }
@@ -234,10 +234,10 @@ impl TransactionMetadataSet {
                     // The latest witness is at the last() position, so just pop() it.
                     // We should be checking if there is a witness at all, but if there is none, it is an
                     // empty vector, for which pop() is a no-op.
-                    let _discard = nd.witnesses.pop(u64::from(reorg_height));
+                    nd.witnesses.pop(u64::from(reorg_height));
                 }
                 for nd in tx.orchard_notes.iter_mut() {
-                    let _discard = nd.witnesses.pop(u64::from(reorg_height));
+                    nd.witnesses.pop(u64::from(reorg_height));
                 }
             }
         }
@@ -262,12 +262,12 @@ impl TransactionMetadataSet {
                     .filter_map(move |sapling_note_description| {
                         if transaction_metadata.block_height <= before_block
                             && sapling_note_description.have_spending_key
-                            && sapling_note_description.witnesses.len() > 0
+                            && !sapling_note_description.witnesses.is_empty()
                             && sapling_note_description.spent.is_none()
                         {
                             Some((
-                                txid.clone(),
-                                PoolNullifier::Sapling(sapling_note_description.nullifier.clone()),
+                                *txid,
+                                PoolNullifier::Sapling(sapling_note_description.nullifier),
                             ))
                         } else {
                             None
@@ -277,13 +277,13 @@ impl TransactionMetadataSet {
                         move |orchard_note_description| {
                             if transaction_metadata.block_height <= before_block
                                 && orchard_note_description.have_spending_key
-                                && orchard_note_description.witnesses.len() > 0
+                                && !orchard_note_description.witnesses.is_empty()
                                 && orchard_note_description.spent.is_none()
                             {
                                 Some((
-                                    txid.clone(),
+                                    *txid,
                                     PoolNullifier::Orchard(
-                                        orchard_note_description.nullifier.clone(),
+                                        orchard_note_description.nullifier,
                                     ),
                                 ))
                             } else {
@@ -297,7 +297,7 @@ impl TransactionMetadataSet {
 
     pub fn total_funds_spent_in(&self, txid: &TxId) -> u64 {
         self.current
-            .get(&txid)
+            .get(txid)
             .map(TransactionMetadata::total_value_spent)
             .unwrap_or(0)
     }
@@ -314,9 +314,9 @@ impl TransactionMetadataSet {
                     .filter(|nd| nd.spent.is_none())
                     .map(move |nd| {
                         (
-                            nd.nullifier.clone(),
+                            nd.nullifier,
                             nd.note.value().inner(),
-                            transaction_metadata.txid.clone(),
+                            transaction_metadata.txid,
                         )
                     })
             })
@@ -335,9 +335,9 @@ impl TransactionMetadataSet {
                     .filter(|nd| nd.spent.is_none())
                     .map(move |nd| {
                         (
-                            nd.nullifier.clone(),
+                            nd.nullifier,
                             nd.note.value().inner(),
-                            transaction_metadata.txid.clone(),
+                            transaction_metadata.txid,
                         )
                     })
             })
@@ -441,7 +441,7 @@ impl TransactionMetadataSet {
             .filter(|(_, transaction_metadata)| {
                 transaction_metadata.unconfirmed && transaction_metadata.block_height < cutoff
             })
-            .map(|(_, transaction_metadata)| transaction_metadata.txid.clone())
+            .map(|(_, transaction_metadata)| transaction_metadata.txid)
             .collect::<Vec<_>>();
 
         txids_to_remove
@@ -469,7 +469,7 @@ impl TransactionMetadataSet {
                     .iter_mut()
                     .find(|n| n.nullifier == *nf)
                     .unwrap();
-                note_data.spent = Some((spent_txid.clone(), spent_at_height.into()));
+                note_data.spent = Some((*spent_txid, spent_at_height.into()));
                 note_data.unconfirmed_spent = None;
                 note_data.note.value().inner()
             }
@@ -482,7 +482,7 @@ impl TransactionMetadataSet {
                     .iter_mut()
                     .find(|n| n.nullifier == *nf)
                     .unwrap();
-                note_data.spent = Some((spent_txid.clone(), spent_at_height.into()));
+                note_data.spent = Some((*spent_txid, spent_at_height.into()));
                 note_data.unconfirmed_spent = None;
                 note_data.note.value().inner()
             }
@@ -511,14 +511,14 @@ impl TransactionMetadataSet {
         unconfirmed: bool,
         datetime: u64,
     ) -> &'_ mut TransactionMetadata {
-        if !self.current.contains_key(&txid) {
+        if !self.current.contains_key(txid) {
             self.current.insert(
-                txid.clone(),
-                TransactionMetadata::new(BlockHeight::from(height), datetime, &txid, unconfirmed),
+                *txid,
+                TransactionMetadata::new(height, datetime, txid, unconfirmed),
             );
-            self.some_txid_from_highest_wallet_block = Some(txid.clone());
+            self.some_txid_from_highest_wallet_block = Some(*txid);
         }
-        let transaction_metadata = self.current.get_mut(&txid).expect("Txid should be present");
+        let transaction_metadata = self.current.get_mut(txid).expect("Txid should be present");
 
         // Make sure the unconfirmed status matches
         if transaction_metadata.unconfirmed != unconfirmed {
@@ -582,17 +582,15 @@ impl TransactionMetadataSet {
         // Record this Tx as having spent some funds
         let transaction_metadata = self.get_or_create_transaction_metadata(
             &txid,
-            BlockHeight::from(height),
+            height,
             unconfirmed,
             timestamp as u64,
         );
 
         // Mark the height correctly, in case this was previously a mempool or unconfirmed tx.
         transaction_metadata.block_height = height;
-        if NnMd::Nullifier::get_nullifiers_spent_in_transaction(transaction_metadata)
-            .iter()
-            .find(|nf| **nf == nullifier)
-            .is_none()
+        if !NnMd::Nullifier::get_nullifiers_spent_in_transaction(transaction_metadata)
+            .iter().any(|nf| *nf == nullifier)
         {
             transaction_metadata.add_spent_nullifier(nullifier.into(), value)
         }
@@ -607,13 +605,9 @@ impl TransactionMetadataSet {
                 .get_mut(&source_txid)
                 .expect("Txid should be present");
 
-            NnMd::transaction_metadata_notes_mut(transaction_metadata)
+            if let Some(nd) = NnMd::transaction_metadata_notes_mut(transaction_metadata)
                 .iter_mut()
-                .find(|n| n.nullifier() == nullifier)
-                .map(|nd| {
-                    // Record the spent height
-                    *nd.spent_mut() = Some((txid, height.into()));
-                });
+                .find(|n| n.nullifier() == nullifier) { *nd.spent_mut() = Some((txid, height.into())); }
         }
     }
 
@@ -627,7 +621,7 @@ impl TransactionMetadataSet {
     ) {
         let transaction_metadata = self.get_or_create_transaction_metadata(
             &txid,
-            BlockHeight::from(height),
+            height,
             unconfirmed,
             timestamp,
         );
@@ -651,7 +645,7 @@ impl TransactionMetadataSet {
                 .find(|u| u.txid == spent_txid && u.output_index == output_num as u64)
             {
                 // Mark this one as spent
-                spent_utxo.spent = Some(source_txid.clone());
+                spent_utxo.spent = Some(source_txid);
                 spent_utxo.spent_at_height = Some(source_height as i32);
                 spent_utxo.unconfirmed_spent = None;
 
@@ -698,7 +692,7 @@ impl TransactionMetadataSet {
         } else {
             transaction_metadata.utxos.push(Utxo {
                 address: taddr,
-                txid: txid.clone(),
+                txid,
                 output_index: output_num as u64,
                 script: vout.script_pubkey.0.clone(),
                 value: vout.value.into(),
@@ -727,7 +721,7 @@ impl TransactionMetadataSet {
 
         let transaction_metadata = self.get_or_create_transaction_metadata(
             &txid,
-            BlockHeight::from(height),
+            height,
             true,
             timestamp,
         );
@@ -827,7 +821,7 @@ impl TransactionMetadataSet {
 
         let transaction_metadata = self.get_or_create_transaction_metadata(
             &txid,
-            BlockHeight::from(height),
+            height,
             unconfirmed,
             timestamp,
         );
@@ -887,12 +881,10 @@ impl TransactionMetadataSet {
         note: Nd::Note,
         memo: Memo,
     ) {
-        self.current.get_mut(txid).map(|transaction_metadata| {
-            Nd::transaction_metadata_notes_mut(transaction_metadata)
+        if let Some(transaction_metadata) = self.current.get_mut(txid) { Nd::transaction_metadata_notes_mut(transaction_metadata)
                 .iter_mut()
                 .find(|n| n.note() == &note)
-                .map(|n| *n.memo_mut() = Some(memo));
-        });
+                .map(|n| *n.memo_mut() = Some(memo)); }
     }
 
     pub fn add_outgoing_metadata(&mut self, txid: &TxId, outgoing_metadata: Vec<OutgoingTxData>) {
@@ -901,11 +893,9 @@ impl TransactionMetadataSet {
             let new_omd: Vec<_> = outgoing_metadata
                 .into_iter()
                 .filter(|om| {
-                    transaction_metadata
+                    !transaction_metadata
                         .outgoing_tx_data
-                        .iter()
-                        .find(|o| **o == *om)
-                        .is_none()
+                        .iter().any(|o| *o == *om)
                 })
                 .collect();
 

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -485,14 +485,14 @@ impl TransactionMetadataSet {
     // transction as change. i.e., If any funds were spent in this transaction, all recieved notes are change notes.
     pub fn check_notes_mark_change(&mut self, txid: &TxId) {
         if self.total_funds_spent_in(txid) > 0 {
-            self.current.get_mut(txid).map(|transaction_metadata| {
+            if let Some(transaction_metadata) = self.current.get_mut(txid) {
                 transaction_metadata.sapling_notes.iter_mut().for_each(|n| {
                     n.is_change = true;
                 });
                 transaction_metadata.orchard_notes.iter_mut().for_each(|n| {
                     n.is_change = true;
                 })
-            });
+            }
         }
     }
 
@@ -868,10 +868,12 @@ impl TransactionMetadataSet {
         memo: Memo,
     ) {
         if let Some(transaction_metadata) = self.current.get_mut(txid) {
-            Nd::transaction_metadata_notes_mut(transaction_metadata)
+            if let Some(n) = Nd::transaction_metadata_notes_mut(transaction_metadata)
                 .iter_mut()
                 .find(|n| n.note() == &note)
-                .map(|n| *n.memo_mut() = Some(memo));
+            {
+                *n.memo_mut() = Some(memo);
+            }
         }
     }
 

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -33,6 +33,7 @@ use super::{
 /// HashMap of all transactions in a wallet, keyed by txid.
 /// Note that the parent is expected to hold a RwLock, so we will assume that all accesses to
 /// this struct are threadsafe/locked properly.
+#[derive(Default)]
 pub struct TransactionMetadataSet {
     #[cfg(not(feature = "integration_test"))]
     pub(crate) current: HashMap<TxId, TransactionMetadata>,
@@ -44,13 +45,6 @@ pub struct TransactionMetadataSet {
 impl TransactionMetadataSet {
     pub fn serialized_version() -> u64 {
         21
-    }
-
-    pub fn new() -> Self {
-        Self {
-            current: HashMap::new(),
-            some_txid_from_highest_wallet_block: None,
-        }
     }
 
     pub fn read_old<R: Read>(

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -533,6 +533,7 @@ impl TransactionMetadataSet {
     }
 
     // Records a TxId as having spent some nullifiers from the wallet.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_new_spent(
         &mut self,
         txid: TxId,
@@ -567,6 +568,7 @@ impl TransactionMetadataSet {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_new_spent_internal<NnMd: ReceivedNoteAndMetadata>(
         &mut self,
         txid: TxId,
@@ -657,6 +659,7 @@ impl TransactionMetadataSet {
         value
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_new_taddr_output(
         &mut self,
         txid: TxId,
@@ -741,6 +744,7 @@ impl TransactionMetadataSet {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_new_sapling_note(
         &mut self,
         fvk: &<SaplingDomain<zingoconfig::ChainType> as DomainWalletExt>::Fvk,
@@ -765,6 +769,7 @@ impl TransactionMetadataSet {
             witness,
         );
     }
+    #[allow(clippy::too_many_arguments)]
     pub fn add_new_orchard_note(
         &mut self,
         fvk: &<OrchardDomain as DomainWalletExt>::Fvk,
@@ -790,6 +795,7 @@ impl TransactionMetadataSet {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn add_new_note<D: DomainWalletExt>(
         &mut self,
         fvk: &D::Fvk,


### PR DESCRIPTION
⚠ This PR extends #320; if #320 is rejected, this needs to be rebased.

This PR fixes all outstanding clippy errors, then attempts to integrate `cargo clippy` into continuous integration.

The `cargo clippy` tool checks many ergonomic and style issues, and sometimes potential bugs. Benefits:

- Ensure the style in zingo matches what standard rust devs are familiar with.
- Teaches zingo devs newer to rust new language and library idioms, improving their rust skill as they go.
- Potentially catch some bugs.

Note that specific clippy checks can be bypassed by using explicit attributes on specific items. This PR used this approach where I thought that fixing the clippy errors would require refactors that seemed too invasive.

Wherever possible I removed code rather than fixing the clippy error when I determined the code was dead.

Every commit used `./util/git-hook-pre-commit.sh` thus passes all of those checks.

⚠ I never ran the fuller integration checks.