### PR TITLE
put position in the right place

### DIFF
--- a/zingolib/src/wallet/keys/extended_transparent.rs
+++ b/zingolib/src/wallet/keys/extended_transparent.rs
@@ -102,9 +102,9 @@ impl ExtendedPrivKey {
                 KeyIndex::hardened_from_normalize_index(config.get_coin_type()).unwrap(),
             )
             .unwrap()
-            .derive_private_key(KeyIndex::hardened_from_normalize_index(0).unwrap())
+            .derive_private_key(KeyIndex::hardened_from_normalize_index(position).unwrap())
             .unwrap()
-            .derive_private_key(KeyIndex::Normal(position))
+            .derive_private_key(KeyIndex::Normal(0))
             .unwrap()
     }
 


### PR DESCRIPTION
We weren't compliant with bip32 transparent keygen for non-zero account indexes. This shouldn't break anything not belonging to @AArnott, as support for non-zero account indexes landed very recently, hasn't hit release, and I think isn't exposed anywhere other than the library. 