### PR TITLE
Remove deprecated net spent

### DIFF
--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -64,3 +64,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `do_save_to_buffer`
   - `do_save_to_buffer_sync`
   - `fix_spent_at_height`
+  - `TransactionRecord::net_spent`

--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -271,13 +271,6 @@ impl TransactionRecord {
     }
 
     /// TODO: Add Doc Comment Here!
-    #[deprecated(note = "unused function with misleading name")]
-    pub fn net_spent(&self) -> u64 {
-        assert!(self.is_outgoing_transaction());
-        self.total_value_spent() - self.total_change_returned()
-    }
-
-    /// TODO: Add Doc Comment Here!
     fn pool_change_returned<D: DomainWalletExt>(&self) -> u64
     where
         <D as zcash_note_encryption::Domain>::Note: PartialEq + Clone,


### PR DESCRIPTION
Builds directly on `dev` to separate concerns.