### PR TITLE
Fix RUSTSEC-2024-0019

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",


### PR DESCRIPTION
(cherry picked from commit cd99cd426456adefab53d5230075ca345998b4f4)