### PR TITLE
uncomment mempool check in with_assertions mod

### DIFF
--- a/zingo-testutils/src/lightclient/with_assertions.rs
+++ b/zingo-testutils/src/lightclient/with_assertions.rs
@@ -48,8 +48,8 @@ where
     // mempool scan shows the same
     sender.do_sync(false).await.unwrap();
     assert_sender_fee(sender, &proposal, &txids).await;
-    // recipient.do_sync(false).await.unwrap();
-    // assert_receiver_fee(recipient, &proposal, &txids).await;
+    recipient.do_sync(false).await.unwrap();
+    assert_receiver_fee(recipient, &proposal, &txids).await;
 
     environment.bump_chain().await;
     // chain scan shows the same


### PR DESCRIPTION
seems like chain_generic tests dont see the mempool. any ideas for how to fix?