### PR TITLE
Upgrade rescan still have outgoing metadata

### DIFF
--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2353,7 +2353,10 @@ mod slow {
                 external_send_txid_with_memo
             );
         }
-        #[ignore = "this test is redundant with the other rescan metadata checkers, those test now show correctness of list_txsummaries "]
+        #[ignore = "this test is redundant with the other rescan metadata checkers.
+         Tests that show correctness of list_txsummaries across rescan:
+           * external_send
+           * self_send "]
         #[tokio::test]
         async fn check_list_txsummaries_across_rescan() {
             let inital_value = 100_000;

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2312,9 +2312,6 @@ mod slow {
         #[tokio::test]
         async fn self_send() {
             let (regtest_manager, _cph, faucet) = scenarios::faucet_default().await;
-            zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
-                .await
-                .unwrap();
             let faucet_sapling_addr = get_base_address_macro!(faucet, "sapling");
             let mut txids = vec![];
             for memo in [None, Some("Second Transaction")] {
@@ -2326,8 +2323,8 @@ mod slow {
                                 faucet_sapling_addr.as_str(),
                                 {
                                     let balance = faucet.do_balance().await;
-                                    dbg!(balance.spendable_sapling_balance.unwrap())
-                                        + dbg!(balance.spendable_orchard_balance.unwrap())
+                                    balance.spendable_sapling_balance.unwrap()
+                                        + balance.spendable_orchard_balance.unwrap()
                                 } - u64::from(MINIMUM_FEE),
                                 memo,
                             )],

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2468,36 +2468,6 @@ mod slow {
         // More explicit than ignoring the unused variable, we only care about this in order to drop it
     }
     #[tokio::test]
-    async fn multiple_outgoing_metadatas_work_right_on_restore() {
-        let inital_value = 100_000;
-        let (ref regtest_manager, _cph, faucet, ref recipient, _txid) =
-            scenarios::faucet_funded_recipient_default(inital_value).await;
-        from_inputs::send(
-            recipient,
-            vec![(&get_base_address_macro!(faucet, "unified"), 10_000, None); 2],
-        )
-        .await
-        .unwrap();
-        zingo_testutils::increase_height_and_wait_for_client(regtest_manager, recipient, 1)
-            .await
-            .unwrap();
-        let pre_rescan_transactions = recipient.do_list_transactions().await;
-        let pre_rescan_summaries = recipient.list_txsummaries().await;
-        recipient.do_rescan().await.unwrap();
-        let post_rescan_transactions = recipient.do_list_transactions().await;
-        let post_rescan_summaries = recipient.list_txsummaries().await;
-        assert_eq!(pre_rescan_transactions, post_rescan_transactions);
-        assert_eq!(pre_rescan_summaries, post_rescan_summaries);
-        let mut outgoing_metadata = pre_rescan_transactions
-            .members()
-            .find_map(|tx| tx.entries().find(|(key, _val)| key == &"outgoing_metadata"))
-            .unwrap()
-            .1
-            .members();
-        // The two outgoing spends were identical. They should be represented as such
-        assert_eq!(outgoing_metadata.next(), outgoing_metadata.next());
-    }
-    #[tokio::test]
     async fn mempool_clearing_and_full_batch_syncs_correct_trees() {
         async fn do_maybe_recent_txid(lc: &LightClient) -> JsonValue {
             json::object! {

--- a/libtonode-tests/tests/legacy.rs
+++ b/libtonode-tests/tests/legacy.rs
@@ -2342,6 +2342,8 @@ mod slow {
                 .unwrap(),
             )
             .unwrap();
+            // TODO:  This chain height bump should be unnecessary. I think removing
+            // this increase_height call reveals a bug!
             zingo_testutils::increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
                 .await
                 .unwrap();

--- a/zingo-testutils/src/macros.rs
+++ b/zingo-testutils/src/macros.rs
@@ -64,3 +64,39 @@ macro_rules! check_client_balances {
         );
     };
 }
+/// Given a client and txid, get the outgoing metadata from the tr
+#[macro_export]
+macro_rules! get_otd {
+    ($client:ident, $txid:ident) => {
+        $client
+            .wallet
+            .transaction_context
+            .transaction_metadata_set
+            .read()
+            .await
+            .transaction_records_by_id
+            .get($txid)
+            .unwrap()
+            .outgoing_tx_data
+            .clone()
+    };
+}
+/// Specific to two tests, validate outgoing metadata before and after rescan
+#[macro_export]
+macro_rules! validate_otds {
+    ($client:ident, $nom_txid:ident, $memo_txid:ident) => {
+        let pre_rescan_no_memo_self_send_outgoing_tx_data = get_otd!($client, $nom_txid);
+        let pre_rescan_with_memo_self_send_outgoing_tx_data = get_otd!($client, $memo_txid);
+        $client.do_rescan().await.unwrap();
+        let post_rescan_no_memo_self_send_outgoing_tx_data = get_otd!($client, $nom_txid);
+        let post_rescan_with_memo_self_send_outgoing_tx_data = get_otd!($client, $memo_txid);
+        assert_eq!(
+            pre_rescan_no_memo_self_send_outgoing_tx_data,
+            post_rescan_no_memo_self_send_outgoing_tx_data
+        );
+        assert_eq!(
+            pre_rescan_with_memo_self_send_outgoing_tx_data,
+            post_rescan_with_memo_self_send_outgoing_tx_data
+        );
+    };
+}

--- a/zingo-testutils/src/macros.rs
+++ b/zingo-testutils/src/macros.rs
@@ -85,9 +85,11 @@ macro_rules! get_otd {
 #[macro_export]
 macro_rules! validate_otds {
     ($client:ident, $nom_txid:ident, $memo_txid:ident) => {
+        let pre_rescan_summaries = $client.list_txsummaries().await;
         let pre_rescan_no_memo_self_send_outgoing_tx_data = get_otd!($client, $nom_txid);
         let pre_rescan_with_memo_self_send_outgoing_tx_data = get_otd!($client, $memo_txid);
         $client.do_rescan().await.unwrap();
+        let post_rescan_summaries = $client.list_txsummaries().await;
         let post_rescan_no_memo_self_send_outgoing_tx_data = get_otd!($client, $nom_txid);
         let post_rescan_with_memo_self_send_outgoing_tx_data = get_otd!($client, $memo_txid);
         assert_eq!(
@@ -98,5 +100,6 @@ macro_rules! validate_otds {
             pre_rescan_with_memo_self_send_outgoing_tx_data,
             post_rescan_with_memo_self_send_outgoing_tx_data
         );
+        assert_eq!(pre_rescan_summaries, post_rescan_summaries);
     };
 }


### PR DESCRIPTION
This test upgrade to two tests:

* depends on more foundational truths than do_list_transcations and do_list_notes
* removes calls to do_list_transactions
* removes calls to do_list_notes
* collects related tests in mod
* removes spurious (and time consuming chain bumps)
* tests an extra case (external send with memo)
* DRYs code with macros
* exposes a potential bug where *pending* outgoing_tx_data is lost across a rescan
* fixes a test that was failing against #1215 (by replacing `do_list_transactions` with direct references to `outgoing_tx_data`)