### PR TITLE
Extend parse send args tests

### DIFF
--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -28,7 +28,7 @@ impl fmt::Display for CommandError {
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
             NonJsonNumberForAmount(e) => write!(f, "Non Number input: {}", e),
-            SingleArgNotJsonArray(e) => write!(f, "{}", e),
+            SingleArgNotJsonArray(e) => write!(f, "argument cannot be parsed to a json array: {}", e),
         }
     }
 }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 #[derive(Debug)]
 pub(crate) enum CommandError {
-    FailedJsonParsing(json::Error),
-    FailedIntParsing(std::num::ParseIntError),
+    ArgsNotJson(json::Error),
+    ParseIntFromString(std::num::ParseIntError),
     UnexpectedType(String),
     MissingKey(String),
     InvalidArguments,
@@ -16,8 +16,8 @@ impl fmt::Display for CommandError {
         use CommandError::*;
 
         match self {
-            FailedJsonParsing(e) => write!(f, "failed to parse argument. {}", e),
-            FailedIntParsing(e) => write!(f, "failed to parse argument. {}", e),
+            ArgsNotJson(e) => write!(f, "failed to parse argument. {}", e),
+            ParseIntFromString(e) => write!(f, "failed to parse argument. {}", e),
             UnexpectedType(e) => write!(f, "arguments cannot be parsed to expected type. {}", e),
             MissingKey(key) => write!(f, "json array is missing \"{}\" key.", key),
             InvalidArguments => write!(f, "arguments given are invalid."),

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -28,7 +28,9 @@ impl fmt::Display for CommandError {
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
             NonJsonNumberForAmount(e) => write!(f, "Non Number input: {}", e),
-            SingleArgNotJsonArray(e) => write!(f, "argument cannot be parsed to a json array: {}", e),
+            SingleArgNotJsonArray(e) => {
+                write!(f, "argument cannot be parsed to a json array: {}", e)
+            }
         }
     }
 }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -3,6 +3,7 @@ use std::fmt;
 #[derive(Debug)]
 pub(crate) enum CommandError {
     ArgsNotJson(json::Error),
+    SingleArgNotJsonArray(String),
     ParseIntFromString(std::num::ParseIntError),
     UnexpectedType(String),
     MissingKey(String),
@@ -27,6 +28,7 @@ impl fmt::Display for CommandError {
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
             NonJsonNumberForAmount(e) => write!(f, "{}", e),
+            SingleArgNotJsonArray(e) => write!(f, "{}", e),
         }
     }
 }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -27,7 +27,7 @@ impl fmt::Display for CommandError {
                 write!(f, "memo's cannot be sent to transparent addresses.")
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
-            NonJsonNumberForAmount(e) => write!(f, "{}", e),
+            NonJsonNumberForAmount => write!(f,  "amount is not a json::number::Number"),
             SingleArgNotJsonArray(e) => write!(f, "{}", e),
         }
     }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -9,6 +9,7 @@ pub(crate) enum CommandError {
     InvalidArguments,
     IncompatibleMemo,
     InvalidMemo(String),
+    NonJsonNumberForAmount(String),
 }
 
 impl fmt::Display for CommandError {
@@ -25,6 +26,7 @@ impl fmt::Display for CommandError {
                 write!(f, "memo's cannot be sent to transparent addresses.")
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
+            NonJsonNumberForAmount(e) => write!(f, "{}", e),
         }
     }
 }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -27,7 +27,7 @@ impl fmt::Display for CommandError {
                 write!(f, "memo's cannot be sent to transparent addresses.")
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
-            NonJsonNumberForAmount => write!(f,  "amount is not a json::number::Number"),
+            NonJsonNumberForAmount(e) => write!(f, "Non Number input: {}", e),
             SingleArgNotJsonArray(e) => write!(f, "{}", e),
         }
     }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -4,7 +4,7 @@ use std::fmt;
 pub(crate) enum CommandError {
     FailedJsonParsing(json::Error),
     FailedIntParsing(std::num::ParseIntError),
-    UnexpectedType,
+    UnexpectedType(String),
     MissingKey(String),
     InvalidArguments,
     IncompatibleMemo,
@@ -18,7 +18,7 @@ impl fmt::Display for CommandError {
         match self {
             FailedJsonParsing(e) => write!(f, "failed to parse argument. {}", e),
             FailedIntParsing(e) => write!(f, "failed to parse argument. {}", e),
-            UnexpectedType => write!(f, "arguments cannot be parsed to expected type."),
+            UnexpectedType(e) => write!(f, "arguments cannot be parsed to expected type. {}", e),
             MissingKey(key) => write!(f, "json array is missing \"{}\" key.", key),
             InvalidArguments => write!(f, "arguments given are invalid."),
             IncompatibleMemo => {

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -33,7 +33,7 @@ pub(super) fn parse_send_args(
                     ))?
                     .to_string();
                 let amount = if !j["amount"].is_number() {
-                    return Err(CommandError::UnexpectedType(
+                    return Err(CommandError::NonJsonNumberForAmount(
                         "amount is not a json::number::Number".to_string(),
                     ));
                 } else {
@@ -184,7 +184,7 @@ mod tests {
                 ["[{\"address\": \"testaddress\", \"amount\": \"Oscar Pepper\", \"memo\": \"testmemo\"}]"];
                 let result = parse_send_args(&args);
                 match result {
-                    Err(CommandError::UnexpectedType(e)) => {
+                    Err(CommandError::NonJsonNumberForAmount(e)) => {
                         assert_eq!(e, "amount is not a json::number::Number".to_string())
                     }
                     _ => panic!(),

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -32,9 +32,10 @@ pub(super) fn parse_send_args(
                     ))?
                     .to_string();
                 let amount = if !j["amount"].is_number() {
-                    return Err(CommandError::NonJsonNumberForAmount(
-                        "amount is not a json::number::Number".to_string(),
-                    ));
+                    return Err(CommandError::NonJsonNumberForAmount(format!(
+                        "\"amount\": {}\nis not a json::number::Number",
+                        j["amount"]
+                    )));
                 } else {
                     j["amount"].as_u64().ok_or(CommandError::UnexpectedType(
                         "amount not a u64!".to_string(),
@@ -184,7 +185,10 @@ mod tests {
                 let result = parse_send_args(&args);
                 match result {
                     Err(CommandError::NonJsonNumberForAmount(e)) => {
-                        assert_eq!(e, "amount is not a json::number::Number".to_string())
+                        assert_eq!(
+                            e,
+                            "\"amount\": Oscar Pepper\nis not a json::number::Number".to_string()
+                        )
                     }
                     _ => panic!(),
                 };

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 //! Module containing utility functions for the commands interface
 
 use crate::commands::error::CommandError;

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -127,10 +127,6 @@ mod tests {
     }
 
     mod fail_parse_send_args {
-        use zcash_primitives::memo::MemoBytes;
-
-        use crate::commands::utils::parse_send_args;
-
         mod json_array {
             use crate::commands::{error::CommandError, utils::parse_send_args};
             #[test]
@@ -267,22 +263,6 @@ mod tests {
                     _ => panic!(),
                 };
             }
-        }
-
-        #[test]
-        fn successful_parse_send_args_single_json() {
-            let args =
-                ["[{\"address\": \"testaddress\", \"amount\": 123, \"memo\": \"testmemo\"}]"];
-            let parsed = parse_send_args(&args).unwrap();
-            // Assuming you have a way to construct MemoBytes from a string for this example
-            assert_eq!(
-                parsed,
-                vec![(
-                    "testaddress".to_string(),
-                    123,
-                    Some(MemoBytes::from_bytes(&"testmemo".as_bytes()).unwrap())
-                )]
-            );
         }
     }
 }

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -251,7 +251,6 @@ mod tests {
             fn wrong_number_of_args() {
                 let args = ["testaddress", "123", "3", "4"];
                 let result = parse_send_args(&args);
-                dbg!(&result);
                 assert!(matches!(result, Err(CommandError::InvalidArguments)));
             }
             #[test]

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -81,7 +81,7 @@ mod tests {
     use crate::wallet;
 
     #[test]
-    fn parse_send_args_test() {
+    fn parse_send_args() {
         let address = "zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p";
         let value_str = "100000";
         let value = 100_000;

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -229,6 +229,7 @@ mod tests {
             }
             #[test]
             fn three_args_wrong_amount_show_trim_requirement() {
+                // Note the " " character after the 1.  The parser can handle by trimming, is that correct?
                 let args = ["testaddress", "1 ", "whatever"];
                 let result = parse_send_args(&args);
                 dbg!(&result);
@@ -243,6 +244,25 @@ mod tests {
                 let result = parse_send_args(&args);
                 dbg!(&result);
                 assert!(matches!(result, Err(CommandError::InvalidArguments)));
+            }
+            #[test]
+            fn invalid_memo() {
+                let long_513_byte_memo = &"a".repeat(513);
+                let args = ["testaddress", "123", long_513_byte_memo];
+
+                let result = parse_send_args(&args);
+                match result {
+                    Err(CommandError::InvalidMemo(e)) => {
+                        assert_eq!(
+                            e,
+                            format!(
+                                "Error creating output. Memo '\"{}\"' is too long",
+                                long_513_byte_memo.to_string()
+                            )
+                        )
+                    }
+                    _ => panic!(),
+                };
             }
         }
     }

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -186,6 +186,29 @@ mod tests {
             };
         }
         #[test]
+        fn invalid_memo() {
+            let arg_contents =
+                "[{\"address\": \"testaddress\", \"amount\": 123, \"memo\": \"testmemo\"}]";
+            let long_513_byte_memo = &"a".repeat(513);
+            let long_memo_args =
+                arg_contents.replace("\"testmemo\"", &format!("\"{}\"", long_513_byte_memo));
+            let args = [long_memo_args.as_str()];
+
+            let result = parse_send_args(&args);
+            match result {
+                Err(CommandError::InvalidMemo(e)) => {
+                    assert_eq!(
+                        e,
+                        format!(
+                            "Error creating output. Memo '\"{}\"' is too long",
+                            long_513_byte_memo.to_string()
+                        )
+                    )
+                }
+                _ => panic!(),
+            };
+        }
+        #[test]
         fn wrong_number_of_args() {
             let args = ["testaddress", "123", "3", "4"];
             let result = parse_send_args(&args);

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -225,7 +225,6 @@ mod tests {
             fn two_args_wrong_amount() {
                 let args = ["testaddress", "foo"];
                 let result = parse_send_args(&args);
-                dbg!(&result);
                 match result {
                     Err(CommandError::ParseIntFromString(e)) => {
                         assert_eq!(
@@ -241,7 +240,6 @@ mod tests {
                 // Note the " " character after the 1.  The parser can handle by trimming, is that correct?
                 let args = ["testaddress", "1 ", "whatever"];
                 let result = parse_send_args(&args);
-                dbg!(&result);
                 match result {
                     Ok(_) => (),
                     _ => panic!(),

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -14,7 +14,7 @@ pub(super) fn parse_send_args(
         let json_args = json::parse(args[0]).map_err(CommandError::ArgsNotJson)?;
 
         if !json_args.is_array() {
-            return Err(CommandError::UnexpectedType(json_args.to_string()));
+            return Err(CommandError::SingleArgNotJsonArray(json_args.to_string()));
         }
 
         json_args
@@ -145,7 +145,7 @@ mod tests {
                 let args = ["1"];
                 let result = parse_send_args(&args);
                 match result {
-                    Err(CommandError::UnexpectedType(e)) => assert_eq!(e, "1".to_string()),
+                    Err(CommandError::SingleArgNotJsonArray(e)) => assert_eq!(e, "1".to_string()),
                     _ => panic!(),
                 };
             }

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -119,11 +119,13 @@ mod tests {
         );
     }
 
-    use super::*;
     mod fail_parse_send_args {
-        use super::*;
+        use zcash_primitives::memo::MemoBytes;
+
+        use crate::commands::utils::parse_send_args;
+
         mod json_array {
-            use super::*;
+            use crate::commands::{error::CommandError, utils::parse_send_args};
             #[test]
             fn failed_json_parsing() {
                 let args = [r#"testaddress{{"#];
@@ -218,7 +220,7 @@ mod tests {
             }
         }
         mod multi_string_args {
-            use super::*;
+            use crate::commands::{error::CommandError, utils::parse_send_args};
             #[test]
             fn two_args_wrong_amount() {
                 let args = ["testaddress", "foo"];

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -117,6 +117,13 @@ mod tests {
                 (address.to_string(), value, Some(memo))
             ]
         );
+        // Note the " " character after the 1.  The parser can handle by trimming, is that correct?
+        let args = ["testaddress", "1 ", "whatever"];
+        let result = super::parse_send_args(&args);
+        match result {
+            Ok(_) => (),
+            _ => panic!(),
+        };
     }
 
     mod fail_parse_send_args {
@@ -232,16 +239,6 @@ mod tests {
                             format!("{}", e)
                         )
                     }
-                    _ => panic!(),
-                };
-            }
-            #[test]
-            fn three_args_wrong_amount_show_trim_requirement() {
-                // Note the " " character after the 1.  The parser can handle by trimming, is that correct?
-                let args = ["testaddress", "1 ", "whatever"];
-                let result = parse_send_args(&args);
-                match result {
-                    Ok(_) => (),
                     _ => panic!(),
                 };
             }

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-//! Currently this mod contains a utility fn that's been factored out of SendCommand
+//! Module containing utility functions for the commands interface
 
 use crate::commands::error::CommandError;
 use crate::wallet;

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -75,7 +75,7 @@ mod tests {
     use crate::wallet;
 
     #[test]
-    fn parse_send_args() {
+    fn parse_send_args_test() {
         let address = "zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p";
         let value_str = "100000";
         let value = 100_000;
@@ -112,9 +112,7 @@ mod tests {
             ]
         );
     }
-}
-#[cfg(test)]
-mod tests {
+
     use super::*;
     mod fail_parse_send_args {
         use super::*;
@@ -265,20 +263,21 @@ mod tests {
                 };
             }
         }
-    }
 
-    #[test]
-    fn successful_parse_send_args_single_json() {
-        let args = ["[{\"address\": \"testaddress\", \"amount\": 123, \"memo\": \"testmemo\"}]"];
-        let parsed = parse_send_args(&args).unwrap();
-        // Assuming you have a way to construct MemoBytes from a string for this example
-        assert_eq!(
-            parsed,
-            vec![(
-                "testaddress".to_string(),
-                123,
-                Some(MemoBytes::from_bytes(&"testmemo".as_bytes()).unwrap())
-            )]
-        );
+        #[test]
+        fn successful_parse_send_args_single_json() {
+            let args =
+                ["[{\"address\": \"testaddress\", \"amount\": 123, \"memo\": \"testmemo\"}]"];
+            let parsed = parse_send_args(&args).unwrap();
+            // Assuming you have a way to construct MemoBytes from a string for this example
+            assert_eq!(
+                parsed,
+                vec![(
+                    "testaddress".to_string(),
+                    123,
+                    Some(MemoBytes::from_bytes(&"testmemo".as_bytes()).unwrap())
+                )]
+            );
+        }
     }
 }


### PR DESCRIPTION
Here are more tests for the parse_send_args helper utility.

There are a few improvements:

* more error variants
* trim against from-single-arg int parsing