### PR TITLE
Single way to create zingoconfig

### DIFF
--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -314,9 +314,10 @@ mod fast {
         let mut wallet_location = regtest_manager.zingo_datadir;
         wallet_location.pop();
         wallet_location.push("zingo_client_1");
-        let zingo_config = ZingoConfig::create_unconnected(
+        let zingo_config = ZingoConfig::new(
             zingoconfig::ChainType::Regtest(regtest_network),
             Some(wallet_location.clone()),
+            None,
         );
         wallet_location.push("zingo-wallet.dat");
         let read_buffer = File::open(wallet_location.clone()).unwrap();
@@ -495,7 +496,7 @@ mod fast {
         // with 3 addresses containig all receivers.
         let data = include_bytes!("zingo-wallet-v26.dat");
 
-        let config = zingoconfig::ZingoConfig::create_unconnected(ChainType::Testnet, None);
+        let config = zingoconfig::ZingoConfig::new(ChainType::Testnet, None, None);
         let wallet = LightWallet::read_internal(&data[..], &config)
             .await
             .map_err(|e| format!("Cannot deserialize LightWallet version 26 file: {}", e))

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -314,11 +314,9 @@ mod fast {
         let mut wallet_location = regtest_manager.zingo_datadir;
         wallet_location.pop();
         wallet_location.push("zingo_client_1");
-        let zingo_config = ZingoConfig::new(
-            zingoconfig::ChainType::Regtest(regtest_network),
-            Some(wallet_location.clone()),
-            None,
-        );
+        let zingo_config = ZingoConfig::build(zingoconfig::ChainType::Regtest(regtest_network))
+            .set_wallet_dir(wallet_location.clone())
+            .create();
         wallet_location.push("zingo-wallet.dat");
         let read_buffer = File::open(wallet_location.clone()).unwrap();
 
@@ -496,7 +494,7 @@ mod fast {
         // with 3 addresses containig all receivers.
         let data = include_bytes!("zingo-wallet-v26.dat");
 
-        let config = zingoconfig::ZingoConfig::new(ChainType::Testnet, None, None);
+        let config = zingoconfig::ZingoConfig::build(ChainType::Testnet).create();
         let wallet = LightWallet::read_internal(&data[..], &config)
             .await
             .map_err(|e| format!("Cannot deserialize LightWallet version 26 file: {}", e))

--- a/zingoconfig/src/lib.rs
+++ b/zingoconfig/src/lib.rs
@@ -62,7 +62,7 @@ pub struct ZingoConfigBuilder {
     pub chain: ChainType,
     pub reorg_buffer_offset: Option<u32>,
     pub monitor_mempool: Option<bool>,
-    /// The directory where the wallet and logfiles will be created. By default, this will be in ~/.zcash on Linux and %APPDATA%\Zcash on Windows.
+    /// The directory where the wallet and logfiles will be created. By default, this will be in ~/.zcash on Linux and %APPDATA%\Zcash on Windows. For mac it is in: ~/Library/Application Support/Zcash
     pub wallet_dir: Option<PathBuf>,
     /// The filename of the wallet. This will be created in the `wallet_dir`.
     pub wallet_name: Option<PathBuf>,

--- a/zingoconfig/src/lib.rs
+++ b/zingoconfig/src/lib.rs
@@ -73,9 +73,19 @@ pub struct ZingoConfig {
 
 impl ZingoConfig {
     // Create an unconnected (to any server) config to test for local wallet etc...
-    pub fn create_unconnected(chain: ChainType, dir: Option<PathBuf>) -> ZingoConfig {
+    pub fn new(
+        chain: ChainType,
+        dir: Option<PathBuf>,
+        lightwalletd_uri: Option<http::Uri>,
+    ) -> ZingoConfig {
+        let raw_uri = if let Some(uri) = lightwalletd_uri {
+            uri
+        } else {
+            http::Uri::default()
+        };
+        let lightwalletd_uri = Arc::new(RwLock::new(raw_uri));
         ZingoConfig {
-            lightwalletd_uri: Arc::new(RwLock::new(http::Uri::default())),
+            lightwalletd_uri,
             chain,
             monitor_mempool: false,
             reorg_buffer_offset: REORG_BUFFER_OFFSET,

--- a/zingoconfig/src/lib.rs
+++ b/zingoconfig/src/lib.rs
@@ -72,7 +72,20 @@ pub struct ZingoConfig {
 }
 
 impl ZingoConfig {
+    #[deprecated]
     // Create an unconnected (to any server) config to test for local wallet etc...
+    pub fn create_unconnected(chain: ChainType, dir: Option<PathBuf>) -> ZingoConfig {
+        ZingoConfig {
+            lightwalletd_uri: Arc::new(RwLock::new(http::Uri::default())),
+            chain,
+            monitor_mempool: false,
+            reorg_buffer_offset: REORG_BUFFER_OFFSET,
+            wallet_dir: dir,
+            wallet_name: DEFAULT_WALLET_NAME.into(),
+            logfile_name: DEFAULT_LOGFILE_NAME.into(),
+        }
+    }
+
     pub fn new(
         chain: ChainType,
         dir: Option<PathBuf>,
@@ -94,7 +107,6 @@ impl ZingoConfig {
             logfile_name: DEFAULT_LOGFILE_NAME.into(),
         }
     }
-
     //Convenience wrapper
     pub fn sapling_activation_height(&self) -> u64 {
         self.chain

--- a/zingoconfig/src/lib.rs
+++ b/zingoconfig/src/lib.rs
@@ -56,6 +56,19 @@ pub fn construct_lightwalletd_uri(server: Option<String>) -> http::Uri {
     .unwrap()
 }
 
+#[derive(Clone, Debug)]
+pub struct ZingoConfigBuilder {
+    pub lightwalletd_uri: Option<http::Uri>,
+    pub chain: ChainType,
+    pub reorg_buffer_offset: Option<u32>,
+    pub monitor_mempool: Option<bool>,
+    /// The directory where the wallet and logfiles will be created. By default, this will be in ~/.zcash on Linux and %APPDATA%\Zcash on Windows.
+    pub wallet_dir: Option<PathBuf>,
+    /// The filename of the wallet. This will be created in the `wallet_dir`.
+    pub wallet_name: Option<PathBuf>,
+    /// The filename of the logfile. This will be created in the `wallet_dir`.
+    pub logfile_name: Option<PathBuf>,
+}
 /// Configuration data that is necessary? and sufficient? for the creation of a LightClient.
 #[derive(Clone, Debug)]
 pub struct ZingoConfig {
@@ -70,41 +83,61 @@ pub struct ZingoConfig {
     /// The filename of the logfile. This will be created in the `wallet_dir`.
     pub logfile_name: PathBuf,
 }
+impl ZingoConfigBuilder {
+    pub fn set_wallet_dir(mut self, dir: PathBuf) -> Self {
+        self.wallet_dir = Some(dir);
+        self
+    }
+    pub fn set_lightwalletd(mut self, lightwalletd_uri: http::Uri) -> Self {
+        self.lightwalletd_uri = Some(lightwalletd_uri);
+        self
+    }
+    pub fn create(&self) -> ZingoConfig {
+        let lightwalletd_uri = if let Some(uri) = self.lightwalletd_uri.clone() {
+            uri
+        } else {
+            http::Uri::default()
+        };
+        ZingoConfig {
+            lightwalletd_uri: Arc::new(RwLock::new(lightwalletd_uri)),
+            chain: self.chain,
+            monitor_mempool: false,
+            reorg_buffer_offset: REORG_BUFFER_OFFSET,
+            wallet_dir: self.wallet_dir.clone(),
+            wallet_name: DEFAULT_WALLET_NAME.into(),
+            logfile_name: DEFAULT_LOGFILE_NAME.into(),
+        }
+    }
+}
+impl Default for ZingoConfigBuilder {
+    fn default() -> Self {
+        ZingoConfigBuilder {
+            lightwalletd_uri: None,
+            monitor_mempool: None,
+            reorg_buffer_offset: None,
+            wallet_dir: None,
+            wallet_name: None,
+            logfile_name: None,
+            chain: ChainType::Mainnet,
+        }
+    }
+}
 
 impl ZingoConfig {
     #[deprecated]
     // Create an unconnected (to any server) config to test for local wallet etc...
     pub fn create_unconnected(chain: ChainType, dir: Option<PathBuf>) -> ZingoConfig {
-        ZingoConfig {
-            lightwalletd_uri: Arc::new(RwLock::new(http::Uri::default())),
-            chain,
-            monitor_mempool: false,
-            reorg_buffer_offset: REORG_BUFFER_OFFSET,
-            wallet_dir: dir,
-            wallet_name: DEFAULT_WALLET_NAME.into(),
-            logfile_name: DEFAULT_LOGFILE_NAME.into(),
+        if let Some(dir) = dir {
+            ZingoConfig::build(chain).set_wallet_dir(dir).create()
+        } else {
+            ZingoConfig::build(chain).create()
         }
     }
 
-    pub fn new(
-        chain: ChainType,
-        dir: Option<PathBuf>,
-        lightwalletd_uri: Option<http::Uri>,
-    ) -> ZingoConfig {
-        let raw_uri = if let Some(uri) = lightwalletd_uri {
-            uri
-        } else {
-            http::Uri::default()
-        };
-        let lightwalletd_uri = Arc::new(RwLock::new(raw_uri));
-        ZingoConfig {
-            lightwalletd_uri,
+    pub fn build(chain: ChainType) -> ZingoConfigBuilder {
+        ZingoConfigBuilder {
             chain,
-            monitor_mempool: false,
-            reorg_buffer_offset: REORG_BUFFER_OFFSET,
-            wallet_dir: dir,
-            wallet_name: DEFAULT_WALLET_NAME.into(),
-            logfile_name: DEFAULT_LOGFILE_NAME.into(),
+            ..ZingoConfigBuilder::default()
         }
     }
     //Convenience wrapper

--- a/zingolib/src/lightclient/deprecated.rs
+++ b/zingolib/src/lightclient/deprecated.rs
@@ -221,7 +221,7 @@ mod tests {
             .expect("This path is available.");
 
         let wallet_name = data_dir.join("zingo-wallet.dat");
-        let config = ZingoConfig::create_unconnected(ChainType::FakeMainnet, Some(data_dir));
+        let config = ZingoConfig::new(ChainType::FakeMainnet, Some(data_dir), None);
         let lc = LightClient::create_from_wallet_base(
             WalletBase::MnemonicPhrase(CHIMNEY_BETTER_SEED.to_string()),
             &config,

--- a/zingolib/src/lightclient/deprecated.rs
+++ b/zingolib/src/lightclient/deprecated.rs
@@ -221,7 +221,9 @@ mod tests {
             .expect("This path is available.");
 
         let wallet_name = data_dir.join("zingo-wallet.dat");
-        let config = ZingoConfig::new(ChainType::FakeMainnet, Some(data_dir), None);
+        let config = ZingoConfig::build(ChainType::FakeMainnet)
+            .set_wallet_dir(data_dir)
+            .create();
         let lc = LightClient::create_from_wallet_base(
             WalletBase::MnemonicPhrase(CHIMNEY_BETTER_SEED.to_string()),
             &config,


### PR DESCRIPTION
ZingoConfig::create_unconnected is still available, but it will generate a compiler warning "deprecated" if used.