### PR TITLE
Add .editorconfig to repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.rs]
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This helps ensure all editors will handle the code files the same way.
For example, my editor was inserting tabs into .rs file which clearly use spaces. By adding this file, the editor always uses spaces for this repo, regardless of my editor's default.s
