### PR TITLE
Fix base height and faucet recipient birthday

### DIFF
--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -617,7 +617,7 @@ pub mod scenarios {
         faucet.do_sync(false).await.unwrap();
         let recipient = sb
             .client_builder
-            .build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false)
+            .build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), BASE_HEIGHT as u64, false)
             .await;
         (
             sb.regtest_manager,

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -18,7 +18,7 @@ use zingolib::lightclient::LightClient;
 
 use crate::scenarios::setup::TestEnvironmentGenerator;
 
-pub const BASE_HEIGHT: u32 = 2;
+pub const BASE_HEIGHT: u32 = 3;
 pub fn build_fvks_from_wallet_capability(wallet_capability: &WalletCapability) -> [Fvk; 3] {
     let o_fvk = Fvk::Orchard(
         orchard::keys::FullViewingKey::try_from(wallet_capability)
@@ -321,8 +321,10 @@ pub mod scenarios {
                             }
                         }),
                 );
-                self.regtest_manager.generate_n_blocks(BASE_HEIGHT).unwrap();
-                while crate::poll_server_height(&self.regtest_manager) != BASE_HEIGHT + 1 {
+                self.regtest_manager
+                    .generate_n_blocks(BASE_HEIGHT - 1)
+                    .unwrap();
+                while crate::poll_server_height(&self.regtest_manager) != BASE_HEIGHT {
                     sleep(std::time::Duration::from_millis(50)).await;
                 }
             }
@@ -550,7 +552,7 @@ pub mod scenarios {
         .await;
         let faucet = sb
             .client_builder
-            .build_new_faucet(BASE_HEIGHT as u64, false)
+            .build_new_faucet(BASE_HEIGHT as u64 - 1, false)
             .await;
         (
             sb.regtest_manager,
@@ -611,14 +613,11 @@ pub mod scenarios {
             None,
         )
         .await;
-        let faucet = sb
-            .client_builder
-            .build_new_faucet(BASE_HEIGHT as u64, false)
-            .await;
+        let faucet = sb.client_builder.build_new_faucet(0, false).await;
         faucet.do_sync(false).await.unwrap();
         let recipient = sb
             .client_builder
-            .build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), BASE_HEIGHT as u64, false)
+            .build_newseed_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false)
             .await;
         (
             sb.regtest_manager,

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -611,7 +611,10 @@ pub mod scenarios {
             None,
         )
         .await;
-        let faucet = sb.client_builder.build_new_faucet(9, false).await;
+        let faucet = sb
+            .client_builder
+            .build_new_faucet(BASE_HEIGHT as u64, false)
+            .await;
         faucet.do_sync(false).await.unwrap();
         let recipient = sb
             .client_builder

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -5,7 +5,7 @@ use orchard::tree::MerkleHashOrchard;
 use shardtree::store::memory::MemoryShardStore;
 use shardtree::ShardTree;
 use std::{fs::File, path::Path, str::FromStr};
-use zingo_testutils::{self, build_fvk_client, data};
+use zingo_testutils::{self, build_fvk_client, data, BASE_HEIGHT};
 
 use bip0039::Mnemonic;
 use data::seeds::HOSPITAL_MUSEUM_SEED;
@@ -905,8 +905,11 @@ async fn send_orchard_back_and_forth() {
     // check start state
     faucet.do_sync(true).await.unwrap();
     let wallet_height = faucet.do_wallet_last_scanned_height().await;
-    assert_eq!(wallet_height.as_fixed_point_u64(0).unwrap(), 3);
-    let three_blocks_reward = block_reward.checked_mul(3).unwrap();
+    assert_eq!(
+        wallet_height.as_fixed_point_u64(0).unwrap(),
+        BASE_HEIGHT as u64
+    );
+    let three_blocks_reward = block_reward.checked_mul(BASE_HEIGHT as u64).unwrap();
     check_client_balances!(faucet, o: 0 s: three_blocks_reward  t: 0);
 
     // post transfer to recipient, and verify


### PR DESCRIPTION
when working on fixing faucet birthday i noticed that BASE_HEIGHT indicates the amount of blocks generated instead of the height of the chain. therefore, all uses of BASE_HEIGHT were followed by `+1`. I may be misunderstanding BASE_HEIGHT but these changes make the code more intuitive to me.