### PR TITLE
Debug clap cli

### DIFF
--- a/zingocli/Cargo.toml
+++ b/zingocli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-zingolib = { path = "../zingolib/" }
+zingolib = { path = "../zingolib/", features = ["deprecations"] }
 zingoconfig = { path = "../zingoconfig/" }
 zingo-testutils = { path = "../zingo-testutils" }
 

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -68,11 +68,13 @@ pub fn build_clap_app() -> clap::ArgMatches {
         ).get_matches()
 }
 
-// Custom function to parse a string into an http::Uri
+/// Custom function to parse a string into an http::Uri
 fn parse_uri(s: &str) -> Result<http::Uri, String> {
     s.parse::<http::Uri>().map_err(|e| e.to_string())
 }
-// Custom function to parse a string into an http::Uri
+/// Custom function to parse a string into a compliant ZIP32/BIP39 mnemonic phrase
+/// currently this is just a whitespace delimited string of 24 words.  I am
+/// poking around to use the actual BIP39 parser (presumably from librustzcash).
 fn parse_seed(s: &str) -> Result<String, String> {
     if let Ok(s) = s.parse::<String>() {
         let count = s.split_whitespace().count();

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -38,6 +38,7 @@ pub fn build_clap_app() -> clap::ArgMatches {
                 .alias("seed")
                 .alias("viewing-key")
                 .value_name("from")
+                .value_parser(parse_seed)
                 .help("Create a new wallet with the given key. Can be a 24-word seed phrase or a viewkey. Will fail if wallet already exists"))
             .arg(Arg::new("birthday")
                 .long("birthday")
@@ -70,6 +71,19 @@ pub fn build_clap_app() -> clap::ArgMatches {
 // Custom function to parse a string into an http::Uri
 fn parse_uri(s: &str) -> Result<http::Uri, String> {
     s.parse::<http::Uri>().map_err(|e| e.to_string())
+}
+// Custom function to parse a string into an http::Uri
+fn parse_seed(s: &str) -> Result<String, String> {
+    if let Ok(s) = s.parse::<String>() {
+        let count = s.split_whitespace().count();
+        if count == 24 {
+            Ok(s)
+        } else {
+            Err(format!("Expected 24 words, but received: {}.", count))
+        }
+    } else {
+        Err("Unexpected failure to parse String!!".to_string())
+    }
 }
 #[cfg(target_os = "linux")]
 /// This function is only tested against Linux.

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -48,6 +48,7 @@ pub fn build_clap_app() -> clap::ArgMatches {
                 .long("server")
                 .value_name("server")
                 .help("Lightwalletd server to connect to.")
+                .value_parser(parse_uri)
                 .default_value(zingoconfig::DEFAULT_LIGHTWALLETD_SERVER))
             .arg(Arg::new("data-dir")
                 .long("data-dir")
@@ -66,6 +67,10 @@ pub fn build_clap_app() -> clap::ArgMatches {
         ).get_matches()
 }
 
+// Custom function to parse a string into an http::Uri
+fn parse_uri(s: &str) -> Result<http::Uri, String> {
+    s.parse::<http::Uri>().map_err(|e| e.to_string())
+}
 #[cfg(target_os = "linux")]
 /// This function is only tested against Linux.
 fn report_permission_error() {
@@ -323,7 +328,7 @@ to scan from the start of the blockchain."
         };
         log::info!("data_dir: {}", &data_dir.to_str().unwrap());
         let mut server = matches
-            .get_one::<String>("server")
+            .get_one::<http::Uri>("server")
             .map(|server| server.to_string());
         let mut child_process_handler = None;
         // Regtest specific launch:

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -42,6 +42,7 @@ pub fn build_clap_app() -> clap::ArgMatches {
             .arg(Arg::new("birthday")
                 .long("birthday")
                 .value_name("birthday")
+                .value_parser(clap::value_parser!(u32))
                 .help("Specify wallet birthday when restoring from seed. This is the earlist block height where the wallet has a transaction."))
             .arg(Arg::new("server")
                 .long("server")
@@ -280,9 +281,9 @@ impl ConfigTemplate {
         } else {
             None
         };
-        let from = matches.get_one::<&str>("from");
+        let from = matches.get_one::<String>("from");
         let maybe_birthday = matches
-            .get_one::<&str>("birthday")
+            .get_one::<u32>("birthday")
             .map(|bday| bday.to_string());
         if from.is_some() && maybe_birthday.is_none() {
             eprintln!("ERROR!");


### PR DESCRIPTION
This code adds parsers at the app/command-line boundary:

* birthday --> u32
* server --> http::Uri
* seed --> string of 24 whitespace delimited elements

It also:
* adds deprecations from zingolib, so that the cli will automatically expose "list"

TODO:

   * Make cli run without cargo.
   * make seed comply with relevant seedphrase-word-library
   * remove crufty post-parse code that's no longer necessary
   * encode commands.rs as clap subcommands

Tests thus far have been manual invocations of:

```
rm -f ~/wallets/sapling-balance-bug/zingo-wallet.dat && cargo run --bin zingo-cli -- --data-dir ~/wallets/sapling-balance-bug/ --seed "daughter safe REDACTED" --birthday 2328948
```

With various values of the birthday and seed values.  I have not yet tested the server argument.