### PR TITLE
Adding a new command to delete the wallet file -> for zingo-pc

### DIFF
--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -917,6 +917,24 @@ fn wallet_saver(lightclient: &LightClient) -> String {
         }
     })
 }
+fn wallet_deleter(lightclient: &LightClient) -> String {
+    RT.block_on(async move {
+        match lightclient.do_delete().await {
+            Ok(_) => {
+                let r = object! { "result" => "success",
+                "wallet_path" => lightclient.config.get_wallet_path().to_str().unwrap() };
+                r.pretty(2)
+            }
+            Err(e) => {
+                let r = object! {
+                    "result" => "error",
+                    "error" => e
+                };
+                r.pretty(2)
+            }
+        }
+    })
+}
 struct SaveCommand {}
 impl Command for SaveCommand {
     fn help(&self) -> &'static str {
@@ -939,7 +957,27 @@ impl Command for SaveCommand {
         wallet_saver(lightclient)
     }
 }
+struct DeleteCommand {}
+impl Command for DeleteCommand {
+    fn help(&self) -> &'static str {
+        indoc! {r#"
+            Delete the wallet from disk
+            Usage:
+            delete
 
+            The wallet is deleted from disk. If you want to use another wallet first you need to remove the existing wallet file
+
+        "#}
+    }
+
+    fn short_help(&self) -> &'static str {
+        "Delete wallet file from disk"
+    }
+
+    fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
+        wallet_deleter(lightclient)
+    }
+}
 struct SeedCommand {}
 impl Command for SeedCommand {
     fn help(&self) -> &'static str {
@@ -1416,7 +1454,7 @@ impl Command for QuitCommand {
 }
 
 pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
-    let entries: [(&'static str, Box<dyn Command>); 36] = [
+    let entries: [(&'static str, Box<dyn Command>); 37] = [
         (("version"), Box::new(GetVersionCommand {})),
         ("sync", Box::new(SyncCommand {})),
         ("syncstatus", Box::new(SyncStatusCommand {})),
@@ -1456,6 +1494,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         ("seed", Box::new(SeedCommand {})),
         ("get_birthday", Box::new(GetBirthdayCommand {})),
         ("wallet_kind", Box::new(WalletKindCommand {})),
+        ("delete", Box::new(DeleteCommand {})),
     ];
 
     HashMap::from(entries)


### PR DESCRIPTION
I tested from zingo-pc (windows) and it works, it removed the wallet file making easy to the user to change to another wallet.
This new command do `nothing`  for IOS or Android, like the command `save`.
And for zingo-cli, I'm not sure, in my testing it did nothing at all even in non-interactive mode.

@zancas @AloeareV Please, take a look carefully, because as you know `rust` is not my thing.