### PR TITLE
Parse send args to final types

### DIFF
--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -722,7 +722,7 @@ pub mod scenarios {
                 DarksideSender::ExternalClient(lc) => lc,
             };
             lightclient
-                .do_shield(&[pool_to_shield], None)
+                .do_shield_test_only(&[pool_to_shield], None)
                 .await
                 .unwrap();
             let mut streamed_raw_txns = self

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -673,7 +673,7 @@ pub mod scenarios {
                 DarksideSender::ExternalClient(lc) => lc,
             };
             lightclient
-                .do_send(vec![(receiver_address, value, None)])
+                .do_send_test_only(vec![(receiver_address, value, None)])
                 .await
                 .unwrap();
             let mut streamed_raw_txns = self

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -556,7 +556,7 @@ async fn reorg_changes_outgoing_tx_height() {
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
     let sent_tx_id = light_client
-        .do_send([(recipient_string, amount, None)].to_vec())
+        .do_send_test_only([(recipient_string, amount, None)].to_vec())
         .await
         .unwrap();
 
@@ -792,7 +792,7 @@ async fn reorg_expires_outgoing_tx_height() {
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
     let sent_tx_id = light_client
-        .do_send([(recipient_string, amount, None)].to_vec())
+        .do_send_test_only([(recipient_string, amount, None)].to_vec())
         .await
         .unwrap();
 
@@ -970,7 +970,7 @@ async fn reorg_changes_outgoing_tx_index() {
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
     let sent_tx_id = light_client
-        .do_send([(recipient_string, amount, None)].to_vec())
+        .do_send_test_only([(recipient_string, amount, None)].to_vec())
         .await
         .unwrap();
 

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -141,7 +141,7 @@ async fn sent_transaction_reorged_into_mempool() {
         }
     );
     let txid = light_client
-        .do_send(vec![(
+        .do_send_test_only(vec![(
             &get_base_address!(recipient, "unified"),
             10_000,
             None,

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -134,7 +134,7 @@ mod fast {
         let (regtest_manager, _cph, faucet, recipient) =
             scenarios::faucet_recipient_default().await;
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "transparent"),
                 100_000,
                 None,
@@ -175,7 +175,8 @@ mod fast {
         );
         assert_eq!(
         recipient
-            .do_send(vec![(&get_base_address!(faucet, "unified"), 100_000, None)])
+            .do_send_test_only
+            (vec![(&get_base_address!(faucet, "unified"), 100_000, None)])
             .await
             .unwrap_err(),
         "The reorg buffer offset has been set to 4 but there are only 1 blocks in the wallet. Please sync at least 4 more blocks before trying again"
@@ -297,7 +298,7 @@ mod fast {
 
         check_client_balances!(faucet, o: 0 s: 2_500_000_000u64 t: 0u64);
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "unified").as_str(),
                 5_000,
                 Some(
@@ -368,7 +369,10 @@ mod fast {
             .members()
             .map(|ua| (ua["address"].as_str().unwrap(), 5_000, None))
             .collect::<Vec<(&str, u64, Option<MemoBytes>)>>();
-        faucet.do_send(address_5000_nonememo_tuples).await.unwrap();
+        faucet
+            .do_send_test_only(address_5000_nonememo_tuples)
+            .await
+            .unwrap();
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 1)
             .await
             .unwrap();
@@ -655,7 +659,7 @@ mod slow {
 
         let sent_value = 0;
         let _sent_transaction_id = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 sent_value,
                 None,
@@ -667,7 +671,7 @@ mod slow {
             .await
             .unwrap();
         let _sent_transaction_id = recipient
-            .do_send(vec![(&get_base_address!(faucet, "unified"), 1000, None)])
+            .do_send_test_only(vec![(&get_base_address!(faucet, "unified"), 1000, None)])
             .await
             .unwrap();
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 5)
@@ -693,7 +697,7 @@ mod slow {
 
         let sent_value = value - u64::from(MINIMUM_FEE);
         let sent_transaction_id = recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 sent_value,
                 None,
@@ -739,7 +743,7 @@ mod slow {
         let faucet_ua = get_base_address!(faucet, "unified");
 
         let _sent_transaction_id = recipient
-            .do_send(vec![(&faucet_ua, sent_value, Some(outgoing_memo))])
+            .do_send_test_only(vec![(&faucet_ua, sent_value, Some(outgoing_memo))])
             .await
             .unwrap();
 
@@ -920,7 +924,7 @@ mod slow {
 
         // Interrupt generating send
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 10_000,
                 Some(Memo::from_str("Interrupting sync!!").unwrap().into()),
@@ -973,7 +977,7 @@ mod slow {
             .await
             .unwrap();
         // 2. send a transaction containing all types of outputs
-        faucet.do_send(addr_amount_memos).await.unwrap();
+        faucet.do_send_test_only(addr_amount_memos).await.unwrap();
         zingo_testutils::increase_height_and_wait_for_client(
             &regtest_manager,
             &original_recipient,
@@ -1036,7 +1040,7 @@ mod slow {
             watch_client.do_rescan().await.unwrap();
             assert_eq!(
                 watch_client
-                    .do_send(vec![(testvectors::EXT_TADDR, 1000, None)])
+                    .do_send_test_only(vec![(testvectors::EXT_TADDR, 1000, None)])
                     .await,
                 Err("Wallet is in watch-only mode and thus it cannot spend.".to_string())
             );
@@ -1052,7 +1056,7 @@ mod slow {
         let value = 100_000;
 
         faucet
-            .do_send(vec![(taddr.as_str(), value, None)])
+            .do_send_test_only(vec![(taddr.as_str(), value, None)])
             .await
             .unwrap();
 
@@ -1070,7 +1074,7 @@ mod slow {
         // 4. We can't spend the funds, as they're transparent. We need to shield first
         let sent_value = 20_000;
         let sent_transaction_error = recipient
-            .do_send(vec![(testvectors::EXT_TADDR, sent_value, None)])
+            .do_send_test_only(vec![(testvectors::EXT_TADDR, sent_value, None)])
             .await
             .unwrap_err();
         assert_eq!(sent_transaction_error, "Insufficient verified shielded funds. Have 0 zats, need 30000 zats. NOTE: funds need at least 1 confirmations before they can be spent. Transparent funds must be shielded before they can be spent. If you are trying to spend transparent funds, please use the shield button and try again in a few minutes.");
@@ -1082,7 +1086,7 @@ mod slow {
 
         let sapling_dust = 100;
         let _sent_transaction_id = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 sapling_dust,
                 None,
@@ -1110,7 +1114,7 @@ mod slow {
         let sapling_enough_for_fee = 10_100;
         faucet.do_sync(false).await.unwrap();
         let _sent_transaction_id = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 sapling_enough_for_fee,
                 None,
@@ -1130,7 +1134,7 @@ mod slow {
         // already in the shielding wallet
         faucet.do_sync(false).await.unwrap();
         let _sent_transaction_id = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 sapling_enough_for_fee,
                 None,
@@ -1172,7 +1176,7 @@ mod slow {
         let (ref regtest_manager, _cph, faucet, ref recipient) =
             scenarios::faucet_recipient_default().await;
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 transparent_funding,
                 None,
@@ -1233,7 +1237,7 @@ mod slow {
         let recipient_unified_address = get_base_address!(recipient, "unified");
         let sent_value = 50_000;
         faucet
-            .do_send(vec![(recipient_unified_address.as_str(), sent_value, None)])
+            .do_send_test_only(vec![(recipient_unified_address.as_str(), sent_value, None)])
             .await
             .unwrap();
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
@@ -1329,7 +1333,7 @@ mod slow {
     ).unwrap();
 
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "sapling"),
                 first_send_to_sapling,
                 None,
@@ -1340,7 +1344,7 @@ mod slow {
             .await
             .unwrap();
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "transparent"),
                 first_send_to_transparent,
                 None,
@@ -1380,7 +1384,7 @@ mod slow {
 
         faucet.do_sync(false).await.unwrap();
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 recipient_second_wave,
                 Some(Memo::from_str("Second wave incoming").unwrap().into()),
@@ -1391,7 +1395,7 @@ mod slow {
             .await
             .unwrap();
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "transparent"),
                 second_send_to_transparent,
                 None,
@@ -1399,7 +1403,7 @@ mod slow {
             .await
             .unwrap();
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "sapling"),
                 second_send_to_sapling,
                 None,
@@ -1411,7 +1415,7 @@ mod slow {
             .unwrap();
 
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "transparent"),
                 third_send_to_transparent,
                 None,
@@ -1569,7 +1573,7 @@ mod slow {
 
         // post transfer to recipient, and verify
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 faucet_to_recipient_amount,
                 Some(Memo::from_str("Orcharding").unwrap().into()),
@@ -1598,7 +1602,7 @@ mod slow {
 
         // post half back to faucet, and verify
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 recipient_to_faucet_amount,
                 Some(Memo::from_str("Sending back").unwrap().into()),
@@ -1633,7 +1637,7 @@ mod slow {
             scenarios::faucet(Pool::Sapling, regtest_network).await;
         let amount_to_send = 5_000;
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(faucet, "unified").as_str(),
                 amount_to_send,
                 Some(Memo::from_str("Scenario test: engage!").unwrap().into()),
@@ -1662,7 +1666,7 @@ mod slow {
             .unwrap();
         check_client_balances!(faucet, o: 0 s: 3_500_000_000u64 t: 0);
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 3_499_990_000u64,
                 None,
@@ -1703,7 +1707,7 @@ mod slow {
         let recipient_unified_address = get_base_address!(recipient, "unified");
         let sent_value = 50_000;
         faucet
-            .do_send(vec![(recipient_unified_address.as_str(), sent_value, None)])
+            .do_send_test_only(vec![(recipient_unified_address.as_str(), sent_value, None)])
             .await
             .unwrap();
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 1)
@@ -1715,14 +1719,14 @@ mod slow {
         let sent_to_zaddr_value = 11_000;
         let sent_to_self_orchard_value = 1_000;
         recipient
-            .do_send(vec![(recipient_taddr.as_str(), sent_to_taddr_value, None)])
+            .do_send_test_only(vec![(recipient_taddr.as_str(), sent_to_taddr_value, None)])
             .await
             .unwrap();
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 1)
             .await
             .unwrap();
         recipient
-            .do_send(vec![
+            .do_send_test_only(vec![
                 (recipient_taddr.as_str(), sent_to_taddr_value, None),
                 (
                     recipient_zaddr.as_str(),
@@ -1739,7 +1743,7 @@ mod slow {
             .unwrap();
         faucet.do_sync(false).await.unwrap();
         faucet
-            .do_send(vec![
+            .do_send_test_only(vec![
                 (recipient_taddr.as_str(), sent_to_taddr_value, None),
                 (
                     recipient_zaddr.as_str(),
@@ -1813,7 +1817,7 @@ mod slow {
         // Construct transaction to wallet-external recipient-address.
         let exit_zaddr = get_base_address!(faucet, "sapling");
         let spent_txid = recipient
-            .do_send(vec![(&exit_zaddr, spent_value, None)])
+            .do_send_test_only(vec![(&exit_zaddr, spent_value, None)])
             .await
             .unwrap();
 
@@ -1847,7 +1851,7 @@ mod slow {
 
         // 2. Send an incoming transaction to fill the wallet
         let faucet_funding_txid = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 value,
                 None,
@@ -1902,7 +1906,7 @@ mod slow {
         let outgoing_memo = Memo::from_str(outgoing_memo_text).unwrap().into();
 
         let sent_transaction_id = recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "sapling"),
                 sent_value,
                 Some(outgoing_memo),
@@ -2042,7 +2046,7 @@ mod slow {
         let for_orchard = dbg!(fee * 10);
         let for_sapling = dbg!(fee / 10);
         faucet
-            .do_send(vec![
+            .do_send_test_only(vec![
                 (
                     &recipient_unified,
                     for_orchard,
@@ -2062,7 +2066,7 @@ mod slow {
         check_client_balances!(recipient, o: for_orchard s: for_sapling t: 0 );
 
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 fee * 5,
                 Some(Memo::from_str("Five times fee.").unwrap().into()),
@@ -2097,14 +2101,14 @@ mod slow {
 
         println!("creating vec");
         faucet
-            .do_send(vec![(&get_base_address!(faucet, "unified"), 10, None); 15])
+            .do_send_test_only(vec![(&get_base_address!(faucet, "unified"), 10, None); 15])
             .await
             .unwrap();
         zingo_testutils::increase_height_and_wait_for_client(regtest_manager, recipient, 10)
             .await
             .unwrap();
         recipient
-            .do_send(vec![(&get_base_address!(faucet, "unified"), 10, None)])
+            .do_send_test_only(vec![(&get_base_address!(faucet, "unified"), 10, None)])
             .await
             .unwrap();
         zingo_testutils::increase_height_and_wait_for_client(regtest_manager, recipient, 10)
@@ -2143,7 +2147,7 @@ mod slow {
         let sapling_addr = get_base_address!(faucet, "sapling");
         for memo in [None, Some("foo")] {
             faucet
-                .do_send(vec![(
+                .do_send_test_only(vec![(
                     sapling_addr.as_str(),
                     {
                         let balance = faucet.do_balance().await;
@@ -2187,7 +2191,7 @@ mod slow {
         let (regtest_manager, _cph, faucet, recipient) =
             scenarios::faucet_recipient_default().await;
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "sapling").as_str(),
                 1_000,
                 Some(Memo::from_str("foo").unwrap().into()),
@@ -2220,7 +2224,7 @@ mod slow {
         // These are sent from the coinbase funded client which will
         // subsequently receive funding via it's orchard-packed UA.
         faucet
-            .do_send(
+            .do_send_test_only(
                 (1..=3)
                     .map(|n| {
                         (
@@ -2241,7 +2245,7 @@ mod slow {
         // 3000 back to 1 it will have to collect funds from two notes to pay the full 3000
         // plus the transaction fee.
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 30000,
                 Some(
@@ -2322,7 +2326,7 @@ mod slow {
         let (ref regtest_manager, _cph, faucet, ref recipient, _txid) =
             scenarios::faucet_funded_recipient_default(inital_value).await;
         recipient
-            .do_send(vec![
+            .do_send_test_only(vec![
                 (&get_base_address!(faucet, "unified"), 10_000, None);
                 2
             ])
@@ -2448,7 +2452,7 @@ mod slow {
         let outgoing_memo = Memo::from_str("Outgoing Memo").unwrap().into();
 
         let sent_transaction_id = recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "sapling"),
                 sent_value,
                 Some(outgoing_memo),
@@ -2648,7 +2652,7 @@ mod slow {
         let outgoing_memo = Memo::from_str("Outgoing Memo").unwrap().into();
 
         let _sent_transaction_id = recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 sent_value,
                 Some(outgoing_memo),
@@ -2819,7 +2823,7 @@ mod slow {
         };
         assert_eq!(expected_post_sync_balance, recipient.do_balance().await);
         recipient
-            .do_send(vec![(&get_base_address!(faucet, "unified"), 14000, None)])
+            .do_send_test_only(vec![(&get_base_address!(faucet, "unified"), 14000, None)])
             .await
             .unwrap();
     }
@@ -2864,7 +2868,7 @@ mod slow {
             );
             let recipient1_diversified_addr = recipient1.do_new_address("tz").await.unwrap();
             faucet
-                .do_send(vec![(
+                .do_send_test_only(vec![(
                     recipient1_diversified_addr[0].as_str().unwrap(),
                     14_000,
                     Some(Memo::from_str("foo").unwrap().into()),
@@ -2931,7 +2935,7 @@ mod slow {
             //The first address in a wallet should always contain all three currently extant
             //receiver types.
             recipient_restored
-                .do_send(vec![(&get_base_address!(faucet, "sapling"), 4_000, None)])
+                .do_send_test_only(vec![(&get_base_address!(faucet, "sapling"), 4_000, None)])
                 .await
                 .unwrap();
             let sender_balance = faucet.do_balance().await;
@@ -2974,7 +2978,7 @@ mod slow {
     }
 
         sapling_faucet
-            .do_send(vec![(&pmc_taddr, 50_000, None)])
+            .do_send_test_only(vec![(&pmc_taddr, 50_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 0 s: 0 t: 50_000);
@@ -2987,7 +2991,7 @@ mod slow {
 
         // 2 Test of a send from a sapling only client to its own unified address
         sapling_faucet
-            .do_send(vec![(&pmc_sapling, 50_000, None)])
+            .do_send_test_only(vec![(&pmc_sapling, 50_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 40_000 s: 50_000 t: 0);
@@ -3000,14 +3004,14 @@ mod slow {
 
         // 3 Test of an orchard-only client to itself
         pool_migration_client
-            .do_send(vec![(&pmc_unified, 70_000, None)])
+            .do_send_test_only(vec![(&pmc_unified, 70_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 70_000 s: 0 t: 0);
 
         // 4 tz transparent and sapling to orchard
         pool_migration_client
-            .do_send(vec![
+            .do_send_test_only(vec![
                 (&pmc_taddr, 30_000, None),
                 (&pmc_sapling, 30_000, None),
             ])
@@ -3020,14 +3024,14 @@ mod slow {
             .await
             .unwrap();
         pool_migration_client
-            .do_send(vec![(&pmc_unified, 20_000, None)])
+            .do_send_test_only(vec![(&pmc_unified, 20_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 40_000 s: 0 t: 0);
 
         // 5 to transparent and orchard to orchard
         pool_migration_client
-            .do_send(vec![(&pmc_taddr, 20_000, None)])
+            .do_send_test_only(vec![(&pmc_taddr, 20_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 10_000 s: 0 t: 20_000);
@@ -3040,20 +3044,20 @@ mod slow {
 
         // 6 sapling and orchard to orchard
         sapling_faucet
-            .do_send(vec![(&pmc_sapling, 20_000, None)])
+            .do_send_test_only(vec![(&pmc_sapling, 20_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 20_000 s: 20_000 t: 0);
 
         pool_migration_client
-            .do_send(vec![(&pmc_unified, 30_000, None)])
+            .do_send_test_only(vec![(&pmc_unified, 30_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 30_000 s: 0 t: 0);
 
         // 7 tzo --> o
         sapling_faucet
-            .do_send(vec![
+            .do_send_test_only(vec![
                 (&pmc_taddr, 20_000, None),
                 (&pmc_sapling, 20_000, None),
             ])
@@ -3066,20 +3070,20 @@ mod slow {
             .await
             .unwrap();
         pool_migration_client
-            .do_send(vec![(&pmc_unified, 40_000, None)])
+            .do_send_test_only(vec![(&pmc_unified, 40_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 50_000 s: 0 t: 0);
 
         // Send from Sapling into empty Orchard pool
         pool_migration_client
-            .do_send(vec![(&pmc_sapling, 40_000, None)])
+            .do_send_test_only(vec![(&pmc_sapling, 40_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 0 s: 40_000 t: 0);
 
         pool_migration_client
-            .do_send(vec![(&pmc_unified, 30_000, None)])
+            .do_send_test_only(vec![(&pmc_unified, 30_000, None)])
             .await
             .unwrap();
         bump_and_check!(o: 30_000 s: 0 t: 0);
@@ -3095,14 +3099,14 @@ mod slow {
         assert!(total_value_to_addrs_iter.next().is_none());
     }
     #[tokio::test]
-    async fn factor_do_shield_to_call_do_send() {
+    async fn factor_do_shield_to_call_do_send_test_only() {
         let (regtest_manager, __cph, faucet, recipient) =
             scenarios::faucet_recipient_default().await;
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 2)
             .await
             .unwrap();
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "transparent"),
                 1_000u64,
                 None,
@@ -3118,7 +3122,7 @@ mod slow {
         // Send of less that transaction fee
         let sent_value = 1000;
         let _sent_transaction_id = recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 sent_value,
                 None,
@@ -3142,7 +3146,7 @@ mod slow {
         let (regtest_manager, _cph, faucet, recipient) =
             scenarios::faucet_recipient(Pool::Orchard, regtest_network).await;
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 100_000,
                 Some(
@@ -3173,7 +3177,7 @@ mod slow {
             }
         );
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 25_000,
                 Some(
@@ -3210,7 +3214,7 @@ mod slow {
             faucet.do_list_notes(true).await.pretty(4)
         );
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &base_uaddress,
                 1_000u64,
                 Some(Memo::from_str("1").unwrap().into()),
@@ -3218,7 +3222,7 @@ mod slow {
             .await
             .unwrap();
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &base_uaddress,
                 1_000u64,
                 Some(Memo::from_str("1").unwrap().into()),
@@ -3234,7 +3238,7 @@ mod slow {
             "2".to_string()
         );
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &base_uaddress,
                 1_000u64,
                 Some(Memo::from_str("aaaa").unwrap().into()),
@@ -3259,7 +3263,7 @@ mod slow {
         let sent_zvalue = 80_000;
         let sent_zmemo = Memo::from_str("Ext z").unwrap().into();
         let sent_transaction_id = recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "sapling"),
                 sent_zvalue,
                 Some(sent_zmemo),
@@ -3356,7 +3360,7 @@ mod slow {
         let (_regtest_manager, _cph, _faucet, recipient, _txid) =
             scenarios::faucet_funded_recipient_default(1_000_000).await;
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 100_000,
                 None,
@@ -3386,7 +3390,7 @@ mod slow {
         for i in 1..4 {
             let _ = faucet.do_sync(false).await;
             faucet
-                .do_send(vec![(
+                .do_send_test_only(vec![(
                     &get_base_address!(recipient, "sapling"),
                     10_100,
                     None,
@@ -3398,7 +3402,7 @@ mod slow {
             zingo_testutils::increase_server_height(&regtest_manager, chainwait).await;
             let _ = recipient.do_sync(false).await;
             recipient
-                .do_send(vec![(
+                .do_send_test_only(vec![(
                     &get_base_address!(recipient, "unified"),
                     amount,
                     None,
@@ -3521,12 +3525,12 @@ mod slow {
         assert_eq!(balance.orchard_balance, Some(expected_balance));
         if expected_balance > 0 {
             let _ = client
-                .do_send(vec![(&get_base_address!(client, "sapling"), 11011, None)])
+                .do_send_test_only(vec![(&get_base_address!(client, "sapling"), 11011, None)])
                 .await
                 .unwrap();
             let _ = client.do_sync(true).await.unwrap();
             let _ = client
-                .do_send(vec![(
+                .do_send_test_only(vec![(
                     &get_base_address!(client, "transparent"),
                     28000,
                     None,
@@ -3610,7 +3614,7 @@ mod basic_transactions {
 
         for _ in 0..2 {
             faucet
-                .do_send(vec![(recipient_addr_ua.as_str(), 40_000, None)])
+                .do_send_test_only(vec![(recipient_addr_ua.as_str(), 40_000, None)])
                 .await
                 .unwrap();
         }
@@ -3623,7 +3627,7 @@ mod basic_transactions {
         faucet.do_sync(true).await.unwrap();
 
         recipient
-            .do_send(vec![(faucet_addr_ua.as_str(), 50_000, None)])
+            .do_send_test_only(vec![(faucet_addr_ua.as_str(), 50_000, None)])
             .await
             .unwrap();
 
@@ -3641,7 +3645,7 @@ mod basic_transactions {
             scenarios::faucet_recipient_default().await;
 
         let txid1 = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "unified").as_str(),
                 40_000,
                 None,
@@ -3650,7 +3654,7 @@ mod basic_transactions {
             .unwrap();
 
         let txid2 = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "sapling").as_str(),
                 40_000,
                 None,
@@ -3659,7 +3663,7 @@ mod basic_transactions {
             .unwrap();
 
         let txid3 = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "transparent").as_str(),
                 40_000,
                 None,
@@ -3777,7 +3781,7 @@ mod basic_transactions {
         assert_eq!(calculated_fee_txid3, expected_fee_txid3 as u64);
 
         let txid4 = recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(faucet, "transparent").as_str(),
                 60_000,
                 None,
@@ -3833,7 +3837,7 @@ mod basic_transactions {
             scenarios::faucet_recipient_default().await;
 
         let txid1 = faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "unified").as_str(),
                 0,
                 None,
@@ -3888,7 +3892,7 @@ mod basic_transactions {
             scenarios::faucet_recipient_default().await;
 
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "transparent").as_str(),
                 40_000,
                 None,
@@ -3948,7 +3952,7 @@ mod basic_transactions {
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
 
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 get_base_address!(recipient, "transparent").as_str(),
                 40_000,
                 None,

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -2214,7 +2214,7 @@ mod slow {
                         (
                             client_2_saplingaddress.as_str(),
                             n * 10000,
-                            Some(memos[n as usize]),
+                            Some(memos[(n - 1) as usize]),
                         )
                     })
                     .collect(),
@@ -3079,7 +3079,7 @@ mod slow {
         assert!(total_value_to_addrs_iter.next().is_none());
     }
     #[tokio::test]
-    async fn factor_do_shield_test_only_to_call_do_send_test_only() {
+    async fn factor_do_shield_to_call_do_send() {
         let (regtest_manager, __cph, faucet, recipient) =
             scenarios::faucet_recipient_default().await;
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 2)

--- a/integration-tests/tests/shield_transparent.rs
+++ b/integration-tests/tests/shield_transparent.rs
@@ -14,7 +14,7 @@ async fn shield_transparent() {
         serde_json::to_string_pretty(&recipient.do_balance().await).unwrap(),
     );
     let proposal = faucet
-        .do_send(vec![(
+        .do_send_test_only(vec![(
             &get_base_address!(recipient, "transparent"),
             transparent_funds,
             None,

--- a/integration-tests/tests/shield_transparent.rs
+++ b/integration-tests/tests/shield_transparent.rs
@@ -42,7 +42,7 @@ async fn shield_transparent() {
     );
 
     let shielding_proposal = recipient
-        .do_shield(&[Pool::Transparent], None)
+        .do_shield_test_only(&[Pool::Transparent], None)
         .await
         .unwrap();
 

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -1360,14 +1360,17 @@ pub mod scenarios {
             .unwrap();
         // shield transparent
         recipient
-            .do_shield(&[Pool::Transparent], None)
+            .do_shield_test_only(&[Pool::Transparent], None)
             .await
             .unwrap();
         increase_height_and_wait_for_client(&scenario_builder.regtest_manager, &recipient, 1)
             .await
             .unwrap();
         // upgrade sapling
-        recipient.do_shield(&[Pool::Sapling], None).await.unwrap();
+        recipient
+            .do_shield_test_only(&[Pool::Sapling], None)
+            .await
+            .unwrap();
         // end
         scenario_builder
             .regtest_manager

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -130,7 +130,7 @@ pub fn check_transaction_equality(first: &JsonValue, second: &JsonValue) -> bool
     true
 }
 
-/// TODO: Add Doc Comment Here!
+/// Send from sender to recipient and then sync the recipient
 pub async fn send_value_between_clients_and_sync(
     manager: &RegtestManager,
     sender: &LightClient,
@@ -143,7 +143,7 @@ pub async fn send_value_between_clients_and_sync(
         &recipient.do_addresses().await[0]["address"]
     );
     let txid = sender
-        .do_send(vec![(
+        .do_send_test_only(vec![(
             &zingolib::get_base_address!(recipient, address_type),
             value,
             None,
@@ -1010,7 +1010,7 @@ pub mod scenarios {
         let orchard_txid = if let Some(funds) = orchard_funds {
             Some(
                 faucet
-                    .do_send(vec![(
+                    .do_send_test_only(vec![(
                         &get_base_address!(recipient, "unified"),
                         funds,
                         None,
@@ -1024,7 +1024,7 @@ pub mod scenarios {
         let sapling_txid = if let Some(funds) = sapling_funds {
             Some(
                 faucet
-                    .do_send(vec![(
+                    .do_send_test_only(vec![(
                         &get_base_address!(recipient, "sapling"),
                         funds,
                         None,
@@ -1038,7 +1038,7 @@ pub mod scenarios {
         let transparent_txid = if let Some(funds) = transparent_funds {
             Some(
                 faucet
-                    .do_send(vec![(
+                    .do_send_test_only(vec![(
                         &get_base_address!(recipient, "transparent"),
                         funds,
                         None,
@@ -1168,7 +1168,7 @@ pub mod scenarios {
             .await;
         faucet.do_sync(false).await.unwrap();
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 value,
                 None,
@@ -1210,7 +1210,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 value,
                 None,
@@ -1222,7 +1222,7 @@ pub mod scenarios {
             .unwrap();
         // send to a faucet
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1234,7 +1234,7 @@ pub mod scenarios {
             .unwrap();
         // send to self sapling
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1276,7 +1276,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet to orchard
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 value.checked_div(2).unwrap(),
                 None,
@@ -1288,7 +1288,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet to sapling
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 value.checked_div(4).unwrap(),
                 None,
@@ -1300,7 +1300,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet to transparent
         faucet
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "transparent"),
                 value.checked_div(4).unwrap(),
                 None,
@@ -1312,7 +1312,7 @@ pub mod scenarios {
             .unwrap();
         // send to a faucet
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(faucet, "unified"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1324,7 +1324,7 @@ pub mod scenarios {
             .unwrap();
         // send to self orchard
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1336,7 +1336,7 @@ pub mod scenarios {
             .unwrap();
         // send to self sapling
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "sapling"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1348,7 +1348,7 @@ pub mod scenarios {
             .unwrap();
         // send to self transparent
         recipient
-            .do_send(vec![(
+            .do_send_test_only(vec![(
                 &get_base_address!(recipient, "transparent"),
                 value.checked_div(10).unwrap(),
                 None,

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `export_save_buffer_runtime`
   - `get_wallet_file_location`
   - `get_wallet_dir_location`
+  - `do_send_test_only` behind `test-features` flag
+  - `do_shield_test_only` behind `test-features` flag
 - `wallet::notes::NoteRecordIdentifier` struct
 - `utils` mod
 - `lightclient::LightClient`:
-  - `do_propose` behind "zip317" feature
+  - `do_propose_spend` behind "zip317" feature
   - `do_send_proposal` behind "zip317" feature
 - `commands`:
   - `ProposeCommand` struct and methods behind "zip317" feature
@@ -37,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `commands`:
   - `get_commands` added propose and quicksend to entries behind "zip317" feature
   - `SendCommand::help` formatting
+- `lightclient::LightClient`:
+  - `do_send` inputs from `Vec<(&str, u64, Option<MemoBytes>)>` to `Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>`
+  - `do_shield` inputs from `Option<String>` to `Option<Address>`
 
 ### Removed
 

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `lightclient::LightClient::do_list_transactions`
+- `wallet::keys::is_shielded_address`
 
 ### Added
 
@@ -17,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `export_save_buffer_runtime`
   - `get_wallet_file_location`
   - `get_wallet_dir_location`
-- `wallet::keys::is_transparent_address` fn
 - `wallet::notes::NoteRecordIdentifier` struct
 - `utils` mod
 - `lightclient::LightClient`:

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -831,12 +831,6 @@ impl Command for ProposeCommand {
                 )
             }
         };
-        if let Err(e) = utils::check_memo_compatibility(&send_inputs, &lightclient.config().chain) {
-            return format!(
-                "Error: {}\nTry 'help propose' for correct usage and examples.",
-                e,
-            );
-        };
         RT.block_on(async move {
             match lightclient
                 .do_propose_spend(
@@ -932,12 +926,6 @@ impl Command for QuickSendCommand {
                     e
                 )
             }
-        };
-        if let Err(e) = utils::check_memo_compatibility(&send_inputs, &lightclient.config().chain) {
-            return format!(
-                "Error: {}\nTry 'help quicksend' for correct usage and examples.",
-                e,
-            );
         };
         RT.block_on(async move {
             if let Err(e) = lightclient

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -836,24 +836,25 @@ impl Command for ProposeCommand {
                 )
             }
         };
-        RT.block_on(async move {
-            match lightclient
-                .do_propose_spend(
-                    send_inputs
-                        .iter()
-                        .map(|(address, amount, memo)| (address.as_str(), *amount, memo.clone()))
-                        .collect(),
-                )
-                .await {
-                Ok(proposal) => {
-                    object! { "fee" => proposal.steps().iter().fold(0, |acc, step| acc + u64::from(step.balance().fee_required())) }
-                }
-                Err(e) => {
-                    object! { "error" => e }
-                }
-            }
-            .pretty(2)
-        })
+        // RT.block_on(async move {
+        //     match lightclient
+        //         .do_propose_spend(
+        //             send_inputs
+        //                 .iter()
+        //                 .map(|(address, amount, memo)| (address.as_str(), *amount, memo.clone()))
+        //                 .collect(),
+        //         )
+        //         .await {
+        //         Ok(proposal) => {
+        //             object! { "fee" => proposal.steps().iter().fold(0, |acc, step| acc + u64::from(step.balance().fee_required())) }
+        //         }
+        //         Err(e) => {
+        //             object! { "error" => e }
+        //         }
+        //     }
+        //     .pretty(2)
+        // })
+        "".to_string()
     }
 }
 
@@ -878,7 +879,7 @@ impl Command for SendCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        let send_inputs = match utils::parse_send_args(args) {
+        let send_inputs = match utils::parse_send_args(args, &lightclient.config().chain) {
             Ok(args) => args,
             Err(e) => {
                 return format!(
@@ -887,25 +888,26 @@ impl Command for SendCommand {
                 )
             }
         };
-        RT.block_on(async move {
-            match lightclient
-                .do_send(
-                    send_inputs
-                        .iter()
-                        .map(|(address, amount, memo)| (address.as_str(), *amount, memo.clone()))
-                        .collect(),
-                )
-                .await
-            {
-                Ok(transaction_id) => {
-                    object! { "txid" => transaction_id }
-                }
-                Err(e) => {
-                    object! { "error" => e }
-                }
-            }
-            .pretty(2)
-        })
+        // RT.block_on(async move {
+        //     match lightclient
+        //         .do_send(
+        //             send_inputs
+        //                 .iter()
+        //                 .map(|(address, amount, memo)| (address.as_str(), *amount, memo.clone()))
+        //                 .collect(),
+        //         )
+        //         .await
+        //     {
+        //         Ok(transaction_id) => {
+        //             object! { "txid" => transaction_id }
+        //         }
+        //         Err(e) => {
+        //             object! { "error" => e }
+        //         }
+        //     }
+        //     .pretty(2)
+        // })
+        "".to_string()
     }
 }
 
@@ -943,29 +945,30 @@ impl Command for QuickSendCommand {
                 )
             }
         };
-        RT.block_on(async move {
-            if let Err(e) = lightclient
-                .do_propose_spend(
-                    send_inputs
-                        .iter()
-                        .map(|(address, amount, memo)| (address.as_str(), *amount, memo.clone()))
-                        .collect(),
-                )
-                .await {
-                return e;
-            };
-            match lightclient
-                .do_send_proposal().await
-            {
-                Ok(txids) => {
-                     object! { "txids" =>  txids.iter().map(|txid| txid.to_string()).collect::<Vec<String>>()}
-                }
-                Err(e) => {
-                    object! { "error" => e }
-                }
-            }
-            .pretty(2)
-        })
+        // RT.block_on(async move {
+        //     if let Err(e) = lightclient
+        //         .do_propose_spend(
+        //             send_inputs
+        //                 .iter()
+        //                 .map(|(address, amount, memo)| (address.as_str(), *amount, memo.clone()))
+        //                 .collect(),
+        //         )
+        //         .await {
+        //         return e;
+        //     };
+        //     match lightclient
+        //         .do_send_proposal().await
+        //     {
+        //         Ok(txids) => {
+        //              object! { "txids" =>  txids.iter().map(|txid| txid.to_string()).collect::<Vec<String>>()}
+        //         }
+        //         Err(e) => {
+        //             object! { "error" => e }
+        //         }
+        //     }
+        //     .pretty(2)
+        // })
+        "".to_string()
     }
 }
 

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -827,7 +827,7 @@ impl Command for ProposeCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        let send_inputs = match utils::parse_send_args(args) {
+        let send_inputs = match utils::parse_send_args(args, &lightclient.config().chain) {
             Ok(args) => args,
             Err(e) => {
                 return format!(
@@ -835,12 +835,6 @@ impl Command for ProposeCommand {
                     e
                 )
             }
-        };
-        if let Err(e) = utils::check_memo_compatibility(&send_inputs, &lightclient.config().chain) {
-            return format!(
-                "Error: {}\nTry 'help send' for correct usage and examples.",
-                e,
-            );
         };
         RT.block_on(async move {
             match lightclient
@@ -892,12 +886,6 @@ impl Command for SendCommand {
                     e
                 )
             }
-        };
-        if let Err(e) = utils::check_memo_compatibility(&send_inputs, &lightclient.config().chain) {
-            return format!(
-                "Error: {}\nTry 'help send' for correct usage and examples.",
-                e,
-            );
         };
         RT.block_on(async move {
             match lightclient
@@ -954,12 +942,6 @@ impl Command for QuickSendCommand {
                     e
                 )
             }
-        };
-        if let Err(e) = utils::check_memo_compatibility(&send_inputs, &lightclient.config().chain) {
-            return format!(
-                "Error: {}\nTry 'help send' for correct usage and examples.",
-                e,
-            );
         };
         RT.block_on(async move {
             if let Err(e) = lightclient

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -11,6 +11,7 @@ pub(crate) enum CommandError {
     IncompatibleMemo,
     InvalidMemo(String),
     NonJsonNumberForAmount(String),
+    ConversionFailed(crate::utils::ConversionError),
 }
 
 impl fmt::Display for CommandError {
@@ -31,6 +32,7 @@ impl fmt::Display for CommandError {
             SingleArgNotJsonArray(e) => {
                 write!(f, "argument cannot be parsed to a json array: {}", e)
             }
+            ConversionFailed(e) => write!(f, "conversion failed. {}", e),
         }
     }
 }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -12,6 +12,7 @@ pub(crate) enum CommandError {
     InvalidMemo(String),
     NonJsonNumberForAmount(String),
     ConversionFailed(crate::utils::ConversionError),
+    InvalidPool,
 }
 
 impl fmt::Display for CommandError {
@@ -28,11 +29,12 @@ impl fmt::Display for CommandError {
                 write!(f, "memo's cannot be sent to transparent addresses.")
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
-            NonJsonNumberForAmount(e) => write!(f, "Non Number input: {}", e),
+            NonJsonNumberForAmount(e) => write!(f, "invalid argument. expected a number. {}", e),
             SingleArgNotJsonArray(e) => {
-                write!(f, "argument cannot be parsed to a json array: {}", e)
+                write!(f, "argument cannot be parsed to a json array. {}", e)
             }
             ConversionFailed(e) => write!(f, "conversion failed. {}", e),
+            InvalidPool => write!(f, "invalid pool."),
         }
     }
 }

--- a/zingolib/src/commands/error.rs
+++ b/zingolib/src/commands/error.rs
@@ -4,6 +4,7 @@ use std::fmt;
 pub(crate) enum CommandError {
     ArgsNotJson(json::Error),
     SingleArgNotJsonArray(String),
+    EmptyJsonArray,
     ParseIntFromString(std::num::ParseIntError),
     UnexpectedType(String),
     MissingKey(String),
@@ -21,6 +22,10 @@ impl fmt::Display for CommandError {
 
         match self {
             ArgsNotJson(e) => write!(f, "failed to parse argument. {}", e),
+            SingleArgNotJsonArray(e) => {
+                write!(f, "argument cannot be parsed to a json array. {}", e)
+            }
+            EmptyJsonArray => write!(f, "json array has no arguments"),
             ParseIntFromString(e) => write!(f, "failed to parse argument. {}", e),
             UnexpectedType(e) => write!(f, "arguments cannot be parsed to expected type. {}", e),
             MissingKey(key) => write!(f, "json array is missing \"{}\" key.", key),
@@ -30,9 +35,6 @@ impl fmt::Display for CommandError {
             }
             InvalidMemo(e) => write!(f, "failed to interpret memo. {}", e),
             NonJsonNumberForAmount(e) => write!(f, "invalid argument. expected a number. {}", e),
-            SingleArgNotJsonArray(e) => {
-                write!(f, "argument cannot be parsed to a json array. {}", e)
-            }
             ConversionFailed(e) => write!(f, "conversion failed. {}", e),
             InvalidPool => write!(f, "invalid pool."),
         }

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -23,7 +23,6 @@ pub(super) fn parse_shield_args(
         _ => return Err(CommandError::InvalidPool),
     };
     let address = if args.len() == 2 {
-        // let address =
         Some(address_from_str(args[1], chain).map_err(CommandError::ConversionFailed)?)
     } else {
         None

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -1,5 +1,5 @@
 //! TODO: Add Mod Description Here!
-use log::{debug, error};
+use log::debug;
 
 use zcash_client_backend::address::Address;
 use zcash_primitives::{
@@ -33,7 +33,7 @@ impl LightClient {
     #[cfg(feature = "zip317")]
     pub async fn do_propose_spend(
         &self,
-        _address_amount_memo_tuples: Vec<(&str, u64, Option<MemoBytes>)>,
+        _receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
     ) -> Result<crate::data::proposal::TransferProposal, String> {
         use crate::test_framework::mocks::ProposalBuilder;
 
@@ -194,7 +194,8 @@ impl LightClient {
         let address = address.unwrap_or(Address::from(
             self.wallet.wallet_capability().addresses()[0].clone(),
         ));
-        let amount = zatoshis_from_u64(balance_to_shield - fee).unwrap();
+        let amount = zatoshis_from_u64(balance_to_shield - fee)
+            .expect("balance cannot be outside valid range of zatoshis");
         let receiver = vec![(address, amount, None)];
 
         let result = {

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -10,10 +10,7 @@ use zcash_primitives::{
 use zcash_proofs::prover::LocalTxProver;
 
 use super::{LightClient, LightWalletSendProgress};
-use crate::{
-    utils::{address_from_str, zatoshis_from_u64},
-    wallet::Pool,
-};
+use crate::{utils::zatoshis_from_u64, wallet::Pool};
 
 #[cfg(feature = "zip317")]
 use zcash_primitives::transaction::TxId;
@@ -111,36 +108,6 @@ impl LightClient {
         result.map(|(transaction_id, _)| transaction_id)
     }
 
-    /// Test only lightclient method for calling `do_send` with primitive rust types
-    ///
-    /// # Panics
-    ///
-    /// Panics if the address, amount or memo conversion fails.
-    #[cfg(feature = "test-features")]
-    pub async fn do_send_test_only(
-        &self,
-        address_amount_memo_tuples: Vec<(&str, u64, Option<&str>)>,
-    ) -> Result<String, String> {
-        let receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)> =
-            address_amount_memo_tuples
-                .into_iter()
-                .map(|(address, amount, memo)| {
-                    let address = address_from_str(address, &self.config().chain)
-                        .expect("should be a valid address");
-                    let amount = zatoshis_from_u64(amount)
-                        .expect("should be inside the range of valid zatoshis");
-                    let memo = memo.map(|memo| {
-                        crate::wallet::utils::interpret_memo_string(memo.to_string())
-                            .expect("should be able to interpret memo")
-                    });
-
-                    (address, amount, memo)
-                })
-                .collect();
-
-        self.do_send(receivers).await
-    }
-
     /// TODO: Add Doc Comment Here!
     pub async fn do_send_progress(&self) -> Result<LightWalletSendProgress, String> {
         let progress = self.wallet.get_send_progress().await;
@@ -218,22 +185,5 @@ impl LightClient {
         };
 
         result.map(|(transaction_id, _)| transaction_id)
-    }
-
-    /// Test only lightclient method for calling `do_shield` with an address as &str
-    ///
-    /// # Panics
-    ///
-    /// Panics if the address conversion fails.
-    #[cfg(feature = "test-features")]
-    pub async fn do_shield_test_only(
-        &self,
-        pools_to_shield: &[Pool],
-        address: Option<&str>,
-    ) -> Result<String, String> {
-        let address = address.map(|addr| {
-            address_from_str(addr, &self.config().chain).expect("should be a valid address")
-        });
-        self.do_shield(pools_to_shield, address).await
     }
 }

--- a/zingolib/src/lightclient/test_features.rs
+++ b/zingolib/src/lightclient/test_features.rs
@@ -1,4 +1,11 @@
-use crate::error::ZingoLibError;
+use zcash_client_backend::address::Address;
+use zcash_primitives::transaction::components::amount::NonNegativeAmount;
+
+use crate::{
+    error::ZingoLibError,
+    utils::{address_from_str, zatoshis_from_u64},
+    wallet::Pool,
+};
 
 use super::*;
 
@@ -13,5 +20,51 @@ impl LightClient {
         )
         .await
         .map_err(ZingoLibError::CantReadWallet)
+    }
+
+    /// Test only lightclient method for calling `do_send` with primitive rust types
+    ///
+    /// # Panics
+    ///
+    /// Panics if the address, amount or memo conversion fails.
+    pub async fn do_send_test_only(
+        &self,
+        address_amount_memo_tuples: Vec<(&str, u64, Option<&str>)>,
+    ) -> Result<String, String> {
+        let receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)> =
+            address_amount_memo_tuples
+                .into_iter()
+                .map(|(address, amount, memo)| {
+                    let address = address_from_str(address, &self.config().chain)
+                        .expect("should be a valid address");
+                    let amount = zatoshis_from_u64(amount)
+                        .expect("should be inside the range of valid zatoshis");
+                    let memo = memo.map(|memo| {
+                        crate::wallet::utils::interpret_memo_string(memo.to_string())
+                            .expect("should be able to interpret memo")
+                    });
+
+                    (address, amount, memo)
+                })
+                .collect();
+
+        self.do_send(receivers).await
+    }
+
+    /// Test only lightclient method for calling `do_shield` with an address as &str
+    ///
+    /// # Panics
+    ///
+    /// Panics if the address conversion fails.
+    #[cfg(feature = "test-features")]
+    pub async fn do_shield_test_only(
+        &self,
+        pools_to_shield: &[Pool],
+        address: Option<&str>,
+    ) -> Result<String, String> {
+        let address = address.map(|addr| {
+            address_from_str(addr, &self.config().chain).expect("should be a valid address")
+        });
+        self.do_shield(pools_to_shield, address).await
     }
 }

--- a/zingolib/src/utils.rs
+++ b/zingolib/src/utils.rs
@@ -25,7 +25,7 @@ pub(crate) fn address_from_str(
 }
 
 pub(crate) fn zatoshis_from_u64(amount: u64) -> Result<NonNegativeAmount, ConversionError> {
-    NonNegativeAmount::from_u64(amount).map_err(|e| ConversionError::OutsideValidRange)
+    NonNegativeAmount::from_u64(amount).map_err(|_e| ConversionError::OutsideValidRange)
 }
 
 /// The error type for conversion errors.
@@ -45,7 +45,7 @@ impl std::error::Error for ConversionError {}
 
 impl fmt::Display for ConversionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             ConversionError::DecodeHexFailed(e) => write!(f, "failed to decode hex. {}", e),
             ConversionError::InvalidStringLength => write!(f, "invalid string length"),
             ConversionError::InvalidAddress(address) => {

--- a/zingolib/src/utils.rs
+++ b/zingolib/src/utils.rs
@@ -2,7 +2,9 @@
 
 use std::fmt;
 
-use zcash_primitives::transaction::TxId;
+use zcash_client_backend::address::Address;
+use zcash_primitives::transaction::{components::amount::NonNegativeAmount, TxId};
+use zingoconfig::ChainType;
 
 /// Converts txid from hex-encoded `&str` to `zcash_primitives::transaction::TxId`.
 ///
@@ -14,13 +16,29 @@ pub fn txid_from_hex_encoded_str(txid: &str) -> Result<TxId, ConversionError> {
     Ok(TxId::from_bytes(txid_bytes))
 }
 
+pub(crate) fn address_from_str(
+    address: &str,
+    chain: &ChainType,
+) -> Result<Address, ConversionError> {
+    Address::decode(chain, address)
+        .ok_or_else(|| ConversionError::InvalidAddress(address.to_string()))
+}
+
+pub(crate) fn zatoshis_from_u64(amount: u64) -> Result<NonNegativeAmount, ConversionError> {
+    NonNegativeAmount::from_u64(amount).map_err(|e| ConversionError::OutsideValidRange)
+}
+
 /// The error type for conversion errors.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ConversionError {
-    /// TODO: Add Doc Comment Here!
+    /// Failed to decode hex
     DecodeHexFailed(hex::FromHexError),
-    /// TODO: Add Doc Comment Here!
+    /// Invalid string length
     InvalidStringLength,
+    /// Invalid recipient address
+    InvalidAddress(String),
+    /// Amount is outside the valid range of zatoshis
+    OutsideValidRange,
 }
 
 impl std::error::Error for ConversionError {}
@@ -30,6 +48,12 @@ impl fmt::Display for ConversionError {
         match *self {
             ConversionError::DecodeHexFailed(e) => write!(f, "failed to decode hex. {}", e),
             ConversionError::InvalidStringLength => write!(f, "invalid string length"),
+            ConversionError::InvalidAddress(address) => {
+                write!(f, "invalid recipient address. {}", address)
+            }
+            ConversionError::OutsideValidRange => {
+                write!(f, "amount is outside the valid range of zatoshis")
+            }
         }
     }
 }

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -83,19 +83,12 @@ pub fn get_zaddr_from_bip39seed(
     (extsk, fvk, address)
 }
 
-/// TODO: Add Doc Comment Here!
+/// Checks if the address str is a valid zcash address
+#[deprecated(note = "address strings are now immediately converted to valid addresses")]
 pub fn is_shielded_address(addr: &str, chain: &ChainType) -> bool {
     matches!(
         address::Address::decode(chain, addr),
         Some(address::Address::Sapling(_)) | Some(address::Address::Unified(_))
-    )
-}
-
-/// TODO: Add Doc Comment Here!
-pub fn is_transparent_address(addr: &str, chain: &ChainType) -> bool {
-    matches!(
-        address::Address::decode(chain, addr),
-        Some(address::Address::Transparent(_))
     )
 }
 


### PR DESCRIPTION
Problem statement: In order to create a `send all` command for a zip317 compatibility we need to be able to distinguish a single argument address (in the case `send all` has no memo) from a single argument json. currently we decode the address much later in `do_send` and therefore if it not json parsable we must assume it is a valid address.

This PR solves this issue by parsing the command arguments into their correct types (or returns a specific error) immediately. This also means there are less stages of conversion in the codebase.

This PRs:
- adds converters for LRZ Address and NonNegativeAmount (Zatoshi) types
- moves send/shield command argument parsing to the top layer, removing `map_tos_to_receivers` in `do_send`

As a by-product:
- changes tests and test framework to use `do_send_test_only` and `do_shield_test_only`
- changes tests to give memos as &str
- fixes a typo and adds doc comments on affected entities
- helperises shield command parsing (with unit test!)
- moves checking memo compatibility into parse_send_args which makes sense and also declutters SendCommand
- improves error handling
- deprecates `is_shielded_address`