### PR TITLE
List tx summaries propagates error

### DIFF
--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -54,7 +54,7 @@ async fn reorg_changes_incoming_tx_height() {
         }
     );
 
-    let before_reorg_transactions = light_client.do_list_txsummaries().await;
+    let before_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -89,7 +89,7 @@ async fn reorg_changes_incoming_tx_height() {
         }
     );
 
-    let after_reorg_transactions = light_client.do_list_txsummaries().await;
+    let after_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(after_reorg_transactions.len(), 1);
     assert_eq!(
@@ -209,7 +209,7 @@ async fn reorg_changes_incoming_tx_index() {
         }
     );
 
-    let before_reorg_transactions = light_client.do_list_txsummaries().await;
+    let before_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -244,7 +244,7 @@ async fn reorg_changes_incoming_tx_index() {
         }
     );
 
-    let after_reorg_transactions = light_client.do_list_txsummaries().await;
+    let after_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(after_reorg_transactions.len(), 1);
     assert_eq!(
@@ -364,7 +364,7 @@ async fn reorg_expires_incoming_tx() {
         }
     );
 
-    let before_reorg_transactions = light_client.do_list_txsummaries().await;
+    let before_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -399,7 +399,7 @@ async fn reorg_expires_incoming_tx() {
         }
     );
 
-    let after_reorg_transactions = light_client.do_list_txsummaries().await;
+    let after_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(after_reorg_transactions.len(), 0);
 }
@@ -541,7 +541,7 @@ async fn reorg_changes_outgoing_tx_height() {
         }
     );
 
-    let before_reorg_transactions = light_client.do_list_txsummaries().await;
+    let before_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -591,11 +591,11 @@ async fn reorg_changes_outgoing_tx_height() {
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
 
-    println!("{:?}", light_client.do_list_txsummaries().await);
+    println!("{:?}", light_client.do_list_txsummaries_assert().await);
 
     assert_eq!(
         light_client
-            .do_list_txsummaries()
+            .do_list_txsummaries_assert()
             .await
             .into_iter()
             .find_map(|v| match v.kind {
@@ -651,11 +651,11 @@ async fn reorg_changes_outgoing_tx_height() {
         expected_after_reorg_balance
     );
 
-    let after_reorg_transactions = light_client.do_list_txsummaries().await;
+    let after_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(after_reorg_transactions.len(), 3);
 
-    println!("{:?}", light_client.do_list_txsummaries().await);
+    println!("{:?}", light_client.do_list_txsummaries_assert().await);
 
     // FIXME: This test is broken because if this issue
     // https://github.com/zingolabs/zingolib/issues/622
@@ -777,7 +777,7 @@ async fn reorg_expires_outgoing_tx_height() {
     light_client.do_sync(true).await.unwrap();
     assert_eq!(light_client.do_balance().await, expected_initial_balance);
 
-    let before_reorg_transactions = light_client.do_list_txsummaries().await;
+    let before_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -820,11 +820,11 @@ async fn reorg_expires_outgoing_tx_height() {
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
 
-    println!("{:?}", light_client.do_list_txsummaries().await);
+    println!("{:?}", light_client.do_list_txsummaries_assert().await);
 
     assert_eq!(
         light_client
-            .do_list_txsummaries()
+            .do_list_txsummaries_assert()
             .await
             .into_iter()
             .find_map(|v| match v.kind {
@@ -863,11 +863,11 @@ async fn reorg_expires_outgoing_tx_height() {
     // sent transaction was never mined and has expired.
     assert_eq!(light_client.do_balance().await, expected_initial_balance);
 
-    let after_reorg_transactions = light_client.do_list_txsummaries().await;
+    let after_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(after_reorg_transactions.len(), 1);
 
-    println!("{:?}", light_client.do_list_txsummaries().await);
+    println!("{:?}", light_client.do_list_txsummaries_assert().await);
 
     // FIXME: This test is broken because if this issue
     // https://github.com/zingolabs/zingolib/issues/622
@@ -955,7 +955,7 @@ async fn reorg_changes_outgoing_tx_index() {
         }
     );
 
-    let before_reorg_transactions = light_client.do_list_txsummaries().await;
+    let before_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -1005,11 +1005,11 @@ async fn reorg_changes_outgoing_tx_index() {
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
 
-    println!("{:?}", light_client.do_list_txsummaries().await);
+    println!("{:?}", light_client.do_list_txsummaries_assert().await);
 
     assert_eq!(
         light_client
-            .do_list_txsummaries()
+            .do_list_txsummaries_assert()
             .await
             .into_iter()
             .find_map(|v| match v.kind {
@@ -1071,7 +1071,7 @@ async fn reorg_changes_outgoing_tx_index() {
         expected_after_reorg_balance
     );
 
-    let after_reorg_transactions = light_client.do_list_txsummaries().await;
+    let after_reorg_transactions = light_client.do_list_txsummaries_assert().await;
 
     assert_eq!(after_reorg_transactions.len(), 3);
 

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -658,7 +658,7 @@ mod slow {
         );
         println!(
             "{}",
-            JsonValue::from(recipient.do_list_txsummaries().await).pretty(4)
+            JsonValue::from(recipient.do_list_txsummaries_assert().await).pretty(4)
         );
     }
     #[tokio::test]
@@ -1179,7 +1179,7 @@ mod slow {
             "{}",
             JsonValue::from(
                 recipient
-                    .do_list_txsummaries()
+                    .do_list_txsummaries_assert()
                     .await
                     .into_iter()
                     .map(JsonValue::from)
@@ -1197,7 +1197,7 @@ mod slow {
             "{}",
             JsonValue::from(
                 recipient
-                    .do_list_txsummaries()
+                    .do_list_txsummaries_assert()
                     .await
                     .into_iter()
                     .map(JsonValue::from)
@@ -1564,7 +1564,7 @@ mod slow {
 
         println!(
             "{}",
-            JsonValue::from(faucet.do_list_txsummaries().await).pretty(4)
+            JsonValue::from(faucet.do_list_txsummaries_assert().await).pretty(4)
         );
         println!(
             "{}",
@@ -2312,10 +2312,10 @@ mod slow {
             .await
             .unwrap();
         let pre_rescan_transactions = recipient.do_list_transactions().await;
-        let pre_rescan_summaries = recipient.do_list_txsummaries().await;
+        let pre_rescan_summaries = recipient.do_list_txsummaries_assert().await;
         recipient.do_rescan().await.unwrap();
         let post_rescan_transactions = recipient.do_list_transactions().await;
-        let post_rescan_summaries = recipient.do_list_txsummaries().await;
+        let post_rescan_summaries = recipient.do_list_txsummaries_assert().await;
         assert_eq!(pre_rescan_transactions, post_rescan_transactions);
         assert_eq!(pre_rescan_summaries, post_rescan_summaries);
         let mut outgoing_metadata = pre_rescan_transactions

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -732,6 +732,12 @@ impl LightClient {
         self.list_tx_summaries().await.0
     }
 
+    pub async fn do_list_txsummaries_assert(&self) -> Vec<ValueTransfer> {
+        let lts = self.list_tx_summaries().await;
+        assert_eq!(lts.1.len(), 0);
+        lts.0
+    }
+
     pub async fn list_tx_summaries(&self) -> (Vec<ValueTransfer>, Vec<ZingoLibError>) {
         let mut summaries: Vec<ValueTransfer> = Vec::new();
         let mut errors: Vec<ZingoLibError> = Vec::new();

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -732,12 +732,6 @@ impl LightClient {
         self.list_tx_summaries().await.0
     }
 
-    pub async fn do_list_txsummaries_assert(&self) -> Vec<ValueTransfer> {
-        let lts = self.list_tx_summaries().await;
-        assert_eq!(lts.1.len(), 0);
-        lts.0
-    }
-
     pub async fn list_tx_summaries(&self) -> (Vec<ValueTransfer>, Vec<ZingoLibError>) {
         let mut summaries: Vec<ValueTransfer> = Vec::new();
         let mut errors: Vec<ZingoLibError> = Vec::new();

--- a/zingolib/src/lightclient/test_features.rs
+++ b/zingolib/src/lightclient/test_features.rs
@@ -11,4 +11,9 @@ impl LightClient {
         .await
         .map_err(ZingoLibError::CantReadWallet)
     }
+    pub async fn do_list_txsummaries_assert(&self) -> Vec<ValueTransfer> {
+        let lts = self.list_tx_summaries().await;
+        assert_eq!(lts.1.len(), 0);
+        lts.0
+    }
 }


### PR DESCRIPTION
do list summaries currently ignores errors in fees. thats okay. this version adds a version of do_list_txsummaries_assert, a test feature that panics if any broken transactions are found.