### PR TITLE
Add user balances struct and fn to LightClient

### DIFF
--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -53,6 +53,8 @@ use zingoconfig::{ZingoConfig, MAX_REORG};
 
 static LOG_INIT: std::sync::Once = std::sync::Once::new();
 
+const MARGINAL_FEE: u64 = 5_000; // From ZIP-317
+
 #[derive(Clone, Debug, Default)]
 pub struct SyncResult {
     pub success: bool,
@@ -146,6 +148,69 @@ pub struct AccountBackupInfo {
 #[derive(Default)]
 struct ZingoSaveBuffer {
     pub buffer: Arc<RwLock<Vec<u8>>>,
+}
+
+/// Balances that may be presented to a user in a wallet app.
+/// The goal is to present a user-friendly and useful view of what the user has or can soon expect
+/// *without* requiring the user to understand the details of the Zcash protocol.
+///
+/// Showing all these balances all the time may overwhelm the user with information.
+/// A simpler view may present an overall balance as:
+///
+/// Name | Value
+/// --- | ---
+/// "Balance" | `spendable` - `minimum_fees` + `immature_change` + `immature_income`
+/// "Incoming" | `incoming`
+///
+/// If dust is sent to the wallet, the simpler view's Incoming balance would include it,
+/// only for it to evaporate when confirmed.
+/// But incoming can always evaporate (e.g. a transaction expires before confirmation),
+/// and the alternatives being to either hide that a transmission was made at all, or to include
+/// the dust in other balances could be more misleading.
+///
+/// An app *could* choose to prominently warn the user if a significant proportion of the incoming balance is dust,
+/// although this event seems very unlikely since it will cost the sender *more* than the amount the recipient is expecting
+/// to 'fool' them into thinking they are receiving value.
+/// The more likely scenario is that the sender is trying to send a small amount of value as a new user and doesn't realize
+/// the value is too small to be useful.
+/// A good Zcash wallet should prevent sending dust in the first place.
+pub struct UserBalances {
+    /// Available for immediate spending.
+    /// Expected fees are *not* deducted from this value, but the app may do so by subtracting `minimum_fees`.
+    /// `dust` is excluded from this value.
+    ///
+    /// For enhanced privacy, the minimum number of required confirmations to spend a note is usually greater than one.
+    pub spendable: u64,
+
+    /// The sum of the change notes that have insufficient confirmations to be spent.
+    pub immature_change: u64,
+
+    /// The minimum fees that can be expected to spend all `spendable + immature_change` funds in the wallet.
+    /// This fee assumes all funds will be sent to a single note.
+    ///
+    /// Balances described by other fields in this struct are not included because they are not confirmed,
+    /// they may amount to dust, or because as `immature_income` funds they may require shielding which has a cost
+    /// and can change the amount of fees required to spend them (e.g. 3 UTXOs shielded together become only 1 note).
+    pub minimum_fees: u64,
+
+    /// The sum of non-change notes with a non-zero confirmation count that is less than the minimum required for spending,
+    /// and all UTXOs (considering that UTXOs must be shielded before spending).
+    /// `fairy_dust` is excluded from this value.
+    ///
+    /// As funds mature, this may not be the exact amount added to `spendable`, since the process of maturing
+    /// may require shielding, which has a cost.
+    pub immature_income: u64,
+
+    /// The sum of all *confirmed* UTXOs and notes that are worth less than the fee to spend them,
+    /// making them essentially inaccessible.
+    pub dust: u64,
+
+    /// The sum of all *unconfirmed* UTXOs and notes that are not change.
+    /// This value includes any applicable `incoming_dust`.
+    pub incoming: u64,
+
+    /// The sum of all *unconfirmed* UTXOs and notes that are not change and are each counted as dust.
+    pub incoming_dust: u64,
 }
 
 /// The LightClient provides a unified interface to the separate concerns that the zingolib library manages.
@@ -461,6 +526,123 @@ impl LightClient {
             unverified_orchard_balance: self.wallet.unverified_orchard_balance(None).await,
             transparent_balance: self.wallet.tbalance(None).await,
         }
+    }
+
+    pub async fn get_user_balances(&self) -> Result<UserBalances, ZingoLibError> {
+        let mut balances = UserBalances {
+            spendable: 0,
+            immature_change: 0,
+            minimum_fees: 0,
+            immature_income: 0,
+            dust: 0,
+            incoming: 0,
+            incoming_dust: 0,
+        };
+
+        // anchor height is the highest block height that contains income that are considered spendable.
+        let anchor_height = self.wallet.get_anchor_height().await;
+
+        self
+            .wallet
+            .transactions()
+            .read()
+            .await
+            .current
+            .iter()
+            .for_each(|(_, tx)| {
+                let mature =
+                    !tx.unconfirmed && tx.block_height <= BlockHeight::from_u32(anchor_height);
+                let incoming = tx.is_incoming_transaction();
+
+                let mut change = 0;
+                let mut useful_value = 0;
+                let mut dust_value = 0;
+                let mut utxo_value = 0;
+                let mut inbound_note_count_nodust = 0;
+                let mut change_note_count = 0;
+
+                tx.orchard_notes
+                    .iter()
+                    .filter(|n| n.spent().is_none() && n.unconfirmed_spent.is_none())
+                    .for_each(|n| {
+                        let value = n.note.value().inner();
+                        if !incoming && n.is_change {
+                            change += value;
+                            change_note_count += 1;
+                        } else if incoming {
+                            if value > MARGINAL_FEE {
+                                useful_value += value;
+                                inbound_note_count_nodust += 1;
+                            } else {
+                                dust_value += value;
+                            }
+                        }
+                    });
+
+                tx.sapling_notes
+                    .iter()
+                    .filter(|n| n.spent().is_none() && n.unconfirmed_spent.is_none())
+                    .for_each(|n| {
+                        let value = n.note.value().inner();
+                        if !incoming && n.is_change {
+                            change += value;
+                            change_note_count += 1;
+                        } else if incoming {
+                            if value > MARGINAL_FEE {
+                                useful_value += value;
+                                inbound_note_count_nodust += 1;
+                            } else {
+                                dust_value += value;
+                            }
+                        }
+                    });
+
+                tx.transparent_notes
+                    .iter()
+                    .filter(|n| n.spent.is_none() && n.unconfirmed_spent.is_none())
+                    .for_each(|n| {
+                        // UTXOs are never 'change', as change would have been shielded.
+                        if incoming {
+                            if n.value > MARGINAL_FEE {
+                                utxo_value += n.value;
+                                inbound_note_count_nodust += 1;
+                            } else {
+                                dust_value += n.value;
+                            }
+                        }
+                    });
+
+                // The fee field only tracks mature income and change.
+                balances.minimum_fees += change_note_count * MARGINAL_FEE;
+                if mature {
+                    balances.minimum_fees += inbound_note_count_nodust * MARGINAL_FEE;
+                }
+
+                if mature {
+                    // Spendable
+                    balances.spendable += useful_value + change;
+                    balances.dust += dust_value;
+                    balances.immature_income += utxo_value; // UTXOs are always immature, since they should be shielded before spending.
+                } else if !tx.unconfirmed {
+                    // Confirmed, but not yet spendable
+                    balances.immature_income += useful_value + utxo_value;
+                    balances.immature_change += change;
+                    balances.dust += dust_value;
+                } else {
+                    // Unconfirmed
+                    balances.immature_change += change;
+                    balances.incoming += useful_value + utxo_value;
+                    balances.incoming_dust += dust_value;
+                }
+            });
+
+        // Add the minimum fee for the receiving note,
+        // but only if there exists notes to spend in the buckets that are covered by the minimum_fee.
+        if balances.minimum_fees > 0 {
+            balances.minimum_fees += MARGINAL_FEE; // The receiving note.
+        }
+
+        Ok(balances)
     }
 
     pub async fn do_decrypt_message(&self, enc_base64: String) -> JsonValue {


### PR DESCRIPTION
This is a port from the functionality originally added to Nerdbank.Zcash in [this change](https://github.com/nerdcash/Nerdbank.Cryptocurrencies/pull/150) and subsequently fixed in [this change](https://github.com/nerdcash/Nerdbank.Cryptocurrencies/pull/157).