### PR TITLE
Ci node16 warning removed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          override: true
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest


### PR DESCRIPTION
This one: `The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/` & `The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/` both fixed.

Ref for the same in zingo-mobile: https://github.com/zingolabs/zingo-mobile/pull/523