### PR TITLE
Add mock proposal and step builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "zingo-status",
  "zingo-testvectors",
  "zingoconfig",
+ "zip32",
 ]
 
 [[package]]

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pub struct crate::wallet::notes::NoteRecordIdentifier
 - `utils` mod
 - `utils::txid_from_hex_encoded_str` fn
+- `test_framework` module
+- `test_framework::mocks` module
 
 ### Changed
 

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pub struct crate::wallet::notes::NoteRecordIdentifier
 - `utils` mod
 - `utils::txid_from_hex_encoded_str` fn
-- `test_framework` module
-- `test_framework::mocks` module
+- `test_framework` mod
 
 ### Changed
 

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -13,7 +13,7 @@ pub mod wallet;
 #[cfg(feature = "test")]
 pub use zingo_testvectors as testvectors;
 #[cfg(feature = "test")]
-pub(crate) mod test_framework;
+pub mod test_framework;
 
 // This line includes the generated `git_description()` function directly into this scope.
 include!(concat!(env!("OUT_DIR"), "/git_description.rs"));

--- a/zingolib/src/test_framework.rs
+++ b/zingolib/src/test_framework.rs
@@ -2,7 +2,7 @@ use zcash_primitives::transaction::TxId;
 
 use crate::wallet::notes::TransparentNote;
 pub(crate) mod macros;
-mod mocks;
+pub mod mocks;
 
 #[allow(dead_code)]
 pub(crate) fn create_empty_txid_and_tnote() -> (zcash_primitives::transaction::TxId, TransparentNote)

--- a/zingolib/src/test_framework/mocks.rs
+++ b/zingolib/src/test_framework/mocks.rs
@@ -4,6 +4,8 @@ use zcash_primitives::transaction::TxId;
 
 use crate::wallet::notes::TransparentNote;
 
+pub use proposal::{ProposalBuilder, StepBuilder};
+
 macro_rules! build_method {
     ($name:ident, $localtype:ty) => {
         pub fn $name(mut self, $name: $localtype) -> Self {

--- a/zingolib/src/test_framework/mocks.rs
+++ b/zingolib/src/test_framework/mocks.rs
@@ -1,23 +1,8 @@
 //! Tools to facilitate mocks for testing
 
-use std::collections::BTreeMap;
+use zcash_primitives::transaction::TxId;
 
-use incrementalmerkletree::Position;
-use nonempty::NonEmpty;
-use sapling_crypto::value::NoteValue;
-use sapling_crypto::zip32::ExtendedSpendingKey;
-use sapling_crypto::Rseed;
-use zcash_client_backend::fees::TransactionBalance;
-use zcash_client_backend::proposal::{Proposal, ShieldedInputs, Step, StepOutput};
-use zcash_client_backend::wallet::{ReceivedNote, WalletTransparentOutput};
-use zcash_client_backend::zip321::TransactionRequest;
-use zcash_client_backend::PoolType;
-use zcash_primitives::consensus::BlockHeight;
-use zcash_primitives::transaction::{
-    components::amount::NonNegativeAmount, fees::zip317::FeeRule, TxId,
-};
-
-use crate::wallet::notes::{NoteRecordIdentifier, TransparentNote};
+use crate::wallet::notes::TransparentNote;
 
 macro_rules! build_method {
     ($name:ident, $localtype:ty) => {
@@ -79,173 +64,199 @@ impl Default for TransparentNoteBuilder {
     }
 }
 
-/// Provides a builder for constructing a mock [`zcash_client_backend::proposal::Proposal`].
-///
-/// # Examples
-///
-/// ```
-/// use zingolib::test_framework::mocks::ProposalBuilder;
-///
-/// let proposal = ProposalBuilder::default().build();
-/// ````
-#[allow(dead_code)]
-pub struct ProposalBuilder {
-    fee_rule: Option<FeeRule>,
-    min_target_height: Option<BlockHeight>,
-    steps: Option<NonEmpty<Step<NoteRecordIdentifier>>>,
-}
+pub mod proposal {
+    //! Module for mocking structs from [`zcash_client_backend::proposal`]
 
-#[allow(dead_code)]
-impl ProposalBuilder {
-    /// Constructs a new [`ProposalBuilder`] with all fields as `None`.
-    pub fn new() -> Self {
-        ProposalBuilder {
-            fee_rule: None,
-            min_target_height: None,
-            steps: None,
-        }
-    }
+    use std::collections::BTreeMap;
 
-    build_method!(fee_rule, FeeRule);
-    build_method!(min_target_height, BlockHeight);
-    build_method!(steps, NonEmpty<Step<NoteRecordIdentifier>>);
+    use incrementalmerkletree::Position;
+    use nonempty::NonEmpty;
+    use sapling_crypto::value::NoteValue;
+    use sapling_crypto::zip32::ExtendedSpendingKey;
+    use sapling_crypto::Rseed;
+    use zcash_client_backend::fees::TransactionBalance;
+    use zcash_client_backend::proposal::{Proposal, ShieldedInputs, Step, StepOutput};
+    use zcash_client_backend::wallet::{ReceivedNote, WalletTransparentOutput};
+    use zcash_client_backend::zip321::TransactionRequest;
+    use zcash_client_backend::PoolType;
+    use zcash_primitives::consensus::BlockHeight;
+    use zcash_primitives::transaction::{
+        components::amount::NonNegativeAmount, fees::zip317::FeeRule, TxId,
+    };
 
-    /// Builds a proposal after all fields have been set.
+    use crate::wallet::notes::NoteRecordIdentifier;
+
+    /// Provides a builder for constructing a mock [`zcash_client_backend::proposal::Proposal`].
     ///
-    /// # Panics
+    /// # Examples
     ///
-    /// `build` will panic if any fields of the builder are `None` or if the build failed
-    /// due to invalid values.
-    pub fn build(self) -> Proposal<FeeRule, NoteRecordIdentifier> {
-        let step = self.steps.unwrap().first().clone();
-        Proposal::single_step(
-            step.transaction_request().clone(),
-            step.payment_pools().clone(),
-            step.transparent_inputs().to_vec(),
-            step.shielded_inputs().cloned(),
-            step.balance().clone(),
-            self.fee_rule.unwrap(),
-            self.min_target_height.unwrap(),
-            step.is_shielding(),
-        )
-        .unwrap()
-    }
-}
-
-impl Default for ProposalBuilder {
-    /// Constructs a new [`ProposalBuilder`] where all fields are preset to default values.
-    fn default() -> Self {
-        ProposalBuilder::new()
-            .fee_rule(FeeRule::standard())
-            .min_target_height(BlockHeight::from_u32(1))
-            .steps(NonEmpty::singleton(StepBuilder::default().build()))
-    }
-}
-
-/// Provides a builder for constructing a mock [`zcash_client_backend::proposal::Step`].
-///
-/// # Examples
-///
-/// ```
-/// use zingolib::test_framework::mocks::StepBuilder;
-///
-/// let step = StepBuilder::default().build();
-/// ````
-pub struct StepBuilder {
-    transaction_request: Option<TransactionRequest>,
-    payment_pools: Option<BTreeMap<usize, PoolType>>,
-    transparent_inputs: Option<Vec<WalletTransparentOutput>>,
-    shielded_inputs: Option<Option<ShieldedInputs<NoteRecordIdentifier>>>,
-    prior_step_inputs: Option<Vec<StepOutput>>,
-    balance: Option<TransactionBalance>,
-    is_shielding: Option<bool>,
-}
-
-impl StepBuilder {
-    /// Constructs a new [`StepBuilder`] with all fields as `None`.
-    pub fn new() -> Self {
-        StepBuilder {
-            transaction_request: None,
-            payment_pools: None,
-            transparent_inputs: None,
-            shielded_inputs: None,
-            prior_step_inputs: None,
-            balance: None,
-            is_shielding: None,
-        }
-    }
-
-    build_method!(transaction_request, TransactionRequest);
-    build_method!(payment_pools, BTreeMap<usize, PoolType>
-    );
-    build_method!(transparent_inputs, Vec<WalletTransparentOutput>);
-    build_method!(
-        shielded_inputs,
-        Option<ShieldedInputs<NoteRecordIdentifier>>
-    );
-    build_method!(prior_step_inputs, Vec<StepOutput>);
-    build_method!(balance, TransactionBalance);
-    build_method!(is_shielding, bool);
-
-    /// Builds a step after all fields have been set.
+    /// ```
+    /// use zingolib::test_framework::mocks::ProposalBuilder;
     ///
-    /// # Panics
-    ///
-    /// `build` will panic if any fields of the builder are `None` or if the build failed
-    /// due to invalid values.
+    /// let proposal = ProposalBuilder::default().build();
+    /// ````
     #[allow(dead_code)]
-    pub fn build(self) -> Step<NoteRecordIdentifier> {
-        Step::from_parts(
-            &[],
-            self.transaction_request.unwrap(),
-            self.payment_pools.unwrap(),
-            self.transparent_inputs.unwrap(),
-            self.shielded_inputs.unwrap(),
-            self.prior_step_inputs.unwrap(),
-            self.balance.unwrap(),
-            self.is_shielding.unwrap(),
-        )
-        .unwrap()
+    pub struct ProposalBuilder {
+        fee_rule: Option<FeeRule>,
+        min_target_height: Option<BlockHeight>,
+        steps: Option<NonEmpty<Step<NoteRecordIdentifier>>>,
     }
-}
 
-impl Default for StepBuilder {
-    /// Constructs a new [`StepBuilder`] where all fields are preset to default values.
-    fn default() -> Self {
-        let txid = TxId::from_bytes([0u8; 32]);
-        let seed = [0u8; 32];
-        let dfvk = ExtendedSpendingKey::master(&seed).to_diversifiable_full_viewing_key();
-        let (_, address) = dfvk.default_address();
-        let note = sapling_crypto::Note::from_parts(
-            address,
-            NoteValue::from_raw(20_000),
-            Rseed::AfterZip212([7; 32]),
-        );
+    #[allow(dead_code)]
+    impl ProposalBuilder {
+        /// Constructs a new [`ProposalBuilder`] with all fields as `None`.
+        pub fn new() -> Self {
+            ProposalBuilder {
+                fee_rule: None,
+                min_target_height: None,
+                steps: None,
+            }
+        }
 
-        Self::new()
-            .transaction_request(TransactionRequest::empty())
-            .payment_pools(BTreeMap::new())
-            .transparent_inputs(vec![])
-            // .shielded_inputs(None)
-            .shielded_inputs(Some(ShieldedInputs::from_parts(
-                BlockHeight::from_u32(1),
-                NonEmpty::singleton(ReceivedNote::from_parts(
-                    NoteRecordIdentifier {
-                        txid,
-                        pool: PoolType::Shielded(zcash_client_backend::ShieldedProtocol::Sapling),
-                        index: 0,
-                    },
-                    txid,
-                    0,
-                    zcash_client_backend::wallet::Note::Sapling(note),
-                    zip32::Scope::External,
-                    Position::from(1),
-                )),
-            )))
-            .prior_step_inputs(vec![])
-            .balance(
-                TransactionBalance::new(vec![], NonNegativeAmount::const_from_u64(20_000)).unwrap(),
+        build_method!(fee_rule, FeeRule);
+        build_method!(min_target_height, BlockHeight);
+        build_method!(steps, NonEmpty<Step<NoteRecordIdentifier>>);
+
+        /// Builds a proposal after all fields have been set.
+        ///
+        /// # Panics
+        ///
+        /// `build` will panic if any fields of the builder are `None` or if the build failed
+        /// due to invalid values.
+        pub fn build(self) -> Proposal<FeeRule, NoteRecordIdentifier> {
+            let step = self.steps.unwrap().first().clone();
+            Proposal::single_step(
+                step.transaction_request().clone(),
+                step.payment_pools().clone(),
+                step.transparent_inputs().to_vec(),
+                step.shielded_inputs().cloned(),
+                step.balance().clone(),
+                self.fee_rule.unwrap(),
+                self.min_target_height.unwrap(),
+                step.is_shielding(),
             )
-            .is_shielding(false)
+            .unwrap()
+        }
+    }
+
+    impl Default for ProposalBuilder {
+        /// Constructs a new [`ProposalBuilder`] where all fields are preset to default values.
+        fn default() -> Self {
+            ProposalBuilder::new()
+                .fee_rule(FeeRule::standard())
+                .min_target_height(BlockHeight::from_u32(1))
+                .steps(NonEmpty::singleton(StepBuilder::default().build()))
+        }
+    }
+
+    /// Provides a builder for constructing a mock [`zcash_client_backend::proposal::Step`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use zingolib::test_framework::mocks::StepBuilder;
+    ///
+    /// let step = StepBuilder::default().build();
+    /// ````
+    pub struct StepBuilder {
+        transaction_request: Option<TransactionRequest>,
+        payment_pools: Option<BTreeMap<usize, PoolType>>,
+        transparent_inputs: Option<Vec<WalletTransparentOutput>>,
+        shielded_inputs: Option<Option<ShieldedInputs<NoteRecordIdentifier>>>,
+        prior_step_inputs: Option<Vec<StepOutput>>,
+        balance: Option<TransactionBalance>,
+        is_shielding: Option<bool>,
+    }
+
+    impl StepBuilder {
+        /// Constructs a new [`StepBuilder`] with all fields as `None`.
+        pub fn new() -> Self {
+            StepBuilder {
+                transaction_request: None,
+                payment_pools: None,
+                transparent_inputs: None,
+                shielded_inputs: None,
+                prior_step_inputs: None,
+                balance: None,
+                is_shielding: None,
+            }
+        }
+
+        build_method!(transaction_request, TransactionRequest);
+        build_method!(payment_pools, BTreeMap<usize, PoolType>
+        );
+        build_method!(transparent_inputs, Vec<WalletTransparentOutput>);
+        build_method!(
+            shielded_inputs,
+            Option<ShieldedInputs<NoteRecordIdentifier>>
+        );
+        build_method!(prior_step_inputs, Vec<StepOutput>);
+        build_method!(balance, TransactionBalance);
+        build_method!(is_shielding, bool);
+
+        /// Builds a step after all fields have been set.
+        ///
+        /// # Panics
+        ///
+        /// `build` will panic if any fields of the builder are `None` or if the build failed
+        /// due to invalid values.
+        #[allow(dead_code)]
+        pub fn build(self) -> Step<NoteRecordIdentifier> {
+            Step::from_parts(
+                &[],
+                self.transaction_request.unwrap(),
+                self.payment_pools.unwrap(),
+                self.transparent_inputs.unwrap(),
+                self.shielded_inputs.unwrap(),
+                self.prior_step_inputs.unwrap(),
+                self.balance.unwrap(),
+                self.is_shielding.unwrap(),
+            )
+            .unwrap()
+        }
+    }
+
+    impl Default for StepBuilder {
+        /// Constructs a new [`StepBuilder`] where all fields are preset to default values.
+        fn default() -> Self {
+            let txid = TxId::from_bytes([0u8; 32]);
+            let seed = [0u8; 32];
+            let dfvk = ExtendedSpendingKey::master(&seed).to_diversifiable_full_viewing_key();
+            let (_, address) = dfvk.default_address();
+            let note = sapling_crypto::Note::from_parts(
+                address,
+                NoteValue::from_raw(20_000),
+                Rseed::AfterZip212([7; 32]),
+            );
+
+            Self::new()
+                .transaction_request(TransactionRequest::empty())
+                .payment_pools(BTreeMap::new())
+                .transparent_inputs(vec![])
+                // .shielded_inputs(None)
+                .shielded_inputs(Some(ShieldedInputs::from_parts(
+                    BlockHeight::from_u32(1),
+                    NonEmpty::singleton(ReceivedNote::from_parts(
+                        NoteRecordIdentifier {
+                            txid,
+                            pool: PoolType::Shielded(
+                                zcash_client_backend::ShieldedProtocol::Sapling,
+                            ),
+                            index: 0,
+                        },
+                        txid,
+                        0,
+                        zcash_client_backend::wallet::Note::Sapling(note),
+                        zip32::Scope::External,
+                        Position::from(1),
+                    )),
+                )))
+                .prior_step_inputs(vec![])
+                .balance(
+                    TransactionBalance::new(vec![], NonNegativeAmount::const_from_u64(20_000))
+                        .unwrap(),
+                )
+                .is_shielding(false)
+        }
     }
 }

--- a/zingolib/src/test_framework/mocks.rs
+++ b/zingolib/src/test_framework/mocks.rs
@@ -1,5 +1,16 @@
 //! Tools to facilitate mocks for testing
-use zcash_primitives::transaction::TxId;
+
+use std::collections::BTreeMap;
+
+use nonempty::NonEmpty;
+use zcash_client_backend::proposal::{Proposal, ShieldedInputs, Step, StepOutput};
+use zcash_client_backend::wallet::WalletTransparentOutput;
+use zcash_client_backend::PoolType;
+use zcash_client_backend::{fees::TransactionBalance, zip321::TransactionRequest};
+use zcash_primitives::transaction::{components::amount::NonNegativeAmount, fees::zip317::FeeRule};
+use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
+
+use crate::wallet::notes::TransparentNote;
 
 macro_rules! build_method {
     ($name:ident, $localtype:ty) => {
@@ -9,7 +20,7 @@ macro_rules! build_method {
         }
     };
 }
-use crate::wallet::notes::TransparentNote;
+
 pub struct TransparentNoteBuilder {
     address: Option<String>,
     txid: Option<TxId>,
@@ -58,5 +69,114 @@ impl Default for TransparentNoteBuilder {
             spent: Some(None),
             unconfirmed_spent: Some(None),
         }
+    }
+}
+
+pub struct ProposalBuilder<FeeRuleT, NoteRef> {
+    fee_rule: Option<FeeRuleT>,
+    min_target_height: Option<BlockHeight>,
+    steps: Option<NonEmpty<Step<NoteRef>>>,
+}
+
+impl<FeeRuleT, NoteRef> ProposalBuilder<FeeRuleT, NoteRef> {
+    pub fn new() -> Self {
+        ProposalBuilder {
+            fee_rule: None,
+            min_target_height: None,
+            steps: None,
+        }
+    }
+
+    build_method!(fee_rule, FeeRuleT);
+    build_method!(min_target_height, BlockHeight);
+    build_method!(steps, NonEmpty<Step<NoteRef>>);
+
+    pub fn build(self) -> Proposal<FeeRuleT, NoteRef> {
+        Proposal::single_step(
+            self.steps.unwrap().first().transaction_request().clone(),
+            self.steps.unwrap().first().payment_pools().clone(),
+            self.steps.unwrap().first().transparent_inputs().to_vec(),
+            self.steps.unwrap().first().shielded_inputs(),
+            self.steps.unwrap().first().balance().clone(),
+            self.fee_rule.unwrap(),
+            self.min_target_height.unwrap(),
+            self.steps.unwrap().first().is_shielding(),
+        )
+        .unwrap()
+    }
+}
+
+pub struct StepBuilder<NoteRef> {
+    transaction_request: Option<TransactionRequest>,
+    payment_pools: Option<BTreeMap<usize, PoolType>>,
+    transparent_inputs: Option<Vec<WalletTransparentOutput>>,
+    shielded_inputs: Option<Option<ShieldedInputs<NoteRef>>>,
+    prior_step_inputs: Option<Vec<StepOutput>>,
+    balance: Option<TransactionBalance>,
+    is_shielding: Option<bool>,
+}
+
+impl<NoteRef> StepBuilder<NoteRef> {
+    pub fn new() -> Self {
+        StepBuilder {
+            transaction_request: None,
+            payment_pools: None,
+            transparent_inputs: None,
+            shielded_inputs: None,
+            prior_step_inputs: None,
+            balance: None,
+            is_shielding: None,
+        }
+    }
+
+    build_method!(transaction_request, TransactionRequest);
+    build_method!(payment_pools, BTreeMap<usize, PoolType>
+    );
+    build_method!(transparent_inputs, Vec<WalletTransparentOutput>);
+    build_method!(shielded_inputs, Option<ShieldedInputs<NoteRef>>);
+    build_method!(prior_step_inputs, Vec<StepOutput>);
+    build_method!(balance, TransactionBalance);
+    build_method!(is_shielding, bool);
+
+    pub fn build(self) -> Step<NoteRef> {
+        Step::from_parts(
+            &[],
+            self.transaction_request.unwrap(),
+            self.payment_pools.unwrap(),
+            self.transparent_inputs.unwrap(),
+            self.shielded_inputs.unwrap(),
+            self.prior_step_inputs.unwrap(),
+            self.balance.unwrap(),
+            self.is_shielding.unwrap(),
+        )
+        .unwrap()
+    }
+}
+
+impl<NoteRef> Default for StepBuilder<NoteRef> {
+    fn default() -> Self {
+        Self::new()
+            .transaction_request(TransactionRequest::empty())
+            .payment_pools(BTreeMap::new())
+            .transparent_inputs(vec![])
+            .shielded_inputs(None)
+            .prior_step_inputs(vec![])
+            .balance(
+                TransactionBalance::new(vec![], NonNegativeAmount::const_from_u64(20_000)).unwrap(),
+            )
+            .is_shielding(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_proposal() {
+        let proposal = ProposalBuilder::new()
+            .fee_rule(FeeRule::standard())
+            .min_target_height(BlockHeight::from_u32(1))
+            .steps(NonEmpty::singleton(StepBuilder::<()>::default().build()));
     }
 }

--- a/zingolib/src/test_framework/mocks.rs
+++ b/zingolib/src/test_framework/mocks.rs
@@ -2,15 +2,22 @@
 
 use std::collections::BTreeMap;
 
+use incrementalmerkletree::Position;
 use nonempty::NonEmpty;
+use sapling_crypto::value::NoteValue;
+use sapling_crypto::zip32::ExtendedSpendingKey;
+use sapling_crypto::Rseed;
+use zcash_client_backend::fees::TransactionBalance;
 use zcash_client_backend::proposal::{Proposal, ShieldedInputs, Step, StepOutput};
-use zcash_client_backend::wallet::WalletTransparentOutput;
+use zcash_client_backend::wallet::{ReceivedNote, WalletTransparentOutput};
+use zcash_client_backend::zip321::TransactionRequest;
 use zcash_client_backend::PoolType;
-use zcash_client_backend::{fees::TransactionBalance, zip321::TransactionRequest};
-use zcash_primitives::transaction::{components::amount::NonNegativeAmount, fees::zip317::FeeRule};
-use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
+use zcash_primitives::consensus::BlockHeight;
+use zcash_primitives::transaction::{
+    components::amount::NonNegativeAmount, fees::zip317::FeeRule, TxId,
+};
 
-use crate::wallet::notes::TransparentNote;
+use crate::wallet::notes::{NoteRecordIdentifier, TransparentNote};
 
 macro_rules! build_method {
     ($name:ident, $localtype:ty) => {
@@ -72,16 +79,25 @@ impl Default for TransparentNoteBuilder {
     }
 }
 
-pub struct ProposalBuilder<FeeRuleT, NoteRef> {
-    fee_rule: Option<FeeRuleT>,
+/// Provides a builder for constructing a mock [`zcash_client_backend::proposal::Proposal`].
+///
+/// # Examples
+///
+/// ```
+/// use zingolib::test_framework::mocks::ProposalBuilder;
+///
+/// let proposal = ProposalBuilder::default().build();
+/// ````
+#[allow(dead_code)]
+pub struct ProposalBuilder {
+    fee_rule: Option<FeeRule>,
     min_target_height: Option<BlockHeight>,
-    steps: Option<NonEmpty<Step<NoteRef>>>,
+    steps: Option<NonEmpty<Step<NoteRecordIdentifier>>>,
 }
 
-impl<FeeRuleT, NoteRef> ProposalBuilder<FeeRuleT, NoteRef>
-where
-    NoteRef: Clone,
-{
+#[allow(dead_code)]
+impl ProposalBuilder {
+    /// Constructs a new [`ProposalBuilder`] with all fields as `None`.
     pub fn new() -> Self {
         ProposalBuilder {
             fee_rule: None,
@@ -90,11 +106,17 @@ where
         }
     }
 
-    build_method!(fee_rule, FeeRuleT);
+    build_method!(fee_rule, FeeRule);
     build_method!(min_target_height, BlockHeight);
-    build_method!(steps, NonEmpty<Step<NoteRef>>);
+    build_method!(steps, NonEmpty<Step<NoteRecordIdentifier>>);
 
-    pub fn build(self) -> Proposal<FeeRuleT, NoteRef> {
+    /// Builds a proposal after all fields have been set.
+    ///
+    /// # Panics
+    ///
+    /// `build` will panic if any fields of the builder are `None` or if the build failed
+    /// due to invalid values.
+    pub fn build(self) -> Proposal<FeeRule, NoteRecordIdentifier> {
         let step = self.steps.unwrap().first().clone();
         Proposal::single_step(
             step.transaction_request().clone(),
@@ -110,17 +132,37 @@ where
     }
 }
 
-pub struct StepBuilder<NoteRef> {
+impl Default for ProposalBuilder {
+    /// Constructs a new [`ProposalBuilder`] where all fields are preset to default values.
+    fn default() -> Self {
+        ProposalBuilder::new()
+            .fee_rule(FeeRule::standard())
+            .min_target_height(BlockHeight::from_u32(1))
+            .steps(NonEmpty::singleton(StepBuilder::default().build()))
+    }
+}
+
+/// Provides a builder for constructing a mock [`zcash_client_backend::proposal::Step`].
+///
+/// # Examples
+///
+/// ```
+/// use zingolib::test_framework::mocks::StepBuilder;
+///
+/// let step = StepBuilder::default().build();
+/// ````
+pub struct StepBuilder {
     transaction_request: Option<TransactionRequest>,
     payment_pools: Option<BTreeMap<usize, PoolType>>,
     transparent_inputs: Option<Vec<WalletTransparentOutput>>,
-    shielded_inputs: Option<Option<ShieldedInputs<NoteRef>>>,
+    shielded_inputs: Option<Option<ShieldedInputs<NoteRecordIdentifier>>>,
     prior_step_inputs: Option<Vec<StepOutput>>,
     balance: Option<TransactionBalance>,
     is_shielding: Option<bool>,
 }
 
-impl<NoteRef> StepBuilder<NoteRef> {
+impl StepBuilder {
+    /// Constructs a new [`StepBuilder`] with all fields as `None`.
     pub fn new() -> Self {
         StepBuilder {
             transaction_request: None,
@@ -137,12 +179,22 @@ impl<NoteRef> StepBuilder<NoteRef> {
     build_method!(payment_pools, BTreeMap<usize, PoolType>
     );
     build_method!(transparent_inputs, Vec<WalletTransparentOutput>);
-    build_method!(shielded_inputs, Option<ShieldedInputs<NoteRef>>);
+    build_method!(
+        shielded_inputs,
+        Option<ShieldedInputs<NoteRecordIdentifier>>
+    );
     build_method!(prior_step_inputs, Vec<StepOutput>);
     build_method!(balance, TransactionBalance);
     build_method!(is_shielding, bool);
 
-    pub fn build(self) -> Step<NoteRef> {
+    /// Builds a step after all fields have been set.
+    ///
+    /// # Panics
+    ///
+    /// `build` will panic if any fields of the builder are `None` or if the build failed
+    /// due to invalid values.
+    #[allow(dead_code)]
+    pub fn build(self) -> Step<NoteRecordIdentifier> {
         Step::from_parts(
             &[],
             self.transaction_request.unwrap(),
@@ -157,30 +209,43 @@ impl<NoteRef> StepBuilder<NoteRef> {
     }
 }
 
-impl<NoteRef> Default for StepBuilder<NoteRef> {
+impl Default for StepBuilder {
+    /// Constructs a new [`StepBuilder`] where all fields are preset to default values.
     fn default() -> Self {
+        let txid = TxId::from_bytes([0u8; 32]);
+        let seed = [0u8; 32];
+        let dfvk = ExtendedSpendingKey::master(&seed).to_diversifiable_full_viewing_key();
+        let (_, address) = dfvk.default_address();
+        let note = sapling_crypto::Note::from_parts(
+            address,
+            NoteValue::from_raw(20_000),
+            Rseed::AfterZip212([7; 32]),
+        );
+
         Self::new()
             .transaction_request(TransactionRequest::empty())
             .payment_pools(BTreeMap::new())
             .transparent_inputs(vec![])
-            .shielded_inputs(None)
+            // .shielded_inputs(None)
+            .shielded_inputs(Some(ShieldedInputs::from_parts(
+                BlockHeight::from_u32(1),
+                NonEmpty::singleton(ReceivedNote::from_parts(
+                    NoteRecordIdentifier {
+                        txid,
+                        pool: PoolType::Shielded(zcash_client_backend::ShieldedProtocol::Sapling),
+                        index: 0,
+                    },
+                    txid,
+                    0,
+                    zcash_client_backend::wallet::Note::Sapling(note),
+                    zip32::Scope::External,
+                    Position::from(1),
+                )),
+            )))
             .prior_step_inputs(vec![])
             .balance(
                 TransactionBalance::new(vec![], NonNegativeAmount::const_from_u64(20_000)).unwrap(),
             )
             .is_shielding(false)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn mock_proposal() {
-        let proposal = ProposalBuilder::new()
-            .fee_rule(FeeRule::standard())
-            .min_target_height(BlockHeight::from_u32(1))
-            .steps(NonEmpty::singleton(StepBuilder::<()>::default().build()));
     }
 }

--- a/zingolib/src/test_framework/mocks.rs
+++ b/zingolib/src/test_framework/mocks.rs
@@ -78,7 +78,10 @@ pub struct ProposalBuilder<FeeRuleT, NoteRef> {
     steps: Option<NonEmpty<Step<NoteRef>>>,
 }
 
-impl<FeeRuleT, NoteRef> ProposalBuilder<FeeRuleT, NoteRef> {
+impl<FeeRuleT, NoteRef> ProposalBuilder<FeeRuleT, NoteRef>
+where
+    NoteRef: Clone,
+{
     pub fn new() -> Self {
         ProposalBuilder {
             fee_rule: None,
@@ -92,15 +95,16 @@ impl<FeeRuleT, NoteRef> ProposalBuilder<FeeRuleT, NoteRef> {
     build_method!(steps, NonEmpty<Step<NoteRef>>);
 
     pub fn build(self) -> Proposal<FeeRuleT, NoteRef> {
+        let step = self.steps.unwrap().first().clone();
         Proposal::single_step(
-            self.steps.unwrap().first().transaction_request().clone(),
-            self.steps.unwrap().first().payment_pools().clone(),
-            self.steps.unwrap().first().transparent_inputs().to_vec(),
-            self.steps.unwrap().first().shielded_inputs(),
-            self.steps.unwrap().first().balance().clone(),
+            step.transaction_request().clone(),
+            step.payment_pools().clone(),
+            step.transparent_inputs().to_vec(),
+            step.shielded_inputs().cloned(),
+            step.balance().clone(),
             self.fee_rule.unwrap(),
             self.min_target_height.unwrap(),
-            self.steps.unwrap().first().is_shielding(),
+            step.is_shielding(),
         )
         .unwrap()
     }


### PR DESCRIPTION
- adds mock proposal and step builders
- defines a good starting point for the format of our mocking framework
- fully cargo docced with examples (following PR will be raised to add cargo docs to proc macro build_method!)
- makes test_framework and mocks modules pub for doc tests and also use in other crates