### PR TITLE
stabilize rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.75.0"
-
+components = [ "clippy", "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 components = [ "clippy", "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.75.0"
+


### PR DESCRIPTION
The current stable version is already built this way. By locking it in, it becomes more stable.