### PR TITLE
Deprecate do_send

### DIFF
--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -713,7 +713,6 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: Pool,
         ) -> (&mut DarksideEnvironment, RawTransaction) {
             self.staged_blockheight = self.staged_blockheight.add(1);
             self.darkside_connector
@@ -725,10 +724,7 @@ pub mod scenarios {
                 DarksideSender::IndexedClient(n) => self.get_lightclient(n),
                 DarksideSender::ExternalClient(lc) => lc,
             };
-            lightclient
-                .shield_from_shield_inputs(&[pool_to_shield], None)
-                .await
-                .unwrap();
+            lightclient.quick_shield().await.unwrap();
             let mut streamed_raw_txns = self
                 .darkside_connector
                 .get_incoming_transactions()
@@ -767,10 +763,9 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: Pool,
             chainbuild_file: &File,
         ) -> &mut DarksideEnvironment {
-            let (_, raw_tx) = self.shield_transaction(sender, pool_to_shield).await;
+            let (_, raw_tx) = self.shield_transaction(sender).await;
             write_raw_transaction(&raw_tx, BranchId::Nu5, chainbuild_file);
             self
         }

--- a/darkside-tests/tests/network_interruption_tests.rs
+++ b/darkside-tests/tests/network_interruption_tests.rs
@@ -105,11 +105,7 @@ async fn shielded_note_marked_as_change_chainbuild() {
             .await;
         scenario.get_lightclient(0).do_sync(false).await.unwrap();
         scenario
-            .shield_and_write_transaction(
-                DarksideSender::IndexedClient(0),
-                Pool::Sapling,
-                &chainbuild_file,
-            )
+            .shield_and_write_transaction(DarksideSender::IndexedClient(0), &chainbuild_file)
             .await;
     }
 

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -1360,18 +1360,17 @@ pub mod scenarios {
             .await
             .unwrap();
         // shield transparent
-        recipient
-            .shield_from_shield_inputs(&[Pool::Transparent], None)
-            .await
-            .unwrap();
+        recipient.quick_shield().await.unwrap();
         increase_height_and_wait_for_client(&scenario_builder.regtest_manager, &recipient, 1)
             .await
             .unwrap();
-        // upgrade sapling
+        /*
+        // upgrade sapling NOT IMPLEMENTED YET
         recipient
             .shield_from_shield_inputs(&[Pool::Sapling], None)
             .await
             .unwrap();
+        */
         // end
         scenario_builder
             .regtest_manager

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -1,15 +1,6 @@
 //! TODO: Add Mod Description Here!
-use log::debug;
 
-use zcash_client_backend::address::Address;
 use zcash_primitives::consensus::BlockHeight;
-use zcash_primitives::transaction::fees::zip317::MINIMUM_FEE;
-use zcash_primitives::transaction::TxId;
-use zcash_proofs::prover::LocalTxProver;
-
-use crate::data::receivers::Receivers;
-use crate::utils::conversion::zatoshis_from_u64;
-use crate::wallet::Pool;
 
 use super::LightClient;
 use super::LightWalletSendProgress;
@@ -23,37 +14,6 @@ impl LightClient {
         ) + 1)
     }
 
-    /// Send funds
-    pub async fn do_send(&self, receivers: Receivers) -> Result<TxId, String> {
-        let transaction_submission_height = self.get_submission_height().await?;
-        // First, get the consensus branch ID
-        debug!("Creating transaction");
-
-        let _lock = self.sync_lock.lock().await;
-        // I am not clear on how long this operation may take, but it's
-        // clearly unnecessary in a send that doesn't include sapling
-        // TODO: Remove from sends that don't include Sapling
-        let (sapling_output, sapling_spend) = crate::wallet::utils::read_sapling_params()?;
-
-        let sapling_prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
-
-        self.wallet
-            .send_to_addresses(
-                sapling_prover,
-                vec![crate::wallet::Pool::Orchard, crate::wallet::Pool::Sapling], // This policy doesn't allow
-                // spend from transparent.
-                receivers,
-                transaction_submission_height,
-                |transaction_bytes| {
-                    crate::grpc_connector::send_transaction(
-                        self.get_server_uri(),
-                        transaction_bytes,
-                    )
-                },
-            )
-            .await
-    }
-
     /// TODO: Add Doc Comment Here!
     pub async fn do_send_progress(&self) -> Result<LightWalletSendProgress, String> {
         let progress = self.wallet.get_send_progress().await;
@@ -61,76 +21,6 @@ impl LightClient {
             progress: progress.clone(),
             interrupt_sync: *self.interrupt_sync.read().await,
         })
-    }
-
-    /// Shield funds. Send transparent or sapling funds to a unified address.
-    /// Defaults to the unified address of the capability if `address` is `None`.
-    pub async fn do_shield(
-        &self,
-        pools_to_shield: &[Pool],
-        address: Option<Address>,
-    ) -> Result<TxId, String> {
-        let transaction_submission_height = self.get_submission_height().await?;
-        let fee = u64::from(MINIMUM_FEE); // TODO: This can no longer be hard coded, and must be calced
-                                          // as a fn of the transactions structure.
-        let tbal = self
-            .wallet
-            .tbalance(None)
-            .await
-            .expect("to receive a balance");
-        let sapling_bal = self
-            .wallet
-            .spendable_sapling_balance(None)
-            .await
-            .unwrap_or(0);
-
-        // Make sure there is a balance, and it is greater than the amount
-        let balance_to_shield = if pools_to_shield.contains(&Pool::Transparent) {
-            tbal
-        } else {
-            0
-        } + if pools_to_shield.contains(&Pool::Sapling) {
-            sapling_bal
-        } else {
-            0
-        };
-        if balance_to_shield <= fee {
-            return Err(format!(
-                "Not enough transparent/sapling balance to shield. Have {} zats, need more than {} zats to cover tx fee",
-                balance_to_shield, fee
-            ));
-        }
-
-        let recipient_address = address.unwrap_or(Address::from(
-            self.wallet.wallet_capability().addresses()[0].clone(),
-        ));
-        let amount = zatoshis_from_u64(balance_to_shield - fee)
-            .expect("balance cannot be outside valid range of zatoshis");
-        let receivers = vec![crate::data::receivers::Receiver {
-            recipient_address,
-            amount,
-            memo: None,
-        }];
-
-        let _lock = self.sync_lock.lock().await;
-        let (sapling_output, sapling_spend) = crate::wallet::utils::read_sapling_params()?;
-
-        let sapling_prover = LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
-
-        self.wallet
-            .send_to_addresses(
-                sapling_prover,
-                pools_to_shield.to_vec(),
-                receivers,
-                transaction_submission_height,
-                |transaction_bytes| {
-                    crate::grpc_connector::send_transaction(
-                        self.get_server_uri(),
-                        transaction_bytes,
-                    )
-                },
-            )
-            .await
     }
 }
 

--- a/zingolib/src/lightclient/test_features.rs
+++ b/zingolib/src/lightclient/test_features.rs
@@ -8,8 +8,7 @@ use zcash_primitives::transaction::TxId;
 use crate::{
     data::{proposal::TransferProposal, receivers::transaction_request_from_receivers},
     error::ZingoLibError,
-    utils::conversion::{address_from_str, testing::receivers_from_send_inputs},
-    wallet::Pool,
+    utils::conversion::testing::receivers_from_send_inputs,
 };
 
 use super::{propose::ProposeSendError, send::send_with_proposal::QuickSendError, LightClient};
@@ -55,38 +54,6 @@ impl LightClient {
             .transaction_request_from_send_inputs(address_amount_memo_tuples)
             .expect("should be able to create a transaction request as receivers are valid.");
         self.quick_send(request).await
-    }
-
-    /// Test only lightclient method for calling `do_send` with primitive rust types
-    ///
-    /// # Panics
-    ///
-    /// Panics if the address, amount or memo conversion fails.
-    pub async fn send_from_send_inputs(
-        &self,
-        address_amount_memo_tuples: Vec<(&str, u64, Option<&str>)>,
-    ) -> Result<String, String> {
-        let receivers =
-            receivers_from_send_inputs(address_amount_memo_tuples, &self.config().chain);
-        self.do_send(receivers).await.map(|txid| txid.to_string())
-    }
-
-    /// Test only lightclient method for calling `do_shield` with an address as &str
-    ///
-    /// # Panics
-    ///
-    /// Panics if the address conversion fails.
-    pub async fn shield_from_shield_inputs(
-        &self,
-        pools_to_shield: &[Pool],
-        address: Option<&str>,
-    ) -> Result<String, String> {
-        let address = address.map(|addr| {
-            address_from_str(addr, &self.config().chain).expect("should be a valid address")
-        });
-        self.do_shield(pools_to_shield, address)
-            .await
-            .map(|txid| txid.to_string())
     }
 
     /// gets the first address that will allow a sender to send to a specific pool, as a string


### PR DESCRIPTION
This causes the integration tests to run against quicksend (wrapped by send).   I get 26 test fails.  I am looking into them now.