### PR TITLE
zip317 integration tests switchover

### DIFF
--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -679,7 +679,7 @@ pub mod scenarios {
                 DarksideSender::IndexedClient(n) => self.get_lightclient(n),
                 DarksideSender::ExternalClient(lc) => lc,
             };
-            zingo_testutils::lightclient::from_inputs::send(
+            zingo_testutils::lightclient::from_inputs::quick_send(
                 lightclient,
                 vec![(receiver_address, value, None)],
             )
@@ -718,7 +718,6 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: PoolType,
         ) -> (&mut DarksideEnvironment, RawTransaction) {
             self.staged_blockheight = self.staged_blockheight.add(1);
             self.darkside_connector
@@ -731,9 +730,7 @@ pub mod scenarios {
                 DarksideSender::ExternalClient(lc) => lc,
             };
             // upgrade sapling
-            zingo_testutils::lightclient::from_inputs::shield(lightclient, &[pool_to_shield], None)
-                .await
-                .unwrap();
+            lightclient.quick_shield().await.unwrap();
             let mut streamed_raw_txns = self
                 .darkside_connector
                 .get_incoming_transactions()
@@ -772,10 +769,9 @@ pub mod scenarios {
             // We can't just take a reference to a LightClient, as that might be a reference to
             // a field of the DarksideScenario which we're taking by exclusive (i.e. mut) reference
             sender: DarksideSender<'_>,
-            pool_to_shield: PoolType,
             chainbuild_file: &File,
         ) -> &mut DarksideEnvironment {
-            let (_, raw_tx) = self.shield_transaction(sender, pool_to_shield).await;
+            let (_, raw_tx) = self.shield_transaction(sender).await;
             write_raw_transaction(&raw_tx, BranchId::Nu5, chainbuild_file);
             self
         }

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -544,6 +544,7 @@ async fn reorg_changes_outgoing_tx_height() {
     );
 
     let before_reorg_transactions = light_client.list_txsummaries().await;
+    dbg!(&before_reorg_transactions);
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -557,10 +558,14 @@ async fn reorg_changes_outgoing_tx_height() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
+    // FIXME: fails to create a sent valuetransfer with quick_send
     let sent_tx_id =
         from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
             .await
             .unwrap();
+    // let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
+    //     .await
+    //     .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 
@@ -593,7 +598,7 @@ async fn reorg_changes_outgoing_tx_height() {
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
 
-    println!("{:?}", light_client.list_txsummaries().await);
+    dbg!(light_client.list_txsummaries().await);
 
     assert_eq!(
         light_client
@@ -687,7 +692,6 @@ async fn reorg_changes_outgoing_tx_height() {
 }
 
 async fn prepare_changes_outgoing_tx_height_before_reorg(uri: http::Uri) -> Result<(), String> {
-    dbg!(&uri);
     let connector = DarksideConnector(uri.clone());
 
     let mut client = connector.get_client().await.unwrap();

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -557,9 +557,10 @@ async fn reorg_changes_outgoing_tx_height() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
-    let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
-        .await
-        .unwrap();
+    let sent_tx_id =
+        from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
+            .await
+            .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 
@@ -795,9 +796,10 @@ async fn reorg_expires_outgoing_tx_height() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
-    let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
-        .await
-        .unwrap();
+    let sent_tx_id =
+        from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
+            .await
+            .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 
@@ -975,9 +977,10 @@ async fn reorg_changes_outgoing_tx_index() {
 
     // Send 100000 zatoshi to some address
     let amount: u64 = 100000;
-    let sent_tx_id = from_inputs::send(&light_client, [(recipient_string, amount, None)].to_vec())
-        .await
-        .unwrap();
+    let sent_tx_id =
+        from_inputs::quick_send(&light_client, [(recipient_string, amount, None)].to_vec())
+            .await
+            .unwrap();
 
     println!("SENT TX ID: {:?}", sent_tx_id);
 

--- a/darkside-tests/tests/network_interruption_tests.rs
+++ b/darkside-tests/tests/network_interruption_tests.rs
@@ -107,11 +107,7 @@ async fn shielded_note_marked_as_change_chainbuild() {
             .await;
         scenario.get_lightclient(0).do_sync(false).await.unwrap();
         scenario
-            .shield_and_write_transaction(
-                DarksideSender::IndexedClient(0),
-                PoolType::Shielded(ShieldedProtocol::Sapling),
-                &chainbuild_file,
-            )
+            .shield_and_write_transaction(DarksideSender::IndexedClient(0), &chainbuild_file)
             .await;
     }
 

--- a/libtonode-tests/tests/chain_generics.rs
+++ b/libtonode-tests/tests/chain_generics.rs
@@ -63,6 +63,10 @@ mod chain_generics {
     async fn send_required_dust() {
         fixtures::send_required_dust::<LibtonodeEnvironment>().await;
     }
+    #[tokio::test]
+    async fn note_selection_order() {
+        fixtures::note_selection_order::<LibtonodeEnvironment>().await;
+    }
     mod environment {
         use zcash_client_backend::PoolType;
 

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3309,6 +3309,8 @@ mod slow {
         assert_eq!(loaded_balance.unverified_orchard_balance, Some(0),);
         check_client_balances!(loaded_client, o: 100_000 s: 0 t: 0 );
     }
+
+    // FIXME: same bug, sent value transfer not created by quick_send
     #[tokio::test]
     async fn by_address_finsight() {
         let (regtest_manager, _cph, faucet, recipient) =
@@ -3326,11 +3328,7 @@ mod slow {
             .unwrap();
         from_inputs::quick_send(&faucet, vec![(&base_uaddress, 1_000u64, Some("1"))])
             .await
-            .expect(
-                "We only have sapling notes, plus a pending orchard note from the \
-            previous send. If we're allowed to select pending notes, we'll attempt \
-            to select that one, and this will fail",
-            );
+            .unwrap();
         assert_eq!(
             JsonValue::from(faucet.do_total_memobytes_to_address().await)[&base_uaddress].pretty(4),
             "2".to_string()
@@ -3343,6 +3341,7 @@ mod slow {
             "6".to_string()
         );
     }
+
     #[tokio::test]
     async fn aborted_resync() {
         let (regtest_manager, _cph, faucet, recipient, _txid) =

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2252,7 +2252,7 @@ mod slow {
             .unwrap();
 
         let client_2_saplingaddress = get_base_address_macro!(recipient, "sapling");
-        // Send three transfers in increasing 1000 zat increments
+        // Send three transfers in increasing 10,000 zat increments
         // These are sent from the coinbase funded client which will
         // subsequently receive funding via it's orchard-packed UA.
         let memos = ["1", "2", "3"];
@@ -2262,7 +2262,7 @@ mod slow {
                 .map(|n| {
                     (
                         client_2_saplingaddress.as_str(),
-                        n * 10000,
+                        n * 10_000,
                         Some(memos[(n - 1) as usize]),
                     )
                 })
@@ -2274,14 +2274,14 @@ mod slow {
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 5)
             .await
             .unwrap();
-        // We know that the largest single note that 2 received from 1 was 3000, for 2 to send
-        // 3000 back to 1 it will have to collect funds from two notes to pay the full 3000
+        // We know that the largest single note that 2 received from 1 was 30_000, for 2 to send
+        // 30_000 back to 1 it will have to collect funds from two notes to pay the full 30_000
         // plus the transaction fee.
         from_inputs::quick_send(
             &recipient,
             vec![(
                 &get_base_address_macro!(faucet, "unified"),
-                30000,
+                30_000,
                 Some("Sending back, should have 2 inputs"),
             )],
         )

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2241,7 +2241,7 @@ mod slow {
     #[tokio::test]
     async fn note_selection_order() {
         // In order to fund a transaction multiple notes may be selected and consumed.
-        // To minimize note selection operations notes are consumed from largest to smallest.
+        // The algorithm selects the smallest covering note(s).
         // In addition to testing the order in which notes are selected this test:
         //   * sends to a sapling address
         //   * sends back to the original sender's UA
@@ -2252,7 +2252,7 @@ mod slow {
             .unwrap();
 
         let client_2_saplingaddress = get_base_address_macro!(recipient, "sapling");
-        // Send three transfers in increasing 10,000 zat increments
+        // Send three transfers in increasing 10_000 zat increments
         // These are sent from the coinbase funded client which will
         // subsequently receive funding via it's orchard-packed UA.
         let memos = ["1", "2", "3"];
@@ -2288,7 +2288,7 @@ mod slow {
         .await
         .unwrap();
         let client_2_notes = recipient.do_list_notes(false).await;
-        // The 3000 zat note to cover the value, plus another for the tx-fee.
+        // The 30_000 zat note to cover the value, plus another for the tx-fee.
         let first_value = client_2_notes["pending_sapling_notes"][0]["value"]
             .as_fixed_point_u64(0)
             .unwrap();
@@ -2296,8 +2296,8 @@ mod slow {
             .as_fixed_point_u64(0)
             .unwrap();
         assert!(
-            first_value == 30000u64 && second_value == 20000u64
-                || first_value == 20000u64 && second_value == 30000u64
+            first_value == 30_000u64 && second_value == 20_000u64
+                || first_value == 20_000u64 && second_value == 30_000u64
         );
         //);
         // Because the above tx fee won't consume a full note, change will be sent back to 2.

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -691,8 +691,9 @@ mod slow {
     use zcash_client_backend::{PoolType, ShieldedProtocol};
     use zcash_primitives::consensus::NetworkConstants;
     use zingo_testutils::lightclient::from_inputs;
-    use zingolib::lightclient::{
-        propose::ProposeSendError, send::send_with_proposal::QuickSendError,
+    use zingolib::{
+        lightclient::{propose::ProposeSendError, send::send_with_proposal::QuickSendError},
+        wallet::tx_map_and_maybe_trees::TxMapAndMaybeTreesTraitError,
     };
 
     use super::*;
@@ -1104,7 +1105,9 @@ mod slow {
                 )
                 .await,
                 Err(QuickSendError::ProposeSend(ProposeSendError::Proposal(
-                    zcash_client_backend::data_api::error::Error::NoSpendingKey(_)
+                    zcash_client_backend::data_api::error::Error::DataSource(
+                        TxMapAndMaybeTreesTraitError::NoSpendCapability
+                    )
                 )))
             ));
         }

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2997,12 +2997,13 @@ mod slow {
         };
         assert_eq!(seed_of_recipient, seed_of_recipient_restored);
     }
+
     #[tokio::test]
-    async fn list_txsummaries_check_fees() {
+    async fn pool_migration_check_fees() {
         // Check that list_txsummaries behaves correctly given different fee scenarios
         let (regtest_manager, _cph, mut client_builder, regtest_network) =
             scenarios::custom_clients_default().await;
-        let sapling_faucet = client_builder.build_faucet(false, regtest_network).await;
+        let faucet = client_builder.build_faucet(false, regtest_network).await;
         let pool_migration_client = client_builder
             .build_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false, regtest_network)
             .await;
@@ -3010,7 +3011,7 @@ mod slow {
         let pmc_sapling = get_base_address_macro!(pool_migration_client, "sapling");
         let pmc_unified = get_base_address_macro!(pool_migration_client, "unified");
         // Ensure that the client has confirmed spendable funds
-        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &sapling_faucet, 3)
+        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 3)
             .await
             .unwrap();
         macro_rules! bump_and_check_pmc {
@@ -3020,27 +3021,25 @@ mod slow {
             };
         }
 
-        // 1 pmc receives 100_000 orchard
-        //  # Expected Fees:
-        //    - legacy: 0
-        //    - 317:    0
-        from_inputs::quick_send(&sapling_faucet, vec![(&pmc_unified, 100_000, None)])
+        // pmc receives 100_000 orchard
+        from_inputs::quick_send(&faucet, vec![(&pmc_unified, 100_000, None)])
             .await
             .unwrap();
         bump_and_check_pmc!(o: 100_000 s: 0 t: 0);
 
-        // 2 to transparent and sapling from orchard
-        //  # Expected Fees:
-        //    - legacy: 10_000
-        //    - 317:    5_000 for transparent + 10_000 for orchard + 10_000 for sapling == 25_000
+        // to transparent and sapling from orchard
+        //
+        // Expected Fees:
+        // 5_000 for transparent + 10_000 for orchard + 10_000 for sapling == 25_000
         from_inputs::quick_send(
             &pool_migration_client,
             vec![(&pmc_taddr, 30_000, None), (&pmc_sapling, 30_000, None)],
         )
         .await
         .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 30_000 t: 30_000);
+        bump_and_check_pmc!(o: 15_000 s: 30_000 t: 30_000);
     }
+
     #[tokio::test]
     async fn from_t_z_o_tz_to_zo_tzo_to_orchard() {
         // Test all possible promoting note source combinations

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -695,7 +695,7 @@ mod fast {
 mod slow {
     use orchard::note_encryption::OrchardDomain;
     use zcash_client_backend::{PoolType, ShieldedProtocol};
-    use zcash_primitives::consensus::NetworkConstants;
+    use zcash_primitives::{consensus::NetworkConstants, transaction::fees::zip317::MARGINAL_FEE};
     use zingo_testutils::lightclient::from_inputs;
     use zingolib::{
         lightclient::{propose::ProposeSendError, send::send_with_proposal::QuickSendError},
@@ -1673,7 +1673,7 @@ mod slow {
         assert_eq!(balance.unverified_orchard_balance, Some(0));
         assert_eq!(
             balance.verified_orchard_balance.unwrap(),
-            625_000_000 - u64::from(MINIMUM_FEE)
+            625_000_000 - 4 * u64::from(MARGINAL_FEE)
         );
     }
     #[tokio::test]

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -1295,10 +1295,10 @@ mod slow {
             {
                 "block_height": 6,
                 "pending": false,
-                "datetime": 1694825595,
-                "txid": "4ee5a583e6462eb4c39f9d8188e855bb1e37d989fcb8b417cff93c27b006e72d",
+                "datetime": 1718023286,
+                "txid": "392da4b0abfc2b3938741301fc109ad2de7641a8054f2cda8c6fa33804b6385a",
                 "zec_price": null,
-                "amount": -30000,
+                "amount": -40000,
                 "outgoing_metadata": [
                     {
                         "address": "zregtestsapling1fmq2ufux3gm0v8qf7x585wj56le4wjfsqsj27zprjghntrerntggg507hxh2ydcdkn7sx8kya7p",
@@ -1351,8 +1351,9 @@ mod slow {
 
         let expected_funds = recipient_initial_funds
             - first_send_to_sapling
+            - (4 * u64::from(MARGINAL_FEE))
             - first_send_to_transparent
-            - (2 * u64::from(MINIMUM_FEE));
+            - (3 * u64::from(MARGINAL_FEE));
         assert_eq!(
             recipient
                 .wallet

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2238,6 +2238,7 @@ mod slow {
         let post_rescan_transactions = faucet.do_list_transactions().await;
         assert_eq!(transactions, post_rescan_transactions);
     }
+    #[ignore]
     #[tokio::test]
     async fn note_selection_order() {
         // In order to fund a transaction multiple notes may be selected and consumed.

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -1163,7 +1163,7 @@ mod slow {
         from_inputs::quick_send(
             &faucet,
             vec![(
-                &get_base_address_macro!(recipient, "sapling"),
+                &get_base_address_macro!(recipient, "transparent"),
                 transparent_funding,
                 None,
             )],
@@ -1212,6 +1212,7 @@ mod slow {
             )
             .pretty(2)
         );
+        // TODO: Add asserts!
     }
     #[tokio::test]
     async fn send_to_ua_saves_full_ua_in_wallet() {

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3775,6 +3775,8 @@ mod slow {
 }
 
 mod basic_transactions {
+    use std::cmp;
+
     use zingo_testutils::{get_base_address_macro, lightclient::from_inputs, scenarios};
 
     #[tokio::test]
@@ -3889,15 +3891,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&faucet, txid1.as_str()).await - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
@@ -3923,15 +3923,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&faucet, txid2.as_str()).await - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid2);
 
-        let expected_fee_txid2 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid2 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid2.transparent_tx_actions
-        //             + tx_actions_txid2.sapling_tx_actions
-        //             + tx_actions_txid2.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid2 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid2.transparent_tx_actions
+                    + tx_actions_txid2.sapling_tx_actions
+                    + tx_actions_txid2.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid2);
 
         assert_eq!(calculated_fee_txid2, expected_fee_txid2 as u64);
@@ -3957,15 +3955,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&faucet, txid3.as_str()).await - 40_000;
         println!("Fee Paid: {}", calculated_fee_txid3);
 
-        let expected_fee_txid3 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid3 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid3.transparent_tx_actions
-        //             + tx_actions_txid3.sapling_tx_actions
-        //             + tx_actions_txid3.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid3 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid3.transparent_tx_actions
+                    + tx_actions_txid3.sapling_tx_actions
+                    + tx_actions_txid3.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid3);
 
         assert_eq!(calculated_fee_txid3, expected_fee_txid3 as u64);
@@ -3974,7 +3970,7 @@ mod basic_transactions {
             &recipient,
             vec![(
                 get_base_address_macro!(faucet, "transparent").as_str(),
-                60_000,
+                55_000,
                 None,
             )],
         )
@@ -4008,18 +4004,16 @@ mod basic_transactions {
         println!("Transaction Actions:\n{:?}", tx_actions_txid4);
 
         let calculated_fee_txid4 =
-            zingo_testutils::total_tx_value(&recipient, txid4.as_str()).await - 60_000;
+            zingo_testutils::total_tx_value(&recipient, txid4.as_str()).await - 55_000;
         println!("Fee Paid: {}", calculated_fee_txid4);
 
-        let expected_fee_txid4 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid4 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid4.transparent_tx_actions
-        //             + tx_actions_txid4.sapling_tx_actions
-        //             + tx_actions_txid4.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid4 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid4.transparent_tx_actions
+                    + tx_actions_txid4.sapling_tx_actions
+                    + tx_actions_txid4.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid4);
 
         assert_eq!(calculated_fee_txid4, expected_fee_txid4 as u64);
@@ -4070,15 +4064,13 @@ mod basic_transactions {
         let calculated_fee_txid1 = zingo_testutils::total_tx_value(&faucet, txid1.as_str()).await;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);
@@ -4132,15 +4124,13 @@ mod basic_transactions {
             zingo_testutils::total_tx_value(&recipient, txid1.as_str()).await;
         println!("Fee Paid: {}", calculated_fee_txid1);
 
-        let expected_fee_txid1 = 10000;
-        // currently expected fee is always 10000 but will change to the following in zip317
-        // let expected_fee_txid1 = 5000
-        //     * (cmp::max(
-        //         2,
-        //         tx_actions_txid1.transparent_tx_actions
-        //             + tx_actions_txid1.sapling_tx_actions
-        //             + tx_actions_txid1.orchard_tx_actions,
-        //     ));
+        let expected_fee_txid1 = 5000
+            * (cmp::max(
+                2,
+                tx_actions_txid1.transparent_tx_actions
+                    + tx_actions_txid1.sapling_tx_actions
+                    + tx_actions_txid1.orchard_tx_actions,
+            ));
         println!("Expected Fee: {}", expected_fee_txid1);
 
         assert_eq!(calculated_fee_txid1, expected_fee_txid1 as u64);

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3048,157 +3048,294 @@ mod slow {
         // app and are not recommended in production.
         // An example is a transaction that "shields" both transparent and
         // sapling value into the orchard value pool.
+        async fn fees(client: &LightClient) -> u64 {
+            client
+                .list_txsummaries()
+                .await
+                .into_iter()
+                .filter_map(|x| {
+                    if let zingolib::wallet::data::summaries::ValueTransferKind::Fee { amount } =
+                        x.kind
+                    {
+                        Some(amount)
+                    } else {
+                        None
+                    }
+                })
+                .sum::<u64>()
+        }
         let (regtest_manager, _cph, mut client_builder, regtest_network) =
             scenarios::custom_clients_default().await;
         let sapling_faucet = client_builder.build_faucet(false, regtest_network).await;
-        let pool_migration_client = client_builder
+        let client = client_builder
             .build_client(HOSPITAL_MUSEUM_SEED.to_string(), 0, false, regtest_network)
             .await;
-        let pmc_taddr = get_base_address_macro!(pool_migration_client, "transparent");
-        let pmc_sapling = get_base_address_macro!(pool_migration_client, "sapling");
-        let pmc_unified = get_base_address_macro!(pool_migration_client, "unified");
+        let pmc_taddr = get_base_address_macro!(client, "transparent");
+        let pmc_sapling = get_base_address_macro!(client, "sapling");
+        let pmc_unified = get_base_address_macro!(client, "unified");
         // Ensure that the client has confirmed spendable funds
-        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &sapling_faucet, 3)
+        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &sapling_faucet, 1)
             .await
             .unwrap();
-        macro_rules! bump_and_check_pmc {
-        (o: $o:tt s: $s:tt t: $t:tt) => {
-            zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &pool_migration_client, 1).await.unwrap();
-            check_client_balances!(pool_migration_client, o:$o s:$s t:$t);
-        };
-    }
+        macro_rules! bump_and_check {
+            (o: $o:tt s: $s:tt t: $t:tt) => {
+                zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &client, 1).await.unwrap();
+                check_client_balances!(client, o:$o s:$s t:$t);
+            };
+        }
 
+        let mut test_dev_total_expected_fee = 0;
         // 1 pmc receives 50_000 transparent
-        //  # Expected Fees:
+        //  # Expected Fees to recipient:
         //    - legacy: 0
         //    - 317:    0
         from_inputs::quick_send(&sapling_faucet, vec![(&pmc_taddr, 50_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 0 s: 0 t: 50_000);
+        bump_and_check!(o: 0 s: 0 t: 50_000);
+        assert_eq!(test_dev_total_expected_fee, 0);
 
         // 2 pmc shields 50_000 transparent, to orchard paying 10_000 fee
-        //  # Expected Fees:
+        //  t -> o
+        //  # Expected Fees to recipient:
         //    - legacy: 10_000
-        //    - 317:    20_000
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 40_000 s: 0 t: 0);
+        //    - 317:    15_000 1-orchard + 1-dummy + 1-transparent in
+        client.quick_shield().await.unwrap();
+        bump_and_check!(o: 35_000 s: 0 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 15_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
         // 3 pmc receives 50_000 sapling
-        //  # Expected Fees:
-        //    - legacy: 10_000
-        //    - 317:    20_000
+        //  # Expected Fees to recipient:
+        //    - legacy: 0
+        //    - 317:    0
         from_inputs::quick_send(&sapling_faucet, vec![(&pmc_sapling, 50_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 40_000 s: 50_000 t: 0);
+        bump_and_check!(o: 35_000 s: 50_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
         // 4 pmc shields 40_000 from sapling to orchard and pays 10_000 fee (should be 20_000 post zip317)
+        //  z -> o
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    20_000
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 80_000 s: 0 t: 0);
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 30_000, None)])
+            .await
+            .unwrap();
+        bump_and_check!(o: 65_000 s: 0 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 5 Self send of 70_000 paying 10_000 fee
+        // 5 Self send of 55_000 paying 10_000 fee
+        //  o -> o
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    10_000
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 70_000, None)])
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 55_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 70_000 s: 0 t: 0);
+        bump_and_check!(o: 55_000 s: 0 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 10_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 4 to transparent and sapling from orchard
+        // 6 to transparent and sapling from orchard
+        //  o -> tz
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    5_000 for transparent + 10_000 for orchard + 10_000 for sapling == 25_000
+        //    - 317:    5_000 for transparent out + 10_000 for orchard + 10_000 for sapling == 25_000
         from_inputs::quick_send(
-            &pool_migration_client,
-            vec![(&pmc_taddr, 30_000, None), (&pmc_sapling, 30_000, None)],
+            &client,
+            vec![(&pmc_taddr, 10_000, None), (&pmc_sapling, 10_000, None)],
         )
         .await
         .unwrap();
-        bump_and_check_pmc!(o: 0 s: 30_000 t: 30_000);
+        bump_and_check!(o: 10_000 s: 10_000 t: 10_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 25_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 5 Shield transparent and sapling to orchard
+        // 7 Receipt
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    disallowed (not *precisely*) BY 317...
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 50_000 s: 0 t: 0);
+        from_inputs::quick_send(&sapling_faucet, vec![(&pmc_taddr, 500_000, None)])
+            .await
+            .unwrap();
+        bump_and_check!(o: 10_000 s: 10_000 t: 510_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 6 self send orchard to orchard
+        // 8 Shield transparent and sapling to orchard
+        //  t -> o
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000 = 10_000 orchard and o-dummy + 10_000 (2 t-notes)
+        client.quick_shield().await.unwrap();
+        bump_and_check!(o: 500_000 s: 10_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
+
+        // 9 self o send orchard to orchard
+        //  o -> o
         //  # Expected Fees:
         //    - legacy: 10_000
         //    - 317:    10_000
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 20_000, None)])
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 30_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 40_000 s: 0 t: 0);
+        bump_and_check!(o: 490_000 s: 10_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 10_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 7 Orchard to transparent self-send
+        // 10 Orchard and Sapling demote all to transparent self-send
+        //  oz -> t
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    (orchard = 10_000 + 5_000) 15_000
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_taddr, 20_000, None)])
+        //    - 317:    15_000 5-o (3 dust)- 10_000 orchard, 1 utxo 5_000 transparent
+        from_inputs::quick_send(&client, vec![(&pmc_taddr, 465_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 10_000 s: 0 t: 20_000);
+        bump_and_check!(o: 10_000 s: 10_000 t: 465_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 15_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 8 Shield transparent to orchard
-        // 7 Orchard to transparent self-send
+        // 10 transparent to transparent
+        // Very explicit catch of reject sending from transparent to other than Self Orchard
+        match from_inputs::quick_send(&client, vec![(&pmc_taddr, 1, None)]).await {
+            Ok(_) => panic!(),
+            Err(QuickSendError::ProposeSend(proposesenderror)) => match proposesenderror {
+                ProposeSendError::Proposal(insufficient) => match insufficient {
+                    zcash_client_backend::data_api::error::Error::DataSource(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::CommitmentTree(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::NoteSelection(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::Proposal(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::ProposalNotSupported => panic!(),
+                    zcash_client_backend::data_api::error::Error::KeyNotRecognized => panic!(),
+                    zcash_client_backend::data_api::error::Error::BalanceError(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::InsufficientFunds {
+                        available,
+                        required,
+                    } => {
+                        assert_eq!(available, NonNegativeAmount::from_u64(20_000).unwrap());
+                        assert_eq!(required, NonNegativeAmount::from_u64(25_001).unwrap());
+                    }
+                    zcash_client_backend::data_api::error::Error::ScanRequired => panic!(),
+                    zcash_client_backend::data_api::error::Error::Builder(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::MemoForbidden => panic!(),
+                    zcash_client_backend::data_api::error::Error::UnsupportedChangeType(_) => {
+                        panic!()
+                    }
+                    zcash_client_backend::data_api::error::Error::NoSupportedReceivers(_) => {
+                        panic!()
+                    }
+                    zcash_client_backend::data_api::error::Error::NoSpendingKey(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::NoteMismatch(_) => panic!(),
+                    zcash_client_backend::data_api::error::Error::AddressNotRecognized(_) => {
+                        panic!()
+                    }
+                },
+                ProposeSendError::TransactionRequestFailed(_) => panic!(),
+                ProposeSendError::ZeroValueSendAll => panic!(),
+                ProposeSendError::BalanceError(_) => panic!(),
+            },
+            _ => panic!(),
+        }
+        bump_and_check!(o: 10_000 s: 10_000 t: 465_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
+
+        // 11 transparent to sapling
+        //  t -> z
+        // 10 transparent to transparent
+        // Very explicit catch of reject sending from transparent to other than Self Orchard
+        match from_inputs::quick_send(&client, vec![(&pmc_sapling, 50_000, None)]).await {
+            Ok(_) => panic!(),
+            Err(QuickSendError::ProposeSend(proposesenderror)) => match proposesenderror {
+                ProposeSendError::Proposal(insufficient) => match insufficient {
+                    zcash_client_backend::data_api::error::Error::InsufficientFunds {
+                        available,
+                        required,
+                    } => {
+                        assert_eq!(available, NonNegativeAmount::from_u64(20_000).unwrap());
+                        assert_eq!(required, NonNegativeAmount::from_u64(70_000).unwrap());
+                    }
+                    _ => {
+                        panic!()
+                    }
+                },
+                _ => panic!(),
+            },
+            _ => panic!(),
+        }
+        // End of 11 no change
+        bump_and_check!(o: 10_000 s: 10_000 t: 465_000);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 0;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
+
+        // 12 Orchard and Sapling demote all to transparent self-send
+        //  t -> o
         //  # Expected Fees:
         //    - legacy: 10_000
-        //    - 317:    disallowed
-        pool_migration_client.quick_shield().await.unwrap();
-        bump_and_check_pmc!(o: 20_000 s: 0 t: 0);
+        //    - 317:    15_000 1t and 2o
+        client.quick_shield().await.unwrap();
+        bump_and_check!(o: 460_000 s: 10_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 15_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 6 sapling and orchard to orchard
-        from_inputs::quick_send(&sapling_faucet, vec![(&pmc_sapling, 20_000, None)])
+        // 13 Orchard and Sapling demote all to transparent self-send
+        //  o -> z
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000 2o and 2s
+        from_inputs::quick_send(&client, vec![(&pmc_sapling, 10_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 20_000 s: 20_000 t: 0);
+        bump_and_check!(o: 430_000 s: 20_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 30_000, None)])
+        // 14 Orchard and Sapling demote all to transparent self-send
+        //  o -> o
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    10_000
+        from_inputs::quick_send(&client, vec![(&pmc_unified, 20_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 0 t: 0);
+        bump_and_check!(o: 420_000 s: 20_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 10_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // 7 tzo --> o
-        from_inputs::quick_send(
-            &sapling_faucet,
-            vec![(&pmc_taddr, 20_000, None), (&pmc_sapling, 20_000, None)],
-        )
-        .await
-        .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 20_000 t: 20_000);
-
-        pool_migration_client.quick_shield().await.unwrap();
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 40_000, None)])
+        // 14 Orchard and Sapling demote all to transparent self-send
+        //  zo -> o
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000
+        from_inputs::quick_send(&client, vec![(&pmc_sapling, 400_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 50_000 s: 0 t: 0);
+        bump_and_check!(o: 10_000 s: 410_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        // Send from Sapling into empty Orchard pool
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_sapling, 40_000, None)])
+        // 15 Orchard and Sapling demote all to transparent self-send
+        //  z -> z
+        //  # Expected Fees:
+        //    - legacy: 10_000
+        //    - 317:    20_000  this transfer must require 4 sapling notes
+        from_inputs::quick_send(&client, vec![(&pmc_sapling, 380_000, None)])
             .await
             .unwrap();
-        bump_and_check_pmc!(o: 0 s: 40_000 t: 0);
+        bump_and_check!(o: 10_000 s: 390_000 t: 0);
+        test_dev_total_expected_fee = test_dev_total_expected_fee + 20_000;
+        assert_eq!(fees(&client).await, test_dev_total_expected_fee);
 
-        from_inputs::quick_send(&pool_migration_client, vec![(&pmc_unified, 30_000, None)])
-            .await
-            .unwrap();
-        bump_and_check_pmc!(o: 30_000 s: 0 t: 0);
-        let mut total_value_to_addrs_iter = pool_migration_client
-            .do_total_value_to_address()
-            .await
-            .0
-            .into_iter();
-        assert_eq!(
-            total_value_to_addrs_iter.next(),
-            Some((String::from("fee"), u64::from((MINIMUM_FEE * 13).unwrap())))
-        );
+        let total_fee = fees(&client).await;
+        assert_eq!(total_fee, test_dev_total_expected_fee);
+        let mut total_value_to_addrs_iter = client.do_total_value_to_address().await.0.into_iter();
+        let from_finsight = total_value_to_addrs_iter.next().unwrap().1;
+        assert_eq!(from_finsight, total_fee);
         assert!(total_value_to_addrs_iter.next().is_none());
     }
     #[tokio::test]

--- a/libtonode-tests/tests/shield_transparent.rs
+++ b/libtonode-tests/tests/shield_transparent.rs
@@ -15,7 +15,7 @@ async fn shield_transparent() {
         serde_json::to_string_pretty(&faucet.do_balance().await).unwrap(),
         serde_json::to_string_pretty(&recipient.do_balance().await).unwrap(),
     );
-    let proposal = from_inputs::send(
+    let proposal = from_inputs::quick_send(
         &faucet,
         vec![(
             &get_base_address_macro!(recipient, "transparent"),

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -423,6 +423,14 @@ pub mod fixtures {
                 .await,
             expected_value_from_transaction_1 - expected_debit_from_transaction_2
         );
+        let received_change_from_transaction_2 = secondary
+            .query_sum_value(OutputQuery {
+                spend_status: OutputSpendStatusQuery::only_unspent(),
+                pools: OutputPoolQuery::one_pool(Shielded(Orchard)),
+            })
+            .await;
+        // if 10_000 or more change incoming, would have used a smaller note
+        assert!(received_change_from_transaction_2 < 10_000);
 
         // with_assertions::propose_send_bump_sync_recipient(
         //     &mut environment,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -384,6 +384,16 @@ pub mod fixtures {
             expected_fee_for_transaction_1
         );
 
+        assert_eq!(
+            secondary
+                .query_sum_value(OutputQuery {
+                    spend_status: OutputSpendStatusQuery::only_unspent(),
+                    pools: OutputPoolQuery::one_pool(Shielded(Sapling)),
+                })
+                .await,
+            expected_value_from_transaction_1
+        );
+
         // toDo: these depend on the number_of_notes and value_from_transaction_2
         let expected_inputs_for_transaction_2 = 2;
         let expected_orchard_contribution_for_transaction_2 = 2;

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -412,6 +412,18 @@ pub mod fixtures {
             expected_fee_for_transaction_2
         );
 
+        let expected_debit_from_transaction_2 =
+            expected_fee_for_transaction_2 + value_from_transaction_2;
+        assert_eq!(
+            secondary
+                .query_sum_value(OutputQuery {
+                    spend_status: OutputSpendStatusQuery::only_unspent(),
+                    pools: OutputPoolQuery::shielded(),
+                })
+                .await,
+            expected_value_from_transaction_1 - expected_debit_from_transaction_2
+        );
+
         // with_assertions::propose_send_bump_sync_recipient(
         //     &mut environment,
         //     &primary,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -396,7 +396,7 @@ pub mod fixtures {
 
         let expected_orchard_contribution_for_transaction_2 = 2;
 
-        // toDo: these depend on the number_of_notes and value_from_transaction_2
+        // calculate what will be spent
         let mut expected_highest_unselected = 10_000 * number_of_notes;
         let mut expected_inputs_for_transaction_2 = 0;
         let mut max_unselected_value_for_transaction_2: i64 =
@@ -413,7 +413,7 @@ pub mod fixtures {
                 break;
             }
             if expected_highest_unselected <= 0 {
-                // did not meet target. expect failure
+                // did not meet target. expect error on send
                 break;
             }
         }
@@ -452,5 +452,16 @@ pub mod fixtures {
             .await;
         // if 10_000 or more change, would have used a smaller note
         assert!(received_change_from_transaction_2 < 10_000);
+
+        assert_eq!(
+            secondary
+                .query_for_ids(OutputQuery {
+                    spend_status: OutputSpendStatusQuery::only_spent(),
+                    pools: OutputPoolQuery::one_pool(Shielded(Sapling)),
+                })
+                .await
+                .len(),
+            expected_inputs_for_transaction_2 as usize
+        );
     }
 }

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -361,7 +361,7 @@ pub mod fixtures {
     {
         // toDo: proptest different values for these first two variables
         let number_of_notes = 4;
-        let value_from_transaction_2: u64 = 65_000;
+        let value_from_transaction_2: u64 = 40_000;
 
         let transaction_1_values = (1..=number_of_notes).map(|n| n * 10_000);
 
@@ -388,12 +388,13 @@ pub mod fixtures {
             expected_fee_for_transaction_1
         );
 
-        // toDo: these depend on the number_of_notes
-        let expected_inputs_for_transaction_2 = 3;
+        // toDo: these depend on the number_of_notes and value_from_transaction_2
+        let expected_inputs_for_transaction_2 = 2;
         let expected_orchard_contribution_for_transaction_2 = 2;
         let expected_fee_for_transaction_2 = (expected_inputs_for_transaction_2
             + expected_orchard_contribution_for_transaction_2)
             * MARGINAL_FEE.into_u64();
+        // the second client selects notes to cover the transaction.
         assert_eq!(
             with_assertions::propose_send_bump_sync_recipient(
                 &mut environment,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -359,19 +359,32 @@ pub mod fixtures {
     where
         CC: ConductChain,
     {
-        let mut environment = CC::setup().await;
+        let number_of_notes = 4;
 
-        let primary = environment.fund_client_orchard(200_000).await;
+        let transaction_1_sends = (1..=number_of_notes).map(|n| n * 10_000);
+
+        let expected_fee_for_transaction_1 = number_of_notes * 2 * MARGINAL_FEE.into_u64();
+        // let expected_funds_from_transaction_1 = oeui.map(x);
+
+        let mut environment = CC::setup().await;
+        let primary = environment
+            .fund_client_orchard(expected_fee_for_transaction_1)
+            .await;
         let secondary = environment.create_client().await;
 
         // Send n=4 transfers in increasing 10_000 zat increments
-        with_assertions::propose_send_bump_sync_recipient(
-            &mut environment,
-            &primary,
-            &secondary,
-            (1..=4).map(|n| (Shielded(Sapling), n * 10_000)).collect(),
-        )
-        .await;
+        assert_eq!(
+            with_assertions::propose_send_bump_sync_recipient(
+                &mut environment,
+                &primary,
+                &secondary,
+                transaction_1_sends
+                    .map(|value| (Shielded(Sapling), value))
+                    .collect()
+            )
+            .await,
+            number_of_notes * 2 * MARGINAL_FEE.into_u64()
+        );
 
         with_assertions::propose_send_bump_sync_recipient(
             &mut environment,

--- a/zingo-testutils/src/chain_generic_tests.rs
+++ b/zingo-testutils/src/chain_generic_tests.rs
@@ -361,34 +361,26 @@ pub mod fixtures {
     {
         let mut environment = CC::setup().await;
 
-        let primary = environment.fund_client_orchard(100_000).await;
+        let primary = environment.fund_client_orchard(200_000).await;
         let secondary = environment.create_client().await;
 
-        // Send three transfers in increasing 10_000 zat increments
+        // Send n=4 transfers in increasing 10_000 zat increments
         with_assertions::propose_send_bump_sync_recipient(
             &mut environment,
             &primary,
             &secondary,
-            (1..=3).map(|n| (Shielded(Sapling), n * 10_000)).collect(),
+            (1..=4).map(|n| (Shielded(Sapling), n * 10_000)).collect(),
+        )
+        .await;
+
+        with_assertions::propose_send_bump_sync_recipient(
+            &mut environment,
+            &primary,
+            &secondary,
+            vec![(Shielded(Orchard), 40_000)],
         )
         .await;
         /*
-        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &recipient, 5)
-            .await
-            .unwrap();
-        // We know that the largest single note that 2 received from 1 was 30_000, for 2 to send
-        // 30_000 back to 1 it will have to collect funds from two notes to pay the full 30_000
-        // plus the transaction fee.
-        from_inputs::quick_send(
-            &recipient,
-            vec![(
-                &get_base_address_macro!(faucet, "unified"),
-                30_000,
-                Some("Sending back, should have 2 inputs"),
-            )],
-        )
-        .await
-        .unwrap();
         let client_2_notes = recipient.do_list_notes(false).await;
         // The 30_000 zat note to cover the value, plus another for the tx-fee.
         let first_value = client_2_notes["pending_sapling_notes"][0]["value"]


### PR DESCRIPTION
conflicts with the way #1184 switches over these tests but there are several benefits, mainly do_send can be deprecated or moved to test-utils but is still available for use in test writing and may make the switchover less work with this option available.
Also, this is a true switchover to quick_send / quick_shield with no temporary functions or confusion.

This PR is intended to be used as a tool to highlight any remaining bugs in zip317 before the feature gate is removed and zip317 is released. All wrong assertions due to zip317 fee changes etc. should be fixed in this PR. however, any actual bug fixes should merge into dev. Feature branchs aiming to fix a bug highlighted by a failing test in this PR should merge into dev. This PR should only be merged into the bug fix branchs temporarily to check the bug has been fixed correctly.

This PR will merge when all tests are passing!