### PR TITLE
Process Spent Note error handling

### DIFF
--- a/zingolib/src/blaze/block_management_reorg_detection.rs
+++ b/zingolib/src/blaze/block_management_reorg_detection.rs
@@ -492,7 +492,7 @@ impl BlockManagementData {
         }
     }
     /// This function handles Orchard and Sapling domains.
-    /// This function takes data from the Untrusted Malicious Proxy, and uses it to construct a witness locally.  I am
+    /// This function takes data from the light server and uses it to construct a witness locally.  should?
     /// currently of the opinion that this function should be factored into separate concerns.
     pub(crate) async fn get_note_witness<D>(
         &self,

--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -1,12 +1,15 @@
 use super::syncdata::BlazeSyncData;
-use crate::wallet::{
-    data::OutgoingTxData,
-    keys::{address_from_pubkeyhash, unified::WalletCapability},
-    traits::{
-        self as zingo_traits, Bundle as _, DomainWalletExt, NoteInterface as _, Recipient as _,
-        ShieldedOutputExt as _, Spend as _, ToBytes as _,
+use crate::{
+    error::{ZingoLibError, ZingoLibResult},
+    wallet::{
+        data::OutgoingTxData,
+        keys::{address_from_pubkeyhash, unified::WalletCapability},
+        traits::{
+            self as zingo_traits, Bundle as _, DomainWalletExt, NoteInterface as _, Recipient as _,
+            ShieldedOutputExt as _, Spend as _, ToBytes as _,
+        },
+        transactions::TransactionMetadataSet,
     },
-    transactions::TransactionMetadataSet,
 };
 use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
 use orchard::note_encryption::OrchardDomain;
@@ -490,13 +493,10 @@ impl TransactionContext {
                     Ok(parsed_zingo_memo) => {
                         arbitrary_memos_with_txids.push((parsed_zingo_memo, transaction.txid()));
                     }
-
-                    Err(e) => log::error!(
-                        "Could not decode wallet internal memo: {e}.\n\
-                    Have you recently used a more up-to-date version of \
-                    this software?\nIf not, this may mean you are being sent \
-                    malicious data.\nSome information may not display correctly."
-                    ),
+                    Err(e) => {
+                        let _memo_error: ZingoLibResult<()> =
+                            ZingoLibError::CouldNotDecodeMemo(e).print_and_pass_error();
+                    }
                 }
             }
             self.transaction_metadata_set

--- a/zingolib/src/blaze/update_notes.rs
+++ b/zingolib/src/blaze/update_notes.rs
@@ -136,7 +136,7 @@ impl UpdateNotes {
                                 spent_at_height,
                                 output_index,
                             )
-                            .expect("To mark note as spent");
+                            .unwrap_or(0);
 
                         // Record the future transaction, the one that has spent the nullifiers received in this transaction in the wallet
                         wallet_transactions

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -11,6 +11,15 @@ pub enum ZingoLibError {
     CantReadWallet(std::io::Error),
 }
 
+type ZingoLibResult<T> = Result<T, ZingoLibError>;
+
+impl ZingoLibError {
+    pub fn print_and_pass_error<T>(self) -> ZingoLibResult<T> {
+        log::error!("{}", self);
+        Err(self)
+    }
+}
+
 impl std::fmt::Display for ZingoLibError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ZingoLibError::*;

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 use std::fmt;
 
+use zcash_primitives::transaction::TxId;
+
 #[derive(Debug)]
 pub enum ZingoLibError {
     NoWalletLocation,
@@ -9,6 +11,8 @@ pub enum ZingoLibError {
     WriteFileError(std::io::Error),
     EmptySaveBuffer,
     CantReadWallet(std::io::Error),
+    NoSuchTxId(TxId),
+    NoSuchOutputInTxId(TxId, u64),
 }
 
 pub type ZingoLibResult<T> = Result<T, ZingoLibError>;
@@ -50,6 +54,17 @@ impl std::fmt::Display for ZingoLibError {
                 f,
                 "Cant read wallet. Corrupt file. Or maybe a backwards version issue? {}",
                 err,
+            ),
+            NoSuchTxId(txid) => write!(
+                f,
+                "Cant find TxId {}!",
+                txid,
+            ),
+            NoSuchOutputInTxId(txid, output_index) => write!(
+                f,
+                "Cant find note with output_index {} in TxId {}",
+                output_index,
+                txid,
             ),
         }
     }

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -11,7 +11,7 @@ pub enum ZingoLibError {
     CantReadWallet(std::io::Error),
 }
 
-type ZingoLibResult<T> = Result<T, ZingoLibError>;
+pub type ZingoLibResult<T> = Result<T, ZingoLibError>;
 
 impl ZingoLibError {
     pub fn print_and_pass_error<T>(self) -> ZingoLibResult<T> {

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -12,7 +12,8 @@ pub enum ZingoLibError {
     EmptySaveBuffer,
     CantReadWallet(std::io::Error),
     NoSuchTxId(TxId),
-    NoSuchOutputInTxId(TxId, u64),
+    NoSuchSaplingOutputInTxId(TxId, u32),
+    NoSuchOrchardOutputInTxId(TxId, u32),
 }
 
 pub type ZingoLibResult<T> = Result<T, ZingoLibError>;
@@ -60,9 +61,15 @@ impl std::fmt::Display for ZingoLibError {
                 "Cant find TxId {}!",
                 txid,
             ),
-            NoSuchOutputInTxId(txid, output_index) => write!(
+            NoSuchSaplingOutputInTxId(txid, output_index) => write!(
                 f,
-                "Cant find note with output_index {} in TxId {}",
+                "Cant find note with sapling output_index {} in TxId {}",
+                output_index,
+                txid,
+            ),
+            NoSuchOrchardOutputInTxId(txid, output_index) => write!(
+                f,
+                "Cant find note with orchard output_index {} in TxId {}",
                 output_index,
                 txid,
             ),

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -14,6 +14,7 @@ pub enum ZingoLibError {
     NoSuchTxId(TxId),
     NoSuchSaplingOutputInTxId(TxId, u32),
     NoSuchOrchardOutputInTxId(TxId, u32),
+    CouldNotDecodeMemo(std::io::Error),
 }
 
 pub type ZingoLibResult<T> = Result<T, ZingoLibError>;
@@ -72,6 +73,11 @@ impl std::fmt::Display for ZingoLibError {
                 "Cant find note with orchard output_index {} in TxId {}",
                 output_index,
                 txid,
+            ),
+            CouldNotDecodeMemo(err) => write!(
+                f,
+                "Could not decode memo. Zingo plans to support foreign memo formats soon. {}",
+                err,
             ),
         }
     }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -344,7 +344,7 @@ impl LightClient {
         Runtime::new()
             .unwrap()
             .block_on(async move { self.export_save_buffer_async().await })
-            .map_err(|err| dbg!(String::from(err)))
+            .map_err(|err| String::from(err))
     }
 
     /// This constructor depends on a wallet that's read from a buffer.

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -335,7 +335,7 @@ impl LightClient {
         if !read_buffer.is_empty() {
             Ok(read_buffer.clone())
         } else {
-            Err(ZingoLibError::EmptySaveBuffer)
+            ZingoLibError::EmptySaveBuffer.print_and_pass_error()
         }
     }
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -344,7 +344,7 @@ impl LightClient {
         Runtime::new()
             .unwrap()
             .block_on(async move { self.export_save_buffer_async().await })
-            .map_err(|err| String::from(err))
+            .map_err(String::from)
     }
 
     /// This constructor depends on a wallet that's read from a buffer.

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -6,7 +6,7 @@ use crate::{
         syncdata::BlazeSyncData, trial_decryptions::TrialDecryptions, update_notes::UpdateNotes,
     },
     compact_formats::RawTransaction,
-    error::ZingoLibError,
+    error::{ZingoLibError, ZingoLibResult},
     grpc_connector::GrpcConnector,
     wallet::{
         data::{
@@ -292,7 +292,7 @@ impl LightClient {
         }
     }
 
-    async fn save_internal_buffer(&self) -> Result<(), ZingoLibError> {
+    async fn save_internal_buffer(&self) -> ZingoLibResult<()> {
         let mut buffer: Vec<u8> = vec![];
         self.wallet
             .write(&mut buffer)
@@ -302,7 +302,7 @@ impl LightClient {
         Ok(())
     }
 
-    async fn rust_write_save_buffer_to_file(&self) -> Result<bool, ZingoLibError> {
+    async fn rust_write_save_buffer_to_file(&self) -> ZingoLibResult<bool> {
         #[cfg(any(target_os = "ios", target_os = "android"))]
         // on mobile platforms, saving from this buffer will be handled by the native layer
         {
@@ -318,7 +318,7 @@ impl LightClient {
                     .map_err(ZingoLibError::WriteFileError)?;
                 Ok(true)
             } else {
-                Err(ZingoLibError::EmptySaveBuffer)
+                ZingoLibError::EmptySaveBuffer.print_and_pass_error()
             }
         }
     }
@@ -329,7 +329,7 @@ impl LightClient {
         Ok(())
     }
 
-    pub async fn export_save_buffer_async(&self) -> Result<Vec<u8>, ZingoLibError> {
+    pub async fn export_save_buffer_async(&self) -> ZingoLibResult<Vec<u8>> {
         self.save_internal_rust().await?;
         let read_buffer = self.save_buffer.buffer.read().await;
         if !read_buffer.is_empty() {


### PR DESCRIPTION
expand error handling to cover the function previously known as mark spent
and standardize search by output index rather than nullifier