### PR TITLE
Trait name conduct chain

### DIFF
--- a/darkside-tests/src/chain_generic_tests.rs
+++ b/darkside-tests/src/chain_generic_tests.rs
@@ -16,6 +16,28 @@ use crate::constants::DARKSIDE_SEED;
 use crate::utils::scenarios::DarksideEnvironment;
 use crate::utils::update_tree_states_for_transaction;
 
+#[tokio::test]
+#[ignore] // darkside cant handle transparent?
+async fn darkside_send_40_000_to_transparent() {
+    send_value_to_pool::<DarksideEnvironment>(40_000, Transparent).await;
+}
+
+proptest! {
+    #![proptest_config(proptest::test_runner::Config::with_cases(4))]
+    #[test]
+    fn send_pvalue_to_orchard(value in 0..90u32) {
+        Runtime::new().unwrap().block_on(async {
+    send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Orchard)).await;
+        });
+     }
+    #[test]
+    fn send_pvalue_to_sapling(value in 0..90u32) {
+        Runtime::new().unwrap().block_on(async {
+    send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Sapling)).await;
+        });
+     }
+}
+
 impl ConductChain for DarksideEnvironment {
     async fn setup() -> Self {
         DarksideEnvironment::new(None).await
@@ -85,26 +107,4 @@ impl ConductChain for DarksideEnvironment {
         self.staged_blockheight = self.staged_blockheight + 1;
         self.apply_blocks(u64::from(self.staged_blockheight)).await;
     }
-}
-
-#[tokio::test]
-#[ignore] // darkside cant handle transparent?
-async fn darkside_send_40_000_to_transparent() {
-    send_value_to_pool::<DarksideEnvironment>(40_000, Transparent).await;
-}
-
-proptest! {
-    #![proptest_config(proptest::test_runner::Config::with_cases(4))]
-    #[test]
-    fn send_pvalue_to_orchard(value in 0..90u32) {
-        Runtime::new().unwrap().block_on(async {
-    send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Orchard)).await;
-        });
-     }
-    #[test]
-    fn send_pvalue_to_sapling(value in 0..90u32) {
-        Runtime::new().unwrap().block_on(async {
-    send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Sapling)).await;
-        });
-     }
 }

--- a/darkside-tests/src/chain_generic_tests.rs
+++ b/darkside-tests/src/chain_generic_tests.rs
@@ -38,6 +38,10 @@ proptest! {
      }
 }
 
+/// known issues include
+///   - transparent sends do not work
+///   - txids are regenerated randomly. zingo can optionally accept_server_txid
+/// these tests cannot portray the full range of network weather.
 impl ConductChain for DarksideEnvironment {
     async fn setup() -> Self {
         DarksideEnvironment::new(None).await

--- a/darkside-tests/src/chain_generic_tests.rs
+++ b/darkside-tests/src/chain_generic_tests.rs
@@ -7,7 +7,7 @@ use zcash_client_backend::ShieldedProtocol::Orchard;
 use zcash_client_backend::ShieldedProtocol::Sapling;
 
 use zingo_testutils::chain_generic_tests::send_value_to_pool;
-use zingo_testutils::chain_generic_tests::ManageScenario;
+use zingo_testutils::chain_generic_tests::ConductChain;
 use zingolib::lightclient::LightClient;
 use zingolib::wallet::WalletBase;
 
@@ -16,7 +16,7 @@ use crate::constants::DARKSIDE_SEED;
 use crate::utils::scenarios::DarksideEnvironment;
 use crate::utils::update_tree_states_for_transaction;
 
-impl ManageScenario for DarksideEnvironment {
+impl ConductChain for DarksideEnvironment {
     async fn setup() -> Self {
         DarksideEnvironment::new(None).await
     }

--- a/integration-tests/tests/chain_generic_tests.rs
+++ b/integration-tests/tests/chain_generic_tests.rs
@@ -29,6 +29,8 @@ struct LibtonodeEnvironment {
     scenario_builder: ScenarioBuilder,
 }
 
+/// known issues include --slow
+/// these tests cannot portray the full range of network weather.
 impl ConductChain for LibtonodeEnvironment {
     async fn setup() -> Self {
         let regtest_network = RegtestNetwork::all_upgrades_active();

--- a/integration-tests/tests/chain_generic_tests.rs
+++ b/integration-tests/tests/chain_generic_tests.rs
@@ -5,7 +5,7 @@ use zcash_client_backend::ShieldedProtocol::Orchard;
 use zcash_client_backend::ShieldedProtocol::Sapling;
 
 use zingo_testutils::chain_generic_tests::send_value_to_pool;
-use zingo_testutils::chain_generic_tests::ManageScenario;
+use zingo_testutils::chain_generic_tests::ConductChain;
 use zingo_testutils::scenarios::setup::ScenarioBuilder;
 use zingoconfig::RegtestNetwork;
 use zingolib::lightclient::LightClient;
@@ -16,7 +16,7 @@ struct LibtonodeEnvironment {
     scenario_builder: ScenarioBuilder,
 }
 
-impl ManageScenario for LibtonodeEnvironment {
+impl ConductChain for LibtonodeEnvironment {
     async fn setup() -> Self {
         let regtest_network = RegtestNetwork::all_upgrades_active();
         let scenario_builder = ScenarioBuilder::build_configure_launch(

--- a/integration-tests/tests/chain_generic_tests.rs
+++ b/integration-tests/tests/chain_generic_tests.rs
@@ -11,6 +11,19 @@ use zingoconfig::RegtestNetwork;
 use zingolib::lightclient::LightClient;
 use zingolib::wallet::WalletBase;
 
+#[tokio::test]
+async fn libtonode_send_40_000_to_transparent() {
+    send_value_to_pool::<LibtonodeEnvironment>(40_000, Transparent).await;
+}
+#[tokio::test]
+async fn libtonode_send_40_000_to_sapling() {
+    send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Sapling)).await;
+}
+#[tokio::test]
+async fn libtonode_send_40_000_to_orchard() {
+    send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Orchard)).await;
+}
+
 struct LibtonodeEnvironment {
     regtest_network: RegtestNetwork,
     scenario_builder: ScenarioBuilder,
@@ -73,17 +86,4 @@ impl ConductChain for LibtonodeEnvironment {
             target
         );
     }
-}
-
-#[tokio::test]
-async fn libtonode_send_40_000_to_transparent() {
-    send_value_to_pool::<LibtonodeEnvironment>(40_000, Transparent).await;
-}
-#[tokio::test]
-async fn libtonode_send_40_000_to_sapling() {
-    send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Sapling)).await;
-}
-#[tokio::test]
-async fn libtonode_send_40_000_to_orchard() {
-    send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Orchard)).await;
 }

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -12,7 +12,7 @@ use zingolib::{get_base_address, wallet::notes::query::OutputPoolQuery};
 #[allow(opaque_hidden_inferred_bound)]
 /// both lib-to-node and darkside can implement this.
 /// implemented on LibtonodeChain and DarksideScenario respectively
-pub trait ManageScenario {
+pub trait ConductChain {
     /// set up the test chain
     async fn setup() -> Self;
     /// builds a faucet (funded from mining)
@@ -60,7 +60,7 @@ pub trait ManageScenario {
 /// creates a proposal, sends it and receives it (upcoming: compares that it was executed correctly) in a chain-generic context
 pub async fn send_value_to_pool<TE>(send_value: u32, pooltype: PoolType)
 where
-    TE: ManageScenario,
+    TE: ConductChain,
 {
     let mut environment = TE::setup().await;
 
@@ -111,7 +111,7 @@ where
 /// runs a send-to-receiver and receives it in a chain-generic context
 pub async fn propose_and_broadcast_value_to_pool<TE>(send_value: u32, pooltype: PoolType)
 where
-    TE: ManageScenario,
+    TE: ConductChain,
 {
     let mut environment = TE::setup().await;
 

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -8,6 +8,58 @@ use zingolib::wallet::notes::query::OutputQuery;
 use zingolib::wallet::notes::query::OutputSpendStatusQuery;
 use zingolib::{get_base_address, wallet::notes::query::OutputPoolQuery};
 
+/// runs a send-to-receiver and receives it in a chain-generic context
+pub async fn propose_and_broadcast_value_to_pool<TE>(send_value: u32, pooltype: PoolType)
+where
+    TE: ConductChain,
+{
+    let mut environment = TE::setup().await;
+
+    dbg!("chain set up, funding client now");
+
+    let sender = environment
+        .fund_client(send_value + 2 * (MARGINAL_FEE.into_u64() as u32))
+        .await;
+
+    dbg!("client is ready to send");
+    dbg!(sender.query_sum_value(OutputQuery::any()).await);
+    dbg!(send_value);
+
+    let recipient = environment.create_client().await;
+    let recipient_address = recipient.get_base_address(pooltype).await;
+    let request = recipient
+        .raw_to_transaction_request(vec![(dbg!(recipient_address), send_value, None)])
+        .unwrap();
+
+    dbg!("recipient ready");
+    dbg!(recipient.query_sum_value(OutputQuery::any()).await);
+    dbg!(request.clone());
+
+    sender.propose_send(request).await.unwrap();
+    sender
+        .complete_and_broadcast_stored_proposal()
+        .await
+        .unwrap();
+
+    environment.bump_chain().await;
+
+    recipient.do_sync(false).await.unwrap();
+
+    assert_eq!(
+        recipient
+            .query_sum_value(OutputQuery {
+                spend_status: OutputSpendStatusQuery {
+                    unspent: true,
+                    pending_spent: false,
+                    spent: false,
+                },
+                pools: OutputPoolQuery::one_pool(pooltype),
+            })
+            .await,
+        send_value as u64
+    );
+}
+
 #[allow(async_fn_in_trait)]
 #[allow(opaque_hidden_inferred_bound)]
 /// both lib-to-node and darkside can implement this.
@@ -86,58 +138,6 @@ where
             send_value as u64,
             None,
         )])
-        .await
-        .unwrap();
-
-    environment.bump_chain().await;
-
-    recipient.do_sync(false).await.unwrap();
-
-    assert_eq!(
-        recipient
-            .query_sum_value(OutputQuery {
-                spend_status: OutputSpendStatusQuery {
-                    unspent: true,
-                    pending_spent: false,
-                    spent: false,
-                },
-                pools: OutputPoolQuery::one_pool(pooltype),
-            })
-            .await,
-        send_value as u64
-    );
-}
-
-/// runs a send-to-receiver and receives it in a chain-generic context
-pub async fn propose_and_broadcast_value_to_pool<TE>(send_value: u32, pooltype: PoolType)
-where
-    TE: ConductChain,
-{
-    let mut environment = TE::setup().await;
-
-    dbg!("chain set up, funding client now");
-
-    let sender = environment
-        .fund_client(send_value + 2 * (MARGINAL_FEE.into_u64() as u32))
-        .await;
-
-    dbg!("client is ready to send");
-    dbg!(sender.query_sum_value(OutputQuery::any()).await);
-    dbg!(send_value);
-
-    let recipient = environment.create_client().await;
-    let recipient_address = recipient.get_base_address(pooltype).await;
-    let request = recipient
-        .raw_to_transaction_request(vec![(dbg!(recipient_address), send_value, None)])
-        .unwrap();
-
-    dbg!("recipient ready");
-    dbg!(recipient.query_sum_value(OutputQuery::any()).await);
-    dbg!(request.clone());
-
-    sender.propose_send(request).await.unwrap();
-    sender
-        .complete_and_broadcast_stored_proposal()
         .await
         .unwrap();
 

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -62,8 +62,10 @@ where
 
 #[allow(async_fn_in_trait)]
 #[allow(opaque_hidden_inferred_bound)]
-/// both lib-to-node and darkside can implement this.
-/// implemented on LibtonodeChain and DarksideScenario respectively
+/// A Lightclient test may involve hosting a server to send data to the LightClient. This trait can be asked to set simple scenarios where a mock LightServer sends data showing a note to a LightClient, the LightClient updates and responds by sending the note, and the Lightserver accepts the transaction and rebroadcasts it...
+/// The initial two implementors are
+/// lib-to-node, which links a lightserver to a zcashd in regtest mode. see `impl ConductChain for LibtoNode
+/// darkside, a mode for the lightserver which mocks zcashd. search 'impl ConductChain for DarksideScenario
 pub trait ConductChain {
     /// set up the test chain
     async fn setup() -> Self;


### PR DESCRIPTION
/// A Lightclient test may involve hosting a server to send data to the LightClient. This trait can be asked to set simple scenarios where a mock LightServer sends data showing a note to a LightClient, the LightClient updates and responds by sending the note, and the Lightserver accepts the transaction and rebroadcasts it...  
/// The initial two implementors are
/// lib-to-node, which links a lightserver to a zcashd in regtest mode. see `impl ConductChain for LibtoNode`
/// darkside, a mode for the lightserver which mocks zcashd. search 'impl ConductChain for DarksideScenario`

