### PR TITLE
Dependabot updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "append-only-vec"
@@ -651,10 +651,9 @@ name = "darkside-tests"
 version = "0.1.0"
 dependencies = [
  "bech32",
- "bip0039",
  "env_logger",
  "futures-util",
- "hex 0.3.2",
+ "hex",
  "http",
  "http-body",
  "hyper",
@@ -1196,12 +1195,6 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-
-[[package]]
-name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
@@ -1416,8 +1409,7 @@ dependencies = [
 name = "integration-tests"
 version = "0.2.0"
 dependencies = [
- "bip0039",
- "hex 0.3.2",
+ "hex",
  "http",
  "itertools 0.10.5",
  "json",
@@ -1898,7 +1890,7 @@ dependencies = [
  "group",
  "halo2_gadgets",
  "halo2_proofs",
- "hex 0.4.3",
+ "hex",
  "incrementalmerkletree",
  "lazy_static",
  "memuse",
@@ -2095,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2312,7 +2304,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "group",
- "hex 0.4.3",
+ "hex",
  "jubjub",
  "pasta_curves",
  "rand_core 0.6.4",
@@ -2409,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.25"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
+checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.5.0",
@@ -2687,7 +2679,7 @@ dependencies = [
  "ff",
  "fpe",
  "group",
- "hex 0.4.3",
+ "hex",
  "incrementalmerkletree",
  "jubjub",
  "lazy_static",
@@ -3022,20 +3014,20 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3080,18 +3072,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3468,7 +3460,7 @@ checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex 0.4.3",
+ "hex",
  "static_assertions",
 ]
 
@@ -3962,7 +3954,7 @@ dependencies = [
  "document-features",
  "group",
  "hdwallet",
- "hex 0.4.3",
+ "hex",
  "incrementalmerkletree",
  "memuse",
  "nom",
@@ -4050,7 +4042,7 @@ dependencies = [
  "fpe",
  "group",
  "hdwallet",
- "hex 0.4.3",
+ "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
@@ -4219,7 +4211,6 @@ dependencies = [
  "base58",
  "base64 0.13.1",
  "bech32",
- "bip0039",
  "bls12_381",
  "build_utils",
  "byteorder",
@@ -4230,7 +4221,7 @@ dependencies = [
  "ff",
  "futures",
  "group",
- "hex 0.3.2",
+ "hex",
  "http",
  "http-body",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ http-body = "0.4.4"
 tonic = {version = "0.10.0", features = ["tls", "tls-roots", "tls-webpki-roots"]}
 prost = "0.12.0"
 tower = { version = "0.4" }
+hex = "0.4"
 
 [profile.release]
 debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ shardtree = "0.2"
 build_utils = { path = "./build_utils" }
 http = "0.2.4"
 hyper = { version = "0.14", features = ["full"] }
+hyper-rustls = { version = "0.23", features = ["http2"] }
 http-body = "0.4.4"
 tonic = {version = "0.10.0", features = ["tls", "tls-roots", "tls-webpki-roots"]}
 prost = "0.12.0"

--- a/darkside-tests/Cargo.toml
+++ b/darkside-tests/Cargo.toml
@@ -18,6 +18,7 @@ tonic = { workspace = true }
 prost = { workspace = true }
 tower = { workspace = true }
 http-body = { workspace = true }
+hex = { workspace = true }
 
 zcash_primitives = { workspace = true }
 tempdir = { workspace = true }
@@ -25,7 +26,6 @@ portpicker = { workspace = true }
 env_logger = "0.10.0"
 bech32 = "0.9.0"
 rand = "0.8.5"
-hex = "0.3"
 tracing-subscriber = "0.3.15"
 itertools = "0.10.5"
 bip0039 = "0.10.1"

--- a/darkside-tests/Cargo.toml
+++ b/darkside-tests/Cargo.toml
@@ -28,7 +28,6 @@ bech32 = "0.9.0"
 rand = "0.8.5"
 tracing-subscriber = "0.3.15"
 itertools = "0.10.5"
-bip0039 = "0.10.1"
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,7 +18,7 @@ shardtree = { workspace = true }
 tokio = { version = "1.25.0", features = ["full"] }
 json = "0.12.4"
 log = "0.4.17"
-hex = "0.3"
+hex = { workspace = true }
 itertools = "0.10.5"
 bip0039 = "0.10.1"
 serde_json = "1.0.107"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,6 +20,5 @@ json = "0.12.4"
 log = "0.4.17"
 hex = { workspace = true }
 itertools = "0.10.5"
-bip0039 = "0.10.1"
 serde_json = "1.0.107"
 http.workspace = true

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 
-use bip0039::Mnemonic;
 use json::JsonValue;
 use orchard::tree::MerkleHashOrchard;
 use shardtree::store::memory::MemoryShardStore;
@@ -8,6 +7,7 @@ use shardtree::ShardTree;
 use std::{fs::File, path::Path, str::FromStr, time::Duration};
 use zcash_address::unified::Fvk;
 use zcash_client_backend::encoding::encode_payment_address;
+use zcash_primitives::zip339::Mnemonic;
 use zcash_primitives::{
     consensus::{BlockHeight, Parameters},
     memo::Memo,

--- a/zingocli/Cargo.toml
+++ b/zingocli/Cargo.toml
@@ -10,13 +10,13 @@ zingo-testutils = { path = "../zingo-testutils" }
 
 clap = { workspace = true }
 http = { workspace = true }
+hyper-rustls = { workspace = true }
 
 rustyline = "11.0.0"
 log = "0.4.17"
 shellwords = "1.1.0"
 futures = "0.3.15"
 rustls-pemfile = "1.0.0"
-hyper-rustls = { version = "0.23", features = ["http2"] }
 tokio =  { version = "1.24.2", features = ["full"] }
 tokio-stream = "0.1.6"
 tokio-rustls = "0.23.3"

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -53,7 +53,7 @@ reqwest = { version = "0.11", features = ["json"] }
 rustls-pemfile = "1.0.0"
 tower-http = { version = "0.2", features = ["add-extension"] }
 futures = { workspace = true }
-hex = "0.3"
+hex = { workspace = true }
 ring = "0.17.0"
 json = "0.12.4"
 webpki-roots = "0.21.0"

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -35,6 +35,7 @@ zcash_encoding = { workspace = true }
 zcash_note_encryption = { workspace = true }
 zcash_primitives = { workspace = true }
 zcash_proofs = { workspace = true }
+hyper-rustls = { workspace = true }
 
 append-only-vec = { git = "https://github.com/zancas/append-only-vec.git", branch = "add_debug_impl" }
 
@@ -44,7 +45,6 @@ log4rs = "1.1.1"
 base64 = "0.13.0"
 bytes = "0.4"
 rand = "0.8.5"
-hyper-rustls = { version = "0.23", features = ["http2"] }
 serde_json = "1.0.82"
 tokio =  { version = "1.24.2", features = ["full"] }
 tokio-stream = "0.1.6"
@@ -63,7 +63,6 @@ ripemd160 = "0.9.1"
 sha2 = "0.9.5"
 base58 = "0.1.0"
 bech32 = "0.9.0"
-bip0039 = "0.10.1"
 sodiumoxide = "0.2.5"
 byteorder = "1"
 pairing = "0.23"
@@ -73,7 +72,7 @@ bls12_381 = "0.8"
 group = "0.13"
 rust-embed = { version = "6.3.0", features = ["debug-embed"] }
 subtle = "2.4.1"
-nonempty = "0.7.0"
+nonempty = "0.7"
 tracing-subscriber = "0.3.15"
 tracing = "0.1.36"
 indoc = "2.0.1"

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -5,7 +5,6 @@ use crate::wallet::data::{SpendableSaplingNote, TransactionRecord};
 use crate::wallet::notes::NoteInterface;
 use crate::wallet::notes::ShieldedNoteInterface;
 
-use bip0039::Mnemonic;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use futures::Future;
 use json::JsonValue;
@@ -38,6 +37,7 @@ use zcash_primitives::transaction::builder::{BuildResult, Progress};
 use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 use zcash_primitives::transaction::fees::fixed::FeeRule as FixedFeeRule;
 use zcash_primitives::transaction::{self, Transaction};
+use zcash_primitives::zip339::Mnemonic;
 use zcash_primitives::{
     consensus::BlockHeight,
     legacy::Script,
@@ -216,7 +216,7 @@ pub struct LightWallet {
     // will start from here.
     birthday: AtomicU64,
 
-    /// The seed for the wallet, stored as a bip0039 Mnemonic, and the account index.
+    /// The seed for the wallet, stored as a zip339 Mnemonic, and the account index.
     /// Can be `None` in case of wallet without spending capability
     /// or created directly from spending keys.
     mnemonic: Option<(Mnemonic, u32)>,

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use append_only_vec::AppendOnlyVec;
-use bip0039::Mnemonic;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use orchard::keys::Scope;
+use zcash_primitives::zip339::Mnemonic;
 
 use secp256k1::SecretKey;
 use zcash_address::unified::{Container, Encoding, Fvk, Ufvk};


### PR DESCRIPTION
Fixes: #580
Fixes: #789

Does not fix #770 which is blocked here:  https://github.com/zcash/librustzcash/pull/1261
Does not fix: #818 which also conflicts with our current version of lrz (possible fixed by updating).



Also included:  unification of `hex` and `hyper-rustls` as workspace dependencies.

Unification of all references to bip0039, as re-export: librustzcash/zcash_primitives/zip339
