### PR TITLE
do not include self sent transparent notes in outgoing tx data

### DIFF
--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3226,7 +3226,7 @@ mod slow {
         // 5 Shield transparent and sapling to orchard
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    disallowed (not *precisely* BY 317...
+        //    - 317:    disallowed (not *precisely*) BY 317...
         from_inputs::shield(
             &pool_migration_client,
             &[

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3226,10 +3226,17 @@ mod slow {
         // 5 Shield transparent and sapling to orchard
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    5_000 for transparent + 10_000 for orchard + 10_000 for sapling == 25_000
-        from_inputs::shield(&pool_migration_client, &[PoolType::Transparent], None)
-            .await
-            .unwrap();
+        //    - 317:    disallowed (not *precisely* BY 317...
+        from_inputs::shield(
+            &pool_migration_client,
+            &[
+                PoolType::Transparent,
+                PoolType::Shielded(ShieldedProtocol::Sapling),
+            ],
+            None,
+        )
+        .await
+        .unwrap();
         bump_and_check_pmc!(o: 50_000 s: 0 t: 0);
 
         // 6 self send orchard to orchard

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -124,12 +124,14 @@ pub mod decrypt_transaction {
                             .recipient_address()
                             .map(|raw_taddr| address_from_pubkeyhash(&self.config, raw_taddr))
                         {
-                            outgoing_metadatas.push(OutgoingTxData {
-                                recipient_address: taddr,
-                                value: u64::from(vout.value),
-                                memo: Memo::Empty,
-                                recipient_ua: None,
-                            });
+                            if !taddrs_set.contains(&taddr) {
+                                outgoing_metadatas.push(OutgoingTxData {
+                                    recipient_address: taddr,
+                                    value: u64::from(vout.value),
+                                    memo: Memo::Empty,
+                                    recipient_ua: None,
+                                });
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This fixes 2 concrete libtonode tests