### PR TITLE
send command refactor and improved error handling

### DIFF
--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Deprecated
+
 - LightClient::do_list_transactions
 
 ### Added
@@ -16,9 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LightClient pub fn export_save_buffer_runtime
 - LightClient pub fn get_wallet_file_location
 - LightClient pub fn get_wallet_dir_location
+- `wallet::keys`:
+  - `is_transparent_address`
 
 ### Changed
+
 - load_client_config fn moves from zingolib to zingoconfig
+- `wallet::keys`:
+  - `is_shielded_address` takes a `&ChainType` instead of a `&ZingoConfig`
 
 ### Removed
 

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1,6 +1,6 @@
-use crate::wallet::keys::is_shielded_address;
+use crate::wallet::keys::is_transparent_address;
 use crate::wallet::{MemoDownloadOption, Pool};
-use crate::{lightclient::LightClient, wallet::utils};
+use crate::{lightclient::LightClient, wallet};
 use indoc::indoc;
 use json::object;
 use lazy_static::lazy_static;
@@ -12,6 +12,11 @@ use zcash_address::unified::{Container, Encoding, Ufvk};
 use zcash_client_backend::address::Address;
 use zcash_primitives::consensus::Parameters;
 use zcash_primitives::transaction::fees::zip317::MINIMUM_FEE;
+
+use self::error::CommandError;
+
+mod error;
+mod utils;
 
 lazy_static! {
     static ref RT: Runtime = tokio::runtime::Runtime::new().unwrap();
@@ -721,7 +726,8 @@ impl Command for EncryptMessageCommand {
                 return format!("{}\n{}", es, self.help());
             }
 
-            let memo = utils::interpret_memo_string(j["memo"].as_str().unwrap().to_string());
+            let memo =
+                wallet::utils::interpret_memo_string(j["memo"].as_str().unwrap().to_string());
             if memo.is_err() {
                 return format!("{}\n{}", memo.err().unwrap(), self.help());
             }
@@ -731,7 +737,7 @@ impl Command for EncryptMessageCommand {
         } else if args.len() == 2 {
             let to = args[0].to_string();
 
-            let memo = utils::interpret_memo_string(args[1].to_string());
+            let memo = wallet::utils::interpret_memo_string(args[1].to_string());
             if memo.is_err() {
                 return format!("{}\n{}", memo.err().unwrap(), self.help());
             }
@@ -790,9 +796,9 @@ impl Command for SendCommand {
         indoc! {r#"
             Send ZEC to a given address(es)
             Usage:
-            send <address> <amount in zatoshis> "optional_memo"
+            send <address> <amount in zatoshis> "<optional_memo>"
             OR
-            send '[{'address': <address>, 'amount': <amount in zatoshis>, 'memo': <optional memo>}, ...]'
+            send '[{"address":"<address>", "amount":<amount in zatoshis>, "memo":"<optional memo>"}, ...]'
 
             NOTE: The fee required to send this transaction (currently ZEC 0.0001) is additionally deducted from your balance.
             Example:
@@ -807,112 +813,33 @@ impl Command for SendCommand {
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
         // Parse the args. There are two argument types.
-        // 1 - A set of 2(+1 optional) arguments for a single address send representing address, value, memo?
-        // 2 - A single argument in the form of a JSON string that is "[{address: address, value: value, memo: memo},...]"
-        if args.is_empty() || args.len() > 3 {
-            return self.help().to_string();
-        }
-
-        RT.block_on(async move {
-            // Check for a single argument that can be parsed as JSON
-            let send_args = if args.len() == 1 {
-                let arg_list = args[0];
-
-                let json_args = match json::parse(arg_list) {
-                    Ok(j) => j,
-                    Err(e) => {
-                        let es = format!("Couldn't understand JSON: {}", e);
-                        return format!("{}\n{}", es, self.help());
-                    }
-                };
-
-                if !json_args.is_array() {
-                    return format!("Couldn't parse argument as array\n{}", self.help());
-                }
-
-                let fee = u64::from(MINIMUM_FEE);
-                let maybe_send_args = json_args
-                    .members()
-                    .map(|j| {
-                        if !j.has_key("address") || !j.has_key("amount") {
-                            Err("Need 'address' and 'amount'\n".to_string())
-                        } else {
-                            let amount = Some(j["amount"].as_u64().unwrap());
-
-                            match amount {
-                                Some(amt) => Ok((
-                                    j["address"].as_str().unwrap().to_string(),
-                                    amt,
-                                    j["memo"].as_str().map(|s| s.to_string()),
-                                )),
-                                None => Err(format!(
-                                    "Not enough in wallet to pay transaction fee of {}",
-                                    fee
-                                )),
-                            }
-                        }
-                    })
-                    .collect::<Result<Vec<(String, u64, Option<String>)>, String>>();
-
-                match maybe_send_args {
-                    Ok(a) => a.clone(),
-                    Err(s) => {
-                        return format!("Error: {}\n{}", s, self.help());
-                    }
-                }
-            } else if args.len() == 2 || args.len() == 3 {
-                let address = args[0].to_string();
-
-                // Make sure we can parse the amount
-                let value = match args[1].parse::<u64>() {
-                    Ok(amt) => amt,
-                    Err(e) => return format!("Couldn't parse amount: {}", e),
-                };
-
-                let memo = if args.len() == 3 {
-                    Some(args[2].to_string())
-                } else {
-                    None
-                };
-
-                // Memo has to be None if not sending to a shielded address
-                if memo.is_some() && !is_shielded_address(&address, &lightclient.config) {
-                    return format!("Can't send a memo to the non-shielded address {}", address);
-                }
-
-                vec![(args[0].to_string(), value, memo)]
-            } else {
-                return self.help().to_string();
-            };
-
-            // Convert to the right format.
-            let mut error = None;
-            let tos = send_args
-                .iter()
-                .map(|(a, v, m)| {
-                    (
-                        a.as_str(),
-                        *v,
-                        match m {
-                            // If the string starts with an "0x", and contains only hex chars ([a-f0-9]+) then
-                            // interpret it as a hex
-                            Some(s) => match utils::interpret_memo_string(s.clone()) {
-                                Ok(m) => Some(m),
-                                Err(e) => {
-                                    error = Some(format!("Couldn't interpret memo: {}", e));
-                                    None
-                                }
-                            },
-                            None => None,
-                        },
-                    )
-                })
-                .collect::<Vec<_>>();
-            if let Some(e) = error {
-                return e;
+        // 1 - A set of 2(+1 optional) arguments for a single address send representing address, amount, memo?
+        // 2 - A single argument in the form of a JSON string that is "[{address: address, value: value, memo: memo}, ...]"
+        let send_inputs = match utils::parse_send_args(args) {
+            Ok(args) => args,
+            Err(e) => {
+                return format!(
+                    "Error: {}\nTry 'help send' for correct usage and examples.",
+                    e
+                )
             }
-
-            match lightclient.do_send(tos).await {
+        };
+        let send_inputs_ref = send_inputs
+            .iter()
+            .map(|(address, amount, memo)| (address.as_str(), *amount, memo.clone()))
+            .collect();
+        for send in &send_inputs {
+            let address = &send.0;
+            let memo = &send.2;
+            if memo.is_some() && is_transparent_address(address, &lightclient.config.chain) {
+                return format!(
+                    "Error: {}\nTry 'help send' for correct usage and examples.",
+                    CommandError::IncompatibleMemo,
+                );
+            }
+        }
+        RT.block_on(async move {
+            match lightclient.do_send(send_inputs_ref).await {
                 Ok(transaction_id) => {
                     object! { "txid" => transaction_id }
                 }
@@ -925,24 +852,6 @@ impl Command for SendCommand {
     }
 }
 
-fn wallet_deleter(lightclient: &LightClient) -> String {
-    RT.block_on(async move {
-        match lightclient.do_delete().await {
-            Ok(_) => {
-                let r = object! { "result" => "success",
-                "wallet_path" => lightclient.config.get_wallet_path().to_str().unwrap() };
-                r.pretty(2)
-            }
-            Err(e) => {
-                let r = object! {
-                    "result" => "error",
-                    "error" => e
-                };
-                r.pretty(2)
-            }
-        }
-    })
-}
 struct DeleteCommand {}
 impl Command for DeleteCommand {
     fn help(&self) -> &'static str {
@@ -961,7 +870,22 @@ impl Command for DeleteCommand {
     }
 
     fn exec(&self, _args: &[&str], lightclient: &LightClient) -> String {
-        wallet_deleter(lightclient)
+        RT.block_on(async move {
+            match lightclient.do_delete().await {
+                Ok(_) => {
+                    let r = object! { "result" => "success",
+                    "wallet_path" => lightclient.config.get_wallet_path().to_str().unwrap() };
+                    r.pretty(2)
+                }
+                Err(e) => {
+                    let r = object! {
+                        "result" => "error",
+                        "error" => e
+                    };
+                    r.pretty(2)
+                }
+            }
+        })
     }
 }
 struct SeedCommand {}

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -4,7 +4,7 @@ use std::fmt;
 pub(crate) enum CommandError {
     FailedJsonParsing(json::Error),
     FailedIntParsing(std::num::ParseIntError),
-    IncorrectType,
+    UnexpectedType,
     MissingKey(String),
     InvalidArguments,
     IncompatibleMemo,
@@ -18,7 +18,7 @@ impl fmt::Display for CommandError {
         match self {
             FailedJsonParsing(e) => write!(f, "failed to parse argument. {}", e),
             FailedIntParsing(e) => write!(f, "failed to parse argument. {}", e),
-            IncorrectType => write!(f, "arguments parsed to incorrect type."),
+            UnexpectedType => write!(f, "arguments cannot be parsed to expected type."),
             MissingKey(key) => write!(f, "json array is missing \"{}\" key.", key),
             InvalidArguments => write!(f, "arguments given are invalid."),
             IncompatibleMemo => {

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -1,0 +1,30 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub(crate) enum CommandError {
+    FailedJsonParsing(json::Error),
+    FailedIntParsing(std::num::ParseIntError),
+    IncorrectType,
+    MissingKey(String),
+    InvalidArguments,
+    IncompatibleMemo,
+    InvalidMemo(String),
+}
+
+impl fmt::Display for CommandError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use CommandError::*;
+
+        match self {
+            FailedJsonParsing(e) => write!(f, "failed to parse argument. {}", e),
+            FailedIntParsing(e) => write!(f, "failed to parse argument. {}", e),
+            IncorrectType => write!(f, "arguments parsed to incorrect type."),
+            MissingKey(key) => write!(f, "json array is missing \"{}\" key.", key),
+            InvalidArguments => write!(f, "arguments given are invalid."),
+            IncompatibleMemo => {
+                write!(f, "memo's cannot be sent to transparent addresses.")
+            }
+            InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
+        }
+    }
+}

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -60,3 +60,47 @@ pub(super) fn parse_send_args(
 
     Ok(send_args)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet;
+
+    #[test]
+    fn parse_send_args() {
+        let address = "zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p";
+        let value_str = "100000";
+        let value = 100_000;
+        let memo_str = "test memo";
+        let memo = wallet::utils::interpret_memo_string(memo_str.to_string()).unwrap();
+
+        // No memo
+        let send_args = &[address, value_str];
+        assert_eq!(
+            super::parse_send_args(send_args).unwrap(),
+            vec![(address.to_string(), value, None)]
+        );
+
+        // Memo
+        let send_args = &[address, value_str, memo_str];
+        assert_eq!(
+            super::parse_send_args(send_args).unwrap(),
+            vec![(address.to_string(), value, Some(memo.clone()))]
+        );
+
+        // Json
+        let json = "[{\"address\":\"tmBsTi2xWTjUdEXnuTceL7fecEQKeWaPDJd\", \"amount\":50000}, \
+            {\"address\":\"zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p\", \
+            \"amount\":100000, \"memo\":\"test memo\"}]";
+        assert_eq!(
+            super::parse_send_args(&[json]).unwrap(),
+            vec![
+                (
+                    "tmBsTi2xWTjUdEXnuTceL7fecEQKeWaPDJd".to_string(),
+                    50_000,
+                    None
+                ),
+                (address.to_string(), value, Some(memo))
+            ]
+        );
+    }
+}

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -1,0 +1,62 @@
+use crate::commands::error::CommandError;
+use crate::wallet;
+use zcash_primitives::memo::MemoBytes;
+
+pub(super) fn parse_send_args(
+    args: &[&str],
+) -> Result<Vec<(String, u64, Option<MemoBytes>)>, CommandError> {
+    // Check for a single argument that can be parsed as JSON
+    let send_args = if args.len() == 1 {
+        let json_args = json::parse(args[0]).map_err(CommandError::FailedJsonParsing)?;
+
+        if !json_args.is_array() {
+            return Err(CommandError::IncorrectType);
+        }
+
+        json_args
+            .members()
+            .map(|j| {
+                if !j.has_key("address") {
+                    return Err(CommandError::MissingKey("address".to_string()));
+                } else if !j.has_key("amount") {
+                    return Err(CommandError::MissingKey("amount".to_string()));
+                }
+
+                let address = j["address"]
+                    .as_str()
+                    .ok_or(CommandError::IncorrectType)?
+                    .to_string();
+                let amount = j["amount"].as_u64().ok_or(CommandError::IncorrectType)?;
+                let memo = if let Some(m) = j["memo"].as_str().map(|s| s.to_string()) {
+                    Some(
+                        wallet::utils::interpret_memo_string(m)
+                            .map_err(CommandError::InvalidMemo)?,
+                    )
+                } else {
+                    None
+                };
+
+                Ok((address, amount, memo))
+            })
+            .collect::<Result<Vec<(String, u64, Option<MemoBytes>)>, CommandError>>()
+    } else if args.len() == 2 || args.len() == 3 {
+        let address = args[0].to_string();
+        let amount = args[1]
+            .parse::<u64>()
+            .map_err(CommandError::FailedIntParsing)?;
+        let memo = if args.len() == 3 {
+            Some(
+                wallet::utils::interpret_memo_string(args[2].to_string())
+                    .map_err(CommandError::InvalidMemo)?,
+            )
+        } else {
+            None
+        };
+
+        Ok(vec![(address, amount, memo)])
+    } else {
+        return Err(CommandError::InvalidArguments);
+    }?;
+
+    Ok(send_args)
+}

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -10,7 +10,7 @@ pub(super) fn parse_send_args(
         let json_args = json::parse(args[0]).map_err(CommandError::FailedJsonParsing)?;
 
         if !json_args.is_array() {
-            return Err(CommandError::IncorrectType);
+            return Err(CommandError::UnexpectedType);
         }
 
         json_args
@@ -24,9 +24,9 @@ pub(super) fn parse_send_args(
 
                 let address = j["address"]
                     .as_str()
-                    .ok_or(CommandError::IncorrectType)?
+                    .ok_or(CommandError::UnexpectedType)?
                     .to_string();
-                let amount = j["amount"].as_u64().ok_or(CommandError::IncorrectType)?;
+                let amount = j["amount"].as_u64().ok_or(CommandError::UnexpectedType)?;
                 let memo = if let Some(m) = j["memo"].as_str().map(|s| s.to_string()) {
                     Some(
                         wallet::utils::interpret_memo_string(m)

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -11,7 +11,7 @@ use zcash_client_backend::address;
 use zcash_primitives::{
     consensus::NetworkConstants, legacy::TransparentAddress, zip32::ChildIndex,
 };
-use zingoconfig::ZingoConfig;
+use zingoconfig::{ChainType, ZingoConfig};
 
 pub mod extended_transparent;
 pub mod unified;
@@ -81,10 +81,17 @@ pub fn get_zaddr_from_bip39seed(
     (extsk, fvk, address)
 }
 
-pub fn is_shielded_address(addr: &str, config: &ZingoConfig) -> bool {
+pub fn is_shielded_address(addr: &str, chain: &ChainType) -> bool {
     matches!(
-        address::Address::decode(&config.chain, addr),
+        address::Address::decode(chain, addr),
         Some(address::Address::Sapling(_)) | Some(address::Address::Unified(_))
+    )
+}
+
+pub fn is_transparent_address(addr: &str, chain: &ChainType) -> bool {
+    matches!(
+        address::Address::decode(chain, addr),
+        Some(address::Address::Transparent(_))
     )
 }
 


### PR DESCRIPTION
- Moves parsing to dedicated command as prereq for zip317 propose command
- Cleans up parsing logic and send command
- Improves error handling
- Adds utils and error sub-mods to commands.rs
- Fixes bug in send help for sending using a json string
- Fixes bug where an incorrect address triggers the wrong error when there is some memo