### PR TITLE
fix no sent valuetransfer bug

### DIFF
--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -3440,34 +3440,23 @@ mod slow {
     async fn by_address_finsight() {
         let (regtest_manager, _cph, faucet, recipient) =
             scenarios::faucet_recipient_default().await;
-        let base_uaddress = get_base_address_macro!(recipient, "unified");
+        let base_uaddress = get_base_address_macro!(recipient, "ua_orchard_only");
         zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 2)
             .await
             .unwrap();
-        println!(
-            "faucet notes: {}",
-            faucet.do_list_notes(true).await.pretty(4)
-        );
-        from_inputs::send(&faucet, vec![(&base_uaddress, 1_000u64, Some("1"))])
+        // from_inputs::send(&faucet, vec![(&base_uaddress, 1_000u64, Some("1"))])
+        //     .await
+        //     .unwrap();
+        from_inputs::quick_send(&faucet, vec![(&base_uaddress, 1_000u64, Some("1"))])
             .await
             .unwrap();
-        from_inputs::send(&faucet, vec![(&base_uaddress, 1_000u64, Some("1"))])
-            .await
-            .expect(
-                "We only have sapling notes, plus a pending orchard note from the \
-            previous send. If we're allowed to select pending notes, we'll attempt \
-            to select that one, and this will fail",
-            );
-        assert_eq!(
-            JsonValue::from(faucet.do_total_memobytes_to_address().await)[&base_uaddress].pretty(4),
-            "2".to_string()
-        );
-        from_inputs::send(&faucet, vec![(&base_uaddress, 1_000u64, Some("aaaa"))])
+        zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
             .await
             .unwrap();
+        dbg!(&base_uaddress);
         assert_eq!(
             JsonValue::from(faucet.do_total_memobytes_to_address().await)[&base_uaddress].pretty(4),
-            "6".to_string()
+            "1".to_string()
         );
     }
     #[tokio::test]

--- a/zingo-testutils/src/macros.rs
+++ b/zingo-testutils/src/macros.rs
@@ -8,6 +8,9 @@ macro_rules! get_base_address_macro {
             "unified" => $client.do_addresses().await[0]["address"]
                 .take()
                 .to_string(),
+            "ua_orchard_only" => $client.do_addresses().await[0]["ua_orchard_only"]
+                .take()
+                .to_string(),
             "sapling" => $client.do_addresses().await[0]["receivers"]["sapling"]
                 .clone()
                 .to_string(),

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -279,7 +279,6 @@ impl LightClient {
     /// Provides a list of value transfers related to this capability
     pub async fn list_txsummaries(&self) -> Vec<ValueTransfer> {
         self.list_txsummaries_and_capture_errors().await.0
-        // dbg!(self.list_txsummaries_and_capture_errors().await.0)
     }
     async fn list_txsummaries_and_capture_errors(
         &self,
@@ -357,7 +356,6 @@ impl LightClient {
                     recipient_address, ..
                 } => {
                     let address = recipient_address.encode();
-                    dbg!(&address);
                     let bytes = summary.memos.iter().fold(0, |sum, m| sum + m.len());
                     memobytes_by_address
                         .entry(address)
@@ -497,7 +495,9 @@ impl LightClient {
             } in &transaction_record.outgoing_tx_data
             {
                 if let Ok(recipient_address) = ZcashAddress::try_from_encoded(
-                    recipient_address, // recipient_ua.as_ref().unwrap_or(recipient_address),
+                    recipient_address,
+                    // TODO: add recipient_ua to zip317 sends
+                    // recipient_ua.as_ref().unwrap_or(recipient_address),
                 ) {
                     let memos = if let Memo::Text(textmemo) = memo {
                         vec![textmemo.clone()]


### PR DESCRIPTION
bug: do_addresses returns the full UA with all receivers where outgoing_tx_data (used by list_txsummaries) only stores the full UA with legacy send. in some tests we try to find by key where the key no longer matches in zip317 send as the UA only has orchard receiver

this PR demonstrates a fix where we no longer store the UA with all receivers in the outgoing_tx_data and add an option to do_addresses that fetches the UA with only an orchard receiver.

alternatively we could implement storing all receivers by populating the Option<Recipient_ua> in zip317 sending but i'm not sure how much work that is. probably a post-release task. I imagine it requires the change memo to retrieve the full UA which may need some thinking...

for now the test passes but needs cleaning up and removing changes to legacy.rs before merge