### PR TITLE
Remove darkside feature gate and rename tests

### DIFF
--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -12,20 +12,20 @@ use crate::utils::scenarios::DarksideEnvironment;
 
 #[tokio::test]
 #[ignore] // darkside cant handle transparent?
-async fn darkside_send_40_000_to_transparent() {
+async fn send_40_000_to_transparent() {
     send_value_to_pool::<DarksideEnvironment>(40_000, Transparent).await;
 }
 
 proptest! {
     #![proptest_config(proptest::test_runner::Config::with_cases(4))]
     #[test]
-    fn darkside_send_pvalue_to_orchard(value in 0..90u64) {
+    fn send_pvalue_to_orchard(value in 0..90u64) {
         Runtime::new().unwrap().block_on(async {
     send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Orchard)).await;
         });
      }
     #[test]
-    fn darkside_send_pvalue_to_sapling(value in 0..90u64) {
+    fn send_pvalue_to_sapling(value in 0..90u64) {
         Runtime::new().unwrap().block_on(async {
     send_value_to_pool::<DarksideEnvironment>(value * 1_000, Shielded(Sapling)).await;
         });

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -150,7 +150,7 @@ async fn sent_transaction_reorged_into_mempool() {
     .unwrap();
     println!("{}", one_txid.first());
     recipient.do_sync(false).await.unwrap();
-    println!("{}", recipient.do_list_transactions().await.pretty(2));
+    dbg!(recipient.list_outputs().await);
 
     let connector = DarksideConnector(server_id.clone());
     let mut streamed_raw_txns = connector.get_incoming_transactions().await.unwrap();
@@ -168,10 +168,7 @@ async fn sent_transaction_reorged_into_mempool() {
 
     recipient.do_sync(false).await.unwrap();
     //  light_client.do_sync(false).await.unwrap();
-    println!(
-        "Recipient pre-reorg: {}",
-        recipient.do_list_transactions().await.pretty(2)
-    );
+    dbg!("Recipient pre-reorg: {}", recipient.list_outputs().await);
     println!(
         "Recipient pre-reorg: {}",
         serde_json::to_string_pretty(&recipient.do_balance().await).unwrap()
@@ -199,18 +196,12 @@ async fn sent_transaction_reorged_into_mempool() {
         "Sender post-reorg: {}",
         serde_json::to_string_pretty(&light_client.do_balance().await).unwrap()
     );
-    println!(
-        "Sender post-reorg: {}",
-        light_client.do_list_transactions().await.pretty(2)
-    );
+    dbg!("Sender post-reorg: {}", light_client.list_outputs().await);
     let loaded_client = zingo_testutils::lightclient::new_client_from_save_buffer(&light_client)
         .await
         .unwrap();
     loaded_client.do_sync(false).await.unwrap();
-    println!(
-        "Sender post-load: {}",
-        loaded_client.do_list_transactions().await.pretty(2)
-    );
+    dbg!("Sender post-load: {}", loaded_client.list_outputs().await);
     assert_eq!(
         loaded_client.do_balance().await.orchard_balance,
         Some(100000000)


### PR DESCRIPTION
#1257 must land first (to fix CI)
Supersedes #1255 merging this merges both!

With this you can run:

`cargo nextest run -p darkside-tests FOO` to run darkside tests that have FOO in their name.