### PR TITLE
Update dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.2"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
@@ -764,13 +764,14 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1867,6 +1868,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"

--- a/zingoconfig/Cargo.toml
+++ b/zingoconfig/Cargo.toml
@@ -12,4 +12,4 @@ zcash_primitives = { workspace = true }
 log4rs = "1.1.1"
 log = "0.4.14"
 http = "0.2.4"
-dirs = "3.0.2"
+dirs = "5.0"


### PR DESCRIPTION
This small PR updates the dirs dependency in response to dependabot's recommendation:  #863 

Additionally it drops the minor version specifier from the semver triple.  We should do this wherever we can.