### PR TITLE
Switch commands back to returning JSON

### DIFF
--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -314,10 +314,7 @@ impl Command for SyncCommand {
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
         RT.block_on(async move {
             match lightclient.do_sync(true).await {
-                Ok(j) => format!(
-                    "Sync success: {}. Scanned {} blocks to reach block {}.",
-                    j.success, j.total_blocks_synced, j.latest_block
-                ),
+                Ok(j) => j.to_json().pretty(2),
                 Err(e) => e,
             }
         })
@@ -416,10 +413,7 @@ impl Command for RescanCommand {
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
         RT.block_on(async move {
             match lightclient.do_rescan().await {
-                Ok(j) => format!(
-                    "Sync success: {}. Scanned {} blocks to reach block {}.",
-                    j.success, j.total_blocks_synced, j.latest_block
-                ),
+                Ok(j) => j.to_json().pretty(2),
                 Err(e) => e,
             }
         })

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -67,6 +67,17 @@ pub struct SyncResult {
     pub total_blocks_synced: u64,
 }
 
+impl SyncResult {
+    /// Converts this object to a JSON object that meets the contract expected by Zingo Mobile.
+    pub fn to_json(&self) -> JsonValue {
+        object! {
+            "result" => if self.success { "success" } else { "failure" },
+            "latest_block" => self.latest_block,
+            "total_blocks_synced" => self.total_blocks_synced,
+        }
+    }
+}
+
 impl std::fmt::Display for SyncResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(


### PR DESCRIPTION
Fixes #463

Sample zingo-cli output after the fix:

```
(main) Block:2214445 (type 'help') >> sync
{
  "result": "success",
  "latest_block": 2214445,
  "total_blocks_synced": 0
}
(main) Block:2214445 (type 'help') >> rescan
**Batch** Current:    1 Total:    2
   Blocks Loaded:    0 TrialDecrypted:    0, Witnesses Updated:    0, Total:    1, 
**Batch** Current:    1 Total:    2
   Blocks Loaded:    0 TrialDecrypted:    0, Witnesses Updated:    0, Total:    1, 
{
  "result": "success",
  "latest_block": 2214446,
  "total_blocks_synced": 1
}
```