### PR TITLE
Mod in chain generic

### DIFF
--- a/darkside-tests/src/chain_generic_tests.rs
+++ b/darkside-tests/src/chain_generic_tests.rs
@@ -7,14 +7,8 @@ use zcash_client_backend::ShieldedProtocol::Orchard;
 use zcash_client_backend::ShieldedProtocol::Sapling;
 
 use zingo_testutils::chain_generic_tests::send_value_to_pool;
-use zingo_testutils::chain_generic_tests::ConductChain;
-use zingolib::lightclient::LightClient;
-use zingolib::wallet::WalletBase;
 
-use crate::constants::ABANDON_TO_DARKSIDE_SAP_10_000_000_ZAT;
-use crate::constants::DARKSIDE_SEED;
 use crate::utils::scenarios::DarksideEnvironment;
-use crate::utils::update_tree_states_for_transaction;
 
 #[tokio::test]
 #[ignore] // darkside cant handle transparent?
@@ -43,15 +37,7 @@ proptest! {
 ///   - txids are regenerated randomly. zingo can optionally accept_server_txid
 /// these tests cannot portray the full range of network weather.
 pub(crate) mod impl_conduct_chain_for_darkside_environment {
-    use proptest::proptest;
-    use tokio::runtime::Runtime;
 
-    use zcash_client_backend::PoolType::Shielded;
-    use zcash_client_backend::PoolType::Transparent;
-    use zcash_client_backend::ShieldedProtocol::Orchard;
-    use zcash_client_backend::ShieldedProtocol::Sapling;
-
-    use zingo_testutils::chain_generic_tests::send_value_to_pool;
     use zingo_testutils::chain_generic_tests::ConductChain;
     use zingolib::lightclient::LightClient;
     use zingolib::wallet::WalletBase;

--- a/darkside-tests/src/chain_generic_tests.rs
+++ b/darkside-tests/src/chain_generic_tests.rs
@@ -42,7 +42,7 @@ proptest! {
 ///   - transparent sends do not work
 ///   - txids are regenerated randomly. zingo can optionally accept_server_txid
 /// these tests cannot portray the full range of network weather.
-pub mod impl_conduct_chain_for_darkside_environment {
+pub(crate) mod impl_conduct_chain_for_darkside_environment {
     use proptest::proptest;
     use tokio::runtime::Runtime;
 

--- a/darkside-tests/src/chain_generic_tests.rs
+++ b/darkside-tests/src/chain_generic_tests.rs
@@ -25,13 +25,13 @@ async fn darkside_send_40_000_to_transparent() {
 proptest! {
     #![proptest_config(proptest::test_runner::Config::with_cases(4))]
     #[test]
-    fn send_pvalue_to_orchard(value in 0..90u32) {
+    fn darkside_send_pvalue_to_orchard(value in 0..90u32) {
         Runtime::new().unwrap().block_on(async {
     send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Orchard)).await;
         });
      }
     #[test]
-    fn send_pvalue_to_sapling(value in 0..90u32) {
+    fn darkside_send_pvalue_to_sapling(value in 0..90u32) {
         Runtime::new().unwrap().block_on(async {
     send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Sapling)).await;
         });

--- a/integration-tests/tests/chain_generic_tests.rs
+++ b/integration-tests/tests/chain_generic_tests.rs
@@ -1,15 +1,9 @@
-use zcash_client_backend::PoolType;
 use zcash_client_backend::PoolType::Shielded;
 use zcash_client_backend::PoolType::Transparent;
 use zcash_client_backend::ShieldedProtocol::Orchard;
 use zcash_client_backend::ShieldedProtocol::Sapling;
 
 use zingo_testutils::chain_generic_tests::send_value_to_pool;
-use zingo_testutils::chain_generic_tests::ConductChain;
-use zingo_testutils::scenarios::setup::ScenarioBuilder;
-use zingoconfig::RegtestNetwork;
-use zingolib::lightclient::LightClient;
-use zingolib::wallet::WalletBase;
 
 use libtonode_environment::LibtonodeEnvironment;
 
@@ -28,12 +22,9 @@ async fn libtonode_send_40_000_to_orchard() {
 
 pub(crate) mod libtonode_environment {
     use zcash_client_backend::PoolType;
-    use zcash_client_backend::PoolType::Shielded;
-    use zcash_client_backend::PoolType::Transparent;
-    use zcash_client_backend::ShieldedProtocol::Orchard;
+
     use zcash_client_backend::ShieldedProtocol::Sapling;
 
-    use zingo_testutils::chain_generic_tests::send_value_to_pool;
     use zingo_testutils::chain_generic_tests::ConductChain;
     use zingo_testutils::scenarios::setup::ScenarioBuilder;
     use zingoconfig::RegtestNetwork;

--- a/integration-tests/tests/chain_generic_tests.rs
+++ b/integration-tests/tests/chain_generic_tests.rs
@@ -11,6 +11,8 @@ use zingoconfig::RegtestNetwork;
 use zingolib::lightclient::LightClient;
 use zingolib::wallet::WalletBase;
 
+use libtonode_environment::LibtonodeEnvironment;
+
 #[tokio::test]
 async fn libtonode_send_40_000_to_transparent() {
     send_value_to_pool::<LibtonodeEnvironment>(40_000, Transparent).await;
@@ -24,68 +26,82 @@ async fn libtonode_send_40_000_to_orchard() {
     send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Orchard)).await;
 }
 
-struct LibtonodeEnvironment {
-    regtest_network: RegtestNetwork,
-    scenario_builder: ScenarioBuilder,
-}
+pub(crate) mod libtonode_environment {
+    use zcash_client_backend::PoolType;
+    use zcash_client_backend::PoolType::Shielded;
+    use zcash_client_backend::PoolType::Transparent;
+    use zcash_client_backend::ShieldedProtocol::Orchard;
+    use zcash_client_backend::ShieldedProtocol::Sapling;
 
-/// known issues include --slow
-/// these tests cannot portray the full range of network weather.
-impl ConductChain for LibtonodeEnvironment {
-    async fn setup() -> Self {
-        let regtest_network = RegtestNetwork::all_upgrades_active();
-        let scenario_builder = ScenarioBuilder::build_configure_launch(
-            Some(PoolType::Shielded(Sapling).into()),
-            None,
-            None,
-            &regtest_network,
-        )
-        .await;
-        LibtonodeEnvironment {
-            regtest_network,
-            scenario_builder,
+    use zingo_testutils::chain_generic_tests::send_value_to_pool;
+    use zingo_testutils::chain_generic_tests::ConductChain;
+    use zingo_testutils::scenarios::setup::ScenarioBuilder;
+    use zingoconfig::RegtestNetwork;
+    use zingolib::lightclient::LightClient;
+    use zingolib::wallet::WalletBase;
+    pub(crate) struct LibtonodeEnvironment {
+        regtest_network: RegtestNetwork,
+        scenario_builder: ScenarioBuilder,
+    }
+
+    /// known issues include --slow
+    /// these tests cannot portray the full range of network weather.
+    impl ConductChain for LibtonodeEnvironment {
+        async fn setup() -> Self {
+            let regtest_network = RegtestNetwork::all_upgrades_active();
+            let scenario_builder = ScenarioBuilder::build_configure_launch(
+                Some(PoolType::Shielded(Sapling).into()),
+                None,
+                None,
+                &regtest_network,
+            )
+            .await;
+            LibtonodeEnvironment {
+                regtest_network,
+                scenario_builder,
+            }
         }
-    }
 
-    async fn create_faucet(&mut self) -> LightClient {
-        self.scenario_builder
-            .client_builder
-            .build_faucet(false, self.regtest_network)
-            .await
-    }
-
-    async fn create_client(&mut self) -> LightClient {
-        let zingo_config = self
-            .scenario_builder
-            .client_builder
-            .make_unique_data_dir_and_load_config(self.regtest_network);
-        LightClient::create_from_wallet_base_async(
-            WalletBase::FreshEntropy,
-            &zingo_config,
-            0,
-            false,
-        )
-        .await
-        .unwrap()
-    }
-
-    async fn bump_chain(&mut self) {
-        let start_height = self
-            .scenario_builder
-            .regtest_manager
-            .get_current_height()
-            .unwrap();
-        let target = start_height + 1;
-        self.scenario_builder
-            .regtest_manager
-            .generate_n_blocks(1)
-            .expect("Called for side effect, failed!");
-        assert_eq!(
+        async fn create_faucet(&mut self) -> LightClient {
             self.scenario_builder
+                .client_builder
+                .build_faucet(false, self.regtest_network)
+                .await
+        }
+
+        async fn create_client(&mut self) -> LightClient {
+            let zingo_config = self
+                .scenario_builder
+                .client_builder
+                .make_unique_data_dir_and_load_config(self.regtest_network);
+            LightClient::create_from_wallet_base_async(
+                WalletBase::FreshEntropy,
+                &zingo_config,
+                0,
+                false,
+            )
+            .await
+            .unwrap()
+        }
+
+        async fn bump_chain(&mut self) {
+            let start_height = self
+                .scenario_builder
                 .regtest_manager
                 .get_current_height()
-                .unwrap(),
-            target
-        );
+                .unwrap();
+            let target = start_height + 1;
+            self.scenario_builder
+                .regtest_manager
+                .generate_n_blocks(1)
+                .expect("Called for side effect, failed!");
+            assert_eq!(
+                self.scenario_builder
+                    .regtest_manager
+                    .get_current_height()
+                    .unwrap(),
+                target
+            );
+        }
     }
 }

--- a/integration-tests/tests/libtonode.rs
+++ b/integration-tests/tests/libtonode.rs
@@ -37,8 +37,6 @@ use zingolib::{
     },
 };
 
-pub mod chain_generic_tests;
-
 fn extract_value_as_u64(input: &JsonValue) -> u64 {
     let note = &input["value"].as_fixed_point_u64(0).unwrap();
     *note

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -8,6 +8,57 @@ use zingolib::wallet::notes::query::OutputQuery;
 use zingolib::wallet::notes::query::OutputSpendStatusQuery;
 use zingolib::{get_base_address, wallet::notes::query::OutputPoolQuery};
 
+#[allow(async_fn_in_trait)]
+#[allow(opaque_hidden_inferred_bound)]
+/// A Lightclient test may involve hosting a server to send data to the LightClient. This trait can be asked to set simple scenarios where a mock LightServer sends data showing a note to a LightClient, the LightClient updates and responds by sending the note, and the Lightserver accepts the transaction and rebroadcasts it...
+/// The initial two implementors are
+/// lib-to-node, which links a lightserver to a zcashd in regtest mode. see `impl ConductChain for LibtoNode
+/// darkside, a mode for the lightserver which mocks zcashd. search 'impl ConductChain for DarksideScenario
+pub trait ConductChain {
+    /// set up the test chain
+    async fn setup() -> Self;
+    /// builds a faucet (funded from mining)
+    async fn create_faucet(&mut self) -> LightClient;
+    /// builds an empty client
+    async fn create_client(&mut self) -> LightClient;
+    /// moves the chain tip forward, confirming transactions that need to be confirmed
+    async fn bump_chain(&mut self);
+
+    /// builds a client and funds it in a certain pool. may need sync before noticing its funds.
+    async fn fund_client(&mut self, value: u32) -> LightClient {
+        let sender = self.create_faucet().await;
+        let recipient = self.create_client().await;
+
+        self.bump_chain().await;
+        sender.do_sync(false).await.unwrap();
+
+        sender
+            .do_send_test_only(vec![(
+                (get_base_address!(recipient, "unified")).as_str(),
+                value as u64,
+                None,
+            )])
+            .await
+            .unwrap();
+
+        self.bump_chain().await;
+
+        recipient.do_sync(false).await.unwrap();
+
+        recipient
+    }
+
+    // async fn start_with_funds(value: u32) -> (LightClient, Self) {
+    //     let chain = Self::setup().await;
+
+    //     let starter = chain
+    //         .fund_client(value + 2 * (MARGINAL_FEE.into_u64() as u32))
+    //         .await;
+
+    //     (starter, chain);
+    // }
+}
+
 /// runs a send-to-receiver and receives it in a chain-generic context
 pub async fn propose_and_broadcast_value_to_pool<TE>(send_value: u32, pooltype: PoolType)
 where
@@ -58,57 +109,6 @@ where
             .await,
         send_value as u64
     );
-}
-
-#[allow(async_fn_in_trait)]
-#[allow(opaque_hidden_inferred_bound)]
-/// A Lightclient test may involve hosting a server to send data to the LightClient. This trait can be asked to set simple scenarios where a mock LightServer sends data showing a note to a LightClient, the LightClient updates and responds by sending the note, and the Lightserver accepts the transaction and rebroadcasts it...
-/// The initial two implementors are
-/// lib-to-node, which links a lightserver to a zcashd in regtest mode. see `impl ConductChain for LibtoNode
-/// darkside, a mode for the lightserver which mocks zcashd. search 'impl ConductChain for DarksideScenario
-pub trait ConductChain {
-    /// set up the test chain
-    async fn setup() -> Self;
-    /// builds a faucet (funded from mining)
-    async fn create_faucet(&mut self) -> LightClient;
-    /// builds an empty client
-    async fn create_client(&mut self) -> LightClient;
-    /// moves the chain tip forward, confirming transactions that need to be confirmed
-    async fn bump_chain(&mut self);
-
-    /// builds a client and funds it in a certain pool. may need sync before noticing its funds.
-    async fn fund_client(&mut self, value: u32) -> LightClient {
-        let sender = self.create_faucet().await;
-        let recipient = self.create_client().await;
-
-        self.bump_chain().await;
-        sender.do_sync(false).await.unwrap();
-
-        sender
-            .do_send_test_only(vec![(
-                (get_base_address!(recipient, "unified")).as_str(),
-                value as u64,
-                None,
-            )])
-            .await
-            .unwrap();
-
-        self.bump_chain().await;
-
-        recipient.do_sync(false).await.unwrap();
-
-        recipient
-    }
-
-    // async fn start_with_funds(value: u32) -> (LightClient, Self) {
-    //     let chain = Self::setup().await;
-
-    //     let starter = chain
-    //         .fund_client(value + 2 * (MARGINAL_FEE.into_u64() as u32))
-    //         .await;
-
-    //     (starter, chain);
-    // }
 }
 
 /// creates a proposal, sends it and receives it (upcoming: compares that it was executed correctly) in a chain-generic context

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -24,7 +24,7 @@ pub trait ConductChain {
     /// moves the chain tip forward, confirming transactions that need to be confirmed
     async fn bump_chain(&mut self);
 
-    /// builds a client and funds it in a certain pool. may need sync before noticing its funds.
+    /// builds a client and funds it in orchard and syncs it
     async fn fund_client(&mut self, value: u32) -> LightClient {
         let sender = self.create_faucet().await;
         let recipient = self.create_client().await;


### PR DESCRIPTION
This is is legibility PR. Set up some mods that will make moving trait implementations between files easier later. Now the use statements wont get tangled between the trait and the tests.