### PR TITLE
Fix is confirmed before bug

### DIFF
--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -32,9 +32,11 @@ impl ConfirmationStatus {
     ///
     /// let status = ConfirmationStatus::Broadcast(10.into());
     /// assert_eq!(status.is_broadcast(), true);
+    /// assert_eq!(status.is_confirmed(), false);
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
     /// assert_eq!(status.is_broadcast(), false);
+    /// assert_eq!(status.is_confirmed(), true);
     /// ```
     pub fn is_broadcast(&self) -> bool {
         matches!(self, Self::Broadcast(_))
@@ -48,9 +50,11 @@ impl ConfirmationStatus {
     ///
     /// let status = ConfirmationStatus::Broadcast(10.into());
     /// assert_eq!(status.is_confirmed(), false);
+    /// assert_eq!(status.is_broadcast(), true);
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
     /// assert_eq!(status.is_confirmed(), true);
+    /// assert_eq!(status.is_broadcast(), false);
     /// ```
     pub fn is_confirmed(&self) -> bool {
         matches!(self, Self::Confirmed(_))
@@ -63,13 +67,13 @@ impl ConfirmationStatus {
     /// use zcash_primitives::consensus::BlockHeight;
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
-    /// assert_eq!(status.is_confirmed_after_or_at(&8.into()), true);
+    /// assert_eq!(status.is_confirmed_after_or_at(&9.into()), true);
     ///
     /// let status = ConfirmationStatus::Broadcast(10.into());
     /// assert_eq!(status.is_confirmed_after_or_at(&10.into()), false);
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
-    /// assert_eq!(status.is_confirmed_after_or_at(&12.into()), false);
+    /// assert_eq!(status.is_confirmed_after_or_at(&11.into()), false);
     /// ```
     pub fn is_confirmed_after_or_at(&self, comparison_height: &BlockHeight) -> bool {
         match self {
@@ -85,13 +89,13 @@ impl ConfirmationStatus {
     /// use zcash_primitives::consensus::BlockHeight;
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
-    /// assert_eq!(status.is_confirmed_before_or_at(&8.into()), false);
+    /// assert_eq!(status.is_confirmed_before_or_at(&9.into()), false);
     ///
     /// let status = ConfirmationStatus::Broadcast(10.into());
     /// assert_eq!(status.is_confirmed_before_or_at(&10.into()), false);
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
-    /// assert_eq!(status.is_confirmed_before_or_at(&12.into()), true);
+    /// assert_eq!(status.is_confirmed_before_or_at(&11.into()), true);
     /// ```
     pub fn is_confirmed_before_or_at(&self, comparison_height: &BlockHeight) -> bool {
         match self {
@@ -109,13 +113,13 @@ impl ConfirmationStatus {
     /// use zcash_primitives::consensus::BlockHeight;
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
-    /// assert_eq!(status.is_confirmed_before(&8.into()), false);
+    /// assert_eq!(status.is_confirmed_before(&9.into()), false);
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
     /// assert_eq!(status.is_confirmed_before(&10.into()), false);
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
-    /// assert_eq!(status.is_confirmed_before(&12.into()), true);
+    /// assert_eq!(status.is_confirmed_before(&11.into()), true);
     /// ```
     pub fn is_confirmed_before(&self, comparison_height: &BlockHeight) -> bool {
         match self {
@@ -131,13 +135,13 @@ impl ConfirmationStatus {
     /// use zcash_primitives::consensus::BlockHeight;
     ///
     /// let status = ConfirmationStatus::Confirmed(10.into());
-    /// assert_eq!(status.is_broadcast_after_or_at(&8.into()), false);
+    /// assert_eq!(status.is_broadcast_after_or_at(&9.into()), false);
     ///
     /// let status = ConfirmationStatus::Broadcast(10.into());
     /// assert_eq!(status.is_broadcast_after_or_at(&10.into()), true);
     ///
     /// let status = ConfirmationStatus::Broadcast(10.into());
-    /// assert_eq!(status.is_broadcast_after_or_at(&12.into()), false);
+    /// assert_eq!(status.is_broadcast_after_or_at(&11.into()), false);
     /// ```
     pub fn is_broadcast_after_or_at(&self, comparison_height: &BlockHeight) -> bool {
         match self {
@@ -153,10 +157,10 @@ impl ConfirmationStatus {
     /// use zcash_primitives::consensus::BlockHeight;
     ///
     /// let status = ConfirmationStatus::Confirmed(16.into());
-    /// assert_eq!(status.is_broadcast_before(&14.into()), false);
+    /// assert_eq!(status.is_broadcast_before(&15.into()), false);
     ///
     /// let status = ConfirmationStatus::Broadcast(12.into());
-    /// assert_eq!(status.is_broadcast_before(&14.into()), true);
+    /// assert_eq!(status.is_broadcast_before(&13.into()), true);
     ///
     /// let status = ConfirmationStatus::Broadcast(14.into());
     /// assert_eq!(status.is_broadcast_before(&14.into()), false);
@@ -205,7 +209,6 @@ impl ConfirmationStatus {
             _ => None,
         }
     }
-    /// this function and the placeholder is not a preferred pattern. please use match whenever possible.
     /// # Examples
     ///
     /// ```

--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -95,7 +95,9 @@ impl ConfirmationStatus {
     /// ```
     pub fn is_confirmed_before_or_at(&self, comparison_height: &BlockHeight) -> bool {
         match self {
-            Self::Confirmed(self_height) => self_height <= comparison_height,
+            Self::Confirmed(self_height) => {
+                self.is_confirmed_before(comparison_height) || self_height == comparison_height
+            }
             _ => false,
         }
     }
@@ -117,7 +119,7 @@ impl ConfirmationStatus {
     /// ```
     pub fn is_confirmed_before(&self, comparison_height: &BlockHeight) -> bool {
         match self {
-            Self::Confirmed(self_height) => self_height <= comparison_height,
+            Self::Confirmed(self_height) => self_height < comparison_height,
             _ => false,
         }
     }

--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -99,6 +99,44 @@ impl ConfirmationStatus {
             _ => false,
         }
     }
+    /// To return true, the status must be confirmed earlier than specified height.
+    /// # Examples
+    ///
+    /// ```
+    /// use zingo_status::confirmation_status::ConfirmationStatus;
+    /// use zcash_primitives::consensus::BlockHeight;
+    ///
+    /// let status = ConfirmationStatus::Confirmed(10.into());
+    /// assert_eq!(status.is_confirmed_before(&8.into()), false);
+    ///
+    /// let status = ConfirmationStatus::Confirmed(10.into());
+    /// assert_eq!(status.is_confirmed_before(&10.into()), false);
+    ///
+    /// let status = ConfirmationStatus::Confirmed(10.into());
+    /// assert_eq!(status.is_confirmed_before(&12.into()), true);
+    /// ```
+    pub fn is_confirmed_before(&self, comparison_height: &BlockHeight) -> bool {
+        match self {
+            Self::Confirmed(self_height) => self_height <= comparison_height,
+            _ => false,
+        }
+    }
+    /// To return true, the status must have broadcast at or later than specified height.
+    /// # Examples
+    ///
+    /// ```
+    /// use zingo_status::confirmation_status::ConfirmationStatus;
+    /// use zcash_primitives::consensus::BlockHeight;
+    ///
+    /// let status = ConfirmationStatus::Confirmed(10.into());
+    /// assert_eq!(status.is_broadcast_after_or_at(&8.into()), false);
+    ///
+    /// let status = ConfirmationStatus::Broadcast(10.into());
+    /// assert_eq!(status.is_broadcast_after_or_at(&10.into()), true);
+    ///
+    /// let status = ConfirmationStatus::Broadcast(10.into());
+    /// assert_eq!(status.is_broadcast_after_or_at(&12.into()), false);
+    /// ```
     pub fn is_broadcast_after_or_at(&self, comparison_height: &BlockHeight) -> bool {
         match self {
             Self::Broadcast(self_height) => self_height >= comparison_height,
@@ -165,7 +203,7 @@ impl ConfirmationStatus {
             _ => None,
         }
     }
-    // this function and the placeholder is not a preferred pattern. please use match whenever possible.
+    /// this function and the placeholder is not a preferred pattern. please use match whenever possible.
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
This PR is mostly a cherry-pick of a commit from the spend_kit branch (see commit message).

I will break up my rationale for this PR into two parts.

## How I Fixed The Bug

  The bug was caused by a tiny smidge of wetness, and copy pasta, coupled with the false belief that the doc tests were protecting us.
  The fix is both correct, and DRYer because it uses composition of relevant functionality rather re-expression of the same thing.

(I also tightened boundary conditions and added assertions to the doc-tests.)
 
## Why I Propose This Way of Organizing PRs

   If this PR is accepted into `dev` it will have some nice properties:

(1)  It will have made the length of the feature branch (as measured in diff from dev) smaller.  I assume this is obviously good.
(2)  It will have decreased the length of distance from the tip of the feature, to the tip of any other feature.
     Here's the thought experiment:
        Oscar is working on some other feature (some sync thing) at the same time.  This PR lands (maybe Oscar reviews it).
   
   Now what?

   There's this chunk of code (on dev) that doesn't really do anything (on dev), *but* it's *probably* necessary for spend_kit (its "origin feature") and some_sync_thing is *aware* of it.   This means that (a) some_sync_thing won't accidentally put something else there.   Maybe some_sync_thing will actually use it.   I dunno'..  but at the end of the day all the `dev`eloping features need to work together.   By sucking pieces of them into `dev`, when it is convenient to do so, we ensure that features being developed against `dev` are aware of each other earlier.