### PR TITLE
unified add pending note with add new note

### DIFF
--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -310,7 +310,7 @@ impl TrialDecryptions {
                     let bsync_data = bsync_data.clone();
                     let transaction_metadata_set = transaction_metadata_set.clone();
                     let detected_transaction_id_sender = detected_transaction_id_sender.clone();
-                    let timestamp = compact_block.time as u64;
+                    let timestamp = compact_block.time;
                     let config = config.clone();
 
                     workers.push(tokio::spawn(async move {
@@ -357,7 +357,7 @@ impl TrialDecryptions {
                                 have_spending_key,
                                 Some(spend_nullifier),
                                 i as u32,
-                                witness.witnessed_position(),
+                                Some(witness.witnessed_position()),
                             );
 
                         debug!("Trial decrypt Detected txid {}", &transaction_id);

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -196,7 +196,6 @@ impl LightClient {
                             let status = ConfirmationStatus::Pending(BlockHeight::from_u32(
                                 rtransaction.height as u32,
                             ));
-
                             TransactionContext::new(
                                 &config,
                                 key.clone(),

--- a/zingolib/src/wallet/notes/orchard.rs
+++ b/zingolib/src/wallet/notes/orchard.rs
@@ -41,6 +41,7 @@ pub struct OrchardNote {
     pub is_change: bool,
 
     /// If the spending key is available in the wallet (i.e., whether to keep witness up-to-date)
+    // FIXME: see comment in SapingNote for this field
     pub have_spending_key: bool,
 }
 

--- a/zingolib/src/wallet/notes/sapling.rs
+++ b/zingolib/src/wallet/notes/sapling.rs
@@ -42,6 +42,8 @@ pub struct SaplingNote {
     pub is_change: bool,
 
     /// If the spending key is available in the wallet (i.e., whether to keep witness up-to-date) Todo should this data point really be here?
+    // FIXME: this seems to be derived from wrong factors such as whether a note is in a pending tx or whether the wallet has the FVK.
+    // it also is only used for getting notes to update which is atleast a conceptual bug. needs investigation and cleaning up.
     pub have_spending_key: bool,
 }
 

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -279,7 +279,7 @@ pub mod decrypt_transaction {
                     .add_taddr_spent(
                         transaction.txid(),
                         status,
-                        block_time as u64,
+                        block_time,
                         total_transparent_value_spent,
                     );
             }
@@ -459,21 +459,23 @@ pub mod decrypt_transaction {
                     Some(plaintext) => plaintext,
                     _ => continue,
                 };
+                self.transaction_metadata_set
+                    .write()
+                    .await
+                    .transaction_records_by_id
+                    .add_new_note::<D>(
+                        transaction.txid(),
+                        status,
+                        block_time,
+                        note.clone(),
+                        to,
+                        false,
+                        None,
+                        output_index as u32,
+                        None,
+                    );
+
                 let memo_bytes = MemoBytes::from_bytes(&memo_bytes.to_bytes()).unwrap();
-                if let Some(height) = status.get_pending_height() {
-                    self.transaction_metadata_set
-                        .write()
-                        .await
-                        .transaction_records_by_id
-                        .add_pending_note::<D>(
-                            transaction.txid(),
-                            height,
-                            block_time as u64,
-                            note.clone(),
-                            to,
-                            output_index,
-                        );
-                }
                 let memo = memo_bytes
                     .clone()
                     .try_into()

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -643,13 +643,5 @@ pub mod decrypt_transaction {
 
             Ok(tree)
         }
-
-        // async fn get_incremental_witness<D: DomainWalletExt>(
-        //     &self,
-        //     commit
-        //     transaction: &Transaction,
-        // ) -> Result<IncrementalWitness<<D::WalletNote as ShieldedNoteInterface>::Node, 32>, String>
-        // {
-        // }
     }
 }

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -552,7 +552,7 @@ impl TransactionRecordsById {
                 .retain(|n| n.nullifier().is_some());
         }
 
-        let zingo_note = D::WalletNote::from_parts(
+        let wallet_note = D::WalletNote::from_parts(
             D::Recipient::diversifier(&to),
             note.clone(),
             position,
@@ -569,12 +569,12 @@ impl TransactionRecordsById {
             .find(|n| n.note() == &note)
         {
             None => {
-                D::WalletNote::transaction_metadata_notes_mut(transaction_record).push(zingo_note);
+                D::WalletNote::transaction_metadata_notes_mut(transaction_record).push(wallet_note);
             }
             #[allow(unused_mut)]
             Some(mut n) => {
                 // An overwrite should be safe here: TODO: test that confirms this
-                *n = zingo_note;
+                *n = wallet_note;
             }
         }
     }

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
@@ -103,6 +103,8 @@ impl super::TxMapAndMaybeTrees {
             .transaction_records_by_id
             .create_modify_get_transaction_record(&spending_txid, status, timestamp as u64);
 
+        // TODO: we should write ALL nullifiers down. not just the ones we think are relevent to the wallet at a given point.
+        // this doesnt cause bugs as we check nullifiers directly in the compact blocks and sync in order.
         if !<D::WalletNote as ShieldedNoteInterface>::Nullifier::get_nullifiers_spent_in_transaction(
             transaction_metadata,
         )

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
@@ -101,7 +101,7 @@ impl super::TxMapAndMaybeTrees {
         // Record this Tx as having spent some funds
         let transaction_metadata = self
             .transaction_records_by_id
-            .create_modify_get_transaction_metadata(&spending_txid, status, timestamp as u64);
+            .create_modify_get_transaction_record(&spending_txid, status, timestamp as u64);
 
         if !<D::WalletNote as ShieldedNoteInterface>::Nullifier::get_nullifiers_spent_in_transaction(
             transaction_metadata,


### PR DESCRIPTION
pending bug was caused by regular mempool checks and/or calls to `scan_full_tx` with a `confirmed` status, as `pending` status was hard coded.

this PR removes `add_pending_note` and modifies `add_new_note` to account for both confirmed and pending so confirmed scans can't set a tx back to pending status.

also adds logic to make sure a pending status cannot override a confirmed one