### PR TITLE
Add get received note from identifier method

### DIFF
--- a/zingolib/src/wallet/notes.rs
+++ b/zingolib/src/wallet/notes.rs
@@ -7,3 +7,23 @@ pub mod sapling;
 pub use sapling::SaplingNote;
 pub mod orchard;
 pub use orchard::OrchardNote;
+
+use zcash_client_backend::PoolType;
+use zcash_primitives::transaction::TxId;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct NoteRecordIdentifier {
+    pub txid: TxId,
+    pub pool: PoolType,
+    pub index: u32,
+}
+
+impl std::fmt::Display for NoteRecordIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "txid {}, {:?}, index {}",
+            self.txid, self.pool, self.index,
+        )
+    }
+}

--- a/zingolib/src/wallet/notes/interface.rs
+++ b/zingolib/src/wallet/notes/interface.rs
@@ -66,4 +66,5 @@ pub trait ShieldedNoteInterface: NoteInterface + Sized {
     fn value_from_note(note: &Self::Note) -> u64;
     fn witnessed_position(&self) -> &Option<Position>;
     fn witnessed_position_mut(&mut self) -> &mut Option<Position>;
+    fn to_zcb_note(&self) -> zcash_client_backend::wallet::Note;
 }

--- a/zingolib/src/wallet/notes/orchard.rs
+++ b/zingolib/src/wallet/notes/orchard.rs
@@ -145,4 +145,7 @@ impl ShieldedNoteInterface for OrchardNote {
     fn output_index(&self) -> &Option<u32> {
         &self.output_index
     }
+    fn to_zcb_note(&self) -> zcash_client_backend::wallet::Note {
+        zcash_client_backend::wallet::Note::Orchard(*self.note())
+    }
 }

--- a/zingolib/src/wallet/notes/sapling.rs
+++ b/zingolib/src/wallet/notes/sapling.rs
@@ -167,4 +167,7 @@ impl ShieldedNoteInterface for SaplingNote {
     fn output_index(&self) -> &Option<u32> {
         &self.output_index
     }
+    fn to_zcb_note(&self) -> zcash_client_backend::wallet::Note {
+        zcash_client_backend::wallet::Note::Sapling(self.note().clone())
+    }
 }

--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -6,7 +6,8 @@ use crate::wallet::notes;
 
 use super::{
     data::{OutgoingTxData, PoolNullifier},
-    traits::DomainWalletExt,
+    notes::NoteRecordIdentifier,
+    traits::{DomainWalletExt, Recipient},
     *,
 };
 
@@ -170,6 +171,43 @@ impl TransactionRecord {
             self.total_sapling_value_spent,
             self.total_orchard_value_spent,
         ]
+    }
+    pub fn get_received_note<D>(
+        &self,
+        index: u32,
+    ) -> Option<
+        zcash_client_backend::wallet::ReceivedNote<
+            NoteRecordIdentifier,
+            zcash_client_backend::wallet::Note,
+        >,
+    >
+    where
+        D: DomainWalletExt + Sized,
+        D::Note: PartialEq + Clone,
+        D::Recipient: Recipient,
+    {
+        let note = D::to_notes_vec(self)
+            .iter()
+            .find(|note| *note.output_index() == Some(index));
+        note.and_then(|note| {
+            let txid = self.txid;
+            let zcb_note = note.to_zcb_note();
+            let note_record_reference = NoteRecordIdentifier {
+                txid,
+                pool: zcash_client_backend::PoolType::Shielded(zcb_note.protocol()),
+                index,
+            };
+            note.witnessed_position().map(|pos| {
+                zcash_client_backend::wallet::ReceivedNote::from_parts(
+                    note_record_reference,
+                    txid,
+                    index as u16,
+                    zcb_note,
+                    zcash_primitives::zip32::Scope::External,
+                    pos,
+                )
+            })
+        })
     }
 }
 // read/write


### PR DESCRIPTION
This PR builds on #911 if that one is rejected, then this one ought not to be considered.

This is the addition of ( get_received_note_from_identifier) an inherent method on TransactionRecordMap which is required to implement InputSource on TransactionRecordMap.