### PR TITLE
Initial integration with ledger application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "ledger-zcash"
 version = "0.6.0"
-source = "git+https://github.com/Zondax/ledger-zcash-rs?rev=324a0851113df4ea77457b5711392beabd021407#324a0851113df4ea77457b5711392beabd021407"
+source = "git+https://github.com/Zondax/ledger-zcash-rs?branch=feat/zingolib#229d8fc735663cb8eb966cb55d4df993f2682601"
 dependencies = [
  "arrayvec",
  "byteorder",
@@ -1920,7 +1920,7 @@ dependencies = [
  "sha2 0.9.9",
  "thiserror",
  "tokio",
- "zcash-hsmbuilder",
+ "zcash-hsmbuilder 0.4.0 (git+https://github.com/Zondax/ledger-zcash-rs?branch=feat/zingolib)",
  "zcash_primitives 0.6.0",
  "zx-bip44",
 ]
@@ -3617,18 +3617,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4489,6 +4489,39 @@ dependencies = [
 [[package]]
 name = "zcash-hsmbuilder"
 version = "0.4.0"
+source = "git+https://github.com/Zondax/ledger-zcash-rs?branch=feat/zingolib#229d8fc735663cb8eb966cb55d4df993f2682601"
+dependencies = [
+ "bellman 0.13.1",
+ "blake2b_simd",
+ "bls12_381 0.7.1",
+ "byteorder",
+ "cfg-if 1.0.0",
+ "chacha20poly1305 0.9.1",
+ "educe",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "hex 0.4.3",
+ "jubjub 0.9.0",
+ "lazy_static",
+ "log",
+ "pairing 0.22.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1 0.21.3",
+ "serde",
+ "serde_derive",
+ "sha2 0.9.9",
+ "tokio",
+ "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481)",
+ "zcash_primitives 0.6.0",
+ "zcash_proofs 0.6.0",
+]
+
+[[package]]
+name = "zcash-hsmbuilder"
+version = "0.4.0"
 source = "git+https://github.com/Zondax/ledger-zcash-rs?rev=324a0851113df4ea77457b5711392beabd021407#324a0851113df4ea77457b5711392beabd021407"
 dependencies = [
  "bellman 0.13.1",
@@ -4899,6 +4932,7 @@ dependencies = [
  "ff 0.13.0",
  "futures",
  "group 0.13.0",
+ "hdwallet 0.4.1",
  "hex 0.3.2",
  "http",
  "http-body",
@@ -4934,6 +4968,7 @@ dependencies = [
  "sodiumoxide",
  "subtle",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
@@ -4944,7 +4979,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "webpki-roots 0.21.1",
- "zcash-hsmbuilder",
+ "zcash-hsmbuilder 0.4.0 (git+https://github.com/Zondax/ledger-zcash-rs?rev=324a0851113df4ea77457b5711392beabd021407)",
  "zcash_address",
  "zcash_client_backend",
  "zcash_encoding 0.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
@@ -29,12 +38,24 @@ dependencies = [
 
 [[package]]
 name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
- "cfg-if",
- "cipher",
+ "cfg-if 1.0.0",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -231,7 +252,7 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -270,6 +291,27 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bellman"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4dd656ef4fdf7debb6d87d4dd92642fcbcdb78cbf6600c13e25c87e4d1a3807"
+dependencies = [
+ "bitvec",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "pairing 0.22.0",
+ "rand_core 0.6.4",
+ "rayon",
+ "subtle",
+]
+
+[[package]]
+name = "bellman"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
@@ -278,15 +320,29 @@ dependencies = [
  "blake2s_simd",
  "byteorder",
  "crossbeam-channel",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "lazy_static",
  "log",
  "num_cpus",
- "pairing",
+ "pairing 0.23.0",
  "rand_core 0.6.4",
  "rayon",
  "subtle",
+]
+
+[[package]]
+name = "bip0039"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0830ae4cc96b0617cc912970c2b17e89456fecbf55e8eed53a956f37ab50c41"
+dependencies = [
+ "hmac 0.11.0",
+ "pbkdf2 0.9.0",
+ "rand 0.8.5",
+ "sha2 0.9.9",
+ "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -295,8 +351,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef0f0152ec5cf17f49a5866afaa3439816207fd4f0a224c0211ffaf5e278426"
 dependencies = [
- "hmac",
- "pbkdf2",
+ "hmac 0.12.1",
+ "pbkdf2 0.10.1",
  "rand 0.8.5",
  "sha2 0.10.8",
  "unicode-normalization",
@@ -383,16 +439,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "bls12_381"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
+dependencies = [
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pairing 0.22.0",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "bls12_381"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
- "ff",
- "group",
- "pairing",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "pairing 0.23.0",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+dependencies = [
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -414,6 +508,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 
 [[package]]
 name = "byteorder"
@@ -443,7 +543,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -457,9 +557,27 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "zeroize",
+]
 
 [[package]]
 name = "chacha20"
@@ -467,9 +585,22 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if",
- "cipher",
+ "cfg-if 1.0.0",
+ "cipher 0.4.4",
  "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
+dependencies = [
+ "aead 0.4.3",
+ "chacha20 0.8.2",
+ "cipher 0.3.0",
+ "poly1305 0.7.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -478,10 +609,10 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -497,6 +628,15 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -652,11 +792,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "darkside-tests"
 version = "0.1.0"
 dependencies = [
  "bech32",
- "bip0039",
+ "bip0039 0.10.1",
  "env_logger",
  "futures-util",
  "hex 0.3.2",
@@ -666,7 +816,7 @@ dependencies = [
  "itertools 0.10.5",
  "json",
  "log",
- "orchard",
+ "orchard 0.7.0",
  "portpicker",
  "prost",
  "rand 0.8.5",
@@ -684,7 +834,7 @@ dependencies = [
  "tracing-test",
  "zcash_address",
  "zcash_client_backend",
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
  "zingo-testutils",
  "zingoconfig",
  "zingolib",
@@ -750,6 +900,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,7 +923,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -791,6 +950,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "document-features"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,7 +997,7 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -828,6 +1005,19 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "env_logger"
@@ -840,6 +1030,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "equihash"
+version = "0.1.0"
+source = "git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481#7183acd2fe12ebf201cae5b871166e356273c481"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
 ]
 
 [[package]]
@@ -897,9 +1096,20 @@ version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -951,12 +1161,26 @@ dependencies = [
 
 [[package]]
 name = "fpe"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd910db5f9ca4dc3116f8c46367825807aa2b942f72565f16b4be0b208a00a9e"
+dependencies = [
+ "block-modes",
+ "cipher 0.3.0",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "fpe"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
 dependencies = [
  "cbc",
- "cipher",
+ "cipher 0.4.4",
  "libm",
  "num-bigint",
  "num-integer",
@@ -1080,7 +1304,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -1093,11 +1317,22 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "memuse",
  "rand_core 0.6.4",
  "subtle",
@@ -1124,17 +1359,35 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f3914f58cc4af5e4fe83d48b02d582be18976bc7e96c3151aa2bf1c98e9f60"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "halo2_proofs 0.1.0",
+ "lazy_static",
+ "pasta_curves 0.4.1",
+ "rand 0.8.5",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_gadgets"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126a150072b0c38c7b573fe3eaf0af944a7fed09e154071bf2436d3f016f7230"
 dependencies = [
  "arrayvec",
  "bitvec",
- "ff",
- "group",
- "halo2_proofs",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "halo2_proofs 0.3.0",
  "lazy_static",
- "pasta_curves",
+ "pasta_curves 0.5.1",
  "rand 0.8.5",
  "subtle",
  "uint",
@@ -1148,16 +1401,30 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 
 [[package]]
 name = "halo2_proofs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pasta_curves 0.4.1",
+ "rand_core 0.6.4",
+ "rayon",
+]
+
+[[package]]
+name = "halo2_proofs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "halo2_legacy_pdqsort",
  "maybe-rayon",
- "pasta_curves",
+ "pasta_curves 0.5.1",
  "rand_core 0.6.4",
  "tracing",
 ]
@@ -1176,6 +1443,18 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdwallet"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd89bf343be18dbe1e505100e48168bbd084760e842a8fed0317d2361470193"
+dependencies = [
+ "lazy_static",
+ "rand_core 0.6.4",
+ "ring 0.16.20",
+ "secp256k1 0.21.3",
+]
+
+[[package]]
+name = "hdwallet"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a03ba7d4c9ea41552cd4351965ff96883e629693ae85005c501bb4b9e1c48a7"
@@ -1183,7 +1462,7 @@ dependencies = [
  "lazy_static",
  "rand_core 0.6.4",
  "ring 0.16.20",
- "secp256k1",
+ "secp256k1 0.26.0",
  "thiserror",
 ]
 
@@ -1210,6 +1489,28 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hidapi"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798154e4b6570af74899d71155fb0072d5b17e6aa12f39c8ef22c60fb8ec99e7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
 
 [[package]]
 name = "hmac"
@@ -1374,6 +1675,15 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5ad43a3f5795945459d577f6589cf62a476e92c79b75e70cd954364e14ce17b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "incrementalmerkletree"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361c467824d4d9d4f284be4b2608800839419dccc4d4608f28345237fe354623"
@@ -1421,18 +1731,18 @@ dependencies = [
 name = "integration-tests"
 version = "0.2.0"
 dependencies = [
- "bip0039",
+ "bip0039 0.10.1",
  "hex 0.3.2",
  "itertools 0.10.5",
  "json",
  "log",
- "orchard",
+ "orchard 0.7.0",
  "serde_json",
  "shardtree",
  "tokio",
  "zcash_address",
  "zcash_client_backend",
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
  "zingo-testutils",
  "zingoconfig",
  "zingolib",
@@ -1505,14 +1815,28 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "jubjub"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
+dependencies = [
+ "bitvec",
+ "bls12_381 0.7.1",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "jubjub"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
- "bls12_381",
- "ff",
- "group",
+ "bls12_381 0.8.0",
+ "ff 0.13.0",
+ "group 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1533,6 +1857,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
+]
+
+[[package]]
+name = "ledger-apdu"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb49f088676533baec18c9b4846c8af3c8ca9dbab80de9b90391851a1185319"
+dependencies = [
+ "arrayref",
+ "no-std-compat",
+ "snafu",
+]
+
+[[package]]
+name = "ledger-transport"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dc35b802e5df613fd337a7d8010213f6b454022d12c003d6a8cc58eaec5f9"
+dependencies = [
+ "async-trait",
+ "ledger-apdu",
+]
+
+[[package]]
+name = "ledger-transport-hid"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04436e96d73d8b7848017ccfaed6624acfeaf5f86a238f1a38d64cc97d3ee"
+dependencies = [
+ "byteorder",
+ "cfg-if 0.1.10",
+ "hex 0.4.3",
+ "hidapi",
+ "ledger-transport",
+ "libc",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "ledger-zcash"
+version = "0.6.0"
+source = "git+https://github.com/Zondax/ledger-zcash-rs?rev=324a0851113df4ea77457b5711392beabd021407#324a0851113df4ea77457b5711392beabd021407"
+dependencies = [
+ "arrayvec",
+ "byteorder",
+ "cfg-if 1.0.0",
+ "educe",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "hex 0.4.3",
+ "jubjub 0.9.0",
+ "lazy_static",
+ "ledger-transport",
+ "ledger-zondax-generic",
+ "log",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1 0.21.3",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror",
+ "tokio",
+ "zcash-hsmbuilder",
+ "zcash_primitives 0.6.0",
+ "zx-bip44",
+]
+
+[[package]]
+name = "ledger-zondax-generic"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902aa4d473a7966336fd64379a3826547b451c744b35fd741048013a93626830"
+dependencies = [
+ "async-trait",
+ "ledger-transport",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -1660,7 +2062,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "rayon",
 ]
 
@@ -1751,9 +2153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
 ]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"
@@ -1850,7 +2258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
  "bitflags 2.4.1",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1889,30 +2297,57 @@ dependencies = [
 
 [[package]]
 name = "orchard"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f918076e191a68d55c5517a16e075ecfe58fc63ed112408263f3d6194597bfcf"
+dependencies = [
+ "aes 0.7.5",
+ "bitvec",
+ "blake2b_simd",
+ "ff 0.12.1",
+ "fpe 0.5.1",
+ "group 0.12.1",
+ "halo2_gadgets 0.1.0",
+ "halo2_proofs 0.1.0",
+ "hex 0.4.3",
+ "incrementalmerkletree 0.3.1",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves 0.4.1",
+ "rand 0.8.5",
+ "reddsa 0.3.0",
+ "serde",
+ "subtle",
+ "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "orchard"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c801aeaccd19bb6916d71f25694b62d223061872900e8022221c1ad8dcad2d"
 dependencies = [
- "aes",
+ "aes 0.8.3",
  "bitvec",
  "blake2b_simd",
- "ff",
- "fpe",
- "group",
- "halo2_gadgets",
- "halo2_proofs",
+ "ff 0.13.0",
+ "fpe 0.6.1",
+ "group 0.13.0",
+ "halo2_gadgets 0.3.0",
+ "halo2_proofs 0.3.0",
  "hex 0.4.3",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.5.0",
  "lazy_static",
  "memuse",
  "nonempty",
- "pasta_curves",
+ "pasta_curves 0.5.1",
  "rand 0.8.5",
- "reddsa",
+ "reddsa 0.5.1",
  "serde",
  "subtle",
  "tracing",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.4.0",
  "zcash_spec",
  "zip32",
 ]
@@ -1934,11 +2369,20 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group 0.12.1",
+]
+
+[[package]]
+name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -1957,7 +2401,7 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1977,17 +2421,42 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "lazy_static",
  "rand 0.8.5",
  "static_assertions",
  "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
+dependencies = [
+ "crypto-mac",
+ "password-hash",
 ]
 
 [[package]]
@@ -2056,13 +2525,24 @@ checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "poly1305"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -2308,16 +2788,33 @@ dependencies = [
 
 [[package]]
 name = "reddsa"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc8038c8b7e481bdf688d0585d4897ed0e9e0cee10aa365dde51238c20e4182"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "group 0.12.1",
+ "jubjub 0.9.0",
+ "pasta_curves 0.4.1",
+ "rand_core 0.6.4",
+ "serde",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "reddsa"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "group",
+ "group 0.13.0",
  "hex 0.4.3",
- "jubjub",
- "pasta_curves",
+ "jubjub 0.10.0",
+ "pasta_curves 0.5.1",
  "rand_core 0.6.4",
  "serde",
  "thiserror",
@@ -2331,7 +2828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a60db2c3bc9c6fd1e8631fee75abc008841d27144be744951d6b9b75f9b569c"
 dependencies = [
  "rand_core 0.6.4",
- "reddsa",
+ "reddsa 0.5.1",
  "serde",
  "thiserror",
  "zeroize",
@@ -2639,7 +3136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clipboard-win",
  "dirs-next",
  "fd-lock",
@@ -2676,20 +3173,20 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f5de898a7cdb7f6d9c8fb888341b6ae6e2aeae88227b7f435f1dda49ecf9e62"
 dependencies = [
- "aes",
- "bellman",
+ "aes 0.8.3",
+ "bellman 0.14.0",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "bls12_381",
+ "bls12_381 0.8.0",
  "byteorder",
  "document-features",
- "ff",
- "fpe",
- "group",
+ "ff 0.13.0",
+ "fpe 0.6.1",
+ "group 0.13.0",
  "hex 0.4.3",
- "incrementalmerkletree",
- "jubjub",
+ "incrementalmerkletree 0.5.0",
+ "jubjub 0.10.0",
  "lazy_static",
  "memuse",
  "rand 0.8.5",
@@ -2697,7 +3194,7 @@ dependencies = [
  "redjubjub",
  "subtle",
  "tracing",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.4.0",
  "zcash_spec",
  "zip32",
 ]
@@ -2729,11 +3226,29 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
+dependencies = [
+ "secp256k1-sys 0.4.2",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2855,7 +3370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -2867,7 +3382,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -2889,7 +3404,7 @@ checksum = "dbf20c7a2747d9083092e3a3eeb9a7ed75577ae364896bebbc5e0bdcd4e97735"
 dependencies = [
  "bitflags 2.4.1",
  "either",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.5.0",
  "tracing",
 ]
 
@@ -2932,6 +3447,28 @@ name = "smallvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+
+[[package]]
+name = "snafu"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "socket2"
@@ -3062,7 +3599,7 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall",
  "rustix",
@@ -3114,7 +3651,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -3512,6 +4049,16 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
@@ -3616,7 +4163,7 @@ version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -3641,7 +4188,7 @@ version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3911,7 +4458,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
 
@@ -3940,14 +4487,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash-hsmbuilder"
+version = "0.4.0"
+source = "git+https://github.com/Zondax/ledger-zcash-rs?rev=324a0851113df4ea77457b5711392beabd021407#324a0851113df4ea77457b5711392beabd021407"
+dependencies = [
+ "bellman 0.13.1",
+ "blake2b_simd",
+ "bls12_381 0.7.1",
+ "byteorder",
+ "cfg-if 1.0.0",
+ "chacha20poly1305 0.9.1",
+ "educe",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "hex 0.4.3",
+ "jubjub 0.9.0",
+ "lazy_static",
+ "log",
+ "pairing 0.22.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1 0.21.3",
+ "serde",
+ "serde_derive",
+ "sha2 0.9.9",
+ "tokio",
+ "zcash_note_encryption 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481)",
+ "zcash_primitives 0.6.0",
+ "zcash_proofs 0.6.0",
+]
+
+[[package]]
 name = "zcash_address"
 version = "0.3.1"
 source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc_4#dd05ba05b504294770c5d36de58ba5165c557def"
 dependencies = [
  "bech32",
- "bs58",
+ "bs58 0.5.0",
  "f4jumble",
- "zcash_encoding",
+ "zcash_encoding 0.2.0",
 ]
 
 [[package]]
@@ -3957,15 +4537,15 @@ source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc_4#dd05b
 dependencies = [
  "base64 0.21.7",
  "bech32",
- "bls12_381",
- "bs58",
+ "bls12_381 0.8.0",
+ "bs58 0.5.0",
  "byteorder",
  "crossbeam-channel",
  "document-features",
- "group",
- "hdwallet",
+ "group 0.13.0",
+ "hdwallet 0.4.1",
  "hex 0.4.3",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.5.0",
  "memuse",
  "nom",
  "nonempty",
@@ -3983,11 +4563,20 @@ dependencies = [
  "tracing",
  "which",
  "zcash_address",
- "zcash_encoding",
+ "zcash_encoding 0.2.0",
  "zcash_keys",
- "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_note_encryption 0.4.0",
+ "zcash_primitives 0.13.0",
  "zip32",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.1.0"
+source = "git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481#7183acd2fe12ebf201cae5b871166e356273c481"
+dependencies = [
+ "byteorder",
+ "nonempty",
 ]
 
 [[package]]
@@ -4005,23 +4594,46 @@ version = "0.0.0"
 source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc_4#dd05ba05b504294770c5d36de58ba5165c557def"
 dependencies = [
  "bech32",
- "bls12_381",
- "bs58",
+ "bls12_381 0.8.0",
+ "bs58 0.5.0",
  "byteorder",
  "document-features",
- "group",
- "hdwallet",
+ "group 0.13.0",
+ "hdwallet 0.4.1",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.7.0",
  "rand_core 0.6.4",
  "sapling-crypto",
  "subtle",
  "tracing",
  "zcash_address",
- "zcash_encoding",
- "zcash_primitives",
+ "zcash_encoding 0.2.0",
+ "zcash_primitives 0.13.0",
  "zip32",
+]
+
+[[package]]
+name = "zcash_note_encryption"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f84ae538f05a8ac74c82527f06b77045ed9553a0871d9db036166a4c344e3a"
+dependencies = [
+ "chacha20 0.8.2",
+ "chacha20poly1305 0.9.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "zcash_note_encryption"
+version = "0.1.0"
+source = "git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481#7183acd2fe12ebf201cae5b871166e356273c481"
+dependencies = [
+ "chacha20 0.8.2",
+ "chacha20poly1305 0.9.1",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4030,11 +4642,47 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b4580cd6cee12e44421dac43169be8d23791650816bdb34e6ddfa70ac89c1c5"
 dependencies = [
- "chacha20",
- "chacha20poly1305",
- "cipher",
+ "chacha20 0.9.1",
+ "chacha20poly1305 0.10.1",
+ "cipher 0.4.4",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.6.0"
+source = "git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481#7183acd2fe12ebf201cae5b871166e356273c481"
+dependencies = [
+ "aes 0.7.5",
+ "bip0039 0.9.0",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bls12_381 0.7.1",
+ "bs58 0.4.0",
+ "byteorder",
+ "chacha20poly1305 0.9.1",
+ "equihash 0.1.0",
+ "ff 0.12.1",
+ "fpe 0.5.1",
+ "group 0.12.1",
+ "hdwallet 0.3.1",
+ "hex 0.4.3",
+ "incrementalmerkletree 0.3.1",
+ "jubjub 0.9.0",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "orchard 0.1.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1 0.21.3",
+ "sha2 0.9.9",
+ "subtle",
+ "zcash_encoding 0.1.0",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481)",
 ]
 
 [[package]]
@@ -4042,36 +4690,54 @@ name = "zcash_primitives"
 version = "0.13.0"
 source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc_4#dd05ba05b504294770c5d36de58ba5165c557def"
 dependencies = [
- "aes",
- "bip0039",
+ "aes 0.8.3",
+ "bip0039 0.10.1",
  "blake2b_simd",
  "byteorder",
  "document-features",
- "equihash",
- "ff",
- "fpe",
- "group",
- "hdwallet",
+ "equihash 0.2.0",
+ "ff 0.13.0",
+ "fpe 0.6.1",
+ "group 0.13.0",
+ "hdwallet 0.4.1",
  "hex 0.4.3",
- "incrementalmerkletree",
- "jubjub",
+ "incrementalmerkletree 0.5.0",
+ "jubjub 0.10.0",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.7.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
  "ripemd",
  "sapling-crypto",
- "secp256k1",
+ "secp256k1 0.26.0",
  "sha2 0.10.8",
  "subtle",
  "tracing",
  "zcash_address",
- "zcash_encoding",
- "zcash_note_encryption",
+ "zcash_encoding 0.2.0",
+ "zcash_note_encryption 0.4.0",
  "zcash_spec",
  "zip32",
+]
+
+[[package]]
+name = "zcash_proofs"
+version = "0.6.0"
+source = "git+https://github.com/adityapk00/librustzcash?rev=7183acd2fe12ebf201cae5b871166e356273c481#7183acd2fe12ebf201cae5b871166e356273c481"
+dependencies = [
+ "bellman 0.13.1",
+ "blake2b_simd",
+ "bls12_381 0.7.1",
+ "byteorder",
+ "directories",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "jubjub 0.9.0",
+ "lazy_static",
+ "rand_core 0.6.4",
+ "zcash_primitives 0.6.0",
 ]
 
 [[package]]
@@ -4079,13 +4745,13 @@ name = "zcash_proofs"
 version = "0.13.0"
 source = "git+https://github.com/zingolabs/librustzcash.git?tag=zingo_rc_4#dd05ba05b504294770c5d36de58ba5165c557def"
 dependencies = [
- "bellman",
+ "bellman 0.14.0",
  "blake2b_simd",
- "bls12_381",
+ "bls12_381 0.8.0",
  "document-features",
- "group",
+ "group 0.13.0",
  "home",
- "jubjub",
+ "jubjub 0.10.0",
  "known-folders",
  "lazy_static",
  "rand_core 0.6.4",
@@ -4093,7 +4759,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
 ]
 
 [[package]]
@@ -4153,10 +4819,10 @@ version = "0.1.0"
 dependencies = [
  "zcash_address",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.2.0",
  "zcash_keys",
- "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_note_encryption 0.4.0",
+ "zcash_primitives 0.13.0",
 ]
 
 [[package]]
@@ -4164,7 +4830,7 @@ name = "zingo-status"
 version = "0.1.0"
 dependencies = [
  "serde_json",
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
 ]
 
 [[package]]
@@ -4173,10 +4839,10 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "http",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.5.0",
  "json",
  "log",
- "orchard",
+ "orchard 0.7.0",
  "portpicker",
  "serde",
  "serde_json",
@@ -4187,7 +4853,7 @@ dependencies = [
  "tracing",
  "zcash_address",
  "zcash_client_backend",
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
  "zingoconfig",
  "zingolib",
 ]
@@ -4196,7 +4862,7 @@ dependencies = [
 name = "zingo-testvectors"
 version = "0.1.0"
 dependencies = [
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
  "zingoconfig",
 ]
 
@@ -4209,7 +4875,7 @@ dependencies = [
  "log",
  "log4rs",
  "zcash_address",
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
 ]
 
 [[package]]
@@ -4220,32 +4886,37 @@ dependencies = [
  "base58",
  "base64 0.13.1",
  "bech32",
- "bip0039",
- "bls12_381",
+ "bip0039 0.10.1",
+ "bls12_381 0.8.0",
  "build_utils",
+ "bytemuck",
  "byteorder",
  "bytes 0.4.12",
+ "cfg-if 1.0.0",
  "concat-idents",
  "derive_more",
  "either",
- "ff",
+ "ff 0.13.0",
  "futures",
- "group",
+ "group 0.13.0",
  "hex 0.3.2",
  "http",
  "http-body",
  "hyper",
  "hyper-rustls",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.5.0",
  "indoc",
  "json",
- "jubjub",
+ "jubjub 0.10.0",
  "lazy_static",
+ "ledger-transport",
+ "ledger-transport-hid",
+ "ledger-zcash",
  "log",
  "log4rs",
  "nonempty",
- "orchard",
- "pairing",
+ "orchard 0.7.0",
+ "pairing 0.23.0",
  "portpicker",
  "prost",
  "rand 0.8.5",
@@ -4255,7 +4926,7 @@ dependencies = [
  "rust-embed",
  "rustls-pemfile",
  "sapling-crypto",
- "secp256k1",
+ "secp256k1 0.26.0",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -4273,16 +4944,18 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "webpki-roots 0.21.1",
+ "zcash-hsmbuilder",
  "zcash_address",
  "zcash_client_backend",
- "zcash_encoding",
- "zcash_note_encryption",
- "zcash_primitives",
- "zcash_proofs",
+ "zcash_encoding 0.2.0",
+ "zcash_note_encryption 0.4.0",
+ "zcash_primitives 0.13.0",
+ "zcash_proofs 0.13.0",
  "zingo-memo",
  "zingo-status",
  "zingo-testvectors",
  "zingoconfig",
+ "zx-bip44",
 ]
 
 [[package]]
@@ -4294,4 +4967,14 @@ dependencies = [
  "blake2b_simd",
  "memuse",
  "subtle",
+]
+
+[[package]]
+name = "zx-bip44"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed17b569d1ea6903d5dc061602c6dc45f816cd0171d67d3b40fc1f6caf1ade0"
+dependencies = [
+ "byteorder",
+ "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ futures = "0.3.15"
 shardtree = "0.2"
 build_utils = { path = "./build_utils" }
 http = "0.2.4"
+hdwallet = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 http-body = "0.4.4"
 tonic = {version = "0.10.0", features = ["tls", "tls-roots", "tls-webpki-roots"]}

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -22,3 +22,6 @@ hex = "0.3"
 itertools = "0.10.5"
 bip0039 = "0.10.1"
 serde_json = "1.0.107"
+
+[features]
+ledger-support = ["zingolib/ledger-support"]

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -3593,3 +3593,24 @@ mod slow {
 async fn proxy_server_worky() {
     zingo_testutils::check_proxy_server_works().await
 }
+
+#[cfg(feature = "ledger-support")]
+mod ledger {
+    use zingolib::wallet::keys::ledger::LedgerWalletCapability;
+
+    use super::*;
+
+    #[test]
+    fn assert_ledger_wallet_loads() {
+        // As we're already in an async context
+        // the block_on call inside LWC::new will
+        // panic unless called in a new thread
+
+        // TODO: This fails as we're not connecting to a ledger app.
+        // Can we mock this?
+        let ledger_capability = std::thread::spawn(LedgerWalletCapability::new)
+            .join()
+            .unwrap()
+            .unwrap();
+    }
+}

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -30,10 +30,7 @@ use zingolib::{
     },
     wallet::{
         data::{COMMITMENT_TREE_LEVELS, MAX_SHARD_LEVEL},
-        keys::{
-            extended_transparent::ExtendedPrivKey,
-            unified::{Capability, Keystore},
-        },
+        keys::{extended_transparent::ExtendedPrivKey, keystore::Keystore, unified::Capability},
         LightWallet, Pool,
     },
 };
@@ -82,6 +79,9 @@ fn check_view_capability_bounds(
     sent_t_value: Option<u64>,
     notes: &JsonValue,
 ) {
+    let Keystore::InMemory(watch_wc) = watch_wc else {
+        todo!("Do this for ledger too")
+    };
     //Orchard
     if !fvks.contains(&ovk) {
         assert!(!watch_wc.orchard.can_view());
@@ -512,7 +512,9 @@ mod fast {
 
         let expected_wc =
             Keystore::new_from_phrase(&config, &expected_mnemonic.0, expected_mnemonic.1).unwrap();
-        let wc = wallet.keystore();
+        let Keystore::InMemory(ref wc) = *wallet.keystore() else {
+            unreachable!("Known to be InMemory due to new_from_phrase impl")
+        };
 
         // We don't want the WalletCapability to impl. `Eq` (because it stores secret keys)
         // so we have to compare each component instead
@@ -579,7 +581,9 @@ mod fast {
 
         let expected_wc =
             Keystore::new_from_phrase(&config, &expected_mnemonic.0, expected_mnemonic.1).unwrap();
-        let wc = wallet.keystore();
+        let Keystore::InMemory(ref wc) = *wallet.keystore() else {
+            unreachable!("Known to be InMemory due to new_from_phrase impl")
+        };
 
         // We don't want the WalletCapability to impl. `Eq` (because it stores secret keys)
         // so we have to compare each component instead
@@ -660,7 +664,9 @@ mod fast {
 
         let expected_wc =
             Keystore::new_from_phrase(&config, &expected_mnemonic.0, expected_mnemonic.1).unwrap();
-        let wc = wallet.keystore();
+        let Keystore::InMemory(ref wc) = *wallet.keystore() else {
+            unreachable!("Known to be InMemory due to new_from_phrase impl")
+        };
 
         let Capability::Spend(orchard_sk) = &wc.orchard else {
             panic!("Expected Orchard Spending Key");

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 use zcash_address::unified::{Fvk, Ufvk};
-use zingolib::wallet::keys::unified::WalletCapability;
+use zingolib::wallet::keys::keystore::Keystore;
 use zingolib::wallet::WalletBase;
 
 use json::JsonValue;
@@ -26,7 +26,7 @@ pub mod grpc_proxy;
 pub mod paths;
 pub mod regtest;
 
-pub fn build_fvks_from_wallet_capability(wallet_capability: &WalletCapability) -> [Fvk; 3] {
+pub fn build_fvks_from_wallet_capability(wallet_capability: &Keystore) -> [Fvk; 3] {
     let o_fvk = Fvk::Orchard(
         orchard::keys::FullViewingKey::try_from(wallet_capability)
             .unwrap()

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -112,7 +112,7 @@ zx-bip44 = { version = "0.1.0", optional = true }
 bytemuck = { version = "1.9.1", optional = true }
 cfg-if = "1.0.0"
 
-
+hdwallet.workspace = true
 sapling-crypto.workspace = true
 thiserror = "1.0.57"
 

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -14,6 +14,15 @@ test-features = ["zingo-testvectors"]
 default = ["embed_params"]
 embed_params = []
 darkside_tests = []
+hsm-compat = ["zcash-hsmbuilder"]
+ledger-support = [
+    "hsm-compat",
+    "ledger-zcash",
+    "ledger-transport-hid",
+    "ledger-transport",
+    "zx-bip44",
+    "bytemuck",
+]
 
 [dependencies]
 zingoconfig = { path = "../zingoconfig" }
@@ -28,9 +37,17 @@ tower = { workspace = true }
 prost = { workspace = true }
 orchard = { workspace = true }
 shardtree = { workspace = true, features = ["legacy-api"] }
-incrementalmerkletree = { workspace = true, features = ["test-dependencies", "legacy-api"] }
+incrementalmerkletree = { workspace = true, features = [
+    "test-dependencies",
+    "legacy-api",
+] }
 zcash_address = { workspace = true }
-zcash_client_backend = { workspace = true, features = ["unstable", "transparent-inputs", "unstable-serialization", "unstable-spanning-tree"] }
+zcash_client_backend = { workspace = true, features = [
+    "unstable",
+    "transparent-inputs",
+    "unstable-serialization",
+    "unstable-spanning-tree",
+] }
 zcash_encoding = { workspace = true }
 zcash_note_encryption = { workspace = true }
 zcash_primitives = { workspace = true }
@@ -46,7 +63,7 @@ bytes = "0.4"
 rand = "0.8.5"
 hyper-rustls = { version = "0.23", features = ["http2"] }
 serde_json = "1.0.82"
-tokio =  { version = "1.24.2", features = ["full"] }
+tokio = { version = "1.24.2", features = ["full"] }
 tokio-stream = "0.1.6"
 tokio-rustls = "0.23.3"
 reqwest = { version = "0.11", features = ["json"] }
@@ -80,7 +97,24 @@ indoc = "2.0.1"
 derive_more = "0.99.17"
 either = "1.8.1"
 serde = { version = "1.0.188", features = ["derive"] }
+zcash-hsmbuilder = { git = "https://github.com/Zondax/ledger-zcash-rs", rev = "324a0851113df4ea77457b5711392beabd021407", default-features = false, features = [
+    "zecwallet-compat",
+], optional = true }
+# ledger-zcash = { git = "https://github.com/Zondax/ledger-zcash-rs", rev = "324a0851113df4ea77457b5711392beabd021407", default-features = false, features = [
+#     "zecwallet-compat",
+# ], optional = true }
+ledger-zcash = { git = "https://github.com/Zondax/ledger-zcash-rs", branch = "feat/zingolib", default-features = false, features = [
+    "zecwallet-compat",
+], optional = true }
+ledger-transport-hid = { version = "0.9", optional = true }
+ledger-transport = { version = "0.9.0", optional = true }
+zx-bip44 = { version = "0.1.0", optional = true }
+bytemuck = { version = "1.9.1", optional = true }
+cfg-if = "1.0.0"
+
+
 sapling-crypto.workspace = true
+thiserror = "1.0.57"
 
 [dev-dependencies]
 portpicker = "0.1.0"

--- a/zingolib/src/blaze/fetch_full_transaction.rs
+++ b/zingolib/src/blaze/fetch_full_transaction.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{ZingoLibError, ZingoLibResult},
     wallet::{
         data::OutgoingTxData,
-        keys::{address_from_pubkeyhash, unified::WalletCapability},
+        keys::{address_from_pubkeyhash, keystore::Keystore},
         notes::ShieldedNoteInterface,
         traits::{
             self as zingo_traits, Bundle as _, DomainWalletExt, Recipient as _,
@@ -44,14 +44,15 @@ use zingoconfig::ZingoConfig;
 #[derive(Clone)]
 pub struct TransactionContext {
     pub config: ZingoConfig,
-    pub(crate) key: Arc<WalletCapability>,
+    // pub(crate) key: Arc<WalletCapability>,
+    pub(crate) key: Arc<Keystore>,
     pub transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
 }
 
 impl TransactionContext {
     pub fn new(
         config: &ZingoConfig,
-        key: Arc<WalletCapability>,
+        key: Arc<Keystore>,
         transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
     ) -> Self {
         Self {

--- a/zingolib/src/blaze/fetch_taddr_transactions.rs
+++ b/zingolib/src/blaze/fetch_taddr_transactions.rs
@@ -1,5 +1,5 @@
 use crate::wallet::keys::address_from_pubkeyhash;
-use crate::wallet::keys::unified::WalletCapability;
+use crate::wallet::keys::keystore::Keystore;
 use zcash_client_backend::proto::service::RawTransaction;
 
 use std::sync::Arc;
@@ -16,7 +16,7 @@ use zcash_primitives::transaction::Transaction;
 use zingoconfig::ZingoConfig;
 
 pub struct FetchTaddrTransactions {
-    wc: Arc<WalletCapability>,
+    wc: Arc<Keystore>,
     config: Arc<ZingoConfig>,
 }
 
@@ -27,7 +27,7 @@ pub type FetchTaddrRequest = (Vec<String>, u64, u64);
 pub type FetchTaddrResponse = Result<RawTransaction, String>;
 
 impl FetchTaddrTransactions {
-    pub fn new(wc: Arc<WalletCapability>, config: Arc<ZingoConfig>) -> Self {
+    pub fn new(wc: Arc<Keystore>, config: Arc<ZingoConfig>) -> Self {
         Self { wc, config }
     }
 

--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -7,7 +7,7 @@ use crate::error::ZingoLibResult;
 use crate::wallet::notes::ShieldedNoteInterface;
 use crate::wallet::{
     data::PoolNullifier,
-    keys::unified::WalletCapability,
+    keys::keystore::Keystore,
     traits::{CompactOutput as _, DomainWalletExt, FromCommitment, Recipient},
     transactions::TransactionMetadataSet,
     utils::txid_from_slice,
@@ -39,7 +39,7 @@ use zingoconfig::ZingoConfig;
 use super::syncdata::BlazeSyncData;
 
 pub struct TrialDecryptions {
-    wc: Arc<WalletCapability>,
+    wc: Arc<Keystore>,
     transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
     config: Arc<ZingoConfig>,
 }
@@ -47,7 +47,7 @@ pub struct TrialDecryptions {
 impl TrialDecryptions {
     pub fn new(
         config: Arc<ZingoConfig>,
-        wc: Arc<WalletCapability>,
+        wc: Arc<Keystore>,
         transaction_metadata_set: Arc<RwLock<TransactionMetadataSet>>,
     ) -> Self {
         Self {
@@ -125,7 +125,7 @@ impl TrialDecryptions {
     async fn trial_decrypt_batch(
         config: Arc<ZingoConfig>,
         compact_blocks: Vec<CompactBlock>,
-        wc: Arc<WalletCapability>,
+        wc: Arc<Keystore>,
         bsync_data: Arc<RwLock<BlazeSyncData>>,
         sapling_ivk: Option<SaplingIvk>,
         orchard_ivk: Option<OrchardIvk>,
@@ -260,7 +260,7 @@ impl TrialDecryptions {
         ivk: D::IncomingViewingKey,
         height: BlockHeight,
         config: &zingoconfig::ZingoConfig,
-        wc: &Arc<WalletCapability>,
+        wc: &Arc<Keystore>,
         bsync_data: &Arc<RwLock<BlazeSyncData>>,
         transaction_metadata_set: &Arc<RwLock<TransactionMetadataSet>>,
         detected_transaction_id_sender: &UnboundedSender<(
@@ -418,7 +418,7 @@ fn update_witnesses<D>(
         BlockHeight,
     )>,
     txmds_writelock: &mut TransactionMetadataSet,
-    wc: &Arc<WalletCapability>,
+    wc: &Arc<Keystore>,
 ) -> ZingoLibResult<()>
 where
     D: DomainWalletExt,

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -116,12 +116,12 @@ impl Command for WalletKindCommand {
             if lightclient.do_seed_phrase().await.is_ok() {
                 object! {"kind" => "Seeded"}.pretty(4)
             } else {
-                let capability = lightclient.wallet.wallet_capability();
+                let capability = lightclient.wallet.keystore();
                 object! {
                     "kind" => "Loaded from key",
-                    "transparent" => capability.transparent.kind_str(),
-                    "sapling" => capability.sapling.kind_str(),
-                    "orchard" => capability.orchard.kind_str(),
+                    "transparent" => capability.transparent_kind_str(),
+                    "sapling" => capability.sapling_kind_str(),
+                    "orchard" => capability.orchard_kind_str(),
                 }
                 .pretty(4)
             }

--- a/zingolib/src/lightclient/deprecated.rs
+++ b/zingolib/src/lightclient/deprecated.rs
@@ -1,3 +1,5 @@
+use crate::wallet::keys::keystore::Keystore;
+
 use super::*;
 use zcash_note_encryption::Domain;
 
@@ -5,7 +7,7 @@ impl LightClient {
     fn add_nonchange_notes<'a, 'b, 'c>(
         &'a self,
         transaction_metadata: &'b TransactionRecord,
-        unified_spend_auth: &'c crate::wallet::keys::unified::WalletCapability,
+        unified_spend_auth: &'c Keystore,
     ) -> impl Iterator<Item = JsonValue> + 'b
     where
         'a: 'b,
@@ -26,7 +28,7 @@ impl LightClient {
     fn add_wallet_notes_in_transaction_to_list_inner<'a, 'b, 'c, D>(
         &'a self,
         transaction_metadata: &'b TransactionRecord,
-        unified_spend_auth: &'c crate::wallet::keys::unified::WalletCapability,
+        unified_spend_auth: &'c Keystore,
     ) -> impl Iterator<Item = JsonValue> + 'b
     where
         'a: 'b,
@@ -123,7 +125,7 @@ impl LightClient {
                 }
 
                 // For each note that is not a change, add a consumer_ui_note.
-                consumer_notes_by_tx.extend(self.add_nonchange_notes(wallet_transaction, &self.wallet.wallet_capability()));
+                consumer_notes_by_tx.extend(self.add_nonchange_notes(wallet_transaction, &self.wallet.keystore()));
 
                 // TODO:  determine if all notes are either Change-or-NotChange, if that's the case
                 // add a sanity check that asserts all notes are processed by this point

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -1011,7 +1011,6 @@ impl LightWallet {
             self.transaction_context.config.chain,
             submission_height,
             transaction::builder::BuildConfig::Standard {
-                // TODO: We probably need this
                 sapling_anchor: Some(sapling_anchor),
                 orchard_anchor: Some(orchard_anchor),
             },

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -12,6 +12,9 @@ use zcash_primitives::{legacy::TransparentAddress, zip32::ChildIndex};
 use zingoconfig::ZingoConfig;
 
 pub mod extended_transparent;
+pub mod keystore;
+#[cfg(feature = "ledger-support")]
+pub mod ledger;
 pub mod unified;
 
 /// Sha256(Sha256(value))

--- a/zingolib/src/wallet/keys/keystore.rs
+++ b/zingolib/src/wallet/keys/keystore.rs
@@ -1,0 +1,450 @@
+// use byteorder::WriteBytesExt;
+use std::collections::{HashMap, HashSet};
+use std::io::{self, Read, Write};
+
+use append_only_vec::AppendOnlyVec;
+use bip0039::Mnemonic;
+
+use orchard::keys::Scope;
+use zcash_address::unified::Ufvk;
+use zcash_client_backend::address::UnifiedAddress;
+// use zcash_encoding::Vector;
+use zcash_primitives::legacy::TransparentAddress;
+use zingoconfig::ZingoConfig;
+
+#[cfg(feature = "ledger-support")]
+use super::ledger::LedgerWalletCapability;
+
+use super::unified::{Capability, ReceiverSelection, WalletCapability};
+use crate::wallet::traits::ReadableWriteable;
+
+#[derive(Debug)]
+pub enum Keystore {
+    InMemory(super::unified::WalletCapability),
+    #[cfg(feature = "ledger-support")]
+    Ledger(super::ledger::LedgerWalletCapability),
+}
+
+impl From<WalletCapability> for Keystore {
+    fn from(value: WalletCapability) -> Self {
+        Self::InMemory(value)
+    }
+}
+
+#[cfg(feature = "ledger-support")]
+impl From<LedgerWalletCapability> for Keystore {
+    fn from(value: LedgerWalletCapability) -> Self {
+        Self::Ledger(value)
+    }
+}
+
+impl Keystore {
+    pub(crate) fn get_ua_from_contained_transparent_receiver(
+        &self,
+        receiver: &TransparentAddress,
+    ) -> Option<UnifiedAddress> {
+        match self {
+            Keystore::InMemory(wc) => wc.get_ua_from_contained_transparent_receiver(receiver),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.get_ua_from_contained_transparent_receiver(receiver),
+        }
+    }
+
+    pub fn addresses(&self) -> &AppendOnlyVec<UnifiedAddress> {
+        match self {
+            Keystore::InMemory(wc) => wc.addresses(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.addresses(),
+        }
+    }
+
+    pub fn transparent_child_keys(
+        &self,
+    ) -> Result<&AppendOnlyVec<(usize, secp256k1::SecretKey)>, String> {
+        match self {
+            Keystore::InMemory(wc) => wc.transparent_child_keys(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.transparent_child_keys(),
+        }
+    }
+
+    pub(crate) fn ufvk(&self) -> Result<Ufvk, zcash_address::unified::ParseError> {
+        match self {
+            Keystore::InMemory(wc) => wc.ufvk(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.ufvk(),
+        }
+    }
+
+    pub fn new_address(
+        &self,
+        desired_receivers: ReceiverSelection,
+        config: &ZingoConfig,
+    ) -> Result<UnifiedAddress, String> {
+        match self {
+            Keystore::InMemory(wc) => wc.new_address(desired_receivers),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.new_address(desired_receivers, config),
+        }
+    }
+
+    pub fn get_taddr_to_secretkey_map(
+        &self,
+        config: &ZingoConfig,
+    ) -> Result<HashMap<String, secp256k1::SecretKey>, String> {
+        match self {
+            Keystore::InMemory(wc) => wc.get_taddr_to_secretkey_map(config),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.get_taddr_to_secretkey_map(config),
+        }
+    }
+
+    pub fn new_from_seed(config: &ZingoConfig, seed: &[u8; 64], position: u32) -> Self {
+        WalletCapability::new_from_seed(config, seed, position).into()
+    }
+
+    pub fn new_from_phrase(
+        config: &ZingoConfig,
+        seed_phrase: &Mnemonic,
+        position: u32,
+    ) -> Result<Self, String> {
+        WalletCapability::new_from_phrase(config, seed_phrase, position).map(Self::from)
+    }
+
+    /// Creates a new `WalletCapability` from a unified spending key.
+    pub fn new_from_usk(usk: &[u8]) -> Result<Self, String> {
+        WalletCapability::new_from_usk(usk).map(Self::from)
+    }
+
+    pub fn new_from_ufvk(config: &ZingoConfig, ufvk_encoded: String) -> Result<Self, String> {
+        WalletCapability::new_from_ufvk(config, ufvk_encoded).map(Self::from)
+    }
+
+    pub(crate) fn get_all_taddrs(&self, config: &ZingoConfig) -> HashSet<String> {
+        match self {
+            Keystore::InMemory(wc) => wc.get_all_taddrs(config),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.get_all_taddrs(config),
+        }
+    }
+
+    pub fn first_sapling_address(&self) -> sapling_crypto::PaymentAddress {
+        match self {
+            Keystore::InMemory(wc) => wc.first_sapling_address(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.first_sapling_address(),
+        }
+    }
+
+    /// Returns a selection of pools where the wallet can spend funds.
+    pub fn can_spend_from_all_pools(&self) -> bool {
+        match self {
+            Keystore::InMemory(wc) => wc.can_spend_from_all_pools(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.can_spend_from_all_pools(),
+        }
+    }
+
+    pub fn get_trees_witness_trees(&self) -> Option<crate::wallet::data::WitnessTrees> {
+        if self.can_spend_from_all_pools() {
+            Some(crate::wallet::data::WitnessTrees::default())
+        } else {
+            None
+        }
+    }
+
+    /// Returns a selection of pools where the wallet can view funds.
+    pub fn can_view(&self) -> ReceiverSelection {
+        match self {
+            Keystore::InMemory(wc) => wc.can_view(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.can_view(),
+        }
+    }
+
+    // Checks if there is spendable Orchard balance capability.
+    pub fn can_spend_orchard(&self) -> bool {
+        match self {
+            Keystore::InMemory(wc) => matches!(wc.orchard, Capability::Spend(_)),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(_) => false, // Adjust based on Ledger's Orchard support
+        }
+    }
+
+    // Checks if there is spendable Sapling balance capability.
+    pub fn can_spend_sapling(&self) -> bool {
+        match self {
+            Keystore::InMemory(wc) => matches!(wc.sapling, Capability::Spend(_)),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => matches!(wc.sapling, Capability::Spend(_)),
+        }
+    }
+
+    // Checks if there is capability to view Transparent balances.
+    pub fn can_view_transparent(&self) -> bool {
+        match self {
+            Keystore::InMemory(wc) => wc.transparent.can_view(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.transparent.can_view(),
+        }
+    }
+}
+
+impl Keystore {
+    #[cfg(feature = "ledger-support")]
+    pub fn new_ledger() -> Result<Self, io::Error> {
+        let lwc = LedgerWalletCapability::new()?;
+        Ok(Self::Ledger(lwc))
+    }
+
+    pub fn wc(&self) -> Option<&WalletCapability> {
+        match self {
+            Self::InMemory(wc) => Some(wc),
+            #[cfg(feature = "ledger-support")]
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "ledger-support")]
+    pub fn ledger_wc(&self) -> Option<&LedgerWalletCapability> {
+        let Self::Ledger(wc) = self else { return None };
+        Some(wc)
+    }
+
+    // Method to get the kind string for the transparent capability
+    pub fn transparent_kind_str(&self) -> &str {
+        match self {
+            Keystore::InMemory(wc) => wc.transparent.kind_str(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.transparent.kind_str(),
+        }
+    }
+
+    // Similarly for sapling and orchard capabilities
+    pub fn sapling_kind_str(&self) -> &str {
+        match self {
+            Keystore::InMemory(wc) => wc.sapling.kind_str(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(wc) => wc.sapling.kind_str(),
+        }
+    }
+
+    pub fn orchard_kind_str(&self) -> &str {
+        match self {
+            Keystore::InMemory(wc) => wc.orchard.kind_str(),
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(_) => "Unsupported by ledger application",
+        }
+    }
+
+    pub fn transparent_capability(
+        &self,
+    ) -> &Capability<
+        super::extended_transparent::ExtendedPubKey,
+        super::extended_transparent::ExtendedPrivKey,
+    > {
+        match self {
+            Self::InMemory(wc) => &wc.transparent,
+            #[cfg(feature = "ledger-support")]
+            Self::Ledger(wc) => &wc.transparent,
+        }
+    }
+}
+
+// This implementation will always use/return an InMemory Keystore.
+// the reason is that keys in ledger devices never lived out of the device, never,
+// even worse if keys or addresses are store into a file.
+// at least this would be our take for now.
+impl ReadableWriteable<()> for Keystore {
+    const VERSION: u8 = 2;
+
+    fn read<R: Read>(reader: R, _input: ()) -> io::Result<Self> {
+        // TODO: Need to figureout what variant to call,
+        // we assume we could have two wallet.dat files?
+        // have a sort of pattern in data file name?
+        let wc = WalletCapability::read(reader, _input)?;
+        Ok(Self::InMemory(wc))
+    }
+
+    fn write<W: Write>(&self, writer: W) -> io::Result<()> {
+        match self {
+            Self::InMemory(wc) => wc.write(writer),
+            #[cfg(feature = "ledger-support")]
+            Self::Ledger(lwc) => lwc.write(writer),
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for super::extended_transparent::ExtendedPrivKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => wc.try_into(),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(lwc) => lwc.try_into(),
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for sapling_crypto::zip32::ExtendedSpendingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => wc.try_into(),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(lwc) => lwc.try_into(),
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for orchard::keys::SpendingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => wc.try_into(),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(_) => {
+                Err("Ledger device does not support Orchard protocol.".to_string())
+            }
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for super::extended_transparent::ExtendedPubKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => wc.try_into(),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(lwc) => lwc.try_into(),
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for orchard::keys::FullViewingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => wc.try_into(),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(_) => {
+                Err("Ledger device does not support Orchard protocol.".to_string())
+            }
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for sapling_crypto::zip32::DiversifiableFullViewingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => wc.try_into(),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(lwc) => lwc.try_into(),
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for sapling_crypto::note_encryption::PreparedIncomingViewingKey {
+    type Error = String;
+
+    fn try_from(value: &Keystore) -> Result<Self, Self::Error> {
+        match value {
+            Keystore::InMemory(wc) => sapling_crypto::SaplingIvk::try_from(wc)
+                .map(|k| sapling_crypto::note_encryption::PreparedIncomingViewingKey::new(&k)),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(lwc) => sapling_crypto::SaplingIvk::try_from(lwc)
+                .map(|k| sapling_crypto::note_encryption::PreparedIncomingViewingKey::new(&k)),
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for orchard::keys::IncomingViewingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => {
+                let fvk: orchard::keys::FullViewingKey = wc.try_into()?;
+                Ok(fvk.to_ivk(Scope::External))
+            }
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(_) => {
+                Err("Ledger device does not support Orchard protocol.".to_string())
+            }
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for orchard::keys::PreparedIncomingViewingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => orchard::keys::IncomingViewingKey::try_from(wc)
+                .map(|k| orchard::keys::PreparedIncomingViewingKey::new(&k)),
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(_) => {
+                Err("Ledger device does not support Orchard protocol.".to_string())
+            }
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for sapling_crypto::SaplingIvk {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => {
+                let fvk: sapling_crypto::zip32::DiversifiableFullViewingKey = wc.try_into()?;
+                Ok(fvk.fvk().vk.ivk())
+            }
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(lwc) => {
+                let fvk: sapling_crypto::zip32::DiversifiableFullViewingKey = lwc.try_into()?;
+                Ok(fvk.fvk().vk.ivk())
+            }
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for orchard::keys::OutgoingViewingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => {
+                let fvk: orchard::keys::FullViewingKey = wc.try_into()?;
+                Ok(fvk.to_ovk(Scope::External))
+            }
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(_) => {
+                Err("Ledger device does not support Orchard protocol.".to_string())
+            }
+        }
+    }
+}
+
+impl TryFrom<&Keystore> for sapling_crypto::keys::OutgoingViewingKey {
+    type Error = String;
+    fn try_from(wc: &Keystore) -> Result<Self, String> {
+        match wc {
+            Keystore::InMemory(wc) => {
+                let fvk: sapling_crypto::zip32::DiversifiableFullViewingKey = wc.try_into()?;
+                Ok(fvk.fvk().ovk)
+            }
+
+            #[cfg(feature = "ledger-support")]
+            Keystore::Ledger(lwc) => {
+                let fvk: sapling_crypto::zip32::DiversifiableFullViewingKey = lwc.try_into()?;
+                Ok(fvk.fvk().ovk)
+            }
+        }
+    }
+}

--- a/zingolib/src/wallet/keys/ledger.rs
+++ b/zingolib/src/wallet/keys/ledger.rs
@@ -249,6 +249,7 @@ impl LedgerWalletCapability {
 
             // This is deprecated. Not sure what the alternative is,
             // other than implementing it ourselves.
+            #[allow(deprecated)]
             let t_addrs = zcash_primitives::legacy::keys::pubkey_to_address(&t_pubkey);
             let ua = UnifiedAddress::from_receivers(None, None, Some(t_addrs));
 
@@ -264,7 +265,7 @@ impl LedgerWalletCapability {
                     self.addresses_write_lock
                         .swap(false, atomic::Ordering::Release);
                     return Err(
-                        "Invalid receivers requested! At least one of sapling or transparent required, orchard is not support"
+                        "Invalid receivers requested! At least one of sapling or transparent required, orchard is not supported"
                             .to_string(),
                     );
                 }

--- a/zingolib/src/wallet/keys/ledger.rs
+++ b/zingolib/src/wallet/keys/ledger.rs
@@ -1,0 +1,802 @@
+use ripemd160::Ripemd160;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::sync::atomic::{self, AtomicBool};
+use std::sync::RwLock;
+use std::{
+    collections::{HashMap, HashSet},
+    io::{self, Read, Write},
+};
+
+use append_only_vec::AppendOnlyVec;
+// use bip0039::Mnemonic;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use ledger_transport::Exchange;
+use ledger_transport_hid::{LedgerHIDError, TransportNativeHID};
+use ledger_zcash::builder::BuilderError;
+use ledger_zcash::{LedgerAppError, ZcashApp};
+// use orchard::keys::Scope;
+
+use sapling_crypto::keys::OutgoingViewingKey;
+use sapling_crypto::{PaymentAddress, SaplingIvk};
+use secp256k1::PublicKey as SecpPublicKey;
+// use secp256k1::SecretKey;
+use zcash_address::unified::Ufvk;
+use zcash_client_backend::address::UnifiedAddress;
+// use zcash_client_backend::keys::{Era, UnifiedSpendingKey};
+use zcash_primitives::{
+    legacy::TransparentAddress,
+    zip32::{ChildIndex, DiversifierIndex},
+};
+
+use sapling_crypto::Diversifier;
+
+use zingoconfig::ZingoConfig;
+use zx_bip44::BIP44Path;
+
+use crate::wallet::traits::ReadableWriteable;
+
+// use super::{
+//     extended_transparent::{ExtendedPrivKey, ExtendedPubKey, KeyIndex},
+//     get_zaddr_from_bip39seed, ToBase58Check,
+// };
+//
+use super::unified::{Capability, ReceiverSelection};
+
+#[derive(Debug, thiserror::Error)]
+pub enum LedgerError {
+    #[error("Error: unable to create keystore")]
+    InitializationError(#[from] LedgerHIDError),
+
+    #[error("Error: error from inner builder: {}", .0)]
+    Builder(#[from] BuilderError),
+    #[error("Error: error when communicating with ledger: {}", .0)]
+    Ledger(#[from] LedgerAppError<<TransportNativeHID as Exchange>::Error>),
+
+    #[error("Error: the provided derivation path length was invalid, expected {} elements", .0)]
+    InvalidPathLength(usize),
+    #[error("Error: unable to parse public key returned from ledger")]
+    InvalidPublicKey,
+
+    #[error("Error: attempted to overflow diversifier index")]
+    DiversifierIndexOverflow,
+
+    #[error("Error: requested key was not found in keystore")]
+    KeyNotFound,
+}
+
+impl From<LedgerError> for std::io::Error {
+    fn from(err: LedgerError) -> Self {
+        use std::io::ErrorKind;
+
+        let kind = match &err {
+            LedgerError::InitializationError(_) => ErrorKind::InvalidInput,
+            LedgerError::Ledger(_) => ErrorKind::BrokenPipe,
+            LedgerError::Builder(_)
+            | LedgerError::InvalidPathLength(_)
+            | LedgerError::InvalidPublicKey
+            | LedgerError::DiversifierIndexOverflow
+            | LedgerError::KeyNotFound => ErrorKind::InvalidData,
+        };
+
+        std::io::Error::new(kind, err)
+    }
+}
+
+pub struct LedgerWalletCapability {
+    app: ZcashApp<TransportNativeHID>,
+
+    pub transparent: Capability<
+        super::extended_transparent::ExtendedPubKey,
+        super::extended_transparent::ExtendedPrivKey,
+    >,
+    pub sapling: Capability<
+        sapling_crypto::zip32::DiversifiableFullViewingKey,
+        sapling_crypto::zip32::ExtendedSpendingKey,
+    >,
+    // Even though ledger application does not support orchard protocol
+    // we keep this field just for "compatibility" but always set to Capability::None
+    pub orchard: Capability<orchard::keys::FullViewingKey, orchard::keys::SpendingKey>,
+
+    // transparent_child_keys: append_only_vec::AppendOnlyVec<(usize, secp256k1::SecretKey)>,
+    // addresses: append_only_vec::AppendOnlyVec<UnifiedAddress>,
+    // Not all diversifier indexes produce valid sapling addresses.
+    // Because of this, the index isn't necessarily equal to addresses.len()
+    // addresses_write_lock: AtomicBool,
+    //this is a public key with a specific path
+    // used to "identify" a ledger
+    // this is useful to detect when a different ledger
+    // is connected instead of the one used with the keystore
+    // originally
+    ledger_id: SecpPublicKey,
+
+    transparent_addrs: RwLock<BTreeMap<[u32; 5], SecpPublicKey>>,
+
+    //associated a path with an ivk and the default diversifier
+    shielded_addrs: RwLock<BTreeMap<[u32; 3], (SaplingIvk, Diversifier, OutgoingViewingKey)>>,
+
+    pub(crate) addresses: append_only_vec::AppendOnlyVec<UnifiedAddress>,
+    // Not all diversifier indexes produce valid sapling addresses.
+    // Because of this, the index isn't necessarily equal to addresses.len()
+    pub(crate) addresses_write_lock: AtomicBool,
+}
+
+impl std::fmt::Debug for LedgerWalletCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LedgerWalletCapability")
+            .field("app", &"ledger-app by Zondax")
+            .field("transparent", &self.transparent)
+            .field("sapling", &self.sapling)
+            .field("orchard", &self.orchard)
+            // .field("transparent_child_keys", &self.transparent_child_keys)
+            // .field("addresses", &self.addresses)
+            .field("transparent_addrs", &self.transparent_addrs)
+            .field("shielded_addrs", &self.shielded_addrs)
+            // .field("addresses_write_lock", &self.addresses_write_lock)
+            .field("ledger_id", &self.ledger_id)
+            .finish()
+    }
+}
+
+impl LedgerWalletCapability {
+    /// Retrieve the connected ledger's "ID"
+    ///
+    /// Uses 44'/1'/0/0/0 derivation path
+    async fn get_id(app: &ZcashApp<TransportNativeHID>) -> Result<SecpPublicKey, LedgerError> {
+        app.get_address_unshielded(
+            &BIP44Path([44 + 0x8000_0000, 1 + 0x8000_0000, 0, 0, 0]),
+            false,
+        )
+        .await
+        .map_err(Into::into)
+        .and_then(|addr| {
+            SecpPublicKey::from_slice(&addr.public_key).map_err(|_| LedgerError::InvalidPublicKey)
+        })
+    }
+
+    /// Attempt to create a handle to a ledger zcash ap
+    ///
+    /// Will attempt to connect to the first available device,
+    /// but won't verify that the correct app is open or that is a "known" device
+    fn connect_ledger() -> Result<ZcashApp<TransportNativeHID>, LedgerError> {
+        let hidapi = ledger_transport_hid::hidapi::HidApi::new().map_err(LedgerHIDError::Hid)?;
+
+        let transport = TransportNativeHID::new(&hidapi)?;
+        let app = ZcashApp::new(transport);
+
+        Ok(app)
+    }
+
+    pub fn new() -> Result<Self, LedgerError> {
+        let app = Self::connect_ledger()?;
+        let ledger_id = futures::executor::block_on(Self::get_id(&app))?;
+
+        Ok(Self {
+            app,
+            ledger_id,
+            // TODO: keep these fields just for compatibility
+            // but ledger application is not limited by this.
+            sapling: Capability::None,
+            transparent: Capability::None,
+            orchard: Capability::None,
+            // transparent_child_keys: AppendOnlyVec::new(),
+            transparent_addrs: Default::default(),
+            shielded_addrs: Default::default(),
+            addresses: AppendOnlyVec::new(),
+            addresses_write_lock: AtomicBool::new(false),
+        })
+    }
+
+    pub(crate) fn get_ua_from_contained_transparent_receiver(
+        &self,
+        receiver: &TransparentAddress,
+    ) -> Option<UnifiedAddress> {
+        self.addresses
+            .iter()
+            .find(|ua| ua.transparent() == Some(receiver))
+            .cloned()
+    }
+
+    // TODO: in our ledger-app integration we do keep a list of paths
+    // not pub/priv keys so it is necessary to figure out how to compute
+    // unified addresses from that list.
+    pub fn addresses(&self) -> &AppendOnlyVec<UnifiedAddress> {
+        &self.addresses
+    }
+
+    // TODO: Incompatible as secrets will never leave the ledger
+    // device.
+    pub fn transparent_child_keys(
+        &self,
+    ) -> Result<&AppendOnlyVec<(usize, secp256k1::SecretKey)>, String> {
+        unimplemented!()
+    }
+
+    // TODO: This currently not supported by ledger application
+    pub(crate) fn ufvk(&self) -> Result<Ufvk, zcash_address::unified::ParseError> {
+        unimplemented!()
+    }
+
+    pub fn new_address(
+        &self,
+        desired_receivers: ReceiverSelection,
+        config: &ZingoConfig,
+    ) -> Result<UnifiedAddress, String> {
+        // Our wallet capability in this case our ledger application
+        // does not make distinction in either it can or not spend or view.
+        // so here we do check for the supported protocols, transparent and sappling
+        if !desired_receivers.transparent || !desired_receivers.sapling {
+            return Err("The wallet is not capable of producing desired receivers.".to_string());
+        }
+
+        let previous_num_addresses = self.addresses.len();
+
+        if desired_receivers.transparent {
+            let count = self
+                .transparent_addrs
+                .read()
+                .map_err(|e| format!("Error: {e}"))?
+                .len();
+
+            let path = Self::t_derivation_path(config.get_coin_type(), count as _);
+
+            let t_pubkey = futures::executor::block_on(self.get_t_pubkey(&path))
+                .map_err(|e| format!("Error: {e}"))?;
+
+            let mut path_u32 = [0u32; 5];
+            path.into_iter()
+                .map(|idx| idx.index())
+                .zip(path_u32.iter_mut())
+                .for_each(|(a, b)| *b = a);
+
+            // This is deprecated. Not sure what the alternative is,
+            // other than implementing it ourselves.
+            let t_addrs = zcash_primitives::legacy::keys::pubkey_to_address(&t_pubkey);
+            let ua = UnifiedAddress::from_receivers(None, None, Some(t_addrs));
+
+            if self
+                .addresses_write_lock
+                .swap(true, atomic::Ordering::Acquire)
+            {
+                return Err("addresses_write_lock collision!".to_string());
+            }
+            let ua = match ua {
+                Some(address) => address,
+                None => {
+                    self.addresses_write_lock
+                        .swap(false, atomic::Ordering::Release);
+                    return Err(
+                        "Invalid receivers requested! At least one of sapling or transparent required, orchard is not support"
+                            .to_string(),
+                    );
+                }
+            };
+
+            // TODO: Do we want to keep to separate lists for transparent address and keys?
+            // what is appending in one fails whereas the other succeded?
+            self.addresses.push(ua.clone());
+
+            assert_eq!(self.addresses.len(), previous_num_addresses + 1);
+            self.addresses_write_lock
+                .swap(false, atomic::Ordering::Release);
+
+            self.transparent_addrs
+                .write()
+                .map(|mut w| w.insert(path_u32, t_pubkey))
+                .map_err(|e| format!("Error: {e}"))?;
+        }
+
+        todo!("Do the same for shielded address, sapling");
+    }
+
+    pub const fn t_derivation_path(coin_type: u32, index: u32) -> [ChildIndex; 5] {
+        [
+            ChildIndex::hardened(44),
+            ChildIndex::hardened(coin_type),
+            ChildIndex::hardened(0),
+            // TODO: Bellow child_index in our lib are meant to be normal
+            // not hardened, but seems zingolib fork of this library
+            // uses only hardened fields in path????
+            ChildIndex::hardened(0),
+            ChildIndex::hardened(index),
+        ]
+    }
+
+    /// Create a new transparent address with path +1 from the latest one
+    pub fn add_taddr(&self, config: &ZingoConfig) -> Result<String, String> {
+        //find the highest path we have
+        let taddrs = self
+            .transparent_addrs
+            .read()
+            .map_err(|e| format!("Error: {e}"))?;
+        let count = taddrs.len();
+
+        let path = taddrs
+            .keys()
+            .last()
+            .cloned()
+            .map(|path| {
+                [
+                    // TODO: last two fields should not be hardened
+                    // but this is what the zcash-primitives provides
+                    ChildIndex::hardened(path[0]),
+                    ChildIndex::hardened(path[1]),
+                    ChildIndex::hardened(path[2]),
+                    ChildIndex::hardened(path[3]),
+                    ChildIndex::hardened(path[4] + 1),
+                ]
+            })
+            // TODO: define how to choose a proper acount, we are using the number of
+            // current taddresses
+            .unwrap_or_else(|| Self::t_derivation_path(config.get_coin_type(), count as _));
+
+        // do not hold any lock longer
+        drop(taddrs);
+
+        let key = futures::executor::block_on(self.get_t_pubkey(&path));
+
+        match key {
+            Ok(key) => {
+                // tpk is of type secp256k1 so
+                // 1. we need to serialize it.
+                // 2. compute its sha256
+                // 3. comput its ripemd160
+                let serialize_key = key.serialize();
+                let sha256_hash = Sha256::digest(&serialize_key);
+                let hash = Ripemd160::digest(sha256_hash.as_slice());
+                Ok(super::ToBase58Check::to_base58check(
+                    hash.as_slice(),
+                    &config.base58_pubkey_address(),
+                    &[],
+                ))
+            }
+            Err(e) => Err(format!("Error: {:?}", e.to_string())),
+        }
+    }
+
+    async fn get_t_pubkey(&self, path: &[ChildIndex]) -> Result<SecpPublicKey, LedgerError> {
+        let path = Self::path_slice_to_bip44(path)?;
+        let Ok(cached) = self.transparent_addrs.read() else {
+            return Err(LedgerError::InvalidPublicKey);
+        };
+
+        let key = cached.get(&path.0).copied();
+        drop(cached);
+
+        match key {
+            Some(key) => Ok(key),
+            None => {
+                let addr = self.app.get_address_unshielded(&path, false).await?;
+
+                let pkey = SecpPublicKey::from_slice(&addr.public_key)
+                    .map_err(|_| LedgerError::InvalidPublicKey)?;
+                self.transparent_addrs
+                    .write()
+                    .expect("Failed to get transparent_addrs RwLock")
+                    .insert(path.0, pkey);
+
+                Ok(pkey)
+            }
+        }
+    }
+
+    fn path_slice_to_bip44(path: &[ChildIndex]) -> Result<BIP44Path, LedgerError> {
+        let path = path
+            .iter()
+            .take(5)
+            .map(|child| child.index())
+            .collect::<Vec<_>>();
+
+        BIP44Path::from_slice(path.as_slice()).map_err(|_| LedgerError::InvalidPathLength(5))
+    }
+
+    // TODO: Incompatible with our ledger-application as secrets never leave the device
+    pub fn get_taddr_to_secretkey_map(
+        &self,
+        _config: &ZingoConfig,
+    ) -> Result<HashMap<String, secp256k1::SecretKey>, String> {
+        // Secrects will never leave the ledger device
+        // so this method does not makes sense.
+        unimplemented!()
+    }
+
+    pub(crate) fn get_all_taddrs(&self, config: &ZingoConfig) -> HashSet<String> {
+        let Ok(taddrs) = self.transparent_addrs.read() else {
+            return Default::default();
+        };
+
+        taddrs
+            .iter()
+            .map(|(_, tpk)| {
+                // tpk is of type secp256k1 so
+                // 1. we need to serialize it.
+                // 2. compute its sha256
+                // 3. comput its ripemd160
+                let serialize_key = tpk.serialize();
+                let sha256_hash = Sha256::digest(&serialize_key);
+                let hash = Ripemd160::digest(sha256_hash.as_slice());
+                super::ToBase58Check::to_base58check(
+                    hash.as_slice(),
+                    &config.base58_pubkey_address(),
+                    &[],
+                )
+            })
+            .collect()
+    }
+
+    pub fn first_sapling_address(&self) -> sapling_crypto::PaymentAddress {
+        let Ok(saddrs) = self.shielded_addrs.try_read() else {
+            unreachable!()
+        };
+
+        // shielded_addrs: RwLock<BTreeMap<[u32; 3], (SaplingIvk, Diversifier, OutgoingViewingKey)>>,
+        let path = saddrs
+            .keys()
+            .next()
+            .cloned()
+            .expect("No sapling address available");
+
+        self.payment_address_from_path(&path)
+            .expect("Error computing paymentAddress")
+    }
+
+    /// Attempt to lookup stored data for given path and compute payment address thereafter
+    pub fn payment_address_from_path(&self, path: &[u32; 3]) -> Option<PaymentAddress> {
+        let Ok(saddrs) = self.shielded_addrs.try_read() else {
+            return None;
+        };
+
+        saddrs
+            .get(path)
+            .and_then(|(ivk, d, _)| ivk.to_payment_address(*d))
+    }
+
+    /// Returns a selection of pools where the wallet can spend funds.
+    pub fn can_spend_from_all_pools(&self) -> bool {
+        // TODO: as a ledger application, we can either view or spend
+        // as our keys lives there.
+        // self.sapling.can_spend() && self.transparent.can_spend()
+        true
+    }
+
+    //TODO: NAME?????!!
+    pub fn get_trees_witness_trees(&self) -> Option<crate::wallet::data::WitnessTrees> {
+        if self.can_spend_from_all_pools() {
+            Some(crate::wallet::data::WitnessTrees::default())
+        } else {
+            None
+        }
+    }
+    /// Returns a selection of pools where the wallet can view funds.
+    pub fn can_view(&self) -> ReceiverSelection {
+        // Not sure why this distintion which seems incompatible
+        // with our ledger application.
+        ReceiverSelection {
+            orchard: false,
+            sapling: true,
+            transparent: true,
+        }
+    }
+
+    fn read_version<R: Read>(reader: &mut R) -> io::Result<u8> {
+        let version = reader.read_u8()?;
+
+        Ok(version)
+    }
+
+    /// Retrieve the defualt diversifier from a given device and path
+    ///
+    /// The defualt diversifier is the first valid diversifier starting
+    /// from index 0
+    async fn get_default_diversifier_from(
+        app: &ZcashApp<TransportNativeHID>,
+        idx: u32,
+    ) -> Result<Diversifier, LedgerError> {
+        let mut index = DiversifierIndex::new();
+
+        loop {
+            let divs = app.get_div_list(idx, &index.as_bytes()).await?;
+            let divs: &[[u8; 11]] = bytemuck::cast_slice(&divs);
+
+            //find the first div that is not all 0s
+            // all 0s is when it's an invalid diversifier
+            for div in divs {
+                if div != &[0; 11] {
+                    return Ok(Diversifier(*div));
+                }
+
+                //increment the index for each diversifier returned
+                index
+                    .increment()
+                    .map_err(|_| LedgerError::DiversifierIndexOverflow)?;
+            }
+        }
+    }
+}
+
+impl ReadableWriteable<()> for LedgerWalletCapability {
+    const VERSION: u8 = 2;
+
+    fn read<R: Read>(mut reader: R, _input: ()) -> io::Result<Self> {
+        let version = Self::read_version(&mut reader)?;
+
+        if version > Self::VERSION {
+            let e = format!(
+                "Don't know how to read ledger wallet version {}. Do you have the latest version?",
+                version
+            );
+            return Err(io::Error::new(io::ErrorKind::InvalidData, e));
+        }
+
+        //retrieve the ledger id and verify it matches with the aocnnected device
+        let ledger_id = {
+            let mut buf = [0; secp256k1::constants::PUBLIC_KEY_SIZE];
+            reader.read_exact(&mut buf)?;
+
+            SecpPublicKey::from_slice(&buf).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Bad public key stored for ledger id: {:?}", e),
+                )
+            })?
+        };
+
+        let app = Self::connect_ledger()?;
+        // lets used futures simpler executor
+        if ledger_id != futures::executor::block_on(Self::get_id(&app))? {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Detected different ledger than used previously".to_string(),
+            ));
+        }
+
+        //read the transparent paths
+        // the keys will be retrieved one by one from the device
+        let transparent_addrs_len = reader.read_u64::<LittleEndian>()?;
+        let mut transparent_addrs = BTreeMap::new();
+        for _ in 0..transparent_addrs_len {
+            let path = {
+                let mut buf = [0; 4 * 5];
+                reader.read_exact(&mut buf)?;
+
+                let path_bytes: [[u8; 4]; 5] = bytemuck::cast(buf);
+                [
+                    u32::from_le_bytes(path_bytes[0]),
+                    u32::from_le_bytes(path_bytes[1]),
+                    u32::from_le_bytes(path_bytes[2]),
+                    u32::from_le_bytes(path_bytes[3]),
+                    u32::from_le_bytes(path_bytes[4]),
+                ]
+            };
+
+            let key =
+                futures::executor::block_on(app.get_address_unshielded(&BIP44Path(path), false))
+                    .map_err(LedgerError::Ledger)?
+                    .public_key;
+            let key = SecpPublicKey::from_slice(&key).map_err(|_| LedgerError::InvalidPublicKey)?;
+
+            transparent_addrs.insert(path, key);
+        }
+
+        //read the transparent(maybe shielded)? paths
+        // the keys and the diversifiers
+        // will be retrieved one by one from the device
+        let shielded_addrs_len = reader.read_u64::<LittleEndian>()?;
+        let mut shielded_addrs = BTreeMap::new();
+        for _ in 0..shielded_addrs_len {
+            let path = {
+                let mut buf = [0; 4 * 3];
+                reader.read_exact(&mut buf)?;
+
+                let path_bytes: [[u8; 4]; 3] = bytemuck::cast(buf);
+                [
+                    u32::from_le_bytes(path_bytes[0]),
+                    u32::from_le_bytes(path_bytes[1]),
+                    u32::from_le_bytes(path_bytes[2]),
+                ]
+            };
+
+            //ZIP32 uses fixed path, so the actual index
+            // is only the latest element
+            let idx = path[2];
+
+            let ivk = futures::executor::block_on(app.get_ivk(idx))
+                .map_err(LedgerError::Ledger) // Convert any errors.
+                .and_then(|ivk| {
+                    let sa = jubjub::Fr::from_bytes(&ivk).map(SaplingIvk);
+                    if sa.is_some().unwrap_u8() == 1 {
+                        Ok(sa.unwrap())
+                    } else {
+                        Err(LedgerError::InvalidPublicKey)
+                    }
+                })?;
+
+            let div = futures::executor::block_on(Self::get_default_diversifier_from(&app, idx))?;
+
+            let ovk = futures::executor::block_on(app.get_ovk(idx))
+                .map(OutgoingViewingKey)
+                .map_err(LedgerError::Ledger)?;
+
+            shielded_addrs.insert(path, (ivk, div, ovk));
+        }
+        // let receiver_selections = Vector::read(reader, |r| ReceiverSelection::read(r, ()))?;
+        // let addresses = append_only_vec::AppendOnlyVec::new();
+        let wc = Self {
+            app,
+            ledger_id,
+            transparent_addrs: RwLock::new(transparent_addrs),
+            shielded_addrs: RwLock::new(shielded_addrs),
+            orchard: Capability::None,
+            transparent: Capability::None,
+            sapling: Capability::None,
+            addresses: append_only_vec::AppendOnlyVec::new(),
+            addresses_write_lock: AtomicBool::new(false),
+        };
+
+        // TODO: how to conciliate this? reader does not know anything about
+        // configuration, but our ledger application requires almost full paths which uses
+        // coin_type and account.
+        // for rs in receiver_selections {
+        //     wc.new_address(rs)
+        //         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        // }
+        //
+        Ok(wc)
+    }
+
+    fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        writer.write_u8(Self::VERSION)?;
+        let id = self.ledger_id.serialize();
+        writer.write_all(&id)?;
+
+        //write the transparent paths
+        let transparent_paths = match self.transparent_addrs.try_read() {
+            Ok(locked_addrs) => locked_addrs
+                .keys()
+                .map(|path| {
+                    [
+                        path[0].to_le_bytes(),
+                        path[1].to_le_bytes(),
+                        path[2].to_le_bytes(),
+                        path[3].to_le_bytes(),
+                        path[4].to_le_bytes(),
+                    ]
+                })
+                .map(|path_bytes| bytemuck::cast(path_bytes))
+                .collect::<Vec<[u8; 4 * 5]>>(),
+            Err(_) => {
+                // Return an empty vector if the lock cannot be acquired
+                Vec::new()
+            }
+        };
+        writer.write_u64::<LittleEndian>(transparent_paths.len() as u64)?;
+        for path in transparent_paths {
+            writer.write_all(&path)?;
+        }
+
+        //write the shielded paths
+        let shielded_paths = match self.shielded_addrs.try_read() {
+            Ok(locked_addrs) => locked_addrs
+                .keys()
+                .map(|path| {
+                    [
+                        path[0].to_le_bytes(),
+                        path[1].to_le_bytes(),
+                        path[2].to_le_bytes(),
+                    ]
+                })
+                .map(|path_bytes| bytemuck::cast::<_, [u8; 4 * 3]>(path_bytes))
+                .collect::<Vec<[u8; 4 * 3]>>(),
+            Err(_) => {
+                // Return an empty vector if the lock cannot be acquired
+                Vec::new()
+            }
+        };
+
+        writer.write_u64::<LittleEndian>(shielded_paths.len() as u64)?;
+        for path in shielded_paths {
+            writer.write_all(&path)?;
+        }
+
+        Ok(())
+    }
+}
+
+// TODO: Incompatible secrets must not live ledger device
+impl TryFrom<&LedgerWalletCapability> for super::extended_transparent::ExtendedPrivKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+// TODO: Incompatible secrets must not live ledger device
+impl TryFrom<&LedgerWalletCapability> for sapling_crypto::zip32::ExtendedSpendingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+// TODO: Incompatible secrets must not live ledger device
+impl TryFrom<&LedgerWalletCapability> for orchard::keys::SpendingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        // Ledger application does not support orchard!
+        unimplemented!()
+    }
+}
+
+impl TryFrom<&LedgerWalletCapability> for super::extended_transparent::ExtendedPubKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+impl TryFrom<&LedgerWalletCapability> for orchard::keys::FullViewingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+impl TryFrom<&LedgerWalletCapability> for sapling_crypto::zip32::DiversifiableFullViewingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+impl TryFrom<&LedgerWalletCapability>
+    for sapling_crypto::note_encryption::PreparedIncomingViewingKey
+{
+    type Error = String;
+
+    fn try_from(_value: &LedgerWalletCapability) -> Result<Self, Self::Error> {
+        unimplemented!()
+    }
+}
+
+// TODO: Orchard is not supported by ledger application
+impl TryFrom<&LedgerWalletCapability> for orchard::keys::IncomingViewingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        // Ledger application does not support orchard!
+        unimplemented!()
+    }
+}
+
+// TODO: Orchard is not supported by ledger application
+impl TryFrom<&LedgerWalletCapability> for orchard::keys::PreparedIncomingViewingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+// TODO: Ledger application supports ivk but we need a BIP44Path
+// somehow we need to pass it so that in here we just call self.get_ivk()
+impl TryFrom<&LedgerWalletCapability> for sapling_crypto::SaplingIvk {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+// TODO: Orchard is not supported by ledger application
+impl TryFrom<&LedgerWalletCapability> for orchard::keys::OutgoingViewingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}
+
+// TODO: Ledger application supports ovk but we need a BIP44Path
+// somehow we need to pass it so that in here we just call self.get_ovk()
+impl TryFrom<&LedgerWalletCapability> for sapling_crypto::keys::OutgoingViewingKey {
+    type Error = String;
+    fn try_from(_wc: &LedgerWalletCapability) -> Result<Self, String> {
+        unimplemented!()
+    }
+}

--- a/zingolib/src/wallet/keys/ledger.rs
+++ b/zingolib/src/wallet/keys/ledger.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use append_only_vec::AppendOnlyVec;
+use hdwallet::KeyIndex;
 // use bip0039::Mnemonic;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use ledger_transport::Exchange;
@@ -24,10 +25,7 @@ use secp256k1::PublicKey as SecpPublicKey;
 use zcash_address::unified::Ufvk;
 use zcash_client_backend::address::UnifiedAddress;
 // use zcash_client_backend::keys::{Era, UnifiedSpendingKey};
-use zcash_primitives::{
-    legacy::TransparentAddress,
-    zip32::{ChildIndex, DiversifierIndex},
-};
+use zcash_primitives::{legacy::TransparentAddress, zip32::DiversifierIndex};
 
 use sapling_crypto::Diversifier;
 
@@ -245,7 +243,7 @@ impl LedgerWalletCapability {
 
             let mut path_u32 = [0u32; 5];
             path.into_iter()
-                .map(|idx| idx.index())
+                .map(|idx| idx.raw_index())
                 .zip(path_u32.iter_mut())
                 .for_each(|(a, b)| *b = a);
 
@@ -289,16 +287,13 @@ impl LedgerWalletCapability {
         todo!("Do the same for shielded address, sapling");
     }
 
-    pub const fn t_derivation_path(coin_type: u32, index: u32) -> [ChildIndex; 5] {
+    pub fn t_derivation_path(coin_type: u32, index: u32) -> [KeyIndex; 5] {
         [
-            ChildIndex::hardened(44),
-            ChildIndex::hardened(coin_type),
-            ChildIndex::hardened(0),
-            // TODO: Bellow child_index in our lib are meant to be normal
-            // not hardened, but seems zingolib fork of this library
-            // uses only hardened fields in path????
-            ChildIndex::hardened(0),
-            ChildIndex::hardened(index),
+            KeyIndex::hardened_from_normalize_index(44).expect("unreachable"),
+            KeyIndex::hardened_from_normalize_index(coin_type).expect("unreachable"),
+            KeyIndex::hardened_from_normalize_index(0).expect("unreachable"),
+            KeyIndex::from_index(0).expect("unreachable"),
+            KeyIndex::from_index(index).expect("unreachable"),
         ]
     }
 
@@ -317,13 +312,11 @@ impl LedgerWalletCapability {
             .cloned()
             .map(|path| {
                 [
-                    // TODO: last two fields should not be hardened
-                    // but this is what the zcash-primitives provides
-                    ChildIndex::hardened(path[0]),
-                    ChildIndex::hardened(path[1]),
-                    ChildIndex::hardened(path[2]),
-                    ChildIndex::hardened(path[3]),
-                    ChildIndex::hardened(path[4] + 1),
+                    KeyIndex::hardened_from_normalize_index(path[0]).expect("unreachable"),
+                    KeyIndex::hardened_from_normalize_index(path[1]).expect("unreachable"),
+                    KeyIndex::hardened_from_normalize_index(path[2]).expect("unreachable"),
+                    KeyIndex::from_index(path[3]).expect("unreachable"),
+                    KeyIndex::from_index(path[4] + 1).expect("unreachable"),
                 ]
             })
             // TODO: define how to choose a proper acount, we are using the number of
@@ -354,7 +347,7 @@ impl LedgerWalletCapability {
         }
     }
 
-    async fn get_t_pubkey(&self, path: &[ChildIndex]) -> Result<SecpPublicKey, LedgerError> {
+    async fn get_t_pubkey(&self, path: &[KeyIndex]) -> Result<SecpPublicKey, LedgerError> {
         let path = Self::path_slice_to_bip44(path)?;
         let Ok(cached) = self.transparent_addrs.read() else {
             return Err(LedgerError::InvalidPublicKey);
@@ -380,11 +373,11 @@ impl LedgerWalletCapability {
         }
     }
 
-    fn path_slice_to_bip44(path: &[ChildIndex]) -> Result<BIP44Path, LedgerError> {
+    fn path_slice_to_bip44(path: &[KeyIndex]) -> Result<BIP44Path, LedgerError> {
         let path = path
             .iter()
             .take(5)
-            .map(|child| child.index())
+            .map(|child| child.raw_index())
             .collect::<Vec<_>>();
 
         BIP44Path::from_slice(path.as_slice()).map_err(|_| LedgerError::InvalidPathLength(5))

--- a/zingolib/src/wallet/notes.rs
+++ b/zingolib/src/wallet/notes.rs
@@ -10,7 +10,7 @@ use zcash_primitives::{
 
 use super::{
     data::TransactionRecord,
-    keys::unified::WalletCapability,
+    keys::keystore::Keystore,
     traits::{FromBytes, FromCommitment, Nullifier, ReadableWriteable, ToBytes},
     Pool,
 };
@@ -20,9 +20,7 @@ use super::{
 pub trait ShieldedNoteInterface: Sized {
     type Diversifier: Copy + FromBytes<11> + ToBytes<11>;
 
-    type Note: PartialEq
-        + for<'a> ReadableWriteable<(Self::Diversifier, &'a WalletCapability)>
-        + Clone;
+    type Note: PartialEq + for<'a> ReadableWriteable<(Self::Diversifier, &'a Keystore)> + Clone;
     type Node: Hashable + HashSer + FromCommitment + Send + Clone + PartialEq + Eq;
     type Nullifier: Nullifier;
 

--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -177,7 +177,7 @@ impl TransactionRecord {
     pub fn read<R: Read>(
         mut reader: R,
         (wallet_capability, mut trees): (
-            &WalletCapability,
+            &Keystore,
             Option<&mut (
                 Vec<(
                     IncrementalWitness<sapling_crypto::Node, COMMITMENT_TREE_LEVELS>,

--- a/zingolib/src/wallet/transactions/read_write.rs
+++ b/zingolib/src/wallet/transactions/read_write.rs
@@ -6,7 +6,7 @@ use std::{
 use zcash_encoding::{Optional, Vector};
 use zcash_primitives::transaction::TxId;
 
-use crate::wallet::{data::TransactionRecord, keys::unified::WalletCapability, WitnessTrees};
+use crate::wallet::{data::TransactionRecord, keys::keystore::Keystore, WitnessTrees};
 
 use super::TransactionMetadataSet;
 impl TransactionMetadataSet {
@@ -14,10 +14,7 @@ impl TransactionMetadataSet {
         22
     }
 
-    pub fn read_old<R: Read>(
-        mut reader: R,
-        wallet_capability: &WalletCapability,
-    ) -> io::Result<Self> {
+    pub fn read_old<R: Read>(mut reader: R, wallet_capability: &Keystore) -> io::Result<Self> {
         // Note, witness_trees will be Some(x) if the wallet has spend capability
         // so this check is a very un-ergonomic way of checking if the wallet
         // can spend.
@@ -63,7 +60,7 @@ impl TransactionMetadataSet {
         })
     }
 
-    pub fn read<R: Read>(mut reader: R, wallet_capability: &WalletCapability) -> io::Result<Self> {
+    pub fn read<R: Read>(mut reader: R, wallet_capability: &Keystore) -> io::Result<Self> {
         let version = reader.read_u64::<LittleEndian>()?;
         if version > Self::serialized_version() {
             return Err(io::Error::new(


### PR DESCRIPTION
This draft PR introduces a foundational step towards secure hardware wallet support within zingolib by integrating a custom ledger application. 
### Changes
- **Keystore Abstraction:** Introduced a new abstraction layer, Keystore, as an enum with two variants: WalletCapability for the existing in-memory wallet functionality, and LedgerWalletCapability for the new ledger integration. This allows for seamless switching between wallet types and makes future extensions possible and easy.

- **Ledger Wallet Capability:** The LedgerWalletCapability encapsulates all interactions with the Ledger device, including transaction signing(not supported yet) and address generation.

- **Support for Sapling and Transparent Addresses:** The ledger application currently supports sapling and transparent addresses, orchard protocol is not supported yet by the ledger-app.

### Challenges
- **Integration with In-memory Key Architecture:** Adapting the ledger's secure key management approach to fit within zingolib's architecture, which currently relies on in-memory keys, poses a significant challenge. This required careful design to ensure that cryptographic operations are executed on the Ledger device, with zingolib managing only the operations that do not involve direct access to private keys, usually done through the TryFrom trait.
- **Partial Address Support:** Currently, the integration does not support orchard and unified addresses. The support for Orchard is not part of the scope of implementing this feature in zingolib but in the ledger-app.
- **Data storage:** Currently we are unable to read address data from wallet.dat file which is used to store important metadata like addresses and key parameters. This is due to the way the ledger app operates.
-  ** Understanding zingolib architecture:** The current integration effort can be improved by a better understanding of the zingo architecture to ensure a seamlessly integration that would facilitate further integration of new features.
- **Types differences:** There are some conflicts between our Rust library and zingolib, the differences are more related to versioning and API compatibility.


There are some TODOs in the code and comments explaining the reason.
This initial integration is still not functional, in order to get there more changes have to be done in:
- Defining how many metadata file the app supports and if differentiating from in memory or ledger-app ones is desirable.
- Proper changes on the UI
- Add support for sapling addresses
- Transaction signing would possibly require adding another abstraction, which for the ledger app is provided via ledger-zcash-rs
- Modifying ledger-zcash-rs library, in order to use raw data, could make easy further integration efforts, decoupling other libraries and relying on simple conversion, for example:  `PublicKey::from_slice()`, and so on.



