### PR TITLE
Refactor send to address

### DIFF
--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1010,14 +1010,18 @@ impl LightClient {
 
         let result = {
             let _lock = self.sync_lock.lock().await;
+            // I am not clear on how long this operation may take, but it's
+            // clearly unnecessary in a send that doesn't include sapling
+            // TODO: Remove from sends that don't include Sapling
             let (sapling_output, sapling_spend) = self.read_sapling_params()?;
 
-            let prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
+            let sapling_prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
 
             self.wallet
                 .send_to_addresses(
-                    prover,
-                    vec![crate::wallet::Pool::Orchard, crate::wallet::Pool::Sapling],
+                    sapling_prover,
+                    vec![crate::wallet::Pool::Orchard, crate::wallet::Pool::Sapling], // This policy doesn't allow
+                    // spend from transparent.
                     address_amount_memo_tuples,
                     transaction_submission_height,
                     |transaction_bytes| {
@@ -1044,8 +1048,13 @@ impl LightClient {
         address: Option<String>,
     ) -> Result<String, String> {
         let transaction_submission_height = self.get_submission_height().await?;
-        let fee = u64::from(MINIMUM_FEE);
-        let tbal = self.wallet.tbalance(None).await.unwrap_or(0);
+        let fee = u64::from(MINIMUM_FEE); // TODO: This can no longer be hard coded, and must be calced
+                                          // as a fn of the transactions structure.
+        let tbal = self
+            .wallet
+            .tbalance(None)
+            .await
+            .expect("to receive a balance");
         let sapling_bal = self
             .wallet
             .spendable_sapling_balance(None)

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1015,7 +1015,7 @@ impl LightClient {
             let prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
 
             self.wallet
-                .send_to_address(
+                .send_to_addresses(
                     prover,
                     vec![crate::wallet::Pool::Orchard, crate::wallet::Pool::Sapling],
                     address_amount_memo_tuples,
@@ -1079,7 +1079,7 @@ impl LightClient {
             let prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
 
             self.wallet
-                .send_to_address(
+                .send_to_addresses(
                     prover,
                     pools_to_shield.to_vec(),
                     vec![(&addr, balance_to_shield - fee, None)],

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -1085,11 +1085,11 @@ impl LightClient {
             let _lock = self.sync_lock.lock().await;
             let (sapling_output, sapling_spend) = self.read_sapling_params()?;
 
-            let prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
+            let sapling_prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
 
             self.wallet
                 .send_to_addresses(
-                    prover,
+                    sapling_prover,
                     pools_to_shield.to_vec(),
                     vec![(&addr, balance_to_shield - fee, None)],
                     transaction_submission_height,

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -1058,7 +1058,7 @@ impl LightWallet {
 
     async fn send_to_addresses_inner<F, Fut, P: TxProver>(
         &self,
-        prover: P,
+        sapling_prover: P,
         policy: NoteSelectionPolicy,
         tos: Vec<(&str, u64, Option<MemoBytes>)>,
         submission_height: BlockHeight,
@@ -1269,7 +1269,7 @@ impl LightWallet {
 
         builder.with_progress_notifier(transmitter);
         let (transaction, _) = match builder.build(
-            &prover,
+            &sapling_prover,
             &transaction::fees::fixed::FeeRule::non_standard(MINIMUM_FEE),
         ) {
             Ok(res) => res,

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -919,7 +919,7 @@ impl LightWallet {
         )
     }
 
-    pub async fn send_to_address<F, Fut, P: TxProver>(
+    pub async fn send_to_addresses<F, Fut, P: TxProver>(
         &self,
         prover: P,
         policy: NoteSelectionPolicy,
@@ -936,7 +936,7 @@ impl LightWallet {
 
         // Call the internal function
         match self
-            .send_to_address_inner(prover, policy, tos, submission_height, broadcast_fn)
+            .send_to_addresses_inner(prover, policy, tos, submission_height, broadcast_fn)
             .await
         {
             Ok((transaction_id, raw_transaction)) => {
@@ -950,7 +950,7 @@ impl LightWallet {
         }
     }
 
-    async fn send_to_address_inner<F, Fut, P: TxProver>(
+    async fn send_to_addresses_inner<F, Fut, P: TxProver>(
         &self,
         prover: P,
         policy: NoteSelectionPolicy,

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -921,7 +921,7 @@ impl LightWallet {
 
     pub async fn send_to_addresses<F, Fut, P: TxProver>(
         &self,
-        prover: P,
+        sapling_prover: P,
         policy: NoteSelectionPolicy,
         tos: Vec<(&str, u64, Option<MemoBytes>)>,
         submission_height: BlockHeight,
@@ -936,7 +936,7 @@ impl LightWallet {
 
         // Call the internal function
         match self
-            .send_to_addresses_inner(prover, policy, tos, submission_height, broadcast_fn)
+            .send_to_addresses_inner(sapling_prover, policy, tos, submission_height, broadcast_fn)
             .await
         {
             Ok((transaction_id, raw_transaction)) => {


### PR DESCRIPTION
@Oscar-Pepper this is a good start into `zingolib` it's just a refactor that makes `send_to_adresses_inner` less spaghetti-code..

Chopping the spaghetti, I call it.

A critical bit that may be questionable is the new scope (smaller) that the read lock is taken and dropped in.