### PR TITLE
cut sync test

### DIFF
--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -3401,7 +3401,7 @@ async fn timed_sync_interrupt() {
     println!("start");
     // let reci_arc = std::sync::Arc::new(recipient);
     recipient.clear_state().await;
-    let timeout = 8;
+    let timeout = 32;
     let what = sync_with_timeout_millis(&recipient, timeout).await;
     match what {
         Ok(_) => {

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -3381,12 +3381,12 @@ mod slow {
             .await
             .unwrap();
         for i in 1..4 {
-            zingo_testutils::increase_server_height(&regtest_manager, 1).await;
+            zingo_testutils::increase_server_height(&regtest_manager, 60).await;
             let _ = recipient.do_sync(false).await;
             recipient
                 .do_send(vec![(
                     &get_base_address!(recipient, "unified"),
-                    200 + i,
+                    60 * i,
                     None,
                 )])
                 .await

--- a/zingo-testutils/src/interrupts.rs
+++ b/zingo-testutils/src/interrupts.rs
@@ -2,6 +2,7 @@ use zingolib::lightclient::LightClient;
 
 pub async fn sync_with_timeout_millis(lightclient: &LightClient, timeout: u64) -> Result<(), ()> {
     tokio::select!(
+        biased;
         _ = tokio::time::sleep(std::time::Duration::from_millis(timeout)) => Err(()),
         _ = lightclient.do_sync(false) => Ok(()),
     )

--- a/zingo-testutils/src/interrupts.rs
+++ b/zingo-testutils/src/interrupts.rs
@@ -1,0 +1,8 @@
+use zingolib::lightclient::LightClient;
+
+pub async fn sync_with_timeout_millis(lightclient: &LightClient, timeout: u64) -> Result<(), ()> {
+    tokio::select!(
+        _ = tokio::time::sleep(std::time::Duration::from_millis(timeout)) => Err(()),
+        _ = lightclient.do_sync(false) => Ok(()),
+    )
+}

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod data;
+pub mod interrupts;
 pub use incrementalmerkletree;
 use zcash_address::unified::{Fvk, Ufvk};
 use zingolib::wallet::keys::unified::WalletCapability;


### PR DESCRIPTION
this adds a failing test that uses tokio::select to drop the sync arbitrarily.