### PR TITLE
rename method to:  RegtestNetwork::set_all_net_upgrades_to_active_at_1, and DRY calls

### DIFF
--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -530,7 +530,7 @@ pub mod scenarios {
                 darkside_connector.0.clone(),
                 darkside_handler.darkside_dir.clone(),
             );
-            let regtest_network = RegtestNetwork::all_upgrades_active();
+            let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
             DarksideScenario {
                 darkside_handler,
                 darkside_connector,

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -34,7 +34,7 @@ async fn reorg_changes_incoming_tx_height() {
             ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
             202,
             true,
-            RegtestNetwork::all_upgrades_active(),
+            RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
         )
         .await;
 
@@ -189,7 +189,7 @@ async fn reorg_changes_incoming_tx_index() {
             ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
             202,
             true,
-            RegtestNetwork::all_upgrades_active(),
+            RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
         )
         .await;
 
@@ -344,7 +344,7 @@ async fn reorg_expires_incoming_tx() {
             ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
             202,
             true,
-            RegtestNetwork::all_upgrades_active(),
+            RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
         )
         .await;
 
@@ -521,7 +521,7 @@ async fn reorg_changes_outgoing_tx_height() {
             ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
             202,
             true,
-            RegtestNetwork::all_upgrades_active(),
+            RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
         )
         .await;
 
@@ -758,7 +758,7 @@ async fn reorg_expires_outgoing_tx_height() {
             ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
             202,
             true,
-            RegtestNetwork::all_upgrades_active(),
+            RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
         )
         .await;
 
@@ -935,7 +935,7 @@ async fn reorg_changes_outgoing_tx_index() {
             ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
             202,
             true,
-            RegtestNetwork::all_upgrades_active(),
+            RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
         )
         .await;
 

--- a/darkside-tests/tests/network_interruption_tests.rs
+++ b/darkside-tests/tests/network_interruption_tests.rs
@@ -37,7 +37,7 @@ async fn interrupt_initial_tree_fetch() {
     prepare_darksidewalletd(server_id.clone(), true)
         .await
         .unwrap();
-    let regtest_network = RegtestNetwork::all_upgrades_active();
+    let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
     let light_client = ClientBuilder::new(server_id, darkside_handler.darkside_dir.clone())
         .build_client(DARKSIDE_SEED.to_string(), 0, true, regtest_network)
         .await;

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -18,7 +18,7 @@ async fn simple_sync() {
     prepare_darksidewalletd(server_id.clone(), true)
         .await
         .unwrap();
-    let regtest_network = RegtestNetwork::all_upgrades_active();
+    let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
     let light_client = ClientBuilder::new(server_id, darkside_handler.darkside_dir.clone())
         .build_client(DARKSIDE_SEED.to_string(), 0, true, regtest_network)
         .await;
@@ -58,7 +58,7 @@ async fn reorg_away_receipt() {
         .await
         .unwrap();
 
-    let regtest_network = RegtestNetwork::all_upgrades_active();
+    let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
     let light_client = ClientBuilder::new(server_id.clone(), darkside_handler.darkside_dir.clone())
         .build_client(DARKSIDE_SEED.to_string(), 0, true, regtest_network)
         .await;
@@ -112,7 +112,7 @@ async fn sent_transaction_reorged_into_mempool() {
 
     let mut client_manager =
         ClientBuilder::new(server_id.clone(), darkside_handler.darkside_dir.clone());
-    let regtest_network = RegtestNetwork::all_upgrades_active();
+    let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
     let light_client = client_manager
         .build_client(DARKSIDE_SEED.to_string(), 0, true, regtest_network)
         .await;

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -287,9 +287,8 @@ mod fast {
 
     #[tokio::test]
     async fn unspent_notes_are_not_saved() {
-        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, recipient) =
-            scenarios::faucet_recipient(Pool::Sapling, regtest_network).await;
+            scenarios::faucet_recipient(Pool::Sapling, None).await;
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
             .await
             .unwrap();
@@ -314,9 +313,11 @@ mod fast {
         let mut wallet_location = regtest_manager.zingo_datadir;
         wallet_location.pop();
         wallet_location.push("zingo_client_1");
-        let zingo_config = ZingoConfig::build(zingoconfig::ChainType::Regtest(regtest_network))
-            .set_wallet_dir(wallet_location.clone())
-            .create();
+        let zingo_config = ZingoConfig::build(zingoconfig::ChainType::Regtest(
+            zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
+        ))
+        .set_wallet_dir(wallet_location.clone())
+        .create();
         wallet_location.push("zingo-wallet.dat");
         let read_buffer = File::open(wallet_location.clone()).unwrap();
 
@@ -604,9 +605,8 @@ mod fast {
 
     #[tokio::test]
     async fn mine_to_transparent() {
-        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, _recipient) =
-            scenarios::faucet_recipient(Pool::Transparent, regtest_network).await;
+            scenarios::faucet_recipient(Pool::Transparent, None).await;
         check_client_balances!(faucet, o: 0 s: 0 t: 1_875_000_000);
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
             .await
@@ -631,9 +631,8 @@ mod fast {
     #[ignore]
     #[tokio::test]
     async fn mine_to_transparent_and_shield() {
-        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, _recipient) =
-            scenarios::faucet_recipient(Pool::Transparent, regtest_network).await;
+            scenarios::faucet_recipient(Pool::Transparent, None).await;
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 100)
             .await
             .unwrap();
@@ -1660,7 +1659,7 @@ mod slow {
     async fn send_heartwood_sapling_funds() {
         let regtest_network = RegtestNetwork::new(1, 1, 1, 1, 3, 5);
         let (regtest_manager, _cph, faucet, recipient) =
-            scenarios::faucet_recipient(Pool::Sapling, regtest_network).await;
+            scenarios::faucet_recipient(Pool::Sapling, Some(regtest_network)).await;
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 3)
             .await
             .unwrap();
@@ -1681,7 +1680,6 @@ mod slow {
     }
     #[tokio::test]
     async fn send_funds_to_all_pools() {
-        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (
             _regtest_manager,
             _cph,
@@ -1695,7 +1693,7 @@ mod slow {
             Some(100_000),
             Some(100_000),
             Pool::Orchard,
-            regtest_network,
+            None,
         )
         .await;
         check_client_balances!(recipient, o: 100_000 s: 100_000 t: 100_000);
@@ -2339,16 +2337,8 @@ mod slow {
             }
         }
         let value = 100_000;
-        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, recipient, orig_transaction_id, _, _) =
-            scenarios::faucet_funded_recipient(
-                Some(value),
-                None,
-                None,
-                Pool::Sapling,
-                regtest_network,
-            )
-            .await;
+            scenarios::faucet_funded_recipient(Some(value), None, None, Pool::Sapling, None).await;
         let orig_transaction_id = orig_transaction_id.unwrap();
         assert_eq!(
             do_maybe_recent_txid(&recipient).await["last_txid"],
@@ -3122,9 +3112,8 @@ mod slow {
     }
     #[tokio::test]
     async fn dont_write_unconfirmed() {
-        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, recipient) =
-            scenarios::faucet_recipient(Pool::Orchard, regtest_network).await;
+            scenarios::faucet_recipient(Pool::Orchard, None).await;
         faucet
             .do_send_test_only(vec![(
                 &get_base_address!(recipient, "unified"),

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -183,7 +183,7 @@ mod fast {
 
     #[tokio::test]
     async fn load_and_parse_different_wallet_versions() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (_sap_wallet, _sap_path, sap_dir) =
             zingo_testutils::get_wallet_nym("sap_only").unwrap();
         let (_loaded_wallet, _) =
@@ -287,7 +287,7 @@ mod fast {
 
     #[tokio::test]
     async fn unspent_notes_are_not_saved() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, recipient) =
             scenarios::faucet_recipient(Pool::Sapling, regtest_network).await;
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
@@ -580,7 +580,7 @@ mod fast {
 
     #[tokio::test]
     async fn mine_to_orchard() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet) =
             scenarios::faucet(Pool::Orchard, regtest_network).await;
         check_client_balances!(faucet, o: 1_875_000_000 s: 0 t: 0);
@@ -592,7 +592,7 @@ mod fast {
 
     #[tokio::test]
     async fn mine_to_sapling() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet) =
             scenarios::faucet(Pool::Sapling, regtest_network).await;
         check_client_balances!(faucet, o: 0 s: 1_875_000_000 t: 0);
@@ -604,7 +604,7 @@ mod fast {
 
     #[tokio::test]
     async fn mine_to_transparent() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, _recipient) =
             scenarios::faucet_recipient(Pool::Transparent, regtest_network).await;
         check_client_balances!(faucet, o: 0 s: 0 t: 1_875_000_000);
@@ -631,7 +631,7 @@ mod fast {
     #[ignore]
     #[tokio::test]
     async fn mine_to_transparent_and_shield() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, _recipient) =
             scenarios::faucet_recipient(Pool::Transparent, regtest_network).await;
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 100)
@@ -1632,7 +1632,7 @@ mod slow {
         // debiting unverified_orchard_balance and crediting verified_orchard_balance.  The debit amount is
         // consistent with all the notes in the relevant block changing state.
         // NOTE that the balance doesn't give insight into the distribution across notes.
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet) =
             scenarios::faucet(Pool::Sapling, regtest_network).await;
         let amount_to_send = 5_000;
@@ -1681,7 +1681,7 @@ mod slow {
     }
     #[tokio::test]
     async fn send_funds_to_all_pools() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (
             _regtest_manager,
             _cph,
@@ -2339,7 +2339,7 @@ mod slow {
             }
         }
         let value = 100_000;
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, recipient, orig_transaction_id, _, _) =
             scenarios::faucet_funded_recipient(
                 Some(value),
@@ -2661,7 +2661,7 @@ mod slow {
     }
     #[tokio::test]
     async fn load_old_wallet_at_reorged_height() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (ref regtest_manager, cph, ref faucet) =
             scenarios::faucet(Pool::Orchard, regtest_network).await;
         println!("Shutting down initial zcd/lwd unneeded processes");
@@ -3122,7 +3122,7 @@ mod slow {
     }
     #[tokio::test]
     async fn dont_write_unconfirmed() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, _cph, faucet, recipient) =
             scenarios::faucet_recipient(Pool::Orchard, regtest_network).await;
         faucet

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -644,9 +644,8 @@ mod fast {
     }
     #[tokio::test]
     async fn mine_to_transparent_and_propose_shielding() {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
         let (regtest_manager, _cph, faucet, _recipient) =
-            scenarios::faucet_recipient(Pool::Transparent, regtest_network).await;
+            scenarios::faucet_recipient(Pool::Transparent, None).await;
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
             .await
             .unwrap();

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -941,13 +941,17 @@ pub mod scenarios {
     /// TODO: Add Doc Comment Here!
     pub async fn faucet_recipient(
         mine_to_pool: Pool,
-        regtest_network: zingoconfig::RegtestNetwork,
+        regtest_network: Option<zingoconfig::RegtestNetwork>,
     ) -> (
         RegtestManager,
         ChildProcessHandler,
         LightClient,
         LightClient,
     ) {
+        let regtest_network = match regtest_network {
+            None => zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
+            Some(network) => network,
+        };
         let mut sb = setup::ScenarioBuilder::build_configure_launch(
             Some(mine_to_pool),
             None,
@@ -982,8 +986,7 @@ pub mod scenarios {
         LightClient,
         LightClient,
     ) {
-        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
-        faucet_recipient(Pool::Orchard, regtest_network).await
+        faucet_recipient(Pool::Orchard, None).await
     }
 
     /// TODO: Add Doc Comment Here!
@@ -992,7 +995,7 @@ pub mod scenarios {
         sapling_funds: Option<u64>,
         transparent_funds: Option<u64>,
         mine_to_pool: Pool,
-        regtest_network: zingoconfig::RegtestNetwork,
+        regtest_network: Option<zingoconfig::RegtestNetwork>,
     ) -> (
         RegtestManager,
         ChildProcessHandler,
@@ -1003,7 +1006,7 @@ pub mod scenarios {
         Option<String>,
     ) {
         let (regtest_manager, child_process_handler, faucet, recipient) =
-            faucet_recipient(mine_to_pool, regtest_network).await;
+            faucet_recipient(mine_to_pool, None).await;
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
             .await
             .unwrap();
@@ -1074,7 +1077,6 @@ pub mod scenarios {
         LightClient,
         String,
     ) {
-        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (
             regtest_manager,
             cph,
@@ -1083,14 +1085,7 @@ pub mod scenarios {
             orchard_txid,
             _sapling_txid,
             _transparent_txid,
-        ) = faucet_funded_recipient(
-            Some(orchard_funds),
-            None,
-            None,
-            Pool::Orchard,
-            regtest_network,
-        )
-        .await;
+        ) = faucet_funded_recipient(Some(orchard_funds), None, None, Pool::Orchard, None).await;
         (
             regtest_manager,
             cph,

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -1006,7 +1006,7 @@ pub mod scenarios {
         Option<String>,
     ) {
         let (regtest_manager, child_process_handler, faucet, recipient) =
-            faucet_recipient(mine_to_pool, None).await;
+            faucet_recipient(mine_to_pool, regtest_network).await;
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
             .await
             .unwrap();

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -898,7 +898,7 @@ pub mod scenarios {
 
     /// TODO: Add Doc Comment Here!
     pub async fn unfunded_client_default() -> (RegtestManager, ChildProcessHandler, LightClient) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         unfunded_client(regtest_network).await
     }
 
@@ -934,7 +934,7 @@ pub mod scenarios {
 
     /// TODO: Add Doc Comment Here!
     pub async fn faucet_default() -> (RegtestManager, ChildProcessHandler, LightClient) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         faucet(Pool::Orchard, regtest_network).await
     }
 
@@ -982,7 +982,7 @@ pub mod scenarios {
         LightClient,
         LightClient,
     ) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         faucet_recipient(Pool::Orchard, regtest_network).await
     }
 
@@ -1074,7 +1074,7 @@ pub mod scenarios {
         LightClient,
         String,
     ) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (
             regtest_manager,
             cph,
@@ -1126,7 +1126,7 @@ pub mod scenarios {
         ClientBuilder,
         zingoconfig::RegtestNetwork,
     ) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let (regtest_manager, cph, client_builder) =
             custom_clients(Pool::Orchard, regtest_network).await;
         (regtest_manager, cph, client_builder, regtest_network)
@@ -1134,7 +1134,7 @@ pub mod scenarios {
 
     /// TODO: Add Doc Comment Here!
     pub async fn unfunded_mobileclient() -> (RegtestManager, ChildProcessHandler) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let scenario_builder = setup::ScenarioBuilder::build_configure_launch(
             None,
             None,
@@ -1150,7 +1150,7 @@ pub mod scenarios {
 
     /// TODO: Add Doc Comment Here!
     pub async fn funded_orchard_mobileclient(value: u64) -> (RegtestManager, ChildProcessHandler) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let mut scenario_builder = setup::ScenarioBuilder::build_configure_launch(
             Some(Pool::Sapling),
             None,
@@ -1189,7 +1189,7 @@ pub mod scenarios {
     pub async fn funded_orchard_with_3_txs_mobileclient(
         value: u64,
     ) -> (RegtestManager, ChildProcessHandler) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let mut scenario_builder = setup::ScenarioBuilder::build_configure_launch(
             Some(Pool::Sapling),
             None,
@@ -1255,7 +1255,7 @@ pub mod scenarios {
     pub async fn funded_orchard_sapling_transparent_shielded_mobileclient(
         value: u64,
     ) -> (RegtestManager, ChildProcessHandler) {
-        let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+        let regtest_network = zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let mut scenario_builder = setup::ScenarioBuilder::build_configure_launch(
             Some(Pool::Sapling),
             None,
@@ -1388,7 +1388,8 @@ pub mod scenarios {
 
         /// TODO: Add Doc Comment Here!
         pub async fn unsynced_basic() -> ChildProcessHandler {
-            let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+            let regtest_network =
+                zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
             setup::ScenarioBuilder::new_load_1153_saplingcb_regtest_chain(&regtest_network)
                 .await
                 .child_process_handler
@@ -1402,7 +1403,8 @@ pub mod scenarios {
             LightClient,
             LightClient,
         ) {
-            let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+            let regtest_network =
+                zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
             let mut sb =
                 setup::ScenarioBuilder::new_load_1153_saplingcb_regtest_chain(&regtest_network)
                     .await;
@@ -1427,7 +1429,8 @@ pub mod scenarios {
             LightClient,
             LightClient,
         ) {
-            let regtest_network = zingoconfig::RegtestNetwork::all_upgrades_active();
+            let regtest_network =
+                zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1();
             let mut sb =
                 setup::ScenarioBuilder::new_load_1153_saplingcb_regtest_chain(&regtest_network)
                     .await;

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -353,11 +353,13 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
             match chain.as_str() {
                 "mainnet" => ChainType::Mainnet,
                 "testnet" => ChainType::Testnet,
-                "regtest" => ChainType::Regtest(zingoconfig::RegtestNetwork::all_upgrades_active()),
+                "regtest" => ChainType::Regtest(
+                    zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
+                ),
                 _ => return Err(chain.clone()),
             }
         } else if is_regtest {
-            ChainType::Regtest(zingoconfig::RegtestNetwork::all_upgrades_active())
+            ChainType::Regtest(zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1())
         } else {
             ChainType::Mainnet
         };

--- a/zingoconfig/src/lib.rs
+++ b/zingoconfig/src/lib.rs
@@ -589,7 +589,7 @@ impl RegtestNetwork {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn all_upgrades_active() -> Self {
+    pub fn set_all_net_upgrades_to_active_at_1() -> Self {
         Self {
             activation_heights: ActivationHeights::new(1, 1, 1, 1, 1, 1),
         }

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -197,7 +197,7 @@ impl Command for ParseAddressCommand {
                     zingoconfig::ChainType::Mainnet,
                     zingoconfig::ChainType::Testnet,
                     zingoconfig::ChainType::Regtest(
-                        zingoconfig::RegtestNetwork::all_upgrades_active(),
+                        zingoconfig::RegtestNetwork::set_all_net_upgrades_to_active_at_1(),
                     ),
                 ]
                 .iter()

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn parse_shield_args() {
-        let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+        let chain = ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
         let address_str = "zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p";
         let address = address_from_str(address_str, &chain).unwrap();
 
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn parse_send_args() {
-        let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+        let chain = ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
         let address_str = "zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p";
         let address = address_from_str(address_str, &chain).unwrap();
         let value_str = "100000";
@@ -225,7 +225,8 @@ mod tests {
 
             #[test]
             fn empty_json_array() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let json = "[]";
                 assert!(matches!(
                     parse_send_args(&[json], &chain),
@@ -234,7 +235,8 @@ mod tests {
             }
             #[test]
             fn failed_json_parsing() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args = [r#"testaddress{{"#];
                 let result = parse_send_args(&args, &chain);
                 match result {
@@ -251,7 +253,8 @@ mod tests {
             }
             #[test]
             fn single_arg_not_an_array_unexpected_type() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args = ["1"];
                 let result = parse_send_args(&args, &chain);
                 match result {
@@ -261,7 +264,8 @@ mod tests {
             }
             #[test]
             fn no_address_missing_key() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args = ["[{\"amount\": 123, \"memo\": \"testmemo\"}]"];
                 let result = parse_send_args(&args, &chain);
                 match result {
@@ -271,7 +275,8 @@ mod tests {
             }
             #[test]
             fn no_amount_missing_key() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args = ["[{\"address\": \"zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p\", \"memo\": \"testmemo\"}]"];
                 let result = parse_send_args(&args, &chain);
                 match result {
@@ -281,7 +286,8 @@ mod tests {
             }
             #[test]
             fn non_string_address() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args = ["[{\"address\": 1, \"amount\": 123, \"memo\": \"testmemo\"}]"];
                 let result = parse_send_args(&args, &chain);
                 match result {
@@ -293,7 +299,8 @@ mod tests {
             }
             #[test]
             fn non_u64_amount() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args =
                             ["[{\"address\": \"zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p\", \"amount\": \"Oscar Pepper\", \"memo\": \"testmemo\"}]"];
                 let result = parse_send_args(&args, &chain);
@@ -309,7 +316,8 @@ mod tests {
             }
             #[test]
             fn invalid_memo() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let arg_contents =
                     "[{\"address\": \"zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p\", \"amount\": 123, \"memo\": \"testmemo\"}]";
                 let long_513_byte_memo = &"a".repeat(513);
@@ -337,7 +345,8 @@ mod tests {
 
             #[test]
             fn two_args_wrong_amount() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args = ["zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p", "foo"];
                 let result = parse_send_args(&args, &chain);
                 match result {
@@ -352,14 +361,16 @@ mod tests {
             }
             #[test]
             fn wrong_number_of_args() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let args = ["zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p", "123", "3", "4"];
                 let result = parse_send_args(&args, &chain);
                 assert!(matches!(result, Err(CommandError::InvalidArguments)));
             }
             #[test]
             fn invalid_memo() {
-                let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+                let chain =
+                    ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
                 let long_513_byte_memo = &"a".repeat(513);
                 let args = ["zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p", "123", long_513_byte_memo];
 
@@ -382,7 +393,7 @@ mod tests {
 
     #[test]
     fn check_memo_compatibility() {
-        let chain = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
+        let chain = ChainType::Regtest(RegtestNetwork::set_all_net_upgrades_to_active_at_1());
         let sapling_address = address_from_str("zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p", &chain).unwrap();
         let transparent_address =
             address_from_str("tmBsTi2xWTjUdEXnuTceL7fecEQKeWaPDJd", &chain).unwrap();

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -735,7 +735,7 @@ mod tests {
             .expect("This path is available.");
 
         let wallet_name = data_dir.join("zingo-wallet.dat");
-        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let regtest_network = RegtestNetwork::set_all_net_upgrades_to_active_at_1();
         let config = ZingoConfig::build(ChainType::Regtest(regtest_network))
             .set_wallet_dir(data_dir)
             .create();


### PR DESCRIPTION
Small improvement to test DRYness (mostly test, rename of fn applies more broadly).