### PR TITLE
Current to transaction records by

### DIFF
--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -747,7 +747,14 @@ mod slow {
             .await
             .unwrap();
 
-        for txid_known in recipient.wallet.transactions().read().await.current.keys() {
+        for txid_known in recipient
+            .wallet
+            .transactions()
+            .read()
+            .await
+            .transaction_records_by_id
+            .keys()
+        {
             dbg!(txid_known);
         }
 
@@ -757,7 +764,7 @@ mod slow {
             .transactions()
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .get(&txid)
             .unwrap()
             .orchard_notes
@@ -790,7 +797,7 @@ mod slow {
             .transactions()
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .get(&txid)
             .unwrap()
             .orchard_notes
@@ -833,7 +840,7 @@ mod slow {
             .transactions()
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .get(&txid)
             .unwrap()
             .orchard_notes
@@ -864,7 +871,7 @@ mod slow {
             .transactions()
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .get(&txid)
             .unwrap()
             .orchard_notes
@@ -3304,7 +3311,7 @@ mod slow {
                     .transaction_metadata_set
                     .read()
                     .await
-                    .current
+                    .transaction_records_by_id
                     .get(requested_txid)
                     .unwrap()
                     .orchard_notes
@@ -3344,7 +3351,7 @@ mod slow {
                     .transaction_metadata_set
                     .read()
                     .await
-                    .current
+                    .transaction_records_by_id
                     .get(requested_txid)
                     .unwrap()
                     .orchard_notes
@@ -3449,7 +3456,7 @@ mod slow {
                 .transaction_metadata_set
                 .read()
                 .await
-                .current
+                .transaction_records_by_id
         );
 
         assert_eq!(bala_sim, bala_syn);

--- a/zingolib/src/lightclient/deprecated.rs
+++ b/zingolib/src/lightclient/deprecated.rs
@@ -115,7 +115,7 @@ impl LightClient {
             .transaction_context.transaction_metadata_set
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .iter()
             .flat_map(|(txid, wallet_transaction)| {
                 let mut consumer_notes_by_tx: Vec<JsonValue> = vec![];

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -96,7 +96,7 @@ impl LightClient {
             .transactions()
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .iter()
             .for_each(|(_, tx)| {
                 let mature = tx
@@ -240,7 +240,7 @@ impl LightClient {
             .transaction_metadata_set
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .iter()
         {
             LightClient::tx_summary_matcher(&mut summaries, *txid, transaction_md);
@@ -482,7 +482,7 @@ impl LightClient {
         let mut pending_sapling_notes: Vec<JsonValue> = vec![];
         let mut spent_sapling_notes: Vec<JsonValue> = vec![];
         // Collect Sapling notes
-        self.wallet.transaction_context.transaction_metadata_set.read().await.current.iter()
+        self.wallet.transaction_context.transaction_metadata_set.read().await.transaction_records_by_id.iter()
             .flat_map( |(transaction_id, transaction_metadata)| {
                 transaction_metadata.sapling_notes.iter().filter_map(move |note_metadata|
                     if !all_notes && note_metadata.spent.is_some() {
@@ -525,7 +525,7 @@ impl LightClient {
         let mut unspent_orchard_notes: Vec<JsonValue> = vec![];
         let mut pending_orchard_notes: Vec<JsonValue> = vec![];
         let mut spent_orchard_notes: Vec<JsonValue> = vec![];
-        self.wallet.transaction_context.transaction_metadata_set.read().await.current.iter()
+        self.wallet.transaction_context.transaction_metadata_set.read().await.transaction_records_by_id.iter()
             .flat_map( |(transaction_id, transaction_metadata)| {
                 transaction_metadata.orchard_notes.iter().filter_map(move |orch_note_metadata|
                     if !all_notes && orch_note_metadata.is_spent() {
@@ -568,7 +568,7 @@ impl LightClient {
         let mut pending_transparent_notes: Vec<JsonValue> = vec![];
         let mut spent_transparent_notes: Vec<JsonValue> = vec![];
 
-        self.wallet.transaction_context.transaction_metadata_set.read().await.current.iter()
+        self.wallet.transaction_context.transaction_metadata_set.read().await.transaction_records_by_id.iter()
             .flat_map( |(transaction_id, wtx)| {
                 wtx.transparent_notes.iter().filter_map(move |utxo|
                     if !all_notes && utxo.is_spent() {

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -52,7 +52,7 @@ impl LightWallet {
                 .transaction_metadata_set
                 .read()
                 .await
-                .current
+                .transaction_records_by_id
                 .values()
                 .map(|transaction| {
                     let mut filtered_notes: Box<dyn Iterator<Item = &D::WalletNote>> = Box::new(
@@ -219,7 +219,7 @@ impl LightWallet {
             .transaction_metadata_set
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .values()
             .map(|wtx| u64::from(wtx.status.get_height()))
             .min();
@@ -238,7 +238,7 @@ impl LightWallet {
             .transaction_metadata_set
             .read()
             .await
-            .current
+            .transaction_records_by_id
             .values()
             .flat_map(|transaction| {
                 transaction

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -143,7 +143,7 @@ impl LightWallet {
             TxMapAndMaybeTrees::read(&mut reader, &wallet_capability)
         }?;
         let txids = transactions
-            .current
+            .transaction_records_by_id
             .keys()
             .cloned()
             .collect::<Vec<transaction::TxId>>();

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -571,7 +571,7 @@ impl LightWallet {
         let tranmds_lth = self.transactions();
         let transaction_metadata_set = tranmds_lth.read().await;
         let mut candidate_notes = transaction_metadata_set
-            .current
+            .transaction_records_by_id
             .iter()
             .flat_map(|(transaction_id, transaction)| {
                 D::WalletNote::transaction_metadata_notes(transaction)

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -229,7 +229,7 @@ pub mod decrypt_transaction {
             let mut spent_utxos = vec![];
 
             {
-                let current = &self
+                let current_transaction_records_by_id = &self
                     .transaction_metadata_set
                     .read()
                     .await
@@ -240,7 +240,9 @@ pub mod decrypt_transaction {
                         let prev_transaction_id = TxId::from_bytes(*vin.prevout.hash());
                         let prev_n = vin.prevout.n() as u64;
 
-                        if let Some(wtx) = current.get(&prev_transaction_id) {
+                        if let Some(wtx) =
+                            current_transaction_records_by_id.get(&prev_transaction_id)
+                        {
                             // One of the tx outputs is a match
                             if let Some(spent_utxo) = wtx
                                 .transparent_notes

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -229,7 +229,11 @@ pub mod decrypt_transaction {
             let mut spent_utxos = vec![];
 
             {
-                let current = &self.transaction_metadata_set.read().await.current;
+                let current = &self
+                    .transaction_metadata_set
+                    .read()
+                    .await
+                    .transaction_records_by_id;
                 if let Some(t_bundle) = transaction.transparent_bundle() {
                     for vin in t_bundle.vin.iter() {
                         // Find the prev txid that was spent
@@ -290,7 +294,7 @@ pub mod decrypt_transaction {
                                 .transaction_metadata_set
                                 .write()
                                 .await
-                                .current
+                                .transaction_records_by_id
                                 .get_mut(&txid)
                             {
                                 if !transaction.outgoing_tx_data.is_empty() {

--- a/zingolib/src/wallet/transactions.rs
+++ b/zingolib/src/wallet/transactions.rs
@@ -6,7 +6,7 @@ use crate::wallet::{data::WitnessTrees, transaction_records_by_id::TransactionRe
 /// Note that the parent is expected to hold a RwLock, so we will assume that all accesses to
 /// this struct are threadsafe/locked properly.
 pub struct TxMapAndMaybeTrees {
-    pub current: TransactionRecordsById,
+    pub transaction_records_by_id: TransactionRecordsById,
     pub witness_trees: Option<WitnessTrees>,
 }
 
@@ -17,18 +17,18 @@ pub mod recording;
 impl TxMapAndMaybeTrees {
     pub(crate) fn new_with_witness_trees() -> TxMapAndMaybeTrees {
         Self {
-            current: TransactionRecordsById(HashMap::new()),
+            transaction_records_by_id: TransactionRecordsById(HashMap::new()),
             witness_trees: Some(WitnessTrees::default()),
         }
     }
     pub(crate) fn new_treeless() -> TxMapAndMaybeTrees {
         Self {
-            current: TransactionRecordsById(HashMap::new()),
+            transaction_records_by_id: TransactionRecordsById(HashMap::new()),
             witness_trees: None,
         }
     }
     pub fn clear(&mut self) {
-        self.current.clear();
+        self.transaction_records_by_id.clear();
         self.witness_trees.as_mut().map(WitnessTrees::clear);
     }
 }

--- a/zingolib/src/wallet/transactions/get.rs
+++ b/zingolib/src/wallet/transactions/get.rs
@@ -17,7 +17,7 @@ impl TxMapAndMaybeTrees {
     ) -> Vec<(TxId, PoolNullifier, Option<u32>)> {
         let before_block = BlockHeight::from_u32(before_block as u32);
 
-        self.current
+        self.transaction_records_by_id
             .iter()
             .filter(|(_, transaction_metadata)| transaction_metadata.status.is_confirmed_before_or_at(&before_block)) // Update only confirmed notes
             .flat_map(|(txid, transaction_metadata)| {
@@ -64,7 +64,7 @@ impl TxMapAndMaybeTrees {
     }
 
     pub fn total_funds_spent_in(&self, txid: &TxId) -> u64 {
-        self.current
+        self.transaction_records_by_id
             .get(txid)
             .map(TransactionRecord::total_value_spent)
             .unwrap_or(0)
@@ -83,7 +83,7 @@ impl TxMapAndMaybeTrees {
         <D as Domain>::Note: PartialEq + Clone,
         <D as Domain>::Recipient: Recipient,
     {
-        self.current
+        self.transaction_records_by_id
             .iter()
             .flat_map(|(_, transaction_metadata)| {
                 D::to_notes_vec(transaction_metadata)
@@ -105,7 +105,7 @@ impl TxMapAndMaybeTrees {
 
     /// This returns an _arbitrary_ confirmed txid from the latest block the wallet is aware of.
     pub fn get_some_txid_from_highest_wallet_block(&self) -> Option<TxId> {
-        self.current
+        self.transaction_records_by_id
             .values()
             .fold(
                 None,
@@ -140,7 +140,7 @@ fn test_get_some_txid_from_highest_wallet_block() {
     let txid_1 = TxId::from_bytes(txid_bytes_1);
     let txid_2 = TxId::from_bytes(txid_bytes_2);
     let txid_3 = TxId::from_bytes(txid_bytes_3);
-    tms.current.insert(
+    tms.transaction_records_by_id.insert(
         txid_1,
         TransactionRecord::new(
             zingo_status::confirmation_status::ConfirmationStatus::Broadcast(
@@ -150,7 +150,7 @@ fn test_get_some_txid_from_highest_wallet_block() {
             &txid_1,
         ),
     );
-    tms.current.insert(
+    tms.transaction_records_by_id.insert(
         txid_2,
         TransactionRecord::new(
             zingo_status::confirmation_status::ConfirmationStatus::Confirmed(
@@ -160,7 +160,7 @@ fn test_get_some_txid_from_highest_wallet_block() {
             &txid_2,
         ),
     );
-    tms.current.insert(
+    tms.transaction_records_by_id.insert(
         txid_3,
         TransactionRecord::new(
             zingo_status::confirmation_status::ConfirmationStatus::Confirmed(
@@ -178,7 +178,7 @@ fn test_get_some_txid_from_highest_wallet_block() {
 impl TxMapAndMaybeTrees {
     pub fn get_fee_by_txid(&self, txid: &TxId) -> u64 {
         match self
-            .current
+            .transaction_records_by_id
             .get(txid)
             .expect("To have the requested txid")
             .get_transaction_fee()

--- a/zingolib/src/wallet/transactions/read_write.rs
+++ b/zingolib/src/wallet/transactions/read_write.rs
@@ -60,7 +60,7 @@ impl TxMapAndMaybeTrees {
         }
 
         Ok(Self {
-            current: map,
+            transaction_records_by_id: map,
             witness_trees,
         })
     }
@@ -125,7 +125,7 @@ impl TxMapAndMaybeTrees {
         };
 
         Ok(Self {
-            current: TransactionRecordsById::from_map(map),
+            transaction_records_by_id: TransactionRecordsById::from_map(map),
             witness_trees,
         })
     }
@@ -138,7 +138,7 @@ impl TxMapAndMaybeTrees {
         // deterministically saved
         {
             let mut transaction_metadatas = self
-                .current
+                .transaction_records_by_id
                 .iter()
                 .collect::<Vec<(&TxId, &TransactionRecord)>>();
             // Don't write down metadata for transactions in the mempool, we'll rediscover

--- a/zingolib/src/wallet/transactions/recording.rs
+++ b/zingolib/src/wallet/transactions/recording.rs
@@ -26,25 +26,27 @@ use super::TxMapAndMaybeTrees;
 impl TxMapAndMaybeTrees {
     pub fn remove_txids(&mut self, txids_to_remove: Vec<TxId>) {
         for txid in &txids_to_remove {
-            self.current.remove(txid);
+            self.transaction_records_by_id.remove(txid);
         }
-        self.current.values_mut().for_each(|transaction_metadata| {
-            // Update UTXOs to rollback any spent utxos
-            transaction_metadata
-                .transparent_notes
-                .iter_mut()
-                .for_each(|utxo| {
-                    if utxo.is_spent() && txids_to_remove.contains(&utxo.spent().unwrap().0) {
-                        *utxo.spent_mut() = None;
-                    }
+        self.transaction_records_by_id
+            .values_mut()
+            .for_each(|transaction_metadata| {
+                // Update UTXOs to rollback any spent utxos
+                transaction_metadata
+                    .transparent_notes
+                    .iter_mut()
+                    .for_each(|utxo| {
+                        if utxo.is_spent() && txids_to_remove.contains(&utxo.spent().unwrap().0) {
+                            *utxo.spent_mut() = None;
+                        }
 
-                    if utxo.unconfirmed_spent.is_some()
-                        && txids_to_remove.contains(&utxo.unconfirmed_spent.unwrap().0)
-                    {
-                        utxo.unconfirmed_spent = None;
-                    }
-                })
-        });
+                        if utxo.unconfirmed_spent.is_some()
+                            && txids_to_remove.contains(&utxo.unconfirmed_spent.unwrap().0)
+                        {
+                            utxo.unconfirmed_spent = None;
+                        }
+                    })
+            });
         self.remove_domain_specific_txids::<SaplingDomain>(&txids_to_remove);
         self.remove_domain_specific_txids::<OrchardDomain>(&txids_to_remove);
     }
@@ -54,24 +56,27 @@ impl TxMapAndMaybeTrees {
         <D as Domain>::Recipient: Recipient,
         <D as Domain>::Note: PartialEq + Clone,
     {
-        self.current.values_mut().for_each(|transaction_metadata| {
-            // Update notes to rollback any spent notes
-            D::to_notes_vec_mut(transaction_metadata)
-                .iter_mut()
-                .for_each(|nd| {
-                    // Mark note as unspent if the txid being removed spent it.
-                    if nd.spent().is_some() && txids_to_remove.contains(&nd.spent().unwrap().0) {
-                        *nd.spent_mut() = None;
-                    }
+        self.transaction_records_by_id
+            .values_mut()
+            .for_each(|transaction_metadata| {
+                // Update notes to rollback any spent notes
+                D::to_notes_vec_mut(transaction_metadata)
+                    .iter_mut()
+                    .for_each(|nd| {
+                        // Mark note as unspent if the txid being removed spent it.
+                        if nd.spent().is_some() && txids_to_remove.contains(&nd.spent().unwrap().0)
+                        {
+                            *nd.spent_mut() = None;
+                        }
 
-                    // Remove unconfirmed spends too
-                    if nd.pending_spent().is_some()
-                        && txids_to_remove.contains(&nd.pending_spent().unwrap().0)
-                    {
-                        *nd.pending_spent_mut() = None;
-                    }
-                });
-        });
+                        // Remove unconfirmed spends too
+                        if nd.pending_spent().is_some()
+                            && txids_to_remove.contains(&nd.pending_spent().unwrap().0)
+                        {
+                            *nd.pending_spent_mut() = None;
+                        }
+                    });
+            });
     }
 
     // During reorgs, we need to remove all txns at a given height, and all spends that refer to any removed txns.
@@ -80,7 +85,7 @@ impl TxMapAndMaybeTrees {
 
         // First, collect txids that need to be removed
         let txids_to_remove = self
-            .current
+            .transaction_records_by_id
             .values()
             .filter_map(|transaction_metadata| {
                 if transaction_metadata
@@ -113,7 +118,7 @@ impl TxMapAndMaybeTrees {
         let cutoff = BlockHeight::from_u32((latest_height.saturating_sub(MAX_REORG as u64)) as u32);
 
         let txids_to_remove = self
-            .current
+            .transaction_records_by_id
             .iter()
             .filter(|(_, transaction_metadata)| {
                 transaction_metadata.status.is_broadcast_before(&cutoff)
@@ -135,7 +140,7 @@ impl TxMapAndMaybeTrees {
     pub fn check_notes_mark_change(&mut self, txid: &TxId) {
         //TODO: Incorrect with a 0-value fee somehow
         if self.total_funds_spent_in(txid) > 0 {
-            if let Some(transaction_metadata) = self.current.get_mut(txid) {
+            if let Some(transaction_metadata) = self.transaction_records_by_id.get_mut(txid) {
                 Self::mark_notes_as_change_for_pool(&mut transaction_metadata.sapling_notes);
                 Self::mark_notes_as_change_for_pool(&mut transaction_metadata.orchard_notes);
             }
@@ -156,7 +161,7 @@ impl TxMapAndMaybeTrees {
         status: ConfirmationStatus,
         datetime: u64,
     ) -> &'_ mut TransactionRecord {
-        self.current
+        self.transaction_records_by_id
             .entry(*txid)
             // If we already have the transaction metadata, it may be newly confirmed. Update confirmation_status
             .and_modify(|transaction_metadata| {
@@ -258,7 +263,9 @@ impl TxMapAndMaybeTrees {
         Ok(if let Some(height) = status.get_confirmed_height() {
             // ie remove_witness_mark_sapling or _orchard
             self.remove_witness_mark::<D>(height, spending_txid, source_txid, output_index)?;
-            if let Some(transaction_spent_from) = self.current.get_mut(&source_txid) {
+            if let Some(transaction_spent_from) =
+                self.transaction_records_by_id.get_mut(&source_txid)
+            {
                 if let Some(confirmed_spent_note) = D::to_notes_vec_mut(transaction_spent_from)
                     .iter_mut()
                     .find(|note| note.nullifier() == Some(spent_nullifier))
@@ -275,7 +282,9 @@ impl TxMapAndMaybeTrees {
             }
         } else if let Some(height) = status.get_broadcast_height() {
             // Mark the unconfirmed_spent. Confirmed spends are already handled in update_notes
-            if let Some(transaction_spent_from) = self.current.get_mut(&source_txid) {
+            if let Some(transaction_spent_from) =
+                self.transaction_records_by_id.get_mut(&source_txid)
+            {
                 if let Some(unconfirmed_spent_note) = D::to_notes_vec_mut(transaction_spent_from)
                     .iter_mut()
                     .find(|note| note.nullifier() == Some(spent_nullifier))
@@ -317,7 +326,9 @@ impl TxMapAndMaybeTrees {
         spending_tx_status: ConfirmationStatus,
     ) -> u64 {
         // Find the UTXO
-        let value = if let Some(utxo_transacion_metadata) = self.current.get_mut(&spent_txid) {
+        let value = if let Some(utxo_transacion_metadata) =
+            self.transaction_records_by_id.get_mut(&spent_txid)
+        {
             if let Some(spent_utxo) = utxo_transacion_metadata
                 .transparent_notes
                 .iter_mut()
@@ -482,7 +493,7 @@ impl TxMapAndMaybeTrees {
         note: Nd::Note,
         memo: Memo,
     ) {
-        if let Some(transaction_metadata) = self.current.get_mut(txid) {
+        if let Some(transaction_metadata) = self.transaction_records_by_id.get_mut(txid) {
             if let Some(n) = Nd::transaction_metadata_notes_mut(transaction_metadata)
                 .iter_mut()
                 .find(|n| n.note() == &note)
@@ -494,7 +505,7 @@ impl TxMapAndMaybeTrees {
 
     pub fn add_outgoing_metadata(&mut self, txid: &TxId, outgoing_metadata: Vec<OutgoingTxData>) {
         // println!("        adding outgoing metadata to txid {}", txid);
-        if let Some(transaction_metadata) = self.current.get_mut(txid) {
+        if let Some(transaction_metadata) = self.transaction_records_by_id.get_mut(txid) {
             transaction_metadata.outgoing_tx_data = outgoing_metadata
         } else {
             error!(
@@ -505,7 +516,11 @@ impl TxMapAndMaybeTrees {
     }
 
     pub fn set_price(&mut self, txid: &TxId, price: Option<f64>) {
-        price.map(|p| self.current.get_mut(txid).map(|tx| tx.price = Some(p)));
+        price.map(|p| {
+            self.transaction_records_by_id
+                .get_mut(txid)
+                .map(|tx| tx.price = Some(p))
+        });
     }
 }
 
@@ -526,7 +541,7 @@ impl TxMapAndMaybeTrees {
         <D as Domain>::Recipient: Recipient,
     {
         let transaction_metadata = self
-            .current
+            .transaction_records_by_id
             .get_mut(&source_txid)
             .expect("Txid should be present");
 
@@ -576,7 +591,7 @@ impl TxMapAndMaybeTrees {
         <D as Domain>::Note: PartialEq + Clone,
         <D as Domain>::Recipient: Recipient,
     {
-        if let Some(tmd) = self.current.get_mut(&txid) {
+        if let Some(tmd) = self.transaction_records_by_id.get_mut(&txid) {
             if let Some(maybe_nnmd) = &mut D::to_notes_vec_mut(tmd).iter_mut().find_map(|nnmd| {
                 if nnmd.output_index().is_some() != output_index.is_some() {
                     return Some(Err(ZingoLibError::MissingOutputIndex(txid)));


### PR DESCRIPTION
The way I pushed this to github was:

`cargo check && cargo check --tests && cargo fmt && cargo clippy && ./utils/trailing-whitespace.sh reject && cargo nextest run -p zingolib --features test && git push --verbose zancas current_to_transaction_records_by_id`