### PR TITLE
Zip317 unify propose for test and interface

### DIFF
--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -822,7 +822,7 @@ impl Command for ProposeCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        let _send_inputs = match utils::parse_send_args(args, &lightclient.config().chain) {
+        let receivers = match utils::parse_send_args(args, &lightclient.config().chain) {
             Ok(args) => args,
             Err(e) => {
                 return format!(
@@ -832,20 +832,19 @@ impl Command for ProposeCommand {
             }
         };
         RT.block_on(async move {
-            todo!()
-            // match lightclient
-            //     .do_propose_send(
-            //         send_inputs
-            //     )
-            //     .await {
-            //     Ok(proposal) => {
-            //         object! { "fee" => proposal.steps().iter().fold(0, |acc, step| acc + u64::from(step.balance().fee_required())) }
-            //     }
-            //     Err(e) => {
-            //         object! { "error" => e.to_string() }
-            //     }
-            // }
-            // .pretty(2)
+            match lightclient
+                .propose_send(
+                    receivers
+                )
+                .await {
+                Ok(proposal) => {
+                    object! { "fee" => proposal.steps().iter().fold(0, |acc, step| acc + u64::from(step.balance().fee_required())) }
+                }
+                Err(e) => {
+                    object! { "error" => e.to_string() }
+                }
+            }
+            .pretty(2)
         })
     }
 }

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -1,6 +1,7 @@
 // Module containing utility functions for the commands interface
 
 use crate::commands::error::CommandError;
+use crate::data::receivers::Receivers;
 use crate::utils::conversion::{address_from_str, zatoshis_from_u64};
 use crate::wallet::{self, Pool};
 use json::JsonValue;
@@ -37,10 +38,7 @@ pub(super) fn parse_shield_args(
 // The send arguments have two possible formats:
 // - 1 argument in the form of a JSON string for multiple sends. '[{"address":"<address>", "value":<value>, "memo":"<optional memo>"}, ...]'
 // - 2 (+1 optional) arguments for a single address send. &["<address>", <amount>, "<optional memo>"]
-pub(super) fn parse_send_args(
-    args: &[&str],
-    chain: &ChainType,
-) -> Result<Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>, CommandError> {
+pub(super) fn parse_send_args(args: &[&str], chain: &ChainType) -> Result<Receivers, CommandError> {
     // Check for a single argument that can be parsed as JSON
     let send_args = if args.len() == 1 {
         let json_args = json::parse(args[0]).map_err(CommandError::ArgsNotJson)?;
@@ -62,7 +60,7 @@ pub(super) fn parse_send_args(
 
                 Ok((address, amount, memo))
             })
-            .collect::<Result<Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>, CommandError>>()
+            .collect::<Result<Receivers, CommandError>>()
     } else if args.len() == 2 || args.len() == 3 {
         let address = address_from_str(args[0], chain).map_err(CommandError::ConversionFailed)?;
         let amount_u64 = args[1]

--- a/zingolib/src/data.rs
+++ b/zingolib/src/data.rs
@@ -14,22 +14,21 @@ pub mod receivers {
 
     pub(crate) type Receivers = Vec<(address::Address, NonNegativeAmount, Option<MemoBytes>)>;
 
-    /// TODO: Add Doc Comment Here!
-    // review! unit test this
-    pub fn build_transaction_request_from_receivers(
+    /// Creates a [`zcash_client_backend::zip321::TransactionRequest`] from receivers.
+    pub(crate) fn transaction_request_from_receivers(
         receivers: Receivers,
     ) -> Result<TransactionRequest, Zip321Error> {
-        let mut payments = vec![];
-        for out in receivers.clone() {
-            payments.push(Payment {
-                recipient_address: out.0,
-                amount: out.1,
-                memo: out.2,
+        let payments = receivers
+            .into_iter()
+            .map(|receiver| Payment {
+                recipient_address: receiver.0,
+                amount: receiver.1,
+                memo: receiver.2,
                 label: None,
                 message: None,
                 other_params: vec![],
-            });
-        }
+            })
+            .collect();
 
         TransactionRequest::new(payments)
     }

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -11,7 +11,6 @@ use zcash_client_backend::zip321::Zip321Error;
 use zcash_client_backend::ShieldedProtocol;
 use zcash_keys::address::Address;
 use zcash_primitives::memo::MemoBytes;
-use zcash_primitives::transaction::components::amount::BalanceError;
 use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
 use thiserror::Error;
@@ -22,58 +21,6 @@ use crate::{
 use crate::{data::proposal::TransferProposal, wallet::tx_map_and_maybe_trees::TxMapAndMaybeTrees};
 use crate::{data::proposal::ZingoProposal, lightclient::LightClient};
 use zingoconfig::ChainType;
-
-/// Errors that can result from do_propose
-#[allow(missing_docs)] // error types document themselves
-#[derive(Debug, Error)]
-pub enum RawToTransactionRequestError {
-    #[error("Could not parse address.")]
-    Address,
-    #[error("Invalid amount: {0}")]
-    Amount(BalanceError),
-    #[error("Invalid memo: {0}")]
-    Memo(zcash_primitives::memo::Error),
-    #[error("Error requesting transaction: {0}")]
-    Zip321(Zip321Error),
-}
-
-impl LightClient {
-    /// takes raw data as input (strings and numbers) and returns a TransactionRequest
-    pub fn raw_to_transaction_request(
-        &self,
-        address_amount_memo_tuples: Vec<(String, u32, Option<String>)>,
-    ) -> Result<TransactionRequest, RawToTransactionRequestError> {
-        let mut payments = vec![];
-        for receiver in address_amount_memo_tuples {
-            let recipient_address = Address::decode(
-                &self.wallet.transaction_context.config.chain,
-                receiver.0.as_str(),
-            )
-            .ok_or(RawToTransactionRequestError::Address)?;
-
-            let amount = NonNegativeAmount::from_u64(receiver.1 as u64)
-                .map_err(RawToTransactionRequestError::Amount)?;
-
-            let memo = match receiver.2 {
-                None => None,
-                Some(memo_string) => Some(
-                    MemoBytes::from_bytes(memo_string.as_bytes())
-                        .map_err(RawToTransactionRequestError::Memo)?,
-                ),
-            };
-            payments.push(Payment {
-                recipient_address,
-                amount,
-                memo,
-                label: None,
-                message: None,
-                other_params: vec![],
-            });
-        }
-
-        TransactionRequest::new(payments).map_err(RawToTransactionRequestError::Zip321)
-    }
-}
 
 type GISKit = GreedyInputSelector<
     TxMapAndMaybeTrees,
@@ -96,6 +43,9 @@ pub enum ProposeSendError {
             zcash_primitives::transaction::fees::zip317::FeeError,
         >,
     ),
+    #[error("{0}")]
+    /// failed to construct a transaction request
+    TransactionRequestFailed(Zip321Error),
 }
 
 /// Errors that can result from do_propose
@@ -120,17 +70,21 @@ pub enum ProposeShieldError {
 }
 
 impl LightClient {
+    /// Stores a proposal in the `latest_proposal` field of the LightClient.
+    /// This field must be populated in order to then send a transaction.
     async fn store_proposal(&self, proposal: ZingoProposal) {
         let mut latest_proposal_lock = self.latest_proposal.write().await;
         *latest_proposal_lock = Some(proposal);
     }
+
     /// Unstable function to expose the zip317 interface for development
     // TOdo: add correct functionality and doc comments / tests
     // TODO: Add migrate_sapling_to_orchard argument
     pub(crate) async fn propose_send(
         &self,
-        request: TransactionRequest,
+        receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
     ) -> Result<TransferProposal, ProposeSendError> {
+        let request = transaction_request_from_receivers(receivers)?;
         let change_strategy = zcash_client_backend::fees::zip317::SingleOutputChangeStrategy::new(
             zcash_primitives::transaction::fees::zip317::FeeRule::standard(),
             None,
@@ -168,9 +122,9 @@ impl LightClient {
     /// Unstable function to expose the zip317 interface for development
     pub async fn propose_send_and_store(
         &self,
-        request: TransactionRequest,
+        receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
     ) -> Result<TransferProposal, ProposeSendError> {
-        let proposal = self.propose_send(request).await?;
+        let proposal = self.propose_send(receivers).await?;
         self.store_proposal(ZingoProposal::Transfer(proposal.clone()))
             .await;
         Ok(proposal)
@@ -215,6 +169,7 @@ impl LightClient {
             })
             .collect::<Vec<_>>())
     }
+
     /// The shield operation consumes a proposal that transfers value
     /// into the Orchard pool.
     ///
@@ -273,6 +228,26 @@ impl LightClient {
         Ok(proposal)
     }
 }
+
+/// Creates a [`zcash_client_backend::zip321::TransactionRequest`] from receivers.
+pub fn transaction_request_from_receivers(
+    receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
+) -> Result<TransactionRequest, ProposeSendError> {
+    let payments = receivers
+        .into_iter()
+        .map(|receiver| Payment {
+            recipient_address: receiver.0,
+            amount: receiver.1,
+            memo: receiver.2,
+            label: None,
+            message: None,
+            other_params: vec![],
+        })
+        .collect();
+
+    TransactionRequest::new(payments).map_err(ProposeSendError::TransactionRequestFailed)
+}
+
 #[cfg(test)]
 mod shielding {
     #[tokio::test]

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -230,7 +230,7 @@ impl LightClient {
 }
 
 /// Creates a [`zcash_client_backend::zip321::TransactionRequest`] from receivers.
-pub fn transaction_request_from_receivers(
+fn transaction_request_from_receivers(
     receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
 ) -> Result<TransactionRequest, ProposeSendError> {
     let payments = receivers

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -143,10 +143,12 @@ pub mod send_with_proposal {
 
     use zcash_client_backend::proposal::Proposal;
     use zcash_client_backend::wallet::NoteId;
-    use zcash_client_backend::zip321::TransactionRequest;
+    use zcash_keys::address::Address;
+    use zcash_primitives::memo::MemoBytes;
     use zcash_primitives::transaction::TxId;
 
     use thiserror::Error;
+    use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
     use crate::lightclient::propose::{ProposeSendError, ProposeShieldError};
     use crate::lightclient::LightClient;
@@ -233,10 +235,10 @@ pub mod send_with_proposal {
         // TODO: add correct functionality and doc comments / tests
         pub async fn quick_send(
             &self,
-            request: TransactionRequest,
+            receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
         ) -> Result<NonEmpty<TxId>, QuickSendError> {
             let proposal = self
-                .propose_send(request)
+                .propose_send(receivers)
                 .await
                 .map_err(QuickSendError::ProposeSend)?;
             self.complete_and_broadcast::<NoteId>(&proposal)

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -3,12 +3,11 @@ use log::debug;
 
 use zcash_client_backend::address::Address;
 use zcash_primitives::consensus::BlockHeight;
-use zcash_primitives::memo::MemoBytes;
-use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 use zcash_primitives::transaction::fees::zip317::MINIMUM_FEE;
 use zcash_primitives::transaction::TxId;
 use zcash_proofs::prover::LocalTxProver;
 
+use crate::data::receivers::Receivers;
 use crate::utils::conversion::zatoshis_from_u64;
 use crate::wallet::Pool;
 
@@ -25,10 +24,7 @@ impl LightClient {
     }
 
     /// Send funds
-    pub async fn do_send(
-        &self,
-        receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
-    ) -> Result<TxId, String> {
+    pub async fn do_send(&self, receivers: Receivers) -> Result<TxId, String> {
         let transaction_submission_height = self.get_submission_height().await?;
         // First, get the consensus branch ID
         debug!("Creating transaction");
@@ -143,13 +139,11 @@ pub mod send_with_proposal {
 
     use zcash_client_backend::proposal::Proposal;
     use zcash_client_backend::wallet::NoteId;
-    use zcash_keys::address::Address;
-    use zcash_primitives::memo::MemoBytes;
     use zcash_primitives::transaction::TxId;
 
     use thiserror::Error;
-    use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
+    use crate::data::receivers::Receivers;
     use crate::lightclient::propose::{ProposeSendError, ProposeShieldError};
     use crate::lightclient::LightClient;
 
@@ -235,7 +229,7 @@ pub mod send_with_proposal {
         // TODO: add correct functionality and doc comments / tests
         pub async fn quick_send(
             &self,
-            receivers: Vec<(Address, NonNegativeAmount, Option<MemoBytes>)>,
+            receivers: Receivers,
         ) -> Result<NonEmpty<TxId>, QuickSendError> {
             let proposal = self
                 .propose_send(receivers)

--- a/zingolib/src/utils/conversion.rs
+++ b/zingolib/src/utils/conversion.rs
@@ -31,9 +31,9 @@ pub(crate) fn zatoshis_from_u64(amount: u64) -> Result<NonNegativeAmount, Conver
 /// Conversions for use in testing only
 #[cfg(feature = "test-features")]
 pub mod testing {
-    use zcash_client_backend::address::Address;
-    use zcash_primitives::{memo::MemoBytes, transaction::components::amount::NonNegativeAmount};
     use zingoconfig::ChainType;
+
+    use crate::data::receivers::Receivers;
 
     use super::{address_from_str, zatoshis_from_u64};
 
@@ -45,7 +45,7 @@ pub mod testing {
     pub fn receivers_from_send_inputs(
         address_amount_memo_tuples: Vec<(&str, u64, Option<&str>)>,
         chain: &ChainType,
-    ) -> Vec<(Address, NonNegativeAmount, Option<MemoBytes>)> {
+    ) -> Receivers {
         address_amount_memo_tuples
             .into_iter()
             .map(|(address, amount, memo)| {

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -866,7 +866,7 @@ mod tests {
     };
     use zingoconfig::ChainType;
 
-    use crate::data::receivers::{build_transaction_request_from_receivers, Receivers};
+    use crate::data::receivers::{transaction_request_from_receivers, Receivers};
 
     #[test]
     fn test_build_request() {
@@ -887,7 +887,7 @@ mod tests {
             (recipient_address_2, amount_2, memo_2),
         ];
         let request: TransactionRequest =
-            build_transaction_request_from_receivers(rec).expect("rec can requestify");
+            transaction_request_from_receivers(rec).expect("rec can requestify");
 
         assert_eq!(
             request.total().expect("total"),


### PR DESCRIPTION
follow on from #1052. Aims to unify testing and command interface once again by having clear layers of conversion where we are converting rust primitive types (i.e. str and u64s) to receivers in the testing/interface layer and then creating transaction requests from the receivers in the proposal layer. This will also help ease the switchover from do_send to propose when zip317 goes online as the inputs are aligned

- reworks raw_to_transaction_request to create a transaction request from receivers
- moves this function to within the propose lightclient methods
- removes uneccessary duplication of code associated with converting raw types and its corresponding error types
- aligns outputs of commands with inputs of propose lightclient methods