### PR TITLE
Add support for targeting win-arm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -2465,15 +2465,13 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+source = "git+https://github.com/awakecoding/ring?branch=0.16.20_alpha#ec78aff5b5c4734957522f092590e0b58a3161cf"
 dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.9.8",
  "untrusted",
- "web-sys",
  "winapi",
 ]
 
@@ -2910,6 +2908,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ debug = false
 [profile.test]
 opt-level = 3
 debug = false
+
+[patch.crates-io]
+ring = { git = "https://github.com/awakecoding/ring", branch = "0.16.20_alpha" }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ cargo build --release
 
 This will launch the interactive prompt. Type `help` to get a list of commands.
 
+## Library:
+We currently depend on `ring` 0.17.0 for win-arm64 support, via cargo's patching mechanism.
+Because patching only applies at the top level of a project, in order to use this library as a dependency, copy the `[patch.crates-io]` section of `Cargo.toml` into your own workspace `Cargo.toml`
+
 ## Notes:
 * If you want to run your own server, please see [zingo lightwalletd](https://github.com/zingolabs/lightwalletd), and then run `./zingo-cli --server http://127.0.0.1:9067`
 * The default log file is in `~/.zcash/zingo-wallet.debug.log`. A default wallet is stored in `~/.zcash/zingo-wallet.dat`


### PR DESCRIPTION
The `ring` crate doesn't natively support win-arm64 yet. But a fork adds that support [as described here][workaround].

- [x] Add support for building the `aarch64-pc-windows-msvc`.
- [ ] Verify that building `x86_64-pc-windows-msvc` hasn't been broken.
- [ ] Add a job to the GitHub workflow that runs in CI/PR to build Windows x64 and arm64 to demonstrate and keep it working.
 
[workaround]: https://github.com/briansmith/ring/issues/1514#issuecomment-1258562375