### PR TITLE
the save update

### DIFF
--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -416,7 +416,7 @@ pub fn startup(
         )?),
         None => {
             if config.wallet_path_exists() {
-                Arc::new(LightClient::read_wallet_from_disk_runtime(&config)?)
+                Arc::new(LightClient::read_wallet_from_disk(&config)?)
             } else {
                 println!("Creating a new wallet");
                 // Call the lightwalletd server to get the current block-height

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -190,13 +190,11 @@ fn start_interactive(
             Err(rustyline::error::ReadlineError::Interrupted) => {
                 println!("CTRL-C");
                 info!("CTRL-C");
-                println!("{}", send_command("save".to_string(), vec![]));
                 break;
             }
             Err(rustyline::error::ReadlineError::Eof) => {
                 println!("CTRL-D");
                 info!("CTRL-D");
-                println!("{}", send_command("save".to_string(), vec![]));
                 break;
             }
             Err(err) => {
@@ -503,9 +501,6 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) {
         }
 
         // Save before exit
-        command_transmitter
-            .send(("save".to_string(), vec![]))
-            .unwrap();
         resp_receiver.recv().unwrap();
     }
 }

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -416,7 +416,7 @@ pub fn startup(
         )?),
         None => {
             if config.wallet_path_exists() {
-                Arc::new(LightClient::read_wallet_from_disk(&config)?)
+                Arc::new(LightClient::read_wallet_from_disk_runtime(&config)?)
             } else {
                 println!("Creating a new wallet");
                 // Call the lightwalletd server to get the current block-height

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -310,7 +310,6 @@ mod fast {
             faucet.do_list_notes(true).await["unspent_orchard_notes"].len(),
             1
         );
-        faucet.save_internal_rust().await.unwrap();
         // Create a new client using the faucet's wallet
 
         // Create zingo config
@@ -3299,7 +3298,6 @@ mod slow {
             recipient_balance.unverified_orchard_balance.unwrap(),
             65_000
         );
-        recipient.save_internal_rust().await.unwrap();
 
         let loaded_client = recipient.new_client_from_save_buffer().await.unwrap();
         let loaded_balance = loaded_client.do_balance().await;

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -3299,19 +3299,9 @@ mod slow {
             recipient_balance.unverified_orchard_balance.unwrap(),
             65_000
         );
-        let wallet_loc = &regtest_manager
-            .zingo_datadir
-            .parent()
-            .unwrap()
-            .join("zingo_client_2");
         recipient.save_internal_rust().await.unwrap();
 
-        let (wallet, config) = zingo_testutils::load_wallet(
-            wallet_loc.to_path_buf(),
-            ChainType::Regtest(regtest_network),
-        )
-        .await;
-        let loaded_client = LightClient::create_from_wallet(wallet, config);
+        let loaded_client = recipient.new_client_from_save_buffer().await.unwrap();
         let loaded_balance = loaded_client.do_balance().await;
         assert_eq!(loaded_balance.unverified_orchard_balance, Some(0),);
         check_client_balances!(loaded_client, o: 100_000 s: 0 t: 0 );

--- a/zingocli/tests/integration_tests.rs
+++ b/zingocli/tests/integration_tests.rs
@@ -310,7 +310,7 @@ mod fast {
             faucet.do_list_notes(true).await["unspent_orchard_notes"].len(),
             1
         );
-        faucet.do_save().await.unwrap();
+        faucet.save_internal_rust().await.unwrap();
         // Create a new client using the faucet's wallet
 
         // Create zingo config
@@ -3304,7 +3304,7 @@ mod slow {
             .parent()
             .unwrap()
             .join("zingo_client_2");
-        recipient.do_save().await.unwrap();
+        recipient.save_internal_rust().await.unwrap();
 
         let (wallet, config) = zingo_testutils::load_wallet(
             wallet_loc.to_path_buf(),

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 
 [features]
 deprecations = ["lightclient-deprecated"]
+test = ["lightclient-deprecated", "test-features"]
 lightclient-deprecated = []
+test-features = []
 default = ["embed_params"]
 embed_params = []
 

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -927,7 +927,7 @@ impl Command for SendCommand {
 
 fn wallet_saver(lightclient: &LightClient) -> String {
     RT.block_on(async move {
-        match lightclient.do_save().await {
+        match lightclient.save_internal_rust().await {
             Ok(_) => {
                 let r = object! { "result" => "success",
                 "wallet_path" => lightclient.config.get_wallet_path().to_str().unwrap() };
@@ -936,7 +936,7 @@ fn wallet_saver(lightclient: &LightClient) -> String {
             Err(e) => {
                 let r = object! {
                     "result" => "error",
-                    "error" => e
+                    "error" => e.to_string()
                 };
                 r.pretty(2)
             }

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -925,24 +925,6 @@ impl Command for SendCommand {
     }
 }
 
-fn wallet_saver(lightclient: &LightClient) -> String {
-    RT.block_on(async move {
-        match lightclient.save_internal_rust().await {
-            Ok(_) => {
-                let r = object! { "result" => "success",
-                "wallet_path" => lightclient.config.get_wallet_path().to_str().unwrap() };
-                r.pretty(2)
-            }
-            Err(e) => {
-                let r = object! {
-                    "result" => "error",
-                    "error" => e.to_string()
-                };
-                r.pretty(2)
-            }
-        }
-    })
-}
 fn wallet_deleter(lightclient: &LightClient) -> String {
     RT.block_on(async move {
         match lightclient.do_delete().await {
@@ -960,28 +942,6 @@ fn wallet_deleter(lightclient: &LightClient) -> String {
             }
         }
     })
-}
-struct SaveCommand {}
-impl Command for SaveCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r#"
-            Save the wallet to disk
-            Usage:
-            save
-
-            The wallet is saved to disk. The wallet is periodically saved to disk (and also saved upon exit)
-            but you can use this command to explicitly save it to disk
-
-        "#}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Save wallet file to disk"
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
-        wallet_saver(lightclient)
-    }
 }
 struct DeleteCommand {}
 impl Command for DeleteCommand {
@@ -1427,7 +1387,7 @@ struct QuitCommand {}
 impl Command for QuitCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
-            Save the wallet to disk and quit
+            Quit the light client
             Usage:
             quit
 
@@ -1475,8 +1435,7 @@ impl Command for QuitCommand {
                     .expect("error while killing regtest-spawned processes!");
             }
         }
-
-        wallet_saver(lightclient)
+        "quit".to_string()
     }
 }
 
@@ -1513,7 +1472,6 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         ("updatecurrentprice", Box::new(UpdateCurrentPriceCommand {})),
         ("send", Box::new(SendCommand {})),
         ("shield", Box::new(ShieldCommand {})),
-        ("save", Box::new(SaveCommand {})),
         ("quit", Box::new(QuitCommand {})),
         ("notes", Box::new(NotesCommand {})),
         ("new", Box::new(NewAddressCommand {})),

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -1,5 +1,49 @@
+use std::error::Error;
+use std::fmt;
+
 #[derive(Debug)]
 pub enum ZingoLibError {
     NoWalletLocation,
     MetadataUnderflow,
+    InternalWriteBufferError(std::io::Error),
+    WriteFileError(std::io::Error),
+    EmptySaveBuffer,
 }
+
+impl std::fmt::Display for ZingoLibError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ZingoLibError::*;
+        match self {
+            NoWalletLocation => write!(
+                f,
+                "No wallet location! (compiled for native rust, wallet location expected)"
+            ),
+            MetadataUnderflow => write!(
+                f,
+                "Metadata underflow! Recorded metadata shows greater output than input value. This may be because input notes are prebirthday."
+            ),
+            InternalWriteBufferError(err) => write!(
+                f,
+                "Internal save error! {} ",
+                err,
+            ),
+            WriteFileError(err) => write!(
+                f,
+                "Could not write to wallet save file. Was this erroneously attempted in mobile?, instead of native save buffer handling? Is there a permission issue? {} ",
+                err,
+            ),
+            EmptySaveBuffer => write!(
+                f,
+                "Empty save buffer. probably save_external was called before save_internal_rust. this is handled by save_external."
+            ),
+        }
+    }
+}
+
+impl From<ZingoLibError> for String {
+    fn from(value: ZingoLibError) -> Self {
+        format!("{value}")
+    }
+}
+
+impl Error for ZingoLibError {}

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -8,6 +8,7 @@ pub enum ZingoLibError {
     InternalWriteBufferError(std::io::Error),
     WriteFileError(std::io::Error),
     EmptySaveBuffer,
+    CantReadWallet(std::io::Error),
 }
 
 impl std::fmt::Display for ZingoLibError {
@@ -35,6 +36,11 @@ impl std::fmt::Display for ZingoLibError {
             EmptySaveBuffer => write!(
                 f,
                 "Empty save buffer. probably save_external was called before save_internal_rust. this is handled by save_external."
+            ),
+            CantReadWallet(err) => write!(
+                f,
+                "Cant read wallet. Corrupt file. Or maybe a backwards version issue? {}",
+                err,
             ),
         }
     }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -2050,3 +2050,5 @@ impl LightClient {
 }
 #[cfg(feature = "lightclient-deprecated")]
 mod deprecated;
+#[cfg(feature = "test-features")]
+mod test_features;

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -143,6 +143,12 @@ pub struct AccountBackupInfo {
     pub account_index: u32,
 }
 
+#[derive(Default)]
+pub struct ZingoSaveBuffer {
+    buffer: Vec<u8>,
+    written: bool,
+}
+
 /// The LightClient provides a unified interface to the separate concerns that the zingolib library manages.
 ///  1. initialization of stored state
 ///      * from seed
@@ -161,6 +167,8 @@ pub struct LightClient {
 
     bsync_data: Arc<RwLock<BlazeSyncData>>,
     interrupt_sync: Arc<RwLock<bool>>,
+
+    save_buffer: ZingoSaveBuffer,
 }
 
 ///  This is the omnibus interface to the library, we are currently in the process of refining this types
@@ -176,6 +184,7 @@ impl LightClient {
             sync_lock: Mutex::new(()),
             bsync_data: Arc::new(RwLock::new(BlazeSyncData::new(&config))),
             interrupt_sync: Arc::new(RwLock::new(false)),
+            save_buffer: ZingoSaveBuffer::default(),
         }
     }
     /// The wallet this fn associates with the lightclient is specifically derived from

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -393,40 +393,27 @@ impl LightClient {
         LightClient::read_wallet_from_buffer(config, BufReader::new(File::open(wallet_path)?))
     }
 
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub async fn do_delete(&self) -> Result<(), String> {
-        #[cfg(any(target_os = "ios", target_os = "android"))]
-        // on mobile platforms, disable the delete, as it will be handled by the native layer
-        {
-            log::debug!("do_delete entered");
-            // on iOS and Android, just return ok
-            Ok(())
-        }
-
-        #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        {
-            log::debug!("do_delete entered");
-            log::debug!("target_os is not ios or android");
-
-            // Check if the file exists before attempting to delete
-            if self.config.wallet_path_exists() {
-                match remove_file(self.config.get_wallet_path()) {
-                    Ok(_) => {
-                        log::debug!("File deleted successfully!");
-                        Ok(())
-                    }
-                    Err(e) => {
-                        let err = format!("ERR: {}", e);
-                        error!("{}", err);
-                        log::debug!("DELETE FAIL ON FILE!");
-                        Err(e.to_string())
-                    }
+        // Check if the file exists before attempting to delete
+        if self.config.wallet_path_exists() {
+            match remove_file(self.config.get_wallet_path()) {
+                Ok(_) => {
+                    log::debug!("File deleted successfully!");
+                    Ok(())
                 }
-            } else {
-                let err = "Error: File does not exist, nothing to delete.".to_string();
-                error!("{}", err);
-                log::debug!("File does not exist, nothing to delete.");
-                Err(err)
+                Err(e) => {
+                    let err = format!("ERR: {}", e);
+                    error!("{}", err);
+                    log::debug!("DELETE FAIL ON FILE!");
+                    Err(e.to_string())
+                }
             }
+        } else {
+            let err = "Error: File does not exist, nothing to delete.".to_string();
+            error!("{}", err);
+            log::debug!("File does not exist, nothing to delete.");
+            Err(err)
         }
     }
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -346,7 +346,7 @@ impl LightClient {
         }
     }
 
-    pub async fn export_save_buffer_runtime(&self) -> Result<Vec<u8>, ZingoLibError> {
+    pub fn export_save_buffer_runtime(&self) -> Result<Vec<u8>, ZingoLibError> {
         Runtime::new()
             .unwrap()
             .block_on(async move { self.export_save_buffer().await })

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -333,6 +333,7 @@ impl LightClient {
         }
     }
 
+    /// This function is the sole correct way to ask LightClient to save.
     pub fn export_save_buffer_runtime(&self) -> Result<Vec<u8>, String> {
         Runtime::new()
             .unwrap()

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -346,10 +346,11 @@ impl LightClient {
         }
     }
 
-    pub fn export_save_buffer_runtime(&self) -> Result<Vec<u8>, ZingoLibError> {
+    pub fn export_save_buffer_runtime(&self) -> Result<Vec<u8>, String> {
         Runtime::new()
             .unwrap()
             .block_on(async move { self.export_save_buffer_async().await })
+            .map_err(|err| String::from(err))
     }
 
     /// This constructor depends on a wallet that's read from a buffer.

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -282,25 +282,12 @@ impl LightClient {
 
     //        SAVE METHODS
 
-    pub async fn save_internal_rust(&self) -> Result<bool, ZingoLibError> {
+    async fn save_internal_rust(&self) -> Result<bool, ZingoLibError> {
         self.save_internal_buffer().await?;
         Ok(self.rust_write_save_buffer_to_file().await?)
     }
 
-    pub async fn save_external(&self) -> Result<Vec<u8>, ZingoLibError> {
-        match self.export_save_buffer_async().await {
-            Ok(buff) => Ok(buff),
-            Err(err) => match err {
-                ZingoLibError::EmptySaveBuffer => {
-                    self.save_internal_buffer().await?;
-                    self.export_save_buffer_async().await
-                }
-                other_err => Err(other_err),
-            },
-        }
-    }
-
-    pub async fn save_internal_buffer(&self) -> Result<(), ZingoLibError> {
+    async fn save_internal_buffer(&self) -> Result<(), ZingoLibError> {
         let mut buffer: Vec<u8> = vec![];
         self.wallet
             .write(&mut buffer)
@@ -310,7 +297,7 @@ impl LightClient {
         Ok(())
     }
 
-    pub async fn rust_write_save_buffer_to_file(&self) -> Result<bool, ZingoLibError> {
+    async fn rust_write_save_buffer_to_file(&self) -> Result<bool, ZingoLibError> {
         #[cfg(any(target_os = "ios", target_os = "android"))]
         // on mobile platforms, saving from this buffer will be handled by the native layer
         {
@@ -331,13 +318,13 @@ impl LightClient {
         }
     }
 
-    pub fn write_to_file(path: Box<Path>, buffer: &Vec<u8>) -> std::io::Result<()> {
+    fn write_to_file(path: Box<Path>, buffer: &Vec<u8>) -> std::io::Result<()> {
         let mut file = File::create(path).unwrap();
         file.write_all(buffer)?;
         Ok(())
     }
 
-    pub async fn export_save_buffer_async(&self) -> Result<Vec<u8>, ZingoLibError> {
+    async fn export_save_buffer_async(&self) -> Result<Vec<u8>, ZingoLibError> {
         let read_buffer = self.save_buffer.buffer.read().await;
         if !read_buffer.is_empty() {
             Ok(read_buffer.clone())

--- a/zingolib/src/lightclient/test_features.rs
+++ b/zingolib/src/lightclient/test_features.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+impl LightClient {
+    pub async fn new_client_from_save_buffer(&self) -> Result<Self, ZingoLibError> {
+        self.save_internal_buffer().await?;
+
+        LightClient::read_wallet_from_buffer_async(
+            &self.config,
+            self.save_buffer.buffer.read().await.as_slice(),
+        )
+        .await
+        .map_err(ZingoLibError::CantReadWallet)
+    }
+}


### PR DESCRIPTION
consumer warning @AArnott @juanky201271 : export_save_buffer_runtime is now the only pub fn to export a LightClient save buffer

ZingoCli: save command removed.

LIghtClient: Keeps an internal save buffer in memory corresponding to the last certified complete state. it created at wallet creation time, updated at the end of each batch, and saved to disk if on an appropriate architecture

Error handling improved. ZingoLibError enum now includes strings and transmutes into other error types when necessary, thanks @AloeareV 

Test Framework: Must now be run with --features test.