### PR TITLE
remove krufted shielded_balance parameter

### DIFF
--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -1468,15 +1468,12 @@ mod slow {
         assert_eq!(
             recipient
                 .wallet
-                .shielded_balance::<OrchardDomain>(None, &[])
+                .shielded_balance::<OrchardDomain>(&[])
                 .await,
             Some(expected_funds)
         );
         assert_eq!(
-            recipient
-                .wallet
-                .verified_balance::<OrchardDomain>(None)
-                .await,
+            recipient.wallet.verified_balance::<OrchardDomain>().await,
             Some(0)
         );
 
@@ -1554,7 +1551,7 @@ mod slow {
         assert_eq!(
             recipient
                 .wallet
-                .shielded_balance::<OrchardDomain>(None, &[])
+                .shielded_balance::<OrchardDomain>(&[])
                 .await,
             Some(second_wave_expected_funds),
         );
@@ -4344,14 +4341,14 @@ async fn zip317_send_all() {
     assert_eq!(
         recipient
             .wallet
-            .confirmed_balance_excluding_dust::<SaplingDomain>(None)
+            .confirmed_balance_excluding_dust::<SaplingDomain>()
             .await,
         Some(0)
     );
     assert_eq!(
         recipient
             .wallet
-            .confirmed_balance_excluding_dust::<OrchardDomain>(None)
+            .confirmed_balance_excluding_dust::<OrchardDomain>()
             .await,
         Some(0)
     );

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -86,21 +86,15 @@ impl LightClient {
     /// TODO: Add Doc Comment Here!
     pub async fn do_balance(&self) -> PoolBalances {
         PoolBalances {
-            sapling_balance: self
-                .wallet
-                .shielded_balance::<SaplingDomain>(None, &[])
-                .await,
-            verified_sapling_balance: self.wallet.verified_balance::<SaplingDomain>(None).await,
-            spendable_sapling_balance: self.wallet.spendable_sapling_balance(None).await,
-            unverified_sapling_balance: self.wallet.unverified_balance::<SaplingDomain>(None).await,
+            sapling_balance: self.wallet.shielded_balance::<SaplingDomain>(&[]).await,
+            verified_sapling_balance: self.wallet.verified_balance::<SaplingDomain>().await,
+            spendable_sapling_balance: self.wallet.spendable_sapling_balance().await,
+            unverified_sapling_balance: self.wallet.unverified_balance::<SaplingDomain>().await,
 
-            orchard_balance: self
-                .wallet
-                .shielded_balance::<OrchardDomain>(None, &[])
-                .await,
-            verified_orchard_balance: self.wallet.verified_balance::<OrchardDomain>(None).await,
-            spendable_orchard_balance: self.wallet.spendable_orchard_balance(None).await,
-            unverified_orchard_balance: self.wallet.unverified_balance::<OrchardDomain>(None).await,
+            orchard_balance: self.wallet.shielded_balance::<OrchardDomain>(&[]).await,
+            verified_orchard_balance: self.wallet.verified_balance::<OrchardDomain>().await,
+            spendable_orchard_balance: self.wallet.spendable_orchard_balance().await,
+            unverified_orchard_balance: self.wallet.unverified_balance::<OrchardDomain>().await,
 
             transparent_balance: self.wallet.tbalance(None).await,
         }

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -154,12 +154,12 @@ impl LightClient {
     ) -> Result<TransferProposal, ProposeSendError> {
         let confirmed_shielded_balance = zatoshis_from_u64(
             self.wallet
-                .confirmed_balance_excluding_dust::<OrchardDomain>(None)
+                .confirmed_balance_excluding_dust::<OrchardDomain>()
                 .await
                 .ok_or(ProposeSendError::NoFullViewingKey)?
                 + self
                     .wallet
-                    .confirmed_balance_excluding_dust::<SaplingDomain>(None)
+                    .confirmed_balance_excluding_dust::<SaplingDomain>()
                     .await
                     .ok_or(ProposeSendError::NoFullViewingKey)?,
         )

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -80,11 +80,7 @@ impl LightClient {
             .tbalance(None)
             .await
             .expect("to receive a balance");
-        let sapling_bal = self
-            .wallet
-            .spendable_sapling_balance(None)
-            .await
-            .unwrap_or(0);
+        let sapling_bal = self.wallet.spendable_sapling_balance().await.unwrap_or(0);
 
         // Make sure there is a balance, and it is greater than the amount
         let balance_to_shield =

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -1,4 +1,4 @@
-//! TODO: Add Mod Discription Here!
+//! Wallet-State reporters as LightWallet methods.
 use orchard::note_encryption::OrchardDomain;
 
 use sapling_crypto::note_encryption::SaplingDomain;

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -18,14 +18,14 @@ use crate::wallet::notes::ShieldedNoteInterface;
 
 use crate::wallet::traits::Diversifiable as _;
 
-use super::keys::unified::{Capability, WalletCapability};
-use super::notes::TransparentOutput;
-use super::traits::DomainWalletExt;
-use super::traits::Recipient;
+use crate::wallet::keys::unified::{Capability, WalletCapability};
+use crate::wallet::notes::TransparentOutput;
+use crate::wallet::traits::DomainWalletExt;
+use crate::wallet::traits::Recipient;
 
-use super::{data::BlockData, tx_map_and_maybe_trees::TxMapAndMaybeTrees};
+use crate::wallet::{data::BlockData, tx_map_and_maybe_trees::TxMapAndMaybeTrees};
 
-use super::LightWallet;
+use crate::wallet::LightWallet;
 impl LightWallet {
     /// TODO: Add Doc Comment Here!
     #[allow(clippy::type_complexity)]


### PR DESCRIPTION
This PR started life as part of my review for #1192 but this seemed like a landable chunk of improvement along the way.

The `target_addr` parameter was being passed `None` in all cases.

I suspect it pre-dated the filter abstraction.

Also in this PR:

* doc-comment for wallet/describe.rs
* super --> crate::wallet in wallet/describe.rs


Creates a trivial conflict with #1192