### PR TITLE
Impl trait for breaking map up

### DIFF
--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `do_send` inputs from `Vec<(&str, u64, Option<MemoBytes>)>` to `Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>`
   - `do_shield` inputs from `Option<String>` to `Option<Address>`
 
+- `TxMapAndMaybeTrees::A --> TransactionRecordsById::A` where A:
+  - add_new_note<D>
+  - check_notes_mark_change
+  - add_taddr_spent
+  - total_funds_spent_in
+  - set_price
+
 ### Removed
 
 - `load_clientconfig` moved to zingoconfig crate

--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -344,17 +344,21 @@ impl TrialDecryptions {
                         );
 
                         let status = ConfirmationStatus::Confirmed(height);
-                        transaction_metadata_set.write().await.add_new_note::<D>(
-                            transaction_id,
-                            status,
-                            timestamp,
-                            note,
-                            to,
-                            have_spending_key,
-                            Some(spend_nullifier),
-                            i as u32,
-                            witness.witnessed_position(),
-                        );
+                        transaction_metadata_set
+                            .write()
+                            .await
+                            .transaction_records_by_id
+                            .add_new_note::<D>(
+                                transaction_id,
+                                status,
+                                timestamp,
+                                note,
+                                to,
+                                have_spending_key,
+                                Some(spend_nullifier),
+                                i as u32,
+                                witness.witnessed_position(),
+                            );
 
                         debug!("Trial decrypt Detected txid {}", &transaction_id);
 

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -597,6 +597,7 @@ impl LightClient {
             .transactions()
             .write()
             .await
+            .transaction_records_by_id
             .clear_expired_mempool(start_block);
 
         // 6. Set the highest verified tree

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -56,6 +56,10 @@ pub struct WitnessTrees {
     pub witness_tree_orchard: ShardTree<OrchStore, COMMITMENT_TREE_LEVELS, MAX_SHARD_LEVEL>,
 }
 
+impl crate::wallet::traits::SpendCapable for WitnessTrees {
+    type RecordsByIds = crate::wallet::transaction_records_by_id::TransactionRecordsById;
+}
+
 fn write_shards<W, H, C>(mut writer: W, store: &MemoryShardStore<H, C>) -> io::Result<()>
 where
     H: Hashable + Clone + Eq + HashSer,

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -153,7 +153,9 @@ impl LightWallet {
         // so we make sure that they are marked as change or not based on our
         // current definition
         for txid in txids {
-            transactions.check_notes_mark_change(&txid)
+            transactions
+                .transaction_records_by_id
+                .check_notes_mark_change(&txid)
         }
 
         let chain_name = utils::read_string(&mut reader)?;

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -175,6 +175,9 @@ impl FromBytes<11> for orchard::keys::Diversifier {
     }
 }
 
+pub trait SpendCapable {
+    type RecordsByIds;
+}
 /// TODO: Add Doc Comment Here!
 pub trait FromCommitment
 where

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -492,6 +492,7 @@ pub mod decrypt_transaction {
                     self.transaction_metadata_set
                         .write()
                         .await
+                        .transaction_records_by_id
                         .add_pending_note::<D>(
                             transaction.txid(),
                             height,

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -137,6 +137,7 @@ pub mod decrypt_transaction {
                 self.transaction_metadata_set
                     .write()
                     .await
+                    .transaction_records_by_id
                     .check_notes_mark_change(&transaction.txid());
             }
 

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -145,6 +145,7 @@ pub mod decrypt_transaction {
                 self.transaction_metadata_set
                     .write()
                     .await
+                    .transaction_records_by_id
                     .add_outgoing_metadata(&transaction.txid(), outgoing_metadatas);
             }
 
@@ -156,6 +157,7 @@ pub mod decrypt_transaction {
                 self.transaction_metadata_set
                     .write()
                     .await
+                    .transaction_records_by_id
                     .set_price(&transaction.txid(), price);
             }
         }
@@ -521,6 +523,7 @@ pub mod decrypt_transaction {
                 self.transaction_metadata_set
                     .write()
                     .await
+                    .transaction_records_by_id
                     .add_memo_to_note_metadata::<D::WalletNote>(&transaction.txid(), note, memo);
             }
             for (_domain, output) in domain_tagged_outputs {

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -96,6 +96,7 @@ pub mod decrypt_transaction {
                 .transaction_metadata_set
                 .read()
                 .await
+                .transaction_records_by_id
                 .total_funds_spent_in(&transaction.txid())
                 > 0
             {

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -219,6 +219,7 @@ pub mod decrypt_transaction {
                             self.transaction_metadata_set
                                 .write()
                                 .await
+                                .transaction_records_by_id
                                 .add_new_taddr_output(
                                     transaction.txid(),
                                     output_taddr.clone(),
@@ -279,6 +280,7 @@ pub mod decrypt_transaction {
                 self.transaction_metadata_set
                     .write()
                     .await
+                    .transaction_records_by_id
                     .mark_txid_utxo_spent(prev_transaction_id, prev_n, transaction_id, status);
             }
 
@@ -286,12 +288,16 @@ pub mod decrypt_transaction {
             if total_transparent_value_spent > 0 {
                 *is_outgoing_transaction = true;
 
-                self.transaction_metadata_set.write().await.add_taddr_spent(
-                    transaction.txid(),
-                    status,
-                    block_time as u64,
-                    total_transparent_value_spent,
-                );
+                self.transaction_metadata_set
+                    .write()
+                    .await
+                    .transaction_records_by_id
+                    .add_taddr_spent(
+                        transaction.txid(),
+                        status,
+                        block_time as u64,
+                        total_transparent_value_spent,
+                    );
             }
         }
 

--- a/zingolib/src/wallet/transactions/get.rs
+++ b/zingolib/src/wallet/transactions/get.rs
@@ -63,13 +63,6 @@ impl TxMapAndMaybeTrees {
             .collect()
     }
 
-    pub fn total_funds_spent_in(&self, txid: &TxId) -> u64 {
-        self.transaction_records_by_id
-            .get(txid)
-            .map(TransactionRecord::total_value_spent)
-            .unwrap_or(0)
-    }
-
     #[allow(clippy::type_complexity)]
     pub fn get_nullifier_value_txid_outputindex_of_unspent_notes<D: DomainWalletExt>(
         &self,

--- a/zingolib/src/wallet/transactions/recording.rs
+++ b/zingolib/src/wallet/transactions/recording.rs
@@ -21,14 +21,12 @@ use crate::{
         traits::{self, DomainWalletExt, Nullifier, Recipient},
     },
 };
-
-impl super::TxMapAndMaybeTrees {
+impl super::TransactionRecordsById {
     /// Invalidates all those transactions which were broadcast but never 'confirmed' accepted by a miner.
     pub(crate) fn clear_expired_mempool(&mut self, latest_height: u64) {
         let cutoff = BlockHeight::from_u32((latest_height.saturating_sub(MAX_REORG as u64)) as u32);
 
         let txids_to_remove = self
-            .transaction_records_by_id
             .iter()
             .filter(|(_, transaction_metadata)| {
                 transaction_metadata.status.is_broadcast_before(&cutoff)
@@ -40,10 +38,11 @@ impl super::TxMapAndMaybeTrees {
             .iter()
             .for_each(|t| println!("Removing expired mempool tx {}", t));
 
-        self.transaction_records_by_id
-            .invalidate_transactions(txids_to_remove);
+        self.invalidate_transactions(txids_to_remove);
     }
+}
 
+impl super::TxMapAndMaybeTrees {
     // Check this transaction to see if it is an outgoing transaction, and if it is, mark all received notes with non-textual memos in this
     // transaction as change. i.e., If any funds were spent in this transaction, all received notes without user-specified memos are change.
     //

--- a/zingolib/src/wallet/transactions/recording.rs
+++ b/zingolib/src/wallet/transactions/recording.rs
@@ -172,8 +172,11 @@ impl super::TransactionRecordsById {
     }
 }
 
+/// Witness tree requiring methods, each method is noted with *HOW* it requires witness trees.
 impl super::TxMapAndMaybeTrees {
-    // Records a TxId as having spent some nullifiers from the wallet.
+    /// Records a TxId as having spent some nullifiers from the wallet.
+    /// witness tree requirement:
+    /// found_spent_nullifier_internal -> mark_note_as_spent -> remove_witness_mark
     #[allow(clippy::too_many_arguments)]
     pub fn found_spent_nullifier(
         &mut self,
@@ -206,6 +209,8 @@ impl super::TxMapAndMaybeTrees {
         }
     }
 
+    /// witness tree requirement:
+    /// mark_note_as_spent -> remove_witness_mark
     #[allow(clippy::too_many_arguments)]
     fn found_spent_nullifier_internal<D: DomainWalletExt>(
         &mut self,
@@ -251,6 +256,8 @@ impl super::TxMapAndMaybeTrees {
     }
 
     // Will mark a note as having been spent at the supplied height and spent_txid.
+    /// witness tree requirement:
+    /// remove_witness_mark ~-> note_datum.witnessed_position
     pub fn mark_note_as_spent<D: DomainWalletExt>(
         &mut self,
         spent_nullifier: <D::WalletNote as ShieldedNoteInterface>::Nullifier,
@@ -306,6 +313,8 @@ impl super::TxMapAndMaybeTrees {
         }) // todO add special error variant
     }
 
+    /// witness tree requirement:
+    ///
     pub(crate) fn add_pending_note<D>(
         &mut self,
         txid: TxId,

--- a/zingolib/src/wallet/transactions/recording.rs
+++ b/zingolib/src/wallet/transactions/recording.rs
@@ -22,8 +22,7 @@ use crate::{
     },
 };
 
-use super::TxMapAndMaybeTrees;
-impl TxMapAndMaybeTrees {
+impl super::TxMapAndMaybeTrees {
     /// Invalidates all those transactions which were broadcast but never 'confirmed' accepted by a miner.
     pub(crate) fn clear_expired_mempool(&mut self, latest_height: u64) {
         let cutoff = BlockHeight::from_u32((latest_height.saturating_sub(MAX_REORG as u64)) as u32);
@@ -437,7 +436,7 @@ impl TxMapAndMaybeTrees {
 }
 
 // shardtree
-impl TxMapAndMaybeTrees {
+impl super::TxMapAndMaybeTrees {
     /// During reorgs, we need to remove all txns at a given height, and all spends that refer to any removed txns.
     pub fn invalidate_all_transactions_after_or_at_height(&mut self, reorg_height: u64) {
         let reorg_height = BlockHeight::from_u32(reorg_height as u32);

--- a/zingolib/src/wallet/transactions/recording.rs
+++ b/zingolib/src/wallet/transactions/recording.rs
@@ -40,6 +40,11 @@ impl super::TransactionRecordsById {
 
         self.invalidate_transactions(txids_to_remove);
     }
+    pub fn total_funds_spent_in(&self, txid: &TxId) -> u64 {
+        self.get(txid)
+            .map(TransactionRecord::total_value_spent)
+            .unwrap_or(0)
+    }
 }
 
 impl super::TxMapAndMaybeTrees {
@@ -49,7 +54,7 @@ impl super::TxMapAndMaybeTrees {
     // TODO: When we start working on multi-sig, this could cause issues about hiding sends-to-self
     pub fn check_notes_mark_change(&mut self, txid: &TxId) {
         //TODO: Incorrect with a 0-value fee somehow
-        if self.total_funds_spent_in(txid) > 0 {
+        if self.transaction_records_by_id.total_funds_spent_in(txid) > 0 {
             if let Some(transaction_metadata) = self.transaction_records_by_id.get_mut(txid) {
                 Self::mark_notes_as_change_for_pool(&mut transaction_metadata.sapling_notes);
                 Self::mark_notes_as_change_for_pool(&mut transaction_metadata.orchard_notes);


### PR DESCRIPTION
Depends on: #980

Problem Statement:

 -- spend-capable data and functionality requires both witness trees and transaction records
 -- optional presence of witness trees on a type that also binds records forces consumers to include match/if logic to adapt behavior as a function of the trees presence

By separating concerns we can offer all functionality to consumers who have access to trees, and also offer a spend-incapable subset to consumers without spend capability.

I am proposing this "SpendCapable" trait to bind relevant functionality with necessary data, in a hierarchical way.