### PR TITLE
Transparent dust guard

### DIFF
--- a/integration-tests/tests/chain_generic_tests.rs
+++ b/integration-tests/tests/chain_generic_tests.rs
@@ -8,6 +8,7 @@ use zingo_testutils::chain_generic_tests::fixtures::propose_and_broadcast_value_
 use zingo_testutils::chain_generic_tests::fixtures::send_grace_input;
 use zingo_testutils::chain_generic_tests::fixtures::send_shield_cycle;
 use zingo_testutils::chain_generic_tests::fixtures::send_value_to_pool;
+use zingo_testutils::chain_generic_tests::fixtures::shield_positive;
 
 use libtonode_environment::LibtonodeEnvironment;
 
@@ -35,6 +36,11 @@ async fn libtonode_propose_and_broadcast_40_000_to_sapling() {
 #[tokio::test]
 async fn libtonode_propose_and_broadcast_40_000_to_orchard() {
     propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Orchard)).await;
+}
+
+#[tokio::test]
+async fn libtonode_shield_positive() {
+    shield_positive::<LibtonodeEnvironment>().await;
 }
 #[tokio::test]
 async fn libtonode_send_shield_cycle() {

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -68,6 +68,7 @@ pub async fn assert_cant_shield(client: &zingolib::lightclient::LightClient) {
                 println!("available {}, required more than {}", available.into_u64(), required.into_u64());
                 true
             },
+            zingolib::lightclient::propose::ProposeShieldError::Dusty => true,
             e => {
                 dbg!(e);
                 false

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -65,7 +65,7 @@ pub async fn assert_send_outputs_match_recipient<NoteId>(
 pub async fn assert_cant_shield(client: &zingolib::lightclient::LightClient) {
     assert!(match client.propose_shield().await.unwrap_err() {
             zingolib::lightclient::propose::ProposeShieldError::Component(zcash_client_backend::data_api::error::Error::NoteSelection(zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelectorError::Change(zcash_client_backend::fees::ChangeError::InsufficientFunds { available, required }))) => {
-                println!("available {}, required {}", available.into_u64(), required.into_u64());
+                println!("available {}, required more than {}", available.into_u64(), required.into_u64());
                 true
             },
             e => {

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -69,7 +69,7 @@ pub async fn assert_cant_shield(client: &zingolib::lightclient::LightClient) {
                 true
             },
             zingolib::lightclient::propose::ProposeShieldError::BelowThreshold(amount) => {
-                println!("possible note {}, threshold {}", amount, zingolib::lightclient::propose::SHIELDING_THRESHOLD);
+                println!("possible note {}, threshold {}", amount, zingolib::lightclient::propose::SHIELDING_CUTOFF);
                 true},
             e => {
                 dbg!(e);

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -62,7 +62,7 @@ pub async fn assert_send_outputs_match_recipient<NoteId>(
 }
 
 /// assert that proposing shield causes a specific error
-pub async fn assert_cant_shield(client: zingolib::lightclient::LightClient, balance: u64) {
+pub async fn assert_cant_shield(client: &zingolib::lightclient::LightClient, balance: u64) {
     assert!(match client.propose_shield().await.unwrap_err() {
             zingolib::lightclient::propose::ProposeShieldError::Component(zcash_client_backend::data_api::error::Error::NoteSelection(zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelectorError::Change(zcash_client_backend::fees::ChangeError::InsufficientFunds { available, required }))) => {
                 println!("available {}, required {}", available.into_u64(), required.into_u64());

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -68,7 +68,9 @@ pub async fn assert_cant_shield(client: &zingolib::lightclient::LightClient) {
                 println!("available {}, required more than {}", available.into_u64(), required.into_u64());
                 true
             },
-            zingolib::lightclient::propose::ProposeShieldError::Dusty => true,
+            zingolib::lightclient::propose::ProposeShieldError::BelowThreshold(amount) => {
+                println!("possible note {}, threshold {}", amount, zingolib::lightclient::propose::SHIELDING_THRESHOLD);
+                true},
             e => {
                 dbg!(e);
                 false

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -60,3 +60,19 @@ pub async fn assert_send_outputs_match_recipient<NoteId>(
         );
     }
 }
+
+/// assert that proposing shield causes a specific error
+pub async fn assert_cant_shield(client: zingolib::lightclient::LightClient, balance: u64) {
+    assert!(match client.propose_shield().await.unwrap_err() {
+            zingolib::lightclient::propose::ProposeShieldError::Component(zcash_client_backend::data_api::error::Error::NoteSelection(zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelectorError::Change(zcash_client_backend::fees::ChangeError::InsufficientFunds { available, required }))) => {
+                println!("available {}, required {}", available.into_u64(), required.into_u64());
+                if available.into_u64() == balance { true } else {
+                    false
+                }
+            },
+            e => {
+                dbg!(e);
+                false
+            }
+        });
+}

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -62,13 +62,11 @@ pub async fn assert_send_outputs_match_recipient<NoteId>(
 }
 
 /// assert that proposing shield causes a specific error
-pub async fn assert_cant_shield(client: &zingolib::lightclient::LightClient, balance: u64) {
+pub async fn assert_cant_shield(client: &zingolib::lightclient::LightClient) {
     assert!(match client.propose_shield().await.unwrap_err() {
             zingolib::lightclient::propose::ProposeShieldError::Component(zcash_client_backend::data_api::error::Error::NoteSelection(zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelectorError::Change(zcash_client_backend::fees::ChangeError::InsufficientFunds { available, required }))) => {
                 println!("available {}, required {}", available.into_u64(), required.into_u64());
-                if available.into_u64() == balance { true } else {
-                    false
-                }
+                true
             },
             e => {
                 dbg!(e);

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -153,7 +153,22 @@ pub mod fixtures {
         );
 
         // the recipient cannot propose shielding
-        assertions::assert_cant_shield(recipient, 1000).await;
+        assertions::assert_cant_shield(&recipient, 1000).await;
+
+        // creates an output for recipient which is too small too send, but not dust
+        assert_eq!(
+            with_assertions::propose_send_bump_sync_recipient(
+                &mut environment,
+                &sender,
+                &recipient,
+                vec![(Transparent, 6000)],
+            )
+            .await,
+            15_000
+        );
+
+        // the recipient cannot propose shielding
+        assertions::assert_cant_shield(&recipient, 6000).await;
     }
 
     /// sends back and forth several times, including sends to transparent

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -156,7 +156,7 @@ pub mod fixtures {
                 ],
             )
             .await,
-            40_000
+            8 * MARGINAL_FEE.into_u64()
         );
 
         // the recipient cannot propose shielding
@@ -172,7 +172,7 @@ pub mod fixtures {
                 vec![(Transparent, nondust_1)],
             )
             .await,
-            15_000
+            3 * MARGINAL_FEE.into_u64()
         );
 
         // the recipient cannot propose shielding
@@ -188,7 +188,7 @@ pub mod fixtures {
                 vec![(Transparent, nondust_2)],
             )
             .await,
-            15_000
+            3 * MARGINAL_FEE.into_u64()
         );
 
         // the recipient cannot propose shielding
@@ -204,11 +204,11 @@ pub mod fixtures {
                 vec![(Transparent, nondust_3)],
             )
             .await,
-            15_000
+            3 * MARGINAL_FEE.into_u64()
         );
 
         // the recipient can propose shielding
-        let expected_shield_fee = 25_000;
+        let expected_shield_fee = 5 * MARGINAL_FEE.into_u64();
         assert_eq!(
             with_assertions::propose_shield_bump_sync(&mut environment, &shielder).await,
             expected_shield_fee,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -137,7 +137,7 @@ pub mod fixtures {
     {
         let mut environment = CC::setup().await;
 
-        let sender = environment.fund_client_orchard(100_000).await;
+        let sender = environment.fund_client_orchard(1_000_000).await;
         let recipient = environment.create_client().await;
 
         // creates a bunch of transparent dust outputs for recipient
@@ -147,12 +147,12 @@ pub mod fixtures {
                 &sender,
                 &recipient,
                 vec![
-                    (Transparent, 1000),
-                    (Transparent, 1000),
-                    (Transparent, 1000),
-                    (Transparent, 1000),
-                    (Transparent, 1000),
-                    (Transparent, 1000)
+                    (Transparent, 1_000),
+                    (Transparent, 1_000),
+                    (Transparent, 1_000),
+                    (Transparent, 1_000),
+                    (Transparent, 1_000),
+                    (Transparent, 1_000)
                 ],
             )
             .await,
@@ -168,7 +168,22 @@ pub mod fixtures {
                 &mut environment,
                 &sender,
                 &recipient,
-                vec![(Transparent, 6000)],
+                vec![(Transparent, 6_000)],
+            )
+            .await,
+            15_000
+        );
+
+        // the recipient cannot propose shielding
+        assertions::assert_cant_shield(&recipient).await;
+
+        // creates an output for recipient which combined with the previous is almost enough to be worth a shield
+        assert_eq!(
+            with_assertions::propose_send_bump_sync_recipient(
+                &mut environment,
+                &sender,
+                &recipient,
+                vec![(Transparent, 14_000)],
             )
             .await,
             15_000

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -160,7 +160,7 @@ pub mod fixtures {
         );
 
         // the recipient cannot propose shielding
-        assertions::assert_cant_shield(&recipient, 1000).await;
+        assertions::assert_cant_shield(&recipient).await;
 
         // creates an output for recipient which is too small too send, but not dust
         assert_eq!(
@@ -175,7 +175,7 @@ pub mod fixtures {
         );
 
         // the recipient cannot propose shielding
-        assertions::assert_cant_shield(&recipient, 6000).await;
+        assertions::assert_cant_shield(&recipient).await;
     }
 
     /// sends back and forth several times, including sends to transparent

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -157,7 +157,10 @@ pub mod fixtures {
 
         assert!(match recipient.propose_shield().await.unwrap_err() {
             zingolib::lightclient::propose::ProposeShieldError::Dusty => true,
-            _ => false,
+            e => {
+                dbg!(e);
+                false
+            }
         });
     }
 

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -140,16 +140,23 @@ pub mod fixtures {
         let sender = environment.fund_client_orchard(100_000).await;
         let recipient = environment.create_client().await;
 
-        // creates a transparent dust output for recipient
+        // creates a bunch of transparent dust outputs for recipient
         assert_eq!(
             with_assertions::propose_send_bump_sync_recipient(
                 &mut environment,
                 &sender,
                 &recipient,
-                vec![(Transparent, 1000)],
+                vec![
+                    (Transparent, 1000),
+                    (Transparent, 1000),
+                    (Transparent, 1000),
+                    (Transparent, 1000),
+                    (Transparent, 1000),
+                    (Transparent, 1000)
+                ],
             )
             .await,
-            15_000
+            40_000
         );
 
         // the recipient cannot propose shielding

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -65,13 +65,13 @@ pub mod fixtures {
     use zcash_client_backend::PoolType::Transparent;
     use zcash_client_backend::ShieldedProtocol::Orchard;
     use zcash_client_backend::ShieldedProtocol::Sapling;
-    use zcash_primitives::transaction::components::amount::NonNegativeAmount;
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
     use zingolib::wallet::notes::query::OutputPoolQuery;
     use zingolib::wallet::notes::query::OutputQuery;
     use zingolib::wallet::notes::query::OutputSpendStatusQuery;
 
+    use crate::assertions;
     use crate::chain_generic_tests::conduct_chain::ConductChain;
     use crate::check_client_balances;
     use crate::lightclient::from_inputs;
@@ -129,22 +129,6 @@ pub mod fixtures {
         assert_eq!(expected_fee, recorded_fee);
     }
 
-    /// assert that proposing shield causes a specific error
-    pub async fn assert_cant_shield(client: zingolib::lightclient::LightClient, balance: u64) {
-        assert!(match client.propose_shield().await.unwrap_err() {
-            zingolib::lightclient::propose::ProposeShieldError::Component(zcash_client_backend::data_api::error::Error::NoteSelection(zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelectorError::Change(zcash_client_backend::fees::ChangeError::InsufficientFunds { available, required }))) => {
-                println!("available {}, required {}", available.into_u64(), required.into_u64());
-                if available.into_u64() == balance { true } else {
-                    false
-                }
-            },
-            e => {
-                dbg!(e);
-                false
-            }
-        });
-    }
-
     /// chain-generic shielding test with dust avoidance
     /// only shield when it would return positive value
     pub async fn shield_positive<CC>()
@@ -169,7 +153,7 @@ pub mod fixtures {
         );
 
         // the recipient cannot propose shielding
-        assert_cant_shield(recipient, 1000).await;
+        assertions::assert_cant_shield(recipient, 1000).await;
     }
 
     /// sends back and forth several times, including sends to transparent

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -177,7 +177,7 @@ pub mod fixtures {
         // the recipient cannot propose shielding
         assertions::assert_cant_shield(&recipient).await;
 
-        // creates an output for recipient which combined with the previous is almost enough to be worth a shield
+        // creates an output for recipient which combined with the previous is still not enough to be worth a shield
         assert_eq!(
             with_assertions::propose_send_bump_sync_recipient(
                 &mut environment,

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -70,6 +70,9 @@ pub enum ProposeShieldError {
     Dusty,
 }
 
+/// below this threshold it is not worth shielding
+pub const SHIELDING_THRESHOLD: u64 = 15_000;
+
 impl LightClient {
     /// Stores a proposal in the `latest_proposal` field of the LightClient.
     /// This field must be populated in order to then send a transaction.
@@ -219,7 +222,7 @@ impl LightClient {
             .balance()
             .proposed_change()
             .iter()
-            .any(|change_value| change_value.value().into_u64() > 15_000)
+            .any(|change_value| change_value.value().into_u64() > SHIELDING_THRESHOLD)
         {
             self.store_proposal(ZingoProposal::Shield(proposal.clone()))
                 .await;

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -70,8 +70,10 @@ pub enum ProposeShieldError {
     BelowThreshold(u64),
 }
 
-/// below this threshold it is not worth shielding
-pub const SHIELDING_THRESHOLD: u64 = 15_000;
+/// a greater note is worth shielding to create. not this one
+/// maybe should be a configuration value
+/// could arguably range from 0 to 3 * MARGINAL_FEE
+pub const SHIELDING_CUTOFF: u64 = 5_000;
 
 impl LightClient {
     /// Stores a proposal in the `latest_proposal` field of the LightClient.
@@ -227,7 +229,7 @@ impl LightClient {
                 std::cmp::max(biggest_change_value_value, change_value.value().into_u64())
             });
 
-        if biggest_change > SHIELDING_THRESHOLD {
+        if biggest_change > SHIELDING_CUTOFF {
             self.store_proposal(ZingoProposal::Shield(proposal.clone()))
                 .await;
             Ok(proposal)

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -46,7 +46,8 @@ pub enum ProposeSendError {
     TransactionRequestFailed(Zip321Error),
 }
 
-/// Errors that can result from do_propose
+/// Errors that can result from do_propose_shield
+#[allow(missing_docs)] // error types document themselves
 #[derive(Debug, Error)]
 pub enum ProposeShieldError {
     /// error in parsed addresses
@@ -65,6 +66,8 @@ pub enum ProposeShieldError {
             zcash_primitives::transaction::fees::zip317::FeeError,
         >,
     ),
+    #[error("Transparent funds are not sufficient to cover the shielding fee.")]
+    Dusty,
 }
 
 impl LightClient {

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -66,8 +66,8 @@ pub enum ProposeShieldError {
             zcash_primitives::transaction::fees::zip317::FeeError,
         >,
     ),
-    #[error("Transparent funds are not sufficient to cover the shielding fee.")]
-    Dusty,
+    #[error("Shielding would create a shielded note with value {0}. This is too small. Wait for more transparent funds before shielding.")]
+    BelowThreshold(u64),
 }
 
 /// below this threshold it is not worth shielding
@@ -232,7 +232,7 @@ impl LightClient {
                 .await;
             Ok(proposal)
         } else {
-            Err(ProposeShieldError::Dusty)
+            Err(ProposeShieldError::BelowThreshold(biggest_change))
         }
     }
 }


### PR DESCRIPTION
From a user perspective, this effects what happens when they Propose Shielding while they have few transparent funds

If they would create a note with value <= SHIELDING_CUTOFF, stop. propose -> error
SHIELDING_CUTOFF = 5_000