### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+# Ensure shell scripts use LF line endings (linux only accepts LF)
+*.sh eol=lf
+*.ps1 eol=lf


### PR DESCRIPTION
Every repo should have this. It ensures that no matter how git itself or text editors are configured on each developer's machine, line endings will always be checked in with LF line endings.
Without this file, CRLF endings can be checked in, leading to huge diffs of nothing but line endings and senseless merge conflicts.