### PR TITLE
Upgrade clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,17 +170,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -475,27 +512,30 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clipboard-win"
@@ -516,6 +556,12 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concat-idents"
@@ -1157,15 +1203,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -1213,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes 1.5.0",
  "http",
@@ -1430,7 +1467,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1455,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
@@ -1676,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -1792,7 +1829,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1807,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -1897,12 +1934,6 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "overload"
@@ -2591,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "bfeae074e687625746172d639330f1de242a178bf3189b51e35a7a21573513ac"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -3072,12 +3103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,9 +3177,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",
@@ -3475,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typemap-ors"
@@ -3514,9 +3539,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+clap = "4.4"
 zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zingo_rc.2" }
 zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zingo_rc.2" }
 zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zingo_rc.2" }

--- a/zingo-testutils/Cargo.toml
+++ b/zingo-testutils/Cargo.toml
@@ -8,16 +8,18 @@ edition = "2021"
 [dependencies]
 zingoconfig = { path = "../zingoconfig" }
 zingolib = { path = "../zingolib" }
+
 zcash_primitives = { workspace = true }
 zcash_address = { workspace = true }
 orchard = { workspace = true }
 portpicker = { workspace = true}
 tempdir = { workspace = true }
+incrementalmerkletree = { workspace = true }
+
 json = "0.12.4"
 log = "0.4.19"
 tokio = "1.28.2"
 http = "0.2.4"
 tracing = "0.1.37"
-incrementalmerkletree = { workspace = true }
 serde_json = "1.0.100"
 serde = { version = "1.0.166", features = ["derive"] }

--- a/zingo-testutils/src/regtest.rs
+++ b/zingo-testutils/src/regtest.rs
@@ -242,7 +242,7 @@ impl RegtestManager {
     pub fn get_chain_tip(&self) -> Result<std::process::Output, std::io::Error> {
         self.get_cli_handle().arg("getchaintips").output()
     }
-    fn prepare_working_directories(&self) {
+    fn clean_regtest_data(&self) {
         // remove contents of existing data directories
         let zcd_subdir = &self.zcashd_data_dir.join("regtest");
 
@@ -262,7 +262,6 @@ impl RegtestManager {
 
         let zingo_file_one = &self.zingo_datadir.join("zingo-wallet.dat");
         let zingo_file_two = &self.zingo_datadir.join("zingo-wallet.debug.log");
-
         std::process::Command::new("rm")
             .arg(zingo_file_one)
             .output()
@@ -350,7 +349,7 @@ impl RegtestManager {
         clean_regtest_data: bool,
     ) -> Result<ChildProcessHandler, LaunchChildProcessError> {
         if clean_regtest_data {
-            self.prepare_working_directories();
+            self.clean_regtest_data();
         }
 
         let (mut zcashd_handle, mut zcashd_logfile) = self.zcashd_launch();
@@ -444,9 +443,6 @@ impl RegtestManager {
             lightwalletd: lightwalletd_child,
             zcash_cli_command: self.get_cli_handle(),
         })
-    }
-    pub fn get_zingo_data_dir(&self) -> PathBuf {
-        self.zingo_datadir.clone()
     }
     pub fn get_current_height(&self) -> Result<u32, String> {
         let wut = self

--- a/zingocli/Cargo.toml
+++ b/zingocli/Cargo.toml
@@ -4,11 +4,16 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
+zingolib = { path = "../zingolib/" }
+zingoconfig = { path = "../zingoconfig/" }
+zingo-testutils = { path = "../zingo-testutils" }
+
+clap = { workspace = true }
+http = { workspace = true }
+
 rustyline = "11.0.0"
-clap = "3.2.20"
 log = "0.4.17"
 shellwords = "1.1.0"
-http = { workspace = true }
 futures = "0.3.15"
 rustls-pemfile = "1.0.0"
 hyper-rustls = { version = "0.23", features = ["http2"] }
@@ -16,7 +21,4 @@ tokio =  { version = "1.24.2", features = ["full"] }
 tokio-stream = "0.1.6"
 tokio-rustls = "0.23.3"
 webpki-roots = "0.21.0"
-zingolib = { path = "../zingolib/" }
-zingoconfig = { path = "../zingoconfig/" }
-zingo-testutils = { path = "../zingo-testutils" }
 json = "0.12.4"

--- a/zingoconfig/Cargo.toml
+++ b/zingoconfig/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+zcash_address = { workspace = true }
+zcash_primitives = { workspace = true }
+
 log4rs = "1.1.1"
 log = "0.4.14"
 http = "0.2.4"
 dirs = "3.0.2"
-zcash_address = { workspace = true }
-zcash_primitives = { workspace = true }

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -16,11 +16,26 @@ embed_params = []
 darkside_tests = []
 
 [dependencies]
+zingoconfig = { path = "../zingoconfig" }
+zingo-memo = { path = "../zingo-memo" }
+
 http-body = { workspace = true }
 hyper = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 prost = { workspace = true }
+orchard = { workspace = true }
+shardtree = { workspace = true, features = ["legacy-api"] }
+incrementalmerkletree = { workspace = true, features = ["test-dependencies", "legacy-api"] }
+zcash_address = { workspace = true }
+zcash_client_backend = { workspace = true, features = ["unstable", "transparent-inputs", "unstable-serialization", "unstable-spanning-tree"] }
+zcash_encoding = { workspace = true }
+zcash_note_encryption = { workspace = true }
+zcash_primitives = { workspace = true }
+zcash_proofs = { workspace = true }
+
+append-only-vec = { git = "https://github.com/zancas/append-only-vec.git", branch = "add_debug_impl" }
+
 log = "0.4.14"
 http = "0.2.4"
 log4rs = "1.1.1"
@@ -55,33 +70,20 @@ jubjub = "0.10.0"
 bls12_381 = "0.8"
 group = "0.13"
 rust-embed = { version = "6.3.0", features = ["debug-embed"] }
-orchard = { workspace = true }
 subtle = "2.4.1"
-incrementalmerkletree = { workspace = true, features = ["test-dependencies", "legacy-api"] }
-zcash_address = { workspace = true }
-zcash_client_backend = { workspace = true, features = ["unstable", "transparent-inputs", "unstable-serialization", "unstable-spanning-tree"] }
-zcash_encoding = { workspace = true }
-zcash_note_encryption = { workspace = true }
-zcash_primitives = { workspace = true }
-zcash_proofs = { workspace = true }
-zingoconfig = { path = "../zingoconfig" }
-zingo-memo = { path = "../zingo-memo" }
 nonempty = "0.7.0"
 tracing-subscriber = "0.3.15"
 tracing = "0.1.36"
 indoc = "2.0.1"
-shardtree = { workspace = true, features = ["legacy-api"] }
 derive_more = "0.99.17"
 either = "1.8.1"
-
-append-only-vec = { git = "https://github.com/zancas/append-only-vec.git", branch = "add_debug_impl" }
 serde = { version = "1.0.188", features = ["derive"] }
 
 [dev-dependencies]
+zingo-testutils = { path = "../zingo-testutils" }
 portpicker = "0.1.0"
 tempfile = "3.3.0"
 concat-idents = "1.1.3"
-zingo-testutils = { path = "../zingo-testutils" }
 
 [build-dependencies]
 tonic-build = { workspace = true }


### PR DESCRIPTION
This PR fixes several bugs, and upgrades to the latest version of clap.

* promotes clap to workspace dependency so it can be used in `zingo-testutils`

* reorganize manifests:
    - relative path
    - workspace dep
    - github-or-other remote
    - crates

* FIX crash on old `zingo-wallet.dat` bug
* FIX wrong default location for `zingo-wallet.dat`
* FIX failure to terminate bug

To test this PR try out the CLI, in both interactive and non-interactive modes, against both `regtest` and mainnet, for example try to the following invocations:


`cargo run help`
`cargo run -- --regtest info`
`cargo run -- info`

`cargo -- --regtest --no-clean`

etc.