### PR TITLE
Refine tx builder helpers

### DIFF
--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -999,11 +999,49 @@ impl LightClient {
             .unwrap()
             .block_on(async move { self.do_seed_phrase().await })
     }
+
+    fn map_tos_to_receivers(
+        &self,
+        tos: Vec<(&str, u64, Option<MemoBytes>)>,
+    ) -> Result<
+        Vec<(
+            zcash_client_backend::address::RecipientAddress,
+            zcash_primitives::transaction::components::Amount,
+            Option<MemoBytes>,
+        )>,
+        String,
+    > {
+        if tos.is_empty() {
+            return Err("Need at least one destination address".to_string());
+        }
+        tos.iter()
+            .map(|to| {
+                let ra = match zcash_client_backend::address::RecipientAddress::decode(
+                    &self.config.chain,
+                    to.0,
+                ) {
+                    Some(to) => to,
+                    None => {
+                        let e = format!("Invalid recipient address: '{}'", to.0);
+                        error!("{}", e);
+                        return Err(e);
+                    }
+                };
+
+                let value =
+                    zcash_primitives::transaction::components::Amount::from_u64(to.1).unwrap();
+
+                Ok((ra, value, to.2.clone()))
+            })
+            .collect()
+    }
+
     //TODO: Add migrate_sapling_to_orchard argument
     pub async fn do_send(
         &self,
         address_amount_memo_tuples: Vec<(&str, u64, Option<MemoBytes>)>,
     ) -> Result<String, String> {
+        let receivers = self.map_tos_to_receivers(address_amount_memo_tuples)?;
         let transaction_submission_height = self.get_submission_height().await?;
         // First, get the concensus branch ID
         debug!("Creating transaction");
@@ -1022,7 +1060,7 @@ impl LightClient {
                     sapling_prover,
                     vec![crate::wallet::Pool::Orchard, crate::wallet::Pool::Sapling], // This policy doesn't allow
                     // spend from transparent.
-                    address_amount_memo_tuples,
+                    receivers,
                     transaction_submission_height,
                     |transaction_bytes| {
                         GrpcConnector::send_transaction(self.get_server_uri(), transaction_bytes)
@@ -1081,6 +1119,9 @@ impl LightClient {
         let addr = address
             .unwrap_or(self.wallet.wallet_capability().addresses()[0].encode(&self.config.chain));
 
+        let receiver = self
+            .map_tos_to_receivers(vec![(&addr, balance_to_shield - fee, None)])
+            .expect("To build shield receiver.");
         let result = {
             let _lock = self.sync_lock.lock().await;
             let (sapling_output, sapling_spend) = self.read_sapling_params()?;
@@ -1091,7 +1132,7 @@ impl LightClient {
                 .send_to_addresses(
                     sapling_prover,
                     pools_to_shield.to_vec(),
-                    vec![(&addr, balance_to_shield - fee, None)],
+                    receiver,
                     transaction_submission_height,
                     |transaction_bytes| {
                         GrpcConnector::send_transaction(self.get_server_uri(), transaction_bytes)


### PR DESCRIPTION
This PR, if landed after the ones I opened earlier is _just_ a refactor that properly separates conversion code out of the `send_to_addresses` code (failing before that fn is ever called in the error case).