### PR TITLE
Fix missing spaces and punctuation in error message

### DIFF
--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -493,9 +493,9 @@ impl TransactionContext {
 
                     Err(e) => log::error!(
                         "Could not decode wallet internal memo: {e}.\n\
-                    Have you recently used a more up-to-date version of\
-                    this software?\nIf not, this may mean you are being sent\
-                    malicious data.\nSome information may not display correctly"
+                    Have you recently used a more up-to-date version of \
+                    this software?\nIf not, this may mean you are being sent \
+                    malicious data.\nSome information may not display correctly."
                     ),
                 }
             }


### PR DESCRIPTION
These messages were printing with "ofthis" and "sentmalicious" appearing at the console.