### PR TITLE
zip317_update_integration_tests

### DIFF
--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -713,7 +713,6 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: Pool,
         ) -> (&mut DarksideEnvironment, RawTransaction) {
             self.staged_blockheight = self.staged_blockheight.add(1);
             self.darkside_connector
@@ -725,10 +724,7 @@ pub mod scenarios {
                 DarksideSender::IndexedClient(n) => self.get_lightclient(n),
                 DarksideSender::ExternalClient(lc) => lc,
             };
-            lightclient
-                .shield_from_shield_inputs(&[pool_to_shield], None)
-                .await
-                .unwrap();
+            lightclient.quick_shield().await.unwrap();
             let mut streamed_raw_txns = self
                 .darkside_connector
                 .get_incoming_transactions()
@@ -767,10 +763,9 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: Pool,
             chainbuild_file: &File,
         ) -> &mut DarksideEnvironment {
-            let (_, raw_tx) = self.shield_transaction(sender, pool_to_shield).await;
+            let (_, raw_tx) = self.shield_transaction(sender).await;
             write_raw_transaction(&raw_tx, BranchId::Nu5, chainbuild_file);
             self
         }

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -677,7 +677,7 @@ pub mod scenarios {
                 DarksideSender::ExternalClient(lc) => lc,
             };
             lightclient
-                .send_from_send_inputs(vec![(receiver_address, value, None)])
+                .quick_send_from_send_inputs(vec![(receiver_address, value, None)])
                 .await
                 .unwrap();
             let mut streamed_raw_txns = self

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -556,7 +556,7 @@ async fn reorg_changes_outgoing_tx_height() {
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
     let sent_tx_id = light_client
-        .send_from_send_inputs([(recipient_string, amount, None)].to_vec())
+        .quick_send_from_send_inputs([(recipient_string, amount, None)].to_vec())
         .await
         .unwrap();
 
@@ -792,7 +792,7 @@ async fn reorg_expires_outgoing_tx_height() {
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
     let sent_tx_id = light_client
-        .send_from_send_inputs([(recipient_string, amount, None)].to_vec())
+        .quick_send_from_send_inputs([(recipient_string, amount, None)].to_vec())
         .await
         .unwrap();
 
@@ -970,7 +970,7 @@ async fn reorg_changes_outgoing_tx_index() {
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
     let sent_tx_id = light_client
-        .send_from_send_inputs([(recipient_string, amount, None)].to_vec())
+        .quick_send_from_send_inputs([(recipient_string, amount, None)].to_vec())
         .await
         .unwrap();
 

--- a/darkside-tests/tests/network_interruption_tests.rs
+++ b/darkside-tests/tests/network_interruption_tests.rs
@@ -105,11 +105,7 @@ async fn shielded_note_marked_as_change_chainbuild() {
             .await;
         scenario.get_lightclient(0).do_sync(false).await.unwrap();
         scenario
-            .shield_and_write_transaction(
-                DarksideSender::IndexedClient(0),
-                Pool::Sapling,
-                &chainbuild_file,
-            )
+            .shield_and_write_transaction(DarksideSender::IndexedClient(0), &chainbuild_file)
             .await;
     }
 

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -148,7 +148,7 @@ async fn sent_transaction_reorged_into_mempool() {
         )])
         .await
         .unwrap();
-    println!("{}", txid);
+    println!("{}", txid.first().to_string());
     recipient.do_sync(false).await.unwrap();
     println!("{}", recipient.do_list_transactions().await.pretty(2));
 

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -141,7 +141,7 @@ async fn sent_transaction_reorged_into_mempool() {
         }
     );
     let txid = light_client
-        .send_from_send_inputs(vec![(
+        .quick_send_from_send_inputs(vec![(
             &get_base_address!(recipient, "unified"),
             10_000,
             None,

--- a/integration-tests/tests/libtonode.rs
+++ b/integration-tests/tests/libtonode.rs
@@ -3695,15 +3695,13 @@ mod basic_transactions {
                 - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (std::cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
@@ -3734,15 +3732,13 @@ mod basic_transactions {
                 - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid2);
 
-        let expected_fee_txid2 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid2 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid2.transparent_tx_actions
-        //             + tx_actions_txid2.sapling_tx_actions
-        //             + tx_actions_txid2.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid2 = 5000
+            * (std::cmp::max(
+                2,
+                tx_actions_txid2.transparent_tx_actions
+                    + tx_actions_txid2.sapling_tx_actions
+                    + tx_actions_txid2.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid2);
 
         assert_eq!(calculated_fee_txid2, expected_fee_txid2 as u64);
@@ -3773,15 +3769,13 @@ mod basic_transactions {
                 - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid3);
 
-        let expected_fee_txid3 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid3 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid3.transparent_tx_actions
-        //             + tx_actions_txid3.sapling_tx_actions
-        //             + tx_actions_txid3.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid3 = 5000
+            * (std::cmp::max(
+                2,
+                tx_actions_txid3.transparent_tx_actions
+                    + tx_actions_txid3.sapling_tx_actions
+                    + tx_actions_txid3.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid3);
 
         assert_eq!(calculated_fee_txid3, expected_fee_txid3 as u64);
@@ -3828,15 +3822,13 @@ mod basic_transactions {
                 - 60_000;
         println!("Fee Paid: {}", calculated_fee_txid4);
 
-        let expected_fee_txid4 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid4 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid4.transparent_tx_actions
-        //             + tx_actions_txid4.sapling_tx_actions
-        //             + tx_actions_txid4.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid4 = 5000
+            * (std::cmp::max(
+                2,
+                tx_actions_txid4.transparent_tx_actions
+                    + tx_actions_txid4.sapling_tx_actions
+                    + tx_actions_txid4.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid4);
 
         assert_eq!(calculated_fee_txid4, expected_fee_txid4 as u64);
@@ -3888,15 +3880,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&faucet, txid1.first().to_string().as_str()).await;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (std::cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
@@ -3949,15 +3939,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&recipient, txid1.first().to_string().as_str()).await;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (std::cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
@@ -4004,15 +3992,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&recipient, txid2.first().to_string().as_str()).await;
         println!("Fee Paid: {}", calculated_fee_txid2);
 
-        let expected_fee_txid2 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid2 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid2.transparent_tx_actions
-        //             + tx_actions_txid2.sapling_tx_actions
-        //             + tx_actions_txid2.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid2 = 5000
+            * (std::cmp::max(
+                2,
+                tx_actions_txid2.transparent_tx_actions
+                    + tx_actions_txid2.sapling_tx_actions
+                    + tx_actions_txid2.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid2);
 
         assert_eq!(calculated_fee_txid2, expected_fee_txid2 as u64);

--- a/integration-tests/tests/shield_transparent.rs
+++ b/integration-tests/tests/shield_transparent.rs
@@ -15,7 +15,7 @@ async fn shield_transparent() {
         serde_json::to_string_pretty(&recipient.do_balance().await).unwrap(),
     );
     let proposal = faucet
-        .send_from_send_inputs(vec![(
+        .quick_send_from_send_inputs(vec![(
             &get_base_address!(recipient, "transparent"),
             transparent_funds,
             None,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -38,7 +38,7 @@ pub mod conduct_chain {
             sender.do_sync(false).await.unwrap();
 
             sender
-                .send_from_send_inputs(vec![(
+                .quick_send_from_send_inputs(vec![(
                     (get_base_address!(recipient, "unified")).as_str(),
                     value,
                     None,
@@ -146,7 +146,7 @@ pub mod fixtures {
 
         for _ in 0..n {
             primary
-                .send_from_send_inputs(vec![(secondary_address.as_str(), 100_000, None)])
+                .quick_send_from_send_inputs(vec![(secondary_address.as_str(), 100_000, None)])
                 .await
                 .unwrap();
             environment.bump_chain().await;
@@ -157,7 +157,7 @@ pub mod fixtures {
             secondary.do_sync(false).await.unwrap();
             dbg!(secondary.do_balance().await);
             secondary
-                .send_from_send_inputs(vec![(primary_address.as_str(), 50_000, None)])
+                .quick_send_from_send_inputs(vec![(primary_address.as_str(), 50_000, None)])
                 .await
                 .unwrap();
             primary.do_sync(false).await.unwrap();
@@ -189,7 +189,7 @@ pub mod fixtures {
         dbg!(recipient.query_sum_value(OutputQuery::any()).await);
 
         sender
-            .send_from_send_inputs(vec![(dbg!(recipient_address).as_str(), send_value, None)])
+            .quick_send_from_send_inputs(vec![(dbg!(recipient_address).as_str(), send_value, None)])
             .await
             .unwrap();
 

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -144,7 +144,7 @@ pub async fn send_value_between_clients_and_sync(
         &recipient.do_addresses().await[0]["address"]
     );
     let txid = sender
-        .send_from_send_inputs(vec![(
+        .quick_send_from_send_inputs(vec![(
             &zingolib::get_base_address!(recipient, address_type),
             value,
             None,
@@ -1011,7 +1011,7 @@ pub mod scenarios {
         let orchard_txid = if let Some(funds) = orchard_funds {
             Some(
                 faucet
-                    .send_from_send_inputs(vec![(
+                    .quick_send_from_send_inputs(vec![(
                         &get_base_address!(recipient, "unified"),
                         funds,
                         None,
@@ -1025,7 +1025,7 @@ pub mod scenarios {
         let sapling_txid = if let Some(funds) = sapling_funds {
             Some(
                 faucet
-                    .send_from_send_inputs(vec![(
+                    .quick_send_from_send_inputs(vec![(
                         &get_base_address!(recipient, "sapling"),
                         funds,
                         None,
@@ -1039,7 +1039,7 @@ pub mod scenarios {
         let transparent_txid = if let Some(funds) = transparent_funds {
             Some(
                 faucet
-                    .send_from_send_inputs(vec![(
+                    .quick_send_from_send_inputs(vec![(
                         &get_base_address!(recipient, "transparent"),
                         funds,
                         None,
@@ -1169,7 +1169,7 @@ pub mod scenarios {
             .await;
         faucet.do_sync(false).await.unwrap();
         faucet
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "unified"),
                 value,
                 None,
@@ -1211,7 +1211,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet
         faucet
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "unified"),
                 value,
                 None,
@@ -1223,7 +1223,7 @@ pub mod scenarios {
             .unwrap();
         // send to a faucet
         recipient
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(faucet, "unified"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1235,7 +1235,7 @@ pub mod scenarios {
             .unwrap();
         // send to self sapling
         recipient
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "sapling"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1277,7 +1277,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet to orchard
         faucet
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "unified"),
                 value.checked_div(2).unwrap(),
                 None,
@@ -1289,7 +1289,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet to sapling
         faucet
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "sapling"),
                 value.checked_div(4).unwrap(),
                 None,
@@ -1301,7 +1301,7 @@ pub mod scenarios {
             .unwrap();
         // received from a faucet to transparent
         faucet
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "transparent"),
                 value.checked_div(4).unwrap(),
                 None,
@@ -1313,7 +1313,7 @@ pub mod scenarios {
             .unwrap();
         // send to a faucet
         recipient
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(faucet, "unified"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1325,7 +1325,7 @@ pub mod scenarios {
             .unwrap();
         // send to self orchard
         recipient
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "unified"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1337,7 +1337,7 @@ pub mod scenarios {
             .unwrap();
         // send to self sapling
         recipient
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "sapling"),
                 value.checked_div(10).unwrap(),
                 None,
@@ -1349,7 +1349,7 @@ pub mod scenarios {
             .unwrap();
         // send to self transparent
         recipient
-            .send_from_send_inputs(vec![(
+            .quick_send_from_send_inputs(vec![(
                 &get_base_address!(recipient, "transparent"),
                 value.checked_div(10).unwrap(),
                 None,

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -1360,18 +1360,17 @@ pub mod scenarios {
             .await
             .unwrap();
         // shield transparent
-        recipient
-            .shield_from_shield_inputs(&[Pool::Transparent], None)
-            .await
-            .unwrap();
+        recipient.quick_shield().await.unwrap();
         increase_height_and_wait_for_client(&scenario_builder.regtest_manager, &recipient, 1)
             .await
             .unwrap();
-        // upgrade sapling
+        /*
+        // upgrade sapling NOT IMPLEMENTED YET
         recipient
             .shield_from_shield_inputs(&[Pool::Sapling], None)
             .await
             .unwrap();
+        */
         // end
         scenario_builder
             .regtest_manager

--- a/zingo-testutils/src/lib.rs
+++ b/zingo-testutils/src/lib.rs
@@ -153,7 +153,7 @@ pub async fn send_value_between_clients_and_sync(
         .unwrap();
     increase_height_and_wait_for_client(manager, sender, 1).await?;
     recipient.do_sync(false).await?;
-    Ok(txid)
+    Ok(txid.first().to_string())
 }
 
 /// This function increases the chain height reliably (with polling) but
@@ -988,6 +988,7 @@ pub mod scenarios {
     }
 
     /// TODO: Add Doc Comment Here!
+    // TODO: Change to return vecs of TxIds in stead of a String of the first one for each pool
     pub async fn faucet_funded_recipient(
         orchard_funds: Option<u64>,
         sapling_funds: Option<u64>,
@@ -1008,7 +1009,7 @@ pub mod scenarios {
         increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
             .await
             .unwrap();
-        let orchard_txid = if let Some(funds) = orchard_funds {
+        let orchard_txids = if let Some(funds) = orchard_funds {
             Some(
                 faucet
                     .quick_send_from_send_inputs(vec![(
@@ -1022,7 +1023,7 @@ pub mod scenarios {
         } else {
             None
         };
-        let sapling_txid = if let Some(funds) = sapling_funds {
+        let sapling_txids = if let Some(funds) = sapling_funds {
             Some(
                 faucet
                     .quick_send_from_send_inputs(vec![(
@@ -1036,7 +1037,7 @@ pub mod scenarios {
         } else {
             None
         };
-        let transparent_txid = if let Some(funds) = transparent_funds {
+        let transparent_txids = if let Some(funds) = transparent_funds {
             Some(
                 faucet
                     .quick_send_from_send_inputs(vec![(
@@ -1059,9 +1060,9 @@ pub mod scenarios {
             child_process_handler,
             faucet,
             recipient,
-            orchard_txid,
-            sapling_txid,
-            transparent_txid,
+            orchard_txids.map(|txid| txid.first().to_string()),
+            sapling_txids.map(|txid| txid.first().to_string()),
+            transparent_txids.map(|txid| txid.first().to_string()),
         )
     }
 

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -38,7 +38,7 @@ pub(super) fn parse_shield_args(
     Ok((pools_to_shield.to_vec(), address))
 }
 
-// Parse the send arguments for `do_send`.
+// Parse the send arguments to receivers for sending.
 // The send arguments have two possible formats:
 // - 1 argument in the form of a JSON string for multiple sends. '[{"address":"<address>", "value":<value>, "memo":"<optional memo>"}, ...]'
 // - 2 (+1 optional) arguments for a single address send. &["<address>", <amount>, "<optional memo>"]


### PR DESCRIPTION
Replaces all calls to do_shield and do_send with quick_send and quick_shield in all integration tests.

This PR should be merged into dev when all test pass. This draft PR can be used as a tool to temp merge into a feature branch to check if it is correctly fixing a failing test

this PR should not include any fixes to the codebase but it should include fixes to wrong assertions in tests such as wrong expected fees etc.