### PR TITLE
rename to transaction state and add variant

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -127,7 +127,7 @@ mod fast {
     use zcash_address::unified::Encoding;
     use zcash_client_backend::{PoolType, ShieldedProtocol};
     use zcash_primitives::transaction::components::amount::NonNegativeAmount;
-    use zingo_status::confirmation_status::ConfirmationStatus;
+    use zingo_status::transaction_source::TransactionSource;
     use zingo_testutils::lightclient::from_inputs;
     use zingolib::wallet::WalletBase;
 
@@ -161,7 +161,7 @@ mod fast {
                 .find(|tx| tx.value() == 20_000)
                 .unwrap()
                 .status(),
-            ConfirmationStatus::Pending(BlockHeight::from_u32(5)) // FIXME: mempool blockheight is at chain hieght instead of chain height + 1
+            TransactionSource::FromMempool(BlockHeight::from_u32(5)) // FIXME: mempool blockheight is at chain hieght instead of chain height + 1
         );
 
         increase_height_and_wait_for_client(&regtest_manager, &recipient, 1)
@@ -175,7 +175,7 @@ mod fast {
                 .find(|tx| tx.value() == 20_000)
                 .unwrap()
                 .status(),
-            ConfirmationStatus::Confirmed(BlockHeight::from_u32(6))
+            TransactionSource::OnChain(BlockHeight::from_u32(6))
         );
     }
 
@@ -741,7 +741,7 @@ mod slow {
     use zcash_primitives::{
         consensus::NetworkConstants, memo::Memo, transaction::fees::zip317::MARGINAL_FEE,
     };
-    use zingo_status::confirmation_status::ConfirmationStatus;
+    use zingo_status::transaction_source::TransactionSource;
     use zingo_testutils::{
         assert_transaction_summary_equality, assert_transaction_summary_exists,
         lightclient::{from_inputs, get_fees_paid_by_client},
@@ -1318,7 +1318,7 @@ mod slow {
 
         let summary_orchard_receipt = TransactionSummaryBuilder::new()
             .blockheight(BlockHeight::from_u32(5))
-            .status(ConfirmationStatus::Confirmed(BlockHeight::from_u32(5)))
+            .status(TransactionSource::OnChain(BlockHeight::from_u32(5)))
             .datetime(0)
             .txid(utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap())
             .value(recipient_initial_funds)
@@ -1356,7 +1356,7 @@ mod slow {
             .unwrap();
         let summary_external_sapling = TransactionSummaryBuilder::new()
             .blockheight(BlockHeight::from_u32(6))
-            .status(ConfirmationStatus::Confirmed(BlockHeight::from_u32(6)))
+            .status(TransactionSource::OnChain(BlockHeight::from_u32(6)))
             .datetime(0)
             .txid(utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap())
             .value(first_send_to_sapling)
@@ -1386,7 +1386,7 @@ mod slow {
         let first_send_to_transparent = 20_000;
         let summary_external_transparent = TransactionSummaryBuilder::new()
             .blockheight(BlockHeight::from_u32(7))
-            .status(ConfirmationStatus::Pending(BlockHeight::from_u32(7)))
+            .status(TransactionSource::FromMempool(BlockHeight::from_u32(7)))
             .datetime(0)
             .txid(utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap())
             .value(first_send_to_transparent)
@@ -1459,7 +1459,7 @@ mod slow {
         let recipient_second_funding = 1_000_000;
         let summary_orchard_receipt_2 = TransactionSummaryBuilder::new()
             .blockheight(BlockHeight::from_u32(8))
-            .status(ConfirmationStatus::Confirmed(BlockHeight::from_u32(8)))
+            .status(TransactionSource::OnChain(BlockHeight::from_u32(8)))
             .datetime(0)
             .txid(utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap())
             .value(recipient_second_funding)
@@ -1497,7 +1497,7 @@ mod slow {
         let second_send_to_transparent = 20_000;
         let summary_exteranl_transparent_2 = TransactionSummaryBuilder::new()
             .blockheight(BlockHeight::from_u32(9))
-            .status(ConfirmationStatus::Confirmed(BlockHeight::from_u32(9)))
+            .status(TransactionSource::OnChain(BlockHeight::from_u32(9)))
             .datetime(0)
             .txid(utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap())
             .value(second_send_to_transparent)
@@ -1537,7 +1537,7 @@ mod slow {
         let second_send_to_sapling = 20_000;
         let summary_external_sapling_2 = TransactionSummaryBuilder::new()
             .blockheight(BlockHeight::from_u32(9))
-            .status(ConfirmationStatus::Confirmed(BlockHeight::from_u32(9)))
+            .status(TransactionSource::OnChain(BlockHeight::from_u32(9)))
             .datetime(0)
             .txid(utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap())
             .value(second_send_to_sapling)
@@ -1578,7 +1578,7 @@ mod slow {
         let external_transparent_3 = 20_000;
         let summary_external_transparent_3 = TransactionSummaryBuilder::new()
             .blockheight(BlockHeight::from_u32(10))
-            .status(ConfirmationStatus::Confirmed(BlockHeight::from_u32(10)))
+            .status(TransactionSource::OnChain(BlockHeight::from_u32(10)))
             .datetime(0)
             .txid(utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap())
             .value(external_transparent_3)

--- a/zingo-status/src/lib.rs
+++ b/zingo-status/src/lib.rs
@@ -3,4 +3,4 @@
 
 #![warn(missing_docs)]
 #[forbid(unsafe_code)]
-pub mod confirmation_status;
+pub mod transaction_source;

--- a/zingo-status/src/transaction_source.rs
+++ b/zingo-status/src/transaction_source.rs
@@ -9,6 +9,7 @@ use zcash_primitives::consensus::BlockHeight;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TransactionSource {
     /// If the transaction has not been broadcast (in band) then it is known only to the client
+    /// (barring side-channel communication).
     ClientOnly(BlockHeight),
     /// The transaction is pending confirmation to the zcash blockchain. It may be waiting in the mempool.
     /// The BlockHeight is the 1 + the height of the chain as the transaction was broadcast, i.e. the target height.

--- a/zingo-testutils/src/assertions.rs
+++ b/zingo-testutils/src/assertions.rs
@@ -5,7 +5,7 @@ use nonempty::NonEmpty;
 use zcash_client_backend::proposal::Proposal;
 use zcash_primitives::transaction::TxId;
 
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 use zingolib::{lightclient::LightClient, wallet::notes::query::OutputQuery};
 
 /// currently checks:
@@ -18,7 +18,7 @@ pub async fn assert_record_fee_and_status<NoteId>(
     client: &LightClient,
     proposal: &Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, NoteId>,
     txids: &NonEmpty<TxId>,
-    expected_status: ConfirmationStatus,
+    expected_status: TransactionSource,
 ) -> u64 {
     let records = &client
         .wallet

--- a/zingo-testutils/src/chain_generics/with_assertions.rs
+++ b/zingo-testutils/src/chain_generics/with_assertions.rs
@@ -8,7 +8,7 @@ use crate::{
     chain_generics::conduct_chain::ConductChain,
     lightclient::{from_inputs, get_base_address},
 };
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 
 /// sends to any combo of recipient clients checks that each recipient also recieved the expected balances
 /// test-only generic
@@ -50,7 +50,7 @@ where
         sender,
         &proposal,
         &txids,
-        ConfirmationStatus::Pending(send_height.into()),
+        TransactionSource::FromMempool(send_height.into()),
     )
     .await;
 
@@ -63,7 +63,7 @@ where
             sender,
             &proposal,
             &txids,
-            ConfirmationStatus::Pending(send_height.into()),
+            TransactionSource::FromMempool(send_height.into()),
         )
         .await;
 
@@ -75,7 +75,7 @@ where
                     recipient,
                     &proposal,
                     &txids,
-                    ConfirmationStatus::Pending(send_height.into()),
+                    TransactionSource::FromMempool(send_height.into()),
                 )
                 .await;
             }
@@ -89,7 +89,7 @@ where
         sender,
         &proposal,
         &txids,
-        ConfirmationStatus::Confirmed((send_height).into()),
+        TransactionSource::OnChain((send_height).into()),
     )
     .await;
     for (recipient, _, _, _) in sends {
@@ -126,7 +126,7 @@ where
         client,
         &proposal,
         &txids,
-        ConfirmationStatus::Pending(send_height.into()),
+        TransactionSource::FromMempool(send_height.into()),
     )
     .await;
 
@@ -137,7 +137,7 @@ where
             client,
             &proposal,
             &txids,
-            ConfirmationStatus::Pending(send_height.into()),
+            TransactionSource::FromMempool(send_height.into()),
         )
         .await;
     }
@@ -149,7 +149,7 @@ where
         client,
         &proposal,
         &txids,
-        ConfirmationStatus::Confirmed(send_height.into()),
+        TransactionSource::OnChain(send_height.into()),
     )
     .await;
 

--- a/zingolib/src/blaze/full_transactions_processor.rs
+++ b/zingolib/src/blaze/full_transactions_processor.rs
@@ -19,7 +19,7 @@ use zcash_primitives::{
     transaction::{Transaction, TxId},
 };
 
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 
 // despite being called fetch_full_transaction, this function sends a txid somewhere else to be fetched as a Transaction. then processes it.
 pub async fn start(
@@ -93,7 +93,7 @@ pub async fn start(
                     last_progress.store(progress, Ordering::SeqCst);
                 }
 
-                let status = ConfirmationStatus::Confirmed(height);
+                let status = TransactionSource::OnChain(height);
                 per_txid_iter_context
                     .scan_full_tx(&transaction, status, block_time, None)
                     .await;
@@ -133,7 +133,7 @@ pub async fn start(
                 .block_data
                 .get_block_timestamp(&height)
                 .await;
-            let status = ConfirmationStatus::Confirmed(height);
+            let status = TransactionSource::OnChain(height);
             transaction_context
                 .scan_full_tx(&transaction, status, block_time, None)
                 .await;

--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -34,7 +34,7 @@ use zcash_primitives::{
     consensus::{BlockHeight, Parameters},
     transaction::{Transaction, TxId},
 };
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 use zingoconfig::ZingoConfig;
 
 use super::syncdata::BlazeSyncData;
@@ -343,7 +343,7 @@ impl TrialDecryptions {
                             u64::from(witness.witnessed_position()),
                         );
 
-                        let status = ConfirmationStatus::Confirmed(height);
+                        let status = TransactionSource::OnChain(height);
                         transaction_metadata_set
                             .write()
                             .await

--- a/zingolib/src/blaze/update_notes.rs
+++ b/zingolib/src/blaze/update_notes.rs
@@ -14,7 +14,7 @@ use tokio::{sync::mpsc::UnboundedSender, task::JoinHandle};
 
 use zcash_primitives::consensus::BlockHeight;
 use zcash_primitives::transaction::TxId;
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 
 use super::syncdata::BlazeSyncData;
 
@@ -135,7 +135,7 @@ impl UpdateNotes {
                             wallet_transactions.write().await;
 
                         // Record the future transaction, the one that has spent the nullifiers received in this transaction in the wallet
-                        let status = ConfirmationStatus::Confirmed(spent_at_height);
+                        let status = TransactionSource::OnChain(spent_at_height);
                         wallet_transactions_write_unlocked.found_spent_nullifier(
                             transaction_id_spent_in,
                             status,

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -18,7 +18,7 @@ use tokio::{
     time::sleep,
 };
 
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 
 use zcash_client_backend::proto::service::RawTransaction;
 use zcash_primitives::{
@@ -193,7 +193,7 @@ impl LightClient {
                         ) {
                             let price = price.read().await.clone();
                             //debug!("Mempool attempting to scan {}", tx.txid());
-                            let status = ConfirmationStatus::Pending(BlockHeight::from_u32(
+                            let status = TransactionSource::FromMempool(BlockHeight::from_u32(
                                 rtransaction.height as u32,
                             ));
 

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -451,7 +451,7 @@ pub mod summaries {
     use chrono::DateTime;
     use json::JsonValue;
     use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-    use zingo_status::confirmation_status::ConfirmationStatus;
+    use zingo_status::transaction_source::TransactionSource;
 
     use crate::{
         error::BuildError,
@@ -469,7 +469,7 @@ pub mod summaries {
     pub struct ValueTransfer {
         txid: TxId,
         datetime: u64,
-        status: ConfirmationStatus,
+        status: TransactionSource,
         blockheight: BlockHeight,
         transaction_fee: Option<u64>,
         zec_price: Option<f64>,
@@ -490,7 +490,7 @@ pub mod summaries {
             self.datetime
         }
         /// TODO: doc comment
-        pub fn status(&self) -> ConfirmationStatus {
+        pub fn status(&self) -> TransactionSource {
             self.status
         }
         /// TODO: doc comment
@@ -662,7 +662,7 @@ pub mod summaries {
     pub struct ValueTransferBuilder {
         txid: Option<TxId>,
         datetime: Option<u64>,
-        status: Option<ConfirmationStatus>,
+        status: Option<TransactionSource>,
         blockheight: Option<BlockHeight>,
         transaction_fee: Option<Option<u64>>,
         zec_price: Option<Option<f64>>,
@@ -693,7 +693,7 @@ pub mod summaries {
 
         build_method!(txid, TxId);
         build_method!(datetime, u64);
-        build_method!(status, ConfirmationStatus);
+        build_method!(status, TransactionSource);
         build_method!(blockheight, BlockHeight);
         build_method!(transaction_fee, Option<u64>);
         build_method!(zec_price, Option<f64>);
@@ -788,7 +788,7 @@ pub mod summaries {
     pub struct TransactionSummary {
         txid: TxId,
         datetime: u64,
-        status: ConfirmationStatus,
+        status: TransactionSource,
         blockheight: BlockHeight,
         kind: TransactionKind,
         value: u64,
@@ -810,7 +810,7 @@ pub mod summaries {
             self.datetime
         }
         /// TODO: doc comment
-        pub fn status(&self) -> ConfirmationStatus {
+        pub fn status(&self) -> TransactionSource {
             self.status
         }
         /// TODO: doc comment
@@ -988,7 +988,7 @@ pub mod summaries {
     pub struct TransactionSummaryBuilder {
         txid: Option<TxId>,
         datetime: Option<u64>,
-        status: Option<ConfirmationStatus>,
+        status: Option<TransactionSource>,
         blockheight: Option<BlockHeight>,
         kind: Option<TransactionKind>,
         value: Option<u64>,
@@ -1021,7 +1021,7 @@ pub mod summaries {
 
         build_method!(txid, TxId);
         build_method!(datetime, u64);
-        build_method!(status, ConfirmationStatus);
+        build_method!(status, TransactionSource);
         build_method!(blockheight, BlockHeight);
         build_method!(kind, TransactionKind);
         build_method!(value, u64);

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -292,7 +292,7 @@ mod tests {
     use orchard::note_encryption::OrchardDomain;
     use sapling_crypto::note_encryption::SaplingDomain;
 
-    use zingo_status::confirmation_status::ConfirmationStatus;
+    use zingo_status::transaction_source::TransactionSource;
     use zingoconfig::ZingoConfigBuilder;
 
     use crate::{
@@ -316,7 +316,7 @@ mod tests {
         )
         .unwrap();
         let confirmed_tx_record = TransactionRecordBuilder::default()
-            .status(ConfirmationStatus::Confirmed(80.into()))
+            .status(TransactionSource::OnChain(80.into()))
             .transparent_outputs(TransparentOutputBuilder::default())
             .sapling_notes(SaplingNoteBuilder::default())
             .sapling_notes(SaplingNoteBuilder::default())
@@ -351,7 +351,7 @@ mod tests {
             )
             .build();
         let pending_tx_record = TransactionRecordBuilder::default()
-            .status(ConfirmationStatus::Pending(95.into()))
+            .status(TransactionSource::FromMempool(95.into()))
             .transparent_outputs(TransparentOutputBuilder::default())
             .sapling_notes(SaplingNoteBuilder::default())
             .orchard_notes(OrchardNoteBuilder::default())

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -44,7 +44,7 @@ use zcash_primitives::{
 use zcash_primitives::{memo::MemoBytes, transaction::TxId};
 
 use zingo_memo::create_wallet_internal_memo_version_0;
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 
 use crate::data::witness_trees::{WitnessTrees, COMMITMENT_TREE_LEVELS, MAX_SHARD_LEVEL};
 
@@ -839,7 +839,7 @@ impl LightWallet {
         {
             let price = self.price.read().await.clone();
 
-            let status = ConfirmationStatus::Pending(submission_height);
+            let status = TransactionSource::FromMempool(submission_height);
             self.transaction_context
                 .scan_full_tx(transaction, status, now() as u32, get_price(now(), &price))
                 .await;

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -90,7 +90,7 @@ pub mod decrypt_transaction {
         transaction::{Transaction, TxId},
     };
     use zingo_memo::{parse_zingo_memo, ParsedMemo};
-    use zingo_status::confirmation_status::ConfirmationStatus;
+    use zingo_status::transaction_source::TransactionSource;
 
     use super::TransactionContext;
 
@@ -98,7 +98,7 @@ pub mod decrypt_transaction {
         pub(crate) async fn scan_full_tx(
             &self,
             transaction: &Transaction,
-            status: ConfirmationStatus,
+            status: TransactionSource,
             block_time: u32,
             price: Option<f64>,
         ) {
@@ -178,7 +178,7 @@ pub mod decrypt_transaction {
         async fn decrypt_transaction_to_record(
             &self,
             transaction: &Transaction,
-            status: ConfirmationStatus,
+            status: TransactionSource,
             block_time: u32,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,
@@ -214,7 +214,7 @@ pub mod decrypt_transaction {
         async fn decrypt_transaction_to_record_transparent(
             &self,
             transaction: &Transaction,
-            status: ConfirmationStatus,
+            status: TransactionSource,
             block_time: u32,
             taddrs_set: &HashSet<String>,
         ) {
@@ -363,7 +363,7 @@ pub mod decrypt_transaction {
         async fn decrypt_transaction_to_record_sapling(
             &self,
             transaction: &Transaction,
-            status: ConfirmationStatus,
+            status: TransactionSource,
             block_time: u32,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,
@@ -382,7 +382,7 @@ pub mod decrypt_transaction {
         async fn decrypt_transaction_to_record_orchard(
             &self,
             transaction: &Transaction,
-            status: ConfirmationStatus,
+            status: TransactionSource,
             block_time: u32,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,
@@ -406,7 +406,7 @@ pub mod decrypt_transaction {
         async fn decrypt_transaction_to_record_domain<D: DomainWalletExt>(
             &self,
             transaction: &Transaction,
-            status: ConfirmationStatus,
+            status: TransactionSource,
             block_time: u32,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,

--- a/zingolib/src/wallet/transaction_record.rs
+++ b/zingolib/src/wallet/transaction_record.rs
@@ -32,7 +32,7 @@ use crate::{
 #[derive(Debug)]
 pub struct TransactionRecord {
     /// the relationship of the transaction to the blockchain. can be either Broadcast (to mempool}, or Confirmed.
-    pub status: zingo_status::confirmation_status::ConfirmationStatus,
+    pub status: zingo_status::transaction_source::TransactionSource,
 
     /// Timestamp of Tx. Added in v4
     pub datetime: u64,
@@ -76,7 +76,7 @@ pub struct TransactionRecord {
 impl TransactionRecord {
     /// TODO: Add Doc Comment Here!
     pub fn new(
-        status: zingo_status::confirmation_status::ConfirmationStatus,
+        status: zingo_status::transaction_source::TransactionSource,
         datetime: u64,
         transaction_id: &TxId,
     ) -> Self {
@@ -429,7 +429,10 @@ impl TransactionRecord {
                 Ok(orchard::note::Nullifier::from_bytes(&n).unwrap())
             })?
         };
-        let status = zingo_status::confirmation_status::ConfirmationStatus::from_blockheight_and_pending_bool(block, pending);
+        let status =
+            zingo_status::transaction_source::TransactionSource::from_blockheight_and_pending_bool(
+                block, pending,
+            );
         Ok(Self {
             status,
             datetime,
@@ -528,7 +531,7 @@ pub enum SendType {
 pub mod mocks {
     //! Mock version of the struct for testing
     use zcash_primitives::transaction::TxId;
-    use zingo_status::confirmation_status::ConfirmationStatus;
+    use zingo_status::transaction_source::TransactionSource;
 
     use crate::{
         mocks::{
@@ -549,7 +552,7 @@ pub mod mocks {
 
     /// to create a mock TransactionRecord
     pub(crate) struct TransactionRecordBuilder {
-        status: Option<ConfirmationStatus>,
+        status: Option<TransactionSource>,
         datetime: Option<u64>,
         txid: Option<TxId>,
         spent_sapling_nullifiers: Vec<SaplingNullifierBuilder>,
@@ -578,7 +581,7 @@ pub mod mocks {
             }
         }
         // Methods to set each field
-        build_method!(status, ConfirmationStatus);
+        build_method!(status, TransactionSource);
         build_method!(datetime, u64);
         build_method!(txid, TxId);
         build_method_push!(spent_sapling_nullifiers, SaplingNullifierBuilder);
@@ -631,7 +634,7 @@ pub mod mocks {
         fn default() -> Self {
             Self {
                 status: Some(
-                    zingo_status::confirmation_status::ConfirmationStatus::Confirmed(
+                    zingo_status::transaction_source::TransactionSource::OnChain(
                         zcash_primitives::consensus::BlockHeight::from_u32(5),
                     ),
                 ),
@@ -734,7 +737,7 @@ pub mod mocks {
             .assign_unique_nullifier()
             .clone();
         let sent_transaction_record = TransactionRecordBuilder::default()
-            .status(ConfirmationStatus::Confirmed(15.into()))
+            .status(TransactionSource::OnChain(15.into()))
             .spent_sapling_nullifiers(sap_null_one.clone())
             .spent_sapling_nullifiers(sap_null_two.clone())
             .spent_orchard_nullifiers(orch_null_one.clone())

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -763,7 +763,24 @@ mod tests {
         use super::*;
         #[test_matrix([true, false], [true, false])]
         fn no_txid_in_trbid(txid_in_trbid: bool, confirmed: bool) {
-            let mut transaction_records_by_id = TransactionRecordsById::default();
+            let mut trbid = TransactionRecordsById::default();
+            if txid_in_trbid {
+                let transaction_record = TransactionRecordBuilder::default().build();
+                let txid = transaction_record.txid;
+                trbid.insert_transaction_record(transaction_record);
+                if confirmed {
+                    dbg!(txid);
+                    assert_eq!(1, 2);
+                } else if !confirmed {
+                    dbg!("not confirmed, but in trbid");
+                }
+            } else if !txid_in_trbid {
+                if confirmed {
+                    dbg!("Not in trbid, but confirmed!");
+                } else if !confirmed {
+                    dbg!("Not in trbid, AND not confirmed!");
+                }
+            }
         }
     }
     #[test]

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -763,13 +763,13 @@ mod tests {
         use zingo_status::transaction_source::TransactionSource;
         #[test_matrix(
             [ClientOnly(2.into()), FromMempool(2.into()), OnChain(2.into())],
-            [ClientOnly(1.into()), FromMempool(1.into()), OnChain(1.into())],
-            [true, false])
-        ]
+            [true, false],
+            [ClientOnly(1.into()), FromMempool(1.into()), OnChain(1.into())]
+        )]
         fn valid_trbid_update(
             input_tx_source: TransactionSource,
-            trbid_tx_source: TransactionSource,
             fresh_trbid: bool,
+            trbid_tx_source: TransactionSource,
         ) {
             // We'll need a trbid regardless.
             let mut trbid = TransactionRecordsById::default();

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -423,7 +423,7 @@ impl TransactionRecordsById {
     pub(crate) fn create_modify_get_transaction_metadata(
         &mut self,
         txid: &TxId,
-        status: zingo_status::confirmation_status::ConfirmationStatus,
+        status: zingo_status::transaction_source::TransactionSource,
         datetime: u64,
     ) -> &'_ mut TransactionRecord {
         // check if there is already a confirmed transaction with the same txid
@@ -453,7 +453,7 @@ impl TransactionRecordsById {
     pub fn add_taddr_spent(
         &mut self,
         txid: TxId,
-        status: zingo_status::confirmation_status::ConfirmationStatus,
+        status: zingo_status::transaction_source::TransactionSource,
         timestamp: u64,
         total_transparent_value_spent: u64,
     ) {
@@ -469,7 +469,7 @@ impl TransactionRecordsById {
         spent_txid: TxId,
         output_num: u32,
         source_txid: TxId,
-        spending_tx_status: zingo_status::confirmation_status::ConfirmationStatus,
+        spending_tx_status: zingo_status::transaction_source::TransactionSource,
     ) -> u64 {
         // Find the UTXO
         let value = if let Some(utxo_transacion_metadata) = self.get_mut(&spent_txid) {
@@ -508,7 +508,7 @@ impl TransactionRecordsById {
         &mut self,
         txid: TxId,
         taddr: String,
-        status: zingo_status::confirmation_status::ConfirmationStatus,
+        status: zingo_status::transaction_source::TransactionSource,
         timestamp: u64,
         vout: &zcash_primitives::transaction::components::TxOut,
         output_num: u32,
@@ -541,7 +541,7 @@ impl TransactionRecordsById {
     pub(crate) fn update_output_index<D: DomainWalletExt>(
         &mut self,
         txid: TxId,
-        status: zingo_status::confirmation_status::ConfirmationStatus,
+        status: zingo_status::transaction_source::TransactionSource,
         timestamp: u64,
         note: D::Note,
         output_index: usize,
@@ -567,7 +567,7 @@ impl TransactionRecordsById {
         to: D::Recipient,
         output_index: usize,
     ) {
-        let status = zingo_status::confirmation_status::ConfirmationStatus::Pending(height);
+        let status = zingo_status::transaction_source::TransactionSource::FromMempool(height);
         let transaction_record =
             self.create_modify_get_transaction_metadata(&txid, status, timestamp);
 
@@ -599,7 +599,7 @@ impl TransactionRecordsById {
     pub(crate) fn add_new_note<D: DomainWalletExt>(
         &mut self,
         txid: TxId,
-        status: zingo_status::confirmation_status::ConfirmationStatus,
+        status: zingo_status::transaction_source::TransactionSource,
         timestamp: u64,
         note: <D::WalletNote as crate::wallet::notes::ShieldedNoteInterface>::Note,
         to: D::Recipient,
@@ -755,20 +755,20 @@ mod tests {
     use sapling_crypto::note_encryption::SaplingDomain;
     use zcash_client_backend::{wallet::ReceivedNote, ShieldedProtocol};
     use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-    use zingo_status::confirmation_status::ConfirmationStatus::Confirmed;
+    use zingo_status::transaction_source::TransactionSource::OnChain;
 
     #[test]
     fn invalidate_all_transactions_after_or_at_height() {
         let transaction_record_later = TransactionRecordBuilder::default()
             .randomize_txid()
-            .status(Confirmed(15.into()))
+            .status(OnChain(15.into()))
             .transparent_outputs(TransparentOutputBuilder::default())
             .build();
         let spending_txid = transaction_record_later.txid;
 
         let transaction_record_early = TransactionRecordBuilder::default()
             .randomize_txid()
-            .status(Confirmed(5.into()))
+            .status(OnChain(5.into()))
             .transparent_outputs(
                 TransparentOutputBuilder::default()
                     .spent(Some((spending_txid, 15)))
@@ -859,7 +859,7 @@ mod tests {
         let mut orchard_nullifier_builder = OrchardNullifierBuilder::new();
 
         let sent_transaction_record = TransactionRecordBuilder::default()
-            .status(Confirmed(15.into()))
+            .status(OnChain(15.into()))
             .spent_sapling_nullifiers(sapling_nullifier_builder.assign_unique_nullifier().clone())
             .spent_sapling_nullifiers(sapling_nullifier_builder.assign_unique_nullifier().clone())
             .spent_orchard_nullifiers(orchard_nullifier_builder.assign_unique_nullifier().clone())
@@ -880,7 +880,7 @@ mod tests {
 
         let first_received_transaction_record = TransactionRecordBuilder::default()
             .randomize_txid()
-            .status(Confirmed(5.into()))
+            .status(OnChain(5.into()))
             .sapling_notes(spent_sapling_note_builder(
                 175_000,
                 (sent_txid, 15),
@@ -907,7 +907,7 @@ mod tests {
             .build();
         let second_received_transaction_record = TransactionRecordBuilder::default()
             .randomize_txid()
-            .status(Confirmed(7.into()))
+            .status(OnChain(7.into()))
             .orchard_notes(spent_orchard_note_builder(
                 200_000,
                 (sent_txid, 15),
@@ -955,7 +955,7 @@ mod tests {
             },
         };
 
-        use zingo_status::confirmation_status::ConfirmationStatus::Confirmed;
+        use zingo_status::transaction_source::TransactionSource::OnChain;
 
         #[test]
         fn spend_not_found() {
@@ -963,7 +963,7 @@ mod tests {
             let mut orchard_nullifier_builder = OrchardNullifierBuilder::new();
 
             let sent_transaction_record = TransactionRecordBuilder::default()
-                .status(Confirmed(15.into()))
+                .status(OnChain(15.into()))
                 .spent_sapling_nullifiers(
                     sapling_nullifier_builder.assign_unique_nullifier().clone(),
                 )
@@ -980,7 +980,7 @@ mod tests {
 
             let received_transaction_record = TransactionRecordBuilder::default()
                 .randomize_txid()
-                .status(Confirmed(5.into()))
+                .status(OnChain(5.into()))
                 .sapling_notes(
                     SaplingNoteBuilder::default()
                         .note(
@@ -1005,7 +1005,7 @@ mod tests {
         #[test]
         fn received_transaction() {
             let transaction_record = TransactionRecordBuilder::default()
-                .status(Confirmed(15.into()))
+                .status(OnChain(15.into()))
                 .transparent_outputs(TransparentOutputBuilder::default())
                 .sapling_notes(SaplingNoteBuilder::default())
                 .orchard_notes(OrchardNoteBuilder::default())
@@ -1022,7 +1022,7 @@ mod tests {
         #[test]
         fn outgoing_tx_data_but_no_spends_found() {
             let transaction_record = TransactionRecordBuilder::default()
-                .status(Confirmed(15.into()))
+                .status(OnChain(15.into()))
                 .transparent_outputs(TransparentOutputBuilder::default())
                 .sapling_notes(SaplingNoteBuilder::default())
                 .orchard_notes(OrchardNoteBuilder::default())
@@ -1040,7 +1040,7 @@ mod tests {
         #[test]
         fn transparent_spends_not_fully_synced() {
             let transaction_record = TransactionRecordBuilder::default()
-                .status(Confirmed(15.into()))
+                .status(OnChain(15.into()))
                 .orchard_notes(
                     OrchardNoteBuilder::default()
                         .note(

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -765,19 +765,28 @@ mod tests {
             [ClientOnly(1.into()), FromMempool(1.into()), OnChain(1.into())],
             [true, false])
         ]
-        fn no_txid_in_trbid(source: TransactionSource, txid_in_trbid: bool) {
+        fn no_txid_in_trbid(source: TransactionSource, fresh_trbid: bool) {
             // We'll need a trbid regardless.
             let mut trbid = TransactionRecordsById::default();
             let mut tx_builder = TransactionRecordBuilder::default();
             match source {
                 ClientOnly(_) => {
-                    todo!()
+                    if fresh_trbid {
+                        todo!()
+                    } else {
+                    }
                 }
                 FromMempool(what_is_this_height) => {
-                    todo!()
+                    if fresh_trbid {
+                        todo!()
+                    } else {
+                    }
                 }
                 OnChain(confirmation_block_height) => {
-                    todo!()
+                    if fresh_trbid {
+                        todo!()
+                    } else {
+                    }
                 }
             }
         }

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -763,8 +763,8 @@ mod tests {
         use super::*;
         #[test_matrix([true, false], [true, false])]
         fn no_txid_in_trbid(txid_in_trbid: bool, confirmed: bool) {
-            let mut trbid = TransactionRecordsById::default();
             if txid_in_trbid {
+                let mut trbid = TransactionRecordsById::default();
                 let transaction_record = TransactionRecordBuilder::default().build();
                 let txid = transaction_record.txid;
                 trbid.insert_transaction_record(transaction_record);

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -757,6 +757,15 @@ mod tests {
     use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
     use zingo_status::confirmation_status::ConfirmationStatus::Confirmed;
 
+    mod create_modify_get_transaction_metadata {
+        use test_case::test_matrix;
+
+        use super::*;
+        #[test_matrix([true, false], [true, false])]
+        fn no_txid_in_trbid(txid_in_trbid: bool, confirmed: bool) {
+            let mut transaction_records_by_id = TransactionRecordsById::default();
+        }
+    }
     #[test]
     fn invalidate_all_transactions_after_or_at_height() {
         let transaction_record_later = TransactionRecordBuilder::default()

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -757,7 +757,15 @@ mod tests {
     use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
     use zingo_status::transaction_source::TransactionSource::{ClientOnly, FromMempool, OnChain};
 
-    mod create_modify_get_transaction_metadata {
+    mod trbid_update {
+        /// The transaction_records_by_id database is a state machine that has enumerable states.
+        /// A txid can either be present with the database, or absent.
+        /// A transaction may have be:
+        ///   ClientOnly:    created locally, and not broadcast (in band)
+        ///   FromMempool:   previously been broadcast by self or other, and then read from the mempool
+        ///                  by a client that is monitoring the mempool
+        ///   OnChain:       confirmed in a block
+        /// I am not at this time making assertions about the exclusiveness of the in-pool, and on-chain states
         use super::*;
         use test_case::test_matrix;
         use zingo_status::transaction_source::TransactionSource;

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -762,14 +762,19 @@ mod tests {
         use test_case::test_matrix;
         use zingo_status::transaction_source::TransactionSource;
         #[test_matrix(
+            [ClientOnly(2.into()), FromMempool(2.into()), OnChain(2.into())],
             [ClientOnly(1.into()), FromMempool(1.into()), OnChain(1.into())],
             [true, false])
         ]
-        fn no_txid_in_trbid(source: TransactionSource, fresh_trbid: bool) {
+        fn valid_trbid_update(
+            input_tx_source: TransactionSource,
+            trbid_tx_source: TransactionSource,
+            fresh_trbid: bool,
+        ) {
             // We'll need a trbid regardless.
             let mut trbid = TransactionRecordsById::default();
             let mut tx_builder = TransactionRecordBuilder::default();
-            match source {
+            match input_tx_source {
                 ClientOnly(_) => {
                     if fresh_trbid {
                         todo!("assert expected state, insert, assert state changes")

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -755,33 +755,20 @@ mod tests {
     use sapling_crypto::note_encryption::SaplingDomain;
     use zcash_client_backend::{wallet::ReceivedNote, ShieldedProtocol};
     use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-    use zingo_status::transaction_source::TransactionSource::{FromMempool, OnChain};
+    use zingo_status::transaction_source::TransactionSource::{ClientOnly, FromMempool, OnChain};
 
     mod create_modify_get_transaction_metadata {
         use super::*;
         use test_case::test_matrix;
-        #[test_matrix([true, false], [true, false])]
-        fn no_txid_in_trbid(txid_in_trbid: bool, confirmed: bool) {
+        use zingo_status::transaction_source::TransactionSource;
+        #[test_matrix(
+            [ClientOnly(1.into()), FromMempool(1.into()), OnChain(1.into())],
+            [true, false])
+        ]
+        fn no_txid_in_trbid(source: TransactionSource, txid_in_trbid: bool) {
             // We'll need a trbid regardless.
             let mut trbid = TransactionRecordsById::default();
             let mut tx_builder = TransactionRecordBuilder::default();
-            if txid_in_trbid {
-                if confirmed {
-                    let transaction_record = tx_builder.status(OnChain(1.into())).build();
-                    trbid.insert_transaction_record(transaction_record);
-                    assert_eq!(1, 2);
-                } else if !confirmed {
-                    let transaction_record = tx_builder.status(FromMempool(1.into())).build();
-                    trbid.insert_transaction_record(transaction_record);
-                    dbg!("not confirmed, but in trbid");
-                }
-            } else if !txid_in_trbid {
-                if confirmed {
-                    dbg!("Not in trbid, but confirmed!");
-                } else if !confirmed {
-                    dbg!("Not in trbid, AND not confirmed!");
-                }
-            }
         }
     }
     #[test]

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -769,6 +769,17 @@ mod tests {
             // We'll need a trbid regardless.
             let mut trbid = TransactionRecordsById::default();
             let mut tx_builder = TransactionRecordBuilder::default();
+            match source {
+                ClientOnly(_) => {
+                    todo!()
+                }
+                FromMempool(what_is_this_height) => {
+                    todo!()
+                }
+                OnChain(confirmation_block_height) => {
+                    todo!()
+                }
+            }
         }
     }
     #[test]

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -755,23 +755,24 @@ mod tests {
     use sapling_crypto::note_encryption::SaplingDomain;
     use zcash_client_backend::{wallet::ReceivedNote, ShieldedProtocol};
     use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-    use zingo_status::confirmation_status::ConfirmationStatus::Confirmed;
+    use zingo_status::confirmation_status::ConfirmationStatus::{Confirmed, Pending};
 
     mod create_modify_get_transaction_metadata {
-        use test_case::test_matrix;
-
         use super::*;
+        use test_case::test_matrix;
         #[test_matrix([true, false], [true, false])]
         fn no_txid_in_trbid(txid_in_trbid: bool, confirmed: bool) {
+            // We'll need a trbid regardless.
+            let mut trbid = TransactionRecordsById::default();
+            let mut tx_builder = TransactionRecordBuilder::default();
             if txid_in_trbid {
-                let mut trbid = TransactionRecordsById::default();
-                let transaction_record = TransactionRecordBuilder::default().build();
-                let txid = transaction_record.txid;
-                trbid.insert_transaction_record(transaction_record);
                 if confirmed {
-                    dbg!(txid);
+                    let transaction_record = tx_builder.status(Confirmed(1.into())).build();
+                    trbid.insert_transaction_record(transaction_record);
                     assert_eq!(1, 2);
                 } else if !confirmed {
+                    let transaction_record = tx_builder.status(Pending(1.into())).build();
+                    trbid.insert_transaction_record(transaction_record);
                     dbg!("not confirmed, but in trbid");
                 }
             } else if !txid_in_trbid {

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -772,20 +772,41 @@ mod tests {
             match source {
                 ClientOnly(_) => {
                     if fresh_trbid {
-                        todo!()
+                        todo!("assert expected state, insert, assert state changes")
                     } else {
+                        todo!("throw appropriate error")
                     }
                 }
                 FromMempool(what_is_this_height) => {
                     if fresh_trbid {
-                        todo!()
+                        todo!(
+                            "assert expected state,
+                             insert,
+                             assert state changes"
+                        )
                     } else {
+                        todo!(
+                            "assert expected state,
+                             check for relationship between in trbid, and processing,
+                             handle,
+                             assert expected state"
+                        )
                     }
                 }
                 OnChain(confirmation_block_height) => {
                     if fresh_trbid {
-                        todo!()
+                        todo!(
+                            "assert expected state,
+                             insert,
+                             assert state changes"
+                        )
                     } else {
+                        todo!(
+                            "assert expected state,
+                             check for relationship between in trbid, and processing,
+                             handle,
+                             assert expected state"
+                        )
                     }
                 }
             }

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -773,7 +773,8 @@ mod tests {
         ) {
             // We'll need a trbid regardless.
             let mut trbid = TransactionRecordsById::default();
-            let mut tx_builder = TransactionRecordBuilder::default();
+            let mut input_tx_builder = TransactionRecordBuilder::default();
+            let mut in_trbid_tx_builder = TransactionRecordBuilder::default();
             match input_tx_source {
                 ClientOnly(_) => {
                     if fresh_trbid {

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/get.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/get.rs
@@ -149,25 +149,25 @@ fn test_get_some_txid_from_highest_wallet_block() {
     let txid_3 = TxId::from_bytes(txid_bytes_3);
     tms.transaction_records_by_id
         .insert_transaction_record(TransactionRecord::new(
-            zingo_status::confirmation_status::ConfirmationStatus::Pending(BlockHeight::from_u32(
-                3_200_000,
-            )),
+            zingo_status::transaction_source::TransactionSource::FromMempool(
+                BlockHeight::from_u32(3_200_000),
+            ),
             100,
             &txid_1,
         ));
     tms.transaction_records_by_id
         .insert_transaction_record(TransactionRecord::new(
-            zingo_status::confirmation_status::ConfirmationStatus::Confirmed(
-                BlockHeight::from_u32(3_000_069),
-            ),
+            zingo_status::transaction_source::TransactionSource::OnChain(BlockHeight::from_u32(
+                3_000_069,
+            )),
             0,
             &txid_2,
         ));
     tms.transaction_records_by_id
         .insert_transaction_record(TransactionRecord::new(
-            zingo_status::confirmation_status::ConfirmationStatus::Confirmed(
-                BlockHeight::from_u32(2_650_000),
-            ),
+            zingo_status::transaction_source::TransactionSource::OnChain(BlockHeight::from_u32(
+                2_650_000,
+            )),
             0,
             &txid_3,
         ));

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
@@ -5,7 +5,7 @@ use orchard::note_encryption::OrchardDomain;
 use sapling_crypto::note_encryption::SaplingDomain;
 use zcash_note_encryption::Domain;
 use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-use zingo_status::confirmation_status::ConfirmationStatus;
+use zingo_status::transaction_source::TransactionSource;
 
 use crate::{
     error::{ZingoLibError, ZingoLibResult},
@@ -45,7 +45,7 @@ impl super::TxMapAndMaybeTrees {
     pub fn found_spent_nullifier(
         &mut self,
         spending_txid: TxId,
-        status: ConfirmationStatus,
+        status: TransactionSource,
         timestamp: u32,
         spent_nullifier: PoolNullifier,
         source_txid: TxId,
@@ -79,7 +79,7 @@ impl super::TxMapAndMaybeTrees {
     fn found_spent_nullifier_internal<D: DomainWalletExt>(
         &mut self,
         spending_txid: TxId,
-        status: ConfirmationStatus,
+        status: TransactionSource,
         timestamp: u32,
         spent_nullifier: <D::WalletNote as ShieldedNoteInterface>::Nullifier,
         source_txid: TxId,
@@ -122,7 +122,7 @@ impl super::TxMapAndMaybeTrees {
         &mut self,
         spent_nullifier: <D::WalletNote as ShieldedNoteInterface>::Nullifier,
         spending_txid: TxId,
-        status: ConfirmationStatus,
+        status: TransactionSource,
         source_txid: TxId,
         output_index: Option<u32>,
     ) -> ZingoLibResult<u64>

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/trait_walletread.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/trait_walletread.rs
@@ -334,7 +334,7 @@ mod tests {
 
     use zcash_client_backend::data_api::WalletRead;
     use zcash_primitives::consensus::BlockHeight;
-    use zingo_status::confirmation_status::ConfirmationStatus::Confirmed;
+    use zingo_status::transaction_source::TransactionSource::OnChain;
 
     use crate::{
         mocks::default_txid,
@@ -404,7 +404,7 @@ mod tests {
                 .insert_transaction_record(
                     TransactionRecordBuilder::default()
                         .transparent_outputs(TransparentOutputBuilder::default())
-                        .status(Confirmed(1000000.into()))
+                        .status(OnChain(1000000.into()))
                         .build(),
                 );
             let spend = Some((default_txid(), 112358));
@@ -413,7 +413,7 @@ mod tests {
                 .insert_transaction_record(
                     TransactionRecordBuilder::default()
                         .sapling_notes(SaplingNoteBuilder::default().spent(spend).clone())
-                        .status(Confirmed(2000000.into()))
+                        .status(OnChain(2000000.into()))
                         .randomize_txid()
                         .build(),
                 );
@@ -422,7 +422,7 @@ mod tests {
                 .insert_transaction_record(
                     TransactionRecordBuilder::default()
                         .orchard_notes(OrchardNoteBuilder::default().pending_spent(spend).clone())
-                        .status(Confirmed(3000000.into()))
+                        .status(OnChain(3000000.into()))
                         .randomize_txid()
                         .build(),
                 );
@@ -433,7 +433,7 @@ mod tests {
                 .insert_transaction_record(
                     TransactionRecordBuilder::default()
                         .sapling_notes(SaplingNoteBuilder::default())
-                        .status(Confirmed(sapling_height.into()))
+                        .status(OnChain(sapling_height.into()))
                         .randomize_txid()
                         .build(),
                 );
@@ -442,7 +442,7 @@ mod tests {
                 .insert_transaction_record(
                     TransactionRecordBuilder::default()
                         .orchard_notes(OrchardNoteBuilder::default())
-                        .status(Confirmed(orchard_height.into()))
+                        .status(OnChain(orchard_height.into()))
                         .randomize_txid()
                         .build(),
                 );
@@ -454,7 +454,7 @@ mod tests {
         fn get_tx_height(tx_height: u32) {
             let mut transaction_records_and_maybe_trees = TxMapAndMaybeTrees::new_with_witness_trees_address_free();
 
-            let transaction_record = TransactionRecordBuilder::default().randomize_txid().status(Confirmed(tx_height.into()))
+            let transaction_record = TransactionRecordBuilder::default().randomize_txid().status(OnChain(tx_height.into()))
             .build();
 
             let txid = transaction_record.txid;


### PR DESCRIPTION
To represent local- or client-only state (usually during creation)