### PR TITLE
added debug-only error panicker

### DIFF
--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -491,7 +491,7 @@ impl TransactionContext {
                     }
                     Err(e) => {
                         let _memo_error: ZingoLibResult<()> =
-                            ZingoLibError::CouldNotDecodeMemo(e).handle();
+                            ZingoLibError::CouldNotDecodeMemo(e).handle_or_panic();
                     }
                 }
             }

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -26,7 +26,7 @@ impl ZingoLibError {
         log::error!("{}", self);
         Err(self)
     }
-    pub fn panic<T>(self) -> ZingoLibResult<T> {
+    pub fn handle_or_panic<T>(self) -> ZingoLibResult<T> {
         log::error!("{}", self);
 
         #[cfg(debug_assertions)]

--- a/zingolib/src/error.rs
+++ b/zingolib/src/error.rs
@@ -24,13 +24,17 @@ pub type ZingoLibResult<T> = Result<T, ZingoLibError>;
 impl ZingoLibError {
     pub fn handle<T>(self) -> ZingoLibResult<T> {
         log::error!("{}", self);
+        Err(self)
+    }
+    pub fn panic<T>(self) -> ZingoLibResult<T> {
+        log::error!("{}", self);
 
-        #[cfg(feature = "test-features")]
+        #[cfg(debug_assertions)]
         {
             panic!("{}", self);
         }
 
-        #[cfg(not(feature = "test-features"))]
+        #[cfg(not(debug_assertions))]
         {
             Err(self)
         }

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -554,7 +554,7 @@ impl TransactionMetadataSet {
         output_index: u32,
     ) -> ZingoLibResult<u64> {
         match self.current.get_mut(&txid) {
-            None => ZingoLibError::NoSuchTxId(txid).handle(),
+            None => ZingoLibError::NoSuchTxId(txid).handle_or_panic(),
             Some(transaction_metadata) => match spent_nullifier {
                 PoolNullifier::Sapling(_sapling_nullifier) => {
                     if let Some(sapling_note_data) = transaction_metadata
@@ -566,7 +566,8 @@ impl TransactionMetadataSet {
                         sapling_note_data.unconfirmed_spent = None;
                         Ok(sapling_note_data.note.value().inner())
                     } else {
-                        ZingoLibError::NoSuchSaplingOutputInTxId(txid, output_index).handle()
+                        ZingoLibError::NoSuchSaplingOutputInTxId(txid, output_index)
+                            .handle_or_panic()
                     }
                 }
                 PoolNullifier::Orchard(_orchard_nullifier) => {
@@ -579,7 +580,8 @@ impl TransactionMetadataSet {
                         orchard_note_data.unconfirmed_spent = None;
                         Ok(orchard_note_data.note.value().inner())
                     } else {
-                        ZingoLibError::NoSuchOrchardOutputInTxId(txid, output_index).handle()
+                        ZingoLibError::NoSuchOrchardOutputInTxId(txid, output_index)
+                            .handle_or_panic()
                     }
                 }
             },


### PR DESCRIPTION
debug_assertions only works in debug. i have tested both sides of this by
introduce an error to lightclient
```
    pub async fn do_sync(&self, print_updates: bool) -> Result<SyncResult, String> {
        // test production
        let _: ZingoLibResult<()> = ZingoLibError::UnknownError.handle_or_panic();
```

cargo run panics
cargo run --release prints an error and keeps going