### PR TITLE
add send-to-self transaction and value transfers kinds

### DIFF
--- a/zingo-testutils/src/chain_generics/fixtures.rs
+++ b/zingo-testutils/src/chain_generics/fixtures.rs
@@ -31,7 +31,7 @@ where
     println!("client is ready to send");
 
     let recipient = environment.create_client().await;
-    let _recorded_fee = with_assertions::propose_send_bump_sync_recipient(
+    with_assertions::propose_send_bump_sync_recipient(
         &mut environment,
         &sender,
         vec![
@@ -62,17 +62,30 @@ where
     );
     assert_eq!(
         sender.value_transfers().await.0[2].kind(),
-        ValueTransferKind::NoteToSelf
+        ValueTransferKind::MemoToSelf
     );
     assert_eq!(recipient.value_transfers().await.0.len(), 1);
     assert_eq!(
         recipient.value_transfers().await.0[0].kind(),
         ValueTransferKind::Received
     );
-    let _shield_fee = with_assertions::propose_shield_bump_sync(&mut environment, &sender).await;
+
+    with_assertions::propose_send_bump_sync_recipient(
+        &mut environment,
+        &sender,
+        vec![(&sender, PoolType::Shielded(Orchard), send_value_self, None)],
+    )
+    .await;
     assert_eq!(sender.value_transfers().await.0.len(), 4);
     assert_eq!(
         sender.value_transfers().await.0[3].kind(),
+        ValueTransferKind::SendToSelf
+    );
+
+    with_assertions::propose_shield_bump_sync(&mut environment, &sender).await;
+    assert_eq!(sender.value_transfers().await.0.len(), 5);
+    assert_eq!(
+        sender.value_transfers().await.0[4].kind(),
         ValueTransferKind::Shield
     );
 }

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -332,7 +332,7 @@ impl LightClient {
                         );
                     });
 
-                    // create 1 note-to-self if a sending transaction receives any number of memos
+                    // create 1 memo-to-self if a sending transaction receives any number of memos
                     if tx.orchard_notes().iter().any(|note| note.memo().is_some())
                         || tx.sapling_notes().iter().any(|note| note.memo().is_some())
                     {
@@ -354,7 +354,7 @@ impl LightClient {
                                 .blockheight(tx.blockheight())
                                 .transaction_fee(tx.fee())
                                 .zec_price(tx.zec_price())
-                                .kind(ValueTransferKind::NoteToSelf)
+                                .kind(ValueTransferKind::MemoToSelf)
                                 .value(0)
                                 .recipient_address(None)
                                 .pool_received(None)
@@ -365,7 +365,7 @@ impl LightClient {
                     }
                 }
                 TransactionKind::Sent(SendType::Shield) => {
-                    // create 1 shielding value tansfer for each pool shielded to
+                    // create 1 shielding value transfer for each pool shielded to
                     if !tx.orchard_notes().is_empty() {
                         let value: u64 =
                             tx.orchard_notes().iter().map(|output| output.value()).sum();
@@ -416,6 +416,58 @@ impl LightClient {
                                     PoolType::Shielded(ShieldedProtocol::Sapling).to_string(),
                                 ))
                                 .memos(memos)
+                                .build()
+                                .expect("all fields should be populated"),
+                        );
+                    }
+                }
+                TransactionKind::Sent(SendType::SendToSelf) => {
+                    // create 1 memo-to-self if a sending transaction receives any number of memos
+                    // otherwise, create 1 send-to-self value transfer so every transaction creates at least 1 value transfer
+                    // eventually we may replace send-to-self with a range of kinds such as deshield and migrate etc.
+                    if tx.orchard_notes().iter().any(|note| note.memo().is_some())
+                        || tx.sapling_notes().iter().any(|note| note.memo().is_some())
+                    {
+                        let memos: Vec<String> = tx
+                            .orchard_notes()
+                            .iter()
+                            .filter_map(|note| note.memo().map(|memo| memo.to_string()))
+                            .chain(
+                                tx.sapling_notes()
+                                    .iter()
+                                    .filter_map(|note| note.memo().map(|memo| memo.to_string())),
+                            )
+                            .collect();
+                        value_transfers.push(
+                            ValueTransferBuilder::new()
+                                .txid(tx.txid())
+                                .datetime(tx.datetime())
+                                .status(tx.status())
+                                .blockheight(tx.blockheight())
+                                .transaction_fee(tx.fee())
+                                .zec_price(tx.zec_price())
+                                .kind(ValueTransferKind::MemoToSelf)
+                                .value(0)
+                                .recipient_address(None)
+                                .pool_received(None)
+                                .memos(memos)
+                                .build()
+                                .expect("all fields should be populated"),
+                        );
+                    } else {
+                        value_transfers.push(
+                            ValueTransferBuilder::new()
+                                .txid(tx.txid())
+                                .datetime(tx.datetime())
+                                .status(tx.status())
+                                .blockheight(tx.blockheight())
+                                .transaction_fee(tx.fee())
+                                .zec_price(tx.zec_price())
+                                .kind(ValueTransferKind::SendToSelf)
+                                .value(0)
+                                .recipient_address(None)
+                                .pool_received(None)
+                                .memos(vec![])
                                 .build()
                                 .expect("all fields should be populated"),
                         );
@@ -527,9 +579,9 @@ impl LightClient {
             .map(|tx| {
                 let kind = transaction_records.transaction_kind(tx);
                 let value = match kind {
-                    TransactionKind::Received | TransactionKind::Sent(SendType::Shield) => {
-                        tx.total_value_received()
-                    }
+                    TransactionKind::Received
+                    | TransactionKind::Sent(SendType::Shield)
+                    | TransactionKind::Sent(SendType::SendToSelf) => tx.total_value_received(),
                     TransactionKind::Sent(SendType::Send) => tx.value_outgoing(),
                 };
                 let fee = transaction_records.calculate_transaction_fee(tx).ok();

--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -513,6 +513,7 @@ impl std::fmt::Display for TransactionKind {
             TransactionKind::Received => write!(f, "received"),
             TransactionKind::Sent(SendType::Send) => write!(f, "sent"),
             TransactionKind::Sent(SendType::Shield) => write!(f, "shield"),
+            TransactionKind::Sent(SendType::SendToSelf) => write!(f, "send-to-self"),
         }
     }
 }
@@ -520,10 +521,12 @@ impl std::fmt::Display for TransactionKind {
 /// TODO: doc comment
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SendType {
-    /// TODO: doc comment
+    /// Transaction is sending funds to recipient other than the creator
     Send,
-    /// TODO: doc comment
+    /// Transaction is only sending funds from transparent pool to the creator's shielded pool
     Shield,
+    /// Transaction is only sending funds to the creator's address(es) and is not a shield
+    SendToSelf,
 }
 
 #[cfg(test)]

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -370,9 +370,12 @@ impl TransactionRecordsById {
             && orchard_spends.is_empty()
             && query_record.total_transparent_value_spent > 0
             && query_record.outgoing_tx_data.is_empty()
+            && (!query_record.orchard_notes().is_empty() | !query_record.sapling_notes().is_empty())
         {
             // TODO: this could be improved by checking outputs recipient addr against the wallet addrs
             TransactionKind::Sent(SendType::Shield)
+        } else if query_record.outgoing_tx_data.is_empty() {
+            TransactionKind::Sent(SendType::SendToSelf)
         } else {
             TransactionKind::Sent(SendType::Send)
         }


### PR DESCRIPTION
this solves a concern from @juanky201271 that some transactions do not create any value transfers and therefore some information is missing from the UI and also the user has no information about the status of a transaction the migrates funds etc.

- adds a new transaction and value transfer kind `send-to-self` so all transaction create at least 1 value transfer
- renames `note-to-self` to `memo-to-self` as there was confusion
- defines a send-to-self transaction as a sending transaction that does not send to another capability, and is not a shield
- defines a send-to-self value transfer as a transfer that is created for a send-to-self transaction when there is no memos in the received notes
- fixes a bug with shield value transfer where is did not check shielded notes were received, meaning t -> t would be listed as a shield