### PR TITLE
remove unnecesary tonic-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4396,7 +4396,6 @@ dependencies = [
  "tempdir",
  "tokio",
  "tonic",
- "tonic-build",
  "tracing",
  "zcash_address",
  "zcash_client_backend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,7 +4483,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,7 +4483,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ orchard = "0.8"
 zip32 = "0.1"
 
 clap = "4.4"
-tonic-build = "0.10"
 tempdir = "0.3"
 portpicker = "0.1"
 incrementalmerkletree = { version = "0.5" }

--- a/darkside-tests/Cargo.toml
+++ b/darkside-tests/Cargo.toml
@@ -43,4 +43,4 @@ sapling-crypto.workspace = true
 proptest = "1.4.0"
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-build = "0.10"

--- a/zingo-netutils/Cargo.toml
+++ b/zingo-netutils/Cargo.toml
@@ -20,5 +20,3 @@ rustls-pemfile = "1.0.0"
 
 [features]
 test-features = []
-
-

--- a/zingo-testutils/Cargo.toml
+++ b/zingo-testutils/Cargo.toml
@@ -31,6 +31,3 @@ tonic = { workspace = true, optional = true }
 tracing = "0.1.37"
 serde_json = "1.0.100"
 serde = { version = "1.0.201", features = ["derive"] }
-
-[build-dependencies]
-tonic-build = { workspace = true }

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -92,5 +92,4 @@ tempfile = "3.3.0"
 concat-idents = "1.1.3"
 
 [build-dependencies]
-tonic-build = { workspace = true }
 build_utils = { workspace = true }

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -25,7 +25,6 @@ hyper = { workspace = true }
 hyper-rustls = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }
-tower = { workspace = true }
 
 orchard = { workspace = true }
 shardtree = { workspace = true, features = ["legacy-api"] }


### PR DESCRIPTION
A nice feature of this little PR is that it clarifies that `tonic-build` is *only* used in `darkside-tests`.