### PR TITLE
add openssl dev to readme and create nextest default config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,4 @@
 [profile.default]
-failure-output = "final"
 fail-fast = false
 
 [profile.ci]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
+[profile.default]
+failure-output = "final"
+fail-fast = false
+
 [profile.ci]
 failure-output = "immediate-final"
 fail-fast = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 zingocli/regtest/data/zcashd/regtest/
 zingocli/regtest/data/lightwalletd/
 zingocli/regtest/data/zingo/
+zingocli/regtest/logs/
 zingocli/regtest/zingo-wallet.dat
 zingocli/regtest/bin
 target

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Zingo-CLI does automatic note and utxo management, which means it doesn't allow 
     * Run `rustup update` to get the latest version of Rust if you already have it installed
 * Rustfmt
     * Run `rustup component add rustfmt` to add rustfmt
-* Build tools
+* Build Tools
     * Please install the build tools for your platform. On Ubuntu `sudo apt install build-essential gcc`
 * Protobuf Compiler
     * Please install the protobuf compiler for your platform. On Ubuntu `sudo apt install protobuf-compiler`
+* OpenSSL Dev
+    * Please install development packages of openssl. On Ubuntu `sudo apt install libssl-dev`
 
 ```
 git clone https://github.com/zingolabs/zingolib.git


### PR DESCRIPTION
- removes the need to run `--non-fail-fast` with nextest runs
- added missing openssl dev package to readme prereqs