### PR TITLE
move load_clientconfig from zingolib into zingoconfig

### DIFF
--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -932,7 +932,7 @@ mod slow {
         let original_recipient = client_builder
             .build_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false, regtest_network)
             .await;
-        let zingo_config = zingolib::load_clientconfig(
+        let zingo_config = zingoconfig::load_clientconfig(
             client_builder.server_id,
             Some(client_builder.zingo_datadir),
             ChainType::Regtest(regtest_network),

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -206,7 +206,7 @@ pub async fn load_wallet(
     let wallet = dir.join("zingo-wallet.dat");
     let lightwalletd_uri = TestEnvironmentGenerator::new(None).get_lightwalletd_uri();
     let zingo_config =
-        zingolib::load_clientconfig(lightwalletd_uri, Some(dir), chaintype, true).unwrap();
+        zingoconfig::load_clientconfig(lightwalletd_uri, Some(dir), chaintype, true).unwrap();
     let from = std::fs::File::open(wallet).unwrap();
 
     let read_lengths = vec![];
@@ -404,7 +404,7 @@ pub mod scenarios {
                 regtest_network: zingoconfig::RegtestNetwork,
             ) -> zingoconfig::ZingoConfig {
                 std::fs::create_dir(&conf_path).unwrap();
-                zingolib::load_clientconfig(
+                zingoconfig::load_clientconfig(
                     self.server_id.clone(),
                     Some(conf_path),
                     zingoconfig::ChainType::Regtest(regtest_network),

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -9,7 +9,7 @@ use clap::{self, Arg};
 use zingo_testutils::regtest;
 use zingoconfig::ChainType;
 use zingolib::wallet::WalletBase;
-use zingolib::{commands, lightclient::LightClient, load_clientconfig};
+use zingolib::{commands, lightclient::LightClient};
 
 pub mod version;
 
@@ -400,7 +400,7 @@ pub fn startup(
     filled_template: &ConfigTemplate,
 ) -> std::io::Result<(Sender<CommandRequest>, Receiver<CommandResponse>)> {
     // Try to get the configuration
-    let config = load_clientconfig(
+    let config = zingoconfig::load_clientconfig(
         filled_template.server.clone(),
         Some(filled_template.data_dir.clone()),
         filled_template.chaintype,

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LightClient pub fn get_wallet_dir_location
 
 ### Changed
+- load_client_config fn moves from zingolib to zingoconfig
 
 ### Removed
 

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -18,45 +18,7 @@ include!(concat!(env!("OUT_DIR"), "/git_description.rs"));
 #[derive(RustEmbed)]
 #[folder = "zcash-params/"]
 pub struct SaplingParams;
-use std::{
-    io::{ErrorKind, Result},
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
-use zingoconfig::{ChainType, ZingoConfig, DEFAULT_LOGFILE_NAME, DEFAULT_WALLET_NAME};
 
-pub fn load_clientconfig(
-    lightwallet_uri: http::Uri,
-    data_dir: Option<PathBuf>,
-    chain: ChainType,
-    monitor_mempool: bool,
-) -> Result<ZingoConfig> {
-    use std::net::ToSocketAddrs;
-    format!(
-        "{}:{}",
-        lightwallet_uri.host().unwrap(),
-        lightwallet_uri.port().unwrap()
-    )
-    .to_socket_addrs()?
-    .next()
-    .ok_or(std::io::Error::new(
-        ErrorKind::ConnectionRefused,
-        "Couldn't resolve server!",
-    ))?;
-
-    // Create a Light Client Config
-    let config = ZingoConfig {
-        lightwalletd_uri: Arc::new(RwLock::new(lightwallet_uri)),
-        chain,
-        monitor_mempool,
-        reorg_buffer_offset: zingoconfig::REORG_BUFFER_OFFSET,
-        wallet_dir: data_dir,
-        wallet_name: DEFAULT_WALLET_NAME.into(),
-        logfile_name: DEFAULT_LOGFILE_NAME.into(),
-    };
-
-    Ok(config)
-}
 pub fn get_latest_block_height(lightwalletd_uri: http::Uri) -> std::io::Result<u64> {
     tokio::runtime::Runtime::new()
         .unwrap()


### PR DESCRIPTION
The `load_clientconfig` fn is more ergonomic when located in `zingoconfig`.

This moves a `pub fn` from `zingolib` to `zingoconfig`, since it changes the public interface I'd like consumers to approve of it, before it merges.

Obviously we're incrementing the semver on this release.