### PR TITLE
Self send transparent receipt

### DIFF
--- a/libtonode-tests/tests/chain_generics.rs
+++ b/libtonode-tests/tests/chain_generics.rs
@@ -11,7 +11,7 @@ mod chain_generics {
         use super::*;
         #[tokio::test]
         async fn to_transparent() {
-            fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
+            fixtures::propose_and_broadcast_orchard_value_to_pool::<LibtonodeEnvironment>(
                 40_000,
                 Transparent,
             )
@@ -19,7 +19,7 @@ mod chain_generics {
         }
         #[tokio::test]
         async fn to_sapling() {
-            fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
+            fixtures::propose_and_broadcast_orchard_value_to_pool::<LibtonodeEnvironment>(
                 40_000,
                 Shielded(Sapling),
             )
@@ -27,7 +27,7 @@ mod chain_generics {
         }
         #[tokio::test]
         async fn to_orchard() {
-            fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
+            fixtures::propose_and_broadcast_orchard_value_to_pool::<LibtonodeEnvironment>(
                 40_000,
                 Shielded(Orchard),
             )

--- a/libtonode-tests/tests/chain_generics.rs
+++ b/libtonode-tests/tests/chain_generics.rs
@@ -33,6 +33,13 @@ mod chain_generics {
             )
             .await;
         }
+        #[tokio::test]
+        async fn to_self_transparent() {
+            fixtures::propose_and_broadcast_orch_to_transparent_selfsend::<LibtonodeEnvironment>(
+                40_000,
+            )
+            .await;
+        }
     }
     mod send_40_000 {
         use super::*;

--- a/libtonode-tests/tests/chain_generics.rs
+++ b/libtonode-tests/tests/chain_generics.rs
@@ -7,39 +7,47 @@ mod chain_generics {
     use zingo_testutils::chain_generic_tests::fixtures;
 
     use environment::LibtonodeEnvironment;
-    #[tokio::test]
-    async fn send_40_000_to_transparent() {
-        fixtures::send_value_to_pool::<LibtonodeEnvironment>(40_000, Transparent).await;
-    }
-    #[tokio::test]
-    async fn send_40_000_to_sapling() {
-        fixtures::send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Sapling)).await;
-    }
-    #[tokio::test]
-    async fn send_40_000_to_orchard() {
-        fixtures::send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Orchard)).await;
-    }
-
-    #[tokio::test]
-    async fn propose_and_broadcast_40_000_to_transparent() {
-        fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(40_000, Transparent)
+    mod propose_and_broadcast_40_000 {
+        use super::*;
+        #[tokio::test]
+        async fn to_transparent() {
+            fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
+                40_000,
+                Transparent,
+            )
             .await;
+        }
+        #[tokio::test]
+        async fn to_sapling() {
+            fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
+                40_000,
+                Shielded(Sapling),
+            )
+            .await;
+        }
+        #[tokio::test]
+        async fn to_orchard() {
+            fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
+                40_000,
+                Shielded(Orchard),
+            )
+            .await;
+        }
     }
-    #[tokio::test]
-    async fn propose_and_broadcast_40_000_to_sapling() {
-        fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
-            40_000,
-            Shielded(Sapling),
-        )
-        .await;
-    }
-    #[tokio::test]
-    async fn propose_and_broadcast_40_000_to_orchard() {
-        fixtures::propose_and_broadcast_value_to_pool::<LibtonodeEnvironment>(
-            40_000,
-            Shielded(Orchard),
-        )
-        .await;
+    mod send_40_000 {
+        use super::*;
+        #[tokio::test]
+        async fn to_transparent() {
+            fixtures::send_value_to_pool::<LibtonodeEnvironment>(40_000, Transparent).await;
+        }
+        #[tokio::test]
+        async fn to_sapling() {
+            fixtures::send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Sapling)).await;
+        }
+        #[tokio::test]
+        async fn to_orchard() {
+            fixtures::send_value_to_pool::<LibtonodeEnvironment>(40_000, Shielded(Orchard)).await;
+        }
     }
     #[tokio::test]
     async fn send_shield_cycle() {

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -28,7 +28,13 @@ pub async fn assert_send_outputs_match_sender<NoteId>(
         let record = records.get(&txids[i]).expect("sender must recognize txid");
         // does this record match this step?
         // may fail in uncertain ways if used on a transaction we dont have an OutgoingViewingKey for
-        let recorded_fee = records.calculate_transaction_fee(record).unwrap();
+        let recorded_fee = match records.calculate_transaction_fee(record) {
+            Ok(calculate_fee) => calculate_fee,
+            Err(e) => {
+                dbg!(format!("{}", e.to_string()));
+                panic!();
+            }
+        };
         assert_eq!(recorded_fee, step.balance().fee_required().into_u64());
 
         total_fee += recorded_fee;

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -76,16 +76,8 @@ pub mod fixtures {
     use crate::lightclient::get_base_address;
     use crate::lightclient::with_assertions;
 
-    /// runs a send-to-receiver and receives it in a chain-generic context
-    pub async fn propose_and_broadcast_value_to_pool<CC>(send_value: u64, pooltype: PoolType)
-    where
-        CC: ConductChain,
-    {
-        let mut environment = CC::setup().await;
-
-        println!("chain set up, funding client now");
-
-        let expected_fee = MARGINAL_FEE.into_u64()
+    fn calculate_basic_from_orchard_fee_for_pool(pooltype: PoolType) -> u64 {
+        MARGINAL_FEE.into_u64()
             * match pooltype {
                 // contribution_transparent = 1
                 //  1 transfer
@@ -104,7 +96,20 @@ pub mod fixtures {
                 //  1 input
                 //  1 output
                 Shielded(Orchard) => 2,
-            };
+            }
+    }
+    /// runs a send-to-receiver and receives it in a chain-generic context
+    pub async fn propose_and_broadcast_orchard_value_to_pool<CC>(
+        send_value: u64,
+        pooltype: PoolType,
+    ) where
+        CC: ConductChain,
+    {
+        let mut environment = CC::setup().await;
+
+        println!("chain set up, funding client now");
+
+        let expected_fee = calculate_basic_from_orchard_fee_for_pool(pooltype);
 
         let sender = environment
             .fund_client_orchard(send_value + expected_fee)

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -98,6 +98,25 @@ pub mod fixtures {
                 Shielded(Orchard) => 2,
             }
     }
+    /// Check behavior when sending to our own transparent receiver
+    pub async fn propose_and_broadcast_orch_to_transparent_selfsend<CC>(send_value: u64)
+    where
+        CC: ConductChain,
+    {
+        let mut environment = CC::setup().await;
+        let expected_fee = calculate_basic_from_orchard_fee_for_pool(Transparent);
+        let sender_recipient = environment
+            .fund_client_orchard(send_value + expected_fee)
+            .await;
+        let recorded_fee = with_assertions::propose_send_bump_sync_recipient(
+            &mut environment,
+            &sender_recipient,
+            &sender_recipient,
+            vec![(Transparent, send_value)],
+        )
+        .await;
+        assert_eq!(expected_fee, recorded_fee);
+    }
     /// runs a send-to-receiver and receives it in a chain-generic context
     pub async fn propose_and_broadcast_orchard_value_to_pool<CC>(
         send_value: u64,

--- a/zingolib/src/lightclient/deprecated.rs
+++ b/zingolib/src/lightclient/deprecated.rs
@@ -138,7 +138,7 @@ impl LightClient {
 
                 // Get the total transparent value received in this transaction
                 // Again we see the assumption that utxos are incoming.
-                let net_transparent_value = total_transparent_received as i64 - wallet_transaction.get_transparent_value_spent() as i64;
+                let net_transparent_value = total_transparent_received as i64 - wallet_transaction.total_transparent_value_spent as i64;
                 let address = wallet_transaction.transparent_outputs.iter().map(|utxo| utxo.address.clone()).collect::<Vec<String>>().join(",");
                 if net_transparent_value > 0 {
                     if let Some(transaction) = consumer_notes_by_tx.iter_mut().find(|transaction| transaction["txid"] == txid.to_string()) {

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -87,12 +87,6 @@ pub mod decrypt_transaction {
             let mut is_outgoing_transaction = false;
             // Collect our t-addresses for easy checking
             let taddrs_set = self.key.get_all_taddrs(&self.config);
-            // Process t-address outputs
-            //  THE FOLLOWING LINE INTENDS TO SAY:  IF THERE EXISTS AT LESAT ONE RECEIVER THAT THE CREATING CAPABILITY DOES NOT CONTROL...
-            // If this transaction in outgoing, i.e., we received sent some money in this transaction, then we need to grab all transparent outputs
-            // that don't belong to us as the outgoing metadata
-            // the assumption is either we already decrypted a compact output and filled in some data
-            // or transparent something
 
             // in the send case, we already know the transaction is outgoing. however, this if clause will not trigger.
             let mut outgoing_metadatas = vec![];

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -87,8 +87,6 @@ pub mod decrypt_transaction {
             let mut is_outgoing_transaction = false;
             // Collect our t-addresses for easy checking
             let taddrs_set = self.key.get_all_taddrs(&self.config);
-
-            // in the send case, we already know the transaction is outgoing. however, this if clause will not trigger.
             let mut outgoing_metadatas = vec![];
             // Execute scanning operations
             self.decrypt_transaction_to_record(

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -99,8 +99,9 @@ pub mod decrypt_transaction {
                 .read()
                 .await
                 .transaction_records_by_id
-                .total_funds_spent_in(&transaction.txid())
+                .value_input_by_capability_to_transaction(&transaction.txid())
                 > 0
+            // This number is only based on the sum of received notes, and therefore marks is_outgoing_true
             {
                 is_outgoing_transaction = true;
             }

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -115,12 +115,14 @@ pub mod decrypt_transaction {
                             .recipient_address()
                             .map(|raw_taddr| address_from_pubkeyhash(&self.config, raw_taddr))
                         {
-                            outgoing_metadatas.push(OutgoingTxData {
-                                recipient_address: taddr,
-                                value: u64::from(vout.value),
-                                memo: Memo::Empty,
-                                recipient_ua: None,
-                            });
+                            if !taddrs_set.contains(&taddr) {
+                                outgoing_metadatas.push(OutgoingTxData {
+                                    recipient_address: taddr,
+                                    value: u64::from(vout.value),
+                                    memo: Memo::Empty,
+                                    recipient_ua: None,
+                                });
+                            }
                         }
                     }
                 }
@@ -534,6 +536,8 @@ pub mod decrypt_transaction {
                     ) {
                         Some((note, payment_address, memo_bytes)) => {
                             // Mark this transaction as an outgoing transaction, so we can grab all outgoing metadata
+                            // The OVK successfully decrypted a note, therefore this transaction is outgoing from the
+                            // Creator.
                             *is_outgoing_transaction = true;
                             let address = payment_address.b32encode_for_network(&self.config.chain);
 

--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -289,7 +289,7 @@ impl TransactionRecord {
 
     /// TODO: Add Doc Comment Here!
     pub fn total_value_spent(&self) -> u64 {
-        self.value_spent_by_pool().iter().sum()
+        self.value_input_by_capability_to_transaction().iter().sum()
     }
 
     /// TODO: Add Doc Comment Here!
@@ -300,7 +300,7 @@ impl TransactionRecord {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn value_spent_by_pool(&self) -> [u64; 3] {
+    pub fn value_input_by_capability_to_transaction(&self) -> [u64; 3] {
         [
             self.total_transparent_value_spent,
             self.total_sapling_value_spent,
@@ -514,7 +514,7 @@ impl TransactionRecord {
         zcash_encoding::Vector::write(&mut writer, &self.orchard_notes, |w, nd| nd.write(w))?;
         zcash_encoding::Vector::write(&mut writer, &self.transparent_outputs, |w, u| u.write(w))?;
 
-        for pool in self.value_spent_by_pool() {
+        for pool in self.value_input_by_capability_to_transaction() {
             writer.write_u64::<LittleEndian>(pool)?;
         }
 
@@ -814,7 +814,7 @@ mod tests {
         assert_eq!(new.total_value_spent(), 0);
         assert_eq!(new.value_outgoing(), 0);
         let t: [u64; 3] = [0, 0, 0];
-        assert_eq!(new.value_spent_by_pool(), t);
+        assert_eq!(new.value_input_by_capability_to_transaction(), t);
     }
     #[test]
     fn single_transparent_note_makes_is_incoming_true() {

--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -225,11 +225,6 @@ impl TransactionRecord {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn get_transparent_value_spent(&self) -> u64 {
-        self.total_transparent_value_spent
-    }
-
-    /// TODO: Add Doc Comment Here!
     #[deprecated(
         note = "replaced by `calculate_transaction_fee` method for [`crate::wallet::transaction_records_by_id::TransactionRecordsById`]"
     )]
@@ -307,7 +302,7 @@ impl TransactionRecord {
     /// TODO: Add Doc Comment Here!
     pub fn value_spent_by_pool(&self) -> [u64; 3] {
         [
-            self.get_transparent_value_spent(),
+            self.total_transparent_value_spent,
             self.total_sapling_value_spent,
             self.total_orchard_value_spent,
         ]
@@ -803,7 +798,7 @@ mod tests {
     #[test]
     pub fn blank_record() {
         let new = TransactionRecordBuilder::default().build();
-        assert_eq!(new.get_transparent_value_spent(), 0);
+        assert_eq!(new.total_transparent_value_spent, 0);
         assert!(!new.is_outgoing_transaction());
         assert!(!new.is_incoming_transaction());
         // assert_eq!(new.net_spent(), 0);

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -361,7 +361,7 @@ impl TransactionRecordsById {
         self.invalidate_transactions(txids_to_remove);
     }
     /// TODO: Add Doc Comment Here!
-    pub fn total_funds_spent_in(&self, txid: &TxId) -> u64 {
+    pub fn value_input_by_capability_to_transaction(&self, txid: &TxId) -> u64 {
         self.get(txid)
             .map(TransactionRecord::total_value_spent)
             .unwrap_or(0)
@@ -373,7 +373,7 @@ impl TransactionRecordsById {
     /// TODO: Add Doc Comment Here!
     pub fn check_notes_mark_change(&mut self, txid: &TxId) {
         //TODO: Incorrect with a 0-value fee somehow
-        if self.total_funds_spent_in(txid) > 0 {
+        if self.value_input_by_capability_to_transaction(txid) > 0 {
             if let Some(transaction_metadata) = self.get_mut(txid) {
                 Self::mark_notes_as_change_for_pool(&mut transaction_metadata.sapling_notes);
                 Self::mark_notes_as_change_for_pool(&mut transaction_metadata.orchard_notes);


### PR DESCRIPTION
This isn't ready to land.   Two legacy tests that have to do with promoting funds from before the heartwoord epoch fail.   I suspect that may have to do with the definition of the OVK.

Any help appreciated!


RUN:

`cargo nextest run -p libtonode-tests heartwood`