### PR TITLE
tag the build with a commit hash, even in the case where there's no t…

### DIFF
--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -7,7 +7,7 @@ pub fn git_description() {
         .output()
         .expect("Failed to execute git command");
     let output = Command::new("git")
-        .args(["describe", "--dirty"])
+        .args(["describe", "--dirty", "--always", "--long"])
         .output()
         .expect("Failed to execute git command");
 


### PR DESCRIPTION
…ag, and the case where the tag points at the tip

This change makes it be the case that an explicit commit hash is *always* included in the build version information.

The result is that users of the app can see a particular commit hash, for the zingolib version that was used in the build.