### PR TITLE
Fix total transparent value spent bug

### DIFF
--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -395,8 +395,8 @@ impl TransactionRecord {
 
         let utxos = zcash_encoding::Vector::read(&mut reader, |r| TransparentOutput::read(r))?;
 
-        let total_sapling_value_spent = reader.read_u64::<LittleEndian>()?;
         let total_transparent_value_spent = reader.read_u64::<LittleEndian>()?;
+        let total_sapling_value_spent = reader.read_u64::<LittleEndian>()?;
         let total_orchard_value_spent = if version >= 22 {
             reader.read_u64::<LittleEndian>()?
         } else {


### PR DESCRIPTION
ontop of #1274 

read order was not aligned with write order. therefore, each time the app was closed and opened the values were saved in opposite positions causing "on and off" bugs like wrong fees and wrong kinds