### PR TITLE
remove inappropriate scan and fail 9 tests

### DIFF
--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -1566,22 +1566,6 @@ impl LightWallet {
                     Some((transaction.txid(), u32::from(submission_height)));
             }
         }
-
-        // Add this transaction to the mempool structure
-        {
-            let price = self.price.read().await.clone();
-
-            self.transaction_context
-                .scan_full_tx(
-                    transaction,
-                    submission_height,
-                    true,
-                    now() as u32,
-                    TransactionMetadata::get_price(now(), &price),
-                )
-                .await;
-        }
-
         Ok((transaction_id, raw_transaction))
     }
 


### PR DESCRIPTION
Hi!  I believe that the excised code was introducing a bug by marking txins as spent before receiving a confirming transaction.

Clearly from the set of 9 failing tests, it was performing important functions as well.

I'd like a hacker to evaluate the removed fn call.   In particular look at each of the call-sites that invokes `scan_full_tx`, you should notice that the argument is a transaction fresh from the lightwalletd.

Next notice that the utxos manipulated by `scan_full_tx` are changed away from the `unconfirmed_spent` state.   This is (I believe) incorrect.

Then run the test suite.   Because of an (unrelated) bug I had to:

```
+    #[ignore]
     #[tokio::test]
     async fn multiple_outgoing_metadatas_work_right_on_restore() {
```