### PR TITLE
Initialize wallet with unified spending key

### DIFF
--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -54,7 +54,7 @@ orchard = { workspace = true }
 subtle = "2.4.1"
 incrementalmerkletree = { workspace = true, features = ["test-dependencies"] }
 zcash_address = { workspace = true }
-zcash_client_backend = { workspace = true }
+zcash_client_backend = { workspace = true, features = ["unstable", "transparent-inputs"] }
 zcash_encoding = { workspace = true }
 zcash_note_encryption = { workspace = true }
 zcash_primitives = { workspace = true }

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -193,7 +193,10 @@ pub enum WalletBase {
     SeedBytes([u8; 32]),
     MnemonicPhrase(String),
     Mnemonic(Mnemonic),
+    /// Unified full viewing key
     Ufvk(String),
+    /// Unified spending key
+    Usk(Vec<u8>),
 }
 impl WalletBase {
     pub fn from_string(base: String) -> WalletBase {
@@ -614,6 +617,17 @@ impl LightWallet {
                 let wc = WalletCapability::new_from_ufvk(&config, ufvk_encoded).map_err(|e| {
                     Error::new(ErrorKind::InvalidData, format!("Error parsing UFVK: {}", e))
                 })?;
+                (wc, None)
+            }
+            WalletBase::Usk(unified_spending_key) => {
+                let wc = WalletCapability::new_from_usk(unified_spending_key.as_slice()).map_err(
+                    |e| {
+                        Error::new(
+                            ErrorKind::InvalidData,
+                            format!("Error parsing unified spending key: {}", e),
+                        )
+                    },
+                )?;
                 (wc, None)
             }
         };


### PR DESCRIPTION
This unlocks the ability for importing a wallet across FFI that has spending keys, but for which the mnemonic is not known, or perhaps the account index is not the 0 presumed by `WalletBase` when given a mnemonic.