### PR TITLE
Add devcontainer.json

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+# Base on the same image that we use in CI
+FROM zingodevops/ci-build:001
+
+# Install devcontainer-specific tools
+RUN apt-get update \
+ && apt-get install -y htop \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "dockerFile": "Dockerfile",
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "16gb",
+        "storage": "32gb"
+    },
+    "postCreateCommand": "ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./zingocli/regtest/bin/",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "EditorConfig.EditorConfig",
+                "github.vscode-github-actions",
+                "Swellaby.rust-pack",
+                "pflannery.vscode-versionlens"
+            ]
+        }
+    }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,16 @@
 # top-most EditorConfig file
 root = true
 
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 [*.rs]
 indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 4
+indent_style = space

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "EditorConfig.EditorConfig",
+        "github.vscode-github-actions",
+        "Swellaby.rust-pack",
+        "pflannery.vscode-versionlens"
+    ]
+}

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn increase_server_height(manager: &RegtestManager, n: u32) {
 
 /// Transaction creation involves using a nonce, which means a non-deterministic txid.
 /// Datetime is also based on time of run.
-/// Vheck all the other fields
+/// Check all the other fields
 pub fn check_transaction_equality(first: &JsonValue, second: &JsonValue) -> bool {
     for (t1, t2) in [(first, second), (second, first)] {
         for (key1, val1) in t1.entries() {


### PR DESCRIPTION
This ensures that VS Code or GitHub Codespaces can automatically create an environment where `cargo build` and `cargo test` work.

## Devcontainer (on its own)

VS Code supports these natively. So long as you have Docker running, it'll create a container and map the git repo you already have into it if you run the "Reopen in devcontainer" command. Then you'll have all the tools necessary to build and test this repo, independent of what you may (not) have available on your regular dev machine.

## Codespaces

Codespaces leverage the devcontainer.json but adds value by hosting the container in the cloud for you. [Learn more about GitHub Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/developing-in-a-codespace).

This root repo should consider [setting up a prebuild](https://docs.github.com/en/codespaces/prebuilding-your-codespaces/configuring-prebuilds) of the Codespace to cache the docker image creation to make Codespace creation take just seconds.

For those using it, GitHub personal accounts can use Codespace VMs for free, to a point. [Learn details here](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces).
Note also that Codespaces VMs will sign your commits only if you have the repo set as a 'trusted' repo in your GitHub personal account settings.

You can see a sample of how Codespaces works by visiting [the source branch of this PR](https://github.com/nerdcash/zingolib/tree/devcontainer) and clicking the "<> Code" button:

![image](https://github.com/zcash/zips/assets/3548/72cafbb7-ca69-458a-8519-292952462ccf)

Or use the `...` button to configure the size of the Codespace VM. Give yourself a 16 core machine and see just how fast `cargo build` can go!