### PR TITLE
Propose fast pr ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,5 +78,4 @@ jobs:
       - name: Run tests
         run: |
           cargo nextest run --verbose --profile ci --archive-file nextest-archive.tar.zst \
-            --workspace-remap ./ --partition count:${{ matrix.partition}}/8
-
+            --workspace-remap ./ --partition count:${{ matrix.partition}}/8 --no-fail-fast -E 'not test(slow)'


### PR DESCRIPTION
This PR builds on #601 .

I think we're getting sufficient signal for merge into `dev` from this subset of the tests (provided we're gating merge from `dev` into release more strictly, with e.g. the full 'nightly' test suite).