### PR TITLE
Override sapling change address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", tag = "fix_change_required" }
-zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", tag = "fix_change_required", features = ["lightwalletd-tonic", "orchard", "transparent-inputs"] }
-zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", tag = "fix_change_required" }
-zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", tag = "fix_change_required", features = ["orchard"] }
+zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", tag = "override_sapling_change_address" }
+zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", tag = "override_sapling_change_address", features = ["lightwalletd-tonic", "orchard", "transparent-inputs"] }
+zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", tag = "override_sapling_change_address" }
+zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", tag = "override_sapling_change_address", features = ["orchard"] }
 zcash_note_encryption = "0.4"
-zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", tag = "fix_change_required" }
-zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", tag = "fix_change_required" }
-zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", tag = "fix_change_required" }
+zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", tag = "override_sapling_change_address" }
+zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", tag = "override_sapling_change_address" }
+zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", tag = "override_sapling_change_address" }
 sapling-crypto = "0.1.2"
 orchard = "0.8"
 zip32 = "0.1"

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -287,6 +287,7 @@ pub mod send_with_proposal {
                     &[],
                     step,
                     Some(usk_to_tkey),
+                    Some(self.wallet.wallet_capability().first_sapling_address()),
                 )
                 .map_err(CompleteAndBroadcastError::Calculation)?;
             let txid = self


### PR DESCRIPTION
LRZ uses some derivation black magic to come up with an internal address for sapling change. we ignore that here and substitute a known address for sapling change