### PR TITLE
Fix update output index hang

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -154,17 +154,14 @@ mod fast {
             .output_index_mut() = None;
 
         let tx_summaries = recipient.transaction_summaries().await.0;
-        assert_eq!(tx_summaries[0].orchard_notes()[0].output_index(), None);
+        assert!(tx_summaries[0].orchard_notes()[0].output_index().is_none());
 
         increase_height_and_wait_for_client(&regtest_manager, &recipient, 1)
             .await
             .unwrap();
 
         let tx_summaries = recipient.transaction_summaries().await.0;
-        assert!(matches!(
-            tx_summaries[0].orchard_notes()[0].output_index(),
-            Some(_)
-        ));
+        assert!(tx_summaries[0].orchard_notes()[0].output_index().is_some());
     }
 
     #[tokio::test]

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -129,9 +129,43 @@ mod fast {
     use zcash_primitives::transaction::components::amount::NonNegativeAmount;
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingo_testutils::lightclient::from_inputs;
-    use zingolib::wallet::WalletBase;
+    use zingolib::{
+        utils::conversion::txid_from_hex_encoded_str,
+        wallet::{notes::ShieldedNoteInterface, WalletBase},
+    };
 
     use super::*;
+
+    #[tokio::test]
+    async fn targetted_rescan() {
+        let (regtest_manager, _cph, _faucet, recipient, txid) =
+            scenarios::orchard_funded_recipient(100_000).await;
+
+        *recipient
+            .wallet
+            .transaction_context
+            .transaction_metadata_set
+            .write()
+            .await
+            .transaction_records_by_id
+            .get_mut(&txid_from_hex_encoded_str(&txid).unwrap())
+            .unwrap()
+            .orchard_notes[0]
+            .output_index_mut() = None;
+
+        let tx_summaries = recipient.transaction_summaries().await.0;
+        assert_eq!(tx_summaries[0].orchard_notes()[0].output_index(), None);
+
+        increase_height_and_wait_for_client(&regtest_manager, &recipient, 1)
+            .await
+            .unwrap();
+
+        let tx_summaries = recipient.transaction_summaries().await.0;
+        assert!(matches!(
+            tx_summaries[0].orchard_notes()[0].output_index(),
+            Some(_)
+        ));
+    }
 
     #[tokio::test]
     async fn received_tx_status_pending_to_confirmed_with_mempool_monitor() {

--- a/zingolib/src/blaze.rs
+++ b/zingolib/src/blaze.rs
@@ -3,12 +3,10 @@
 pub(super) mod block_management_reorg_detection;
 pub(super) mod fetch_compact_blocks;
 pub(super) mod fetch_taddr_transactions;
-/// alternative name: daemon_for_txid_lookup_and_record_updates
-/// this function can update a few details about a TransactionRecord. it has numerous gaps
-/// It is the closest thing Zingo has to conditional rescan. it needs to be conditional rescan. as of this git commit 41cf89b it is not.
 pub(super) mod full_transactions_processor;
 pub(super) mod sync_status;
 pub(super) mod syncdata;
+pub(super) mod targetted_rescan;
 pub(super) mod trial_decryptions;
 pub(super) mod update_notes;
 

--- a/zingolib/src/blaze/full_transactions_processor.rs
+++ b/zingolib/src/blaze/full_transactions_processor.rs
@@ -95,7 +95,7 @@ pub async fn start(
 
                 let status = ConfirmationStatus::Confirmed(height);
                 per_txid_iter_context
-                    .scan_full_tx(&transaction, status, block_time, None)
+                    .scan_full_tx(&transaction, status, Some(block_time), None)
                     .await;
 
                 Ok::<_, String>(())
@@ -135,7 +135,7 @@ pub async fn start(
                 .await;
             let status = ConfirmationStatus::Confirmed(height);
             transaction_context
-                .scan_full_tx(&transaction, status, block_time, None)
+                .scan_full_tx(&transaction, status, Some(block_time), None)
                 .await;
         }
 

--- a/zingolib/src/blaze/targetted_rescan.rs
+++ b/zingolib/src/blaze/targetted_rescan.rs
@@ -1,0 +1,64 @@
+use crate::wallet::{data::BlockData, transaction_context::TransactionContext};
+use futures::{stream::FuturesUnordered, StreamExt};
+
+use std::sync::Arc;
+use tokio::{
+    sync::{mpsc::UnboundedSender, oneshot, RwLock},
+    task::JoinHandle,
+};
+
+use zcash_primitives::{
+    consensus::BlockHeight,
+    transaction::{Transaction, TxId},
+};
+
+use zingo_status::confirmation_status::ConfirmationStatus;
+
+pub async fn start(
+    wallet_blocks: Arc<RwLock<Vec<BlockData>>>,
+    transaction_context: TransactionContext,
+    fulltx_fetcher: UnboundedSender<(TxId, oneshot::Sender<Result<Transaction, String>>)>,
+) -> JoinHandle<Result<(), String>> {
+    tokio::spawn(async move {
+        let mut workers = FuturesUnordered::new();
+
+        // collect any outdated transaction records that are incomplete and missing output indexes
+        let unindexed_records_result =
+            if let Some(highest_wallet_block) = wallet_blocks.read().await.first() {
+                transaction_context
+                    .unindexed_records(BlockHeight::from_u32(highest_wallet_block.height as u32))
+                    .await
+            } else {
+                Ok(())
+            };
+
+        // fetch and re-scan incomplete transactions
+        if let Err(incomplete_transaction_txids) = unindexed_records_result {
+            for (txid, height) in incomplete_transaction_txids {
+                let fulltx_fetcher_sub = fulltx_fetcher.clone();
+                let transaction_context_sub = transaction_context.clone();
+                workers.push(tokio::spawn(async move {
+                    let transaction = {
+                        // Fetch the TxId from LightwalletD and process all the parts of it.
+                        let (transmitter, receiver) = oneshot::channel();
+                        fulltx_fetcher_sub.send((txid, transmitter)).unwrap();
+                        receiver.await.unwrap()?
+                    };
+
+                    let status = ConfirmationStatus::Confirmed(height);
+                    transaction_context_sub
+                        .scan_full_tx(&transaction, status, None, None)
+                        .await;
+
+                    Ok::<_, String>(())
+                }));
+            }
+        }
+
+        while let Some(r) = workers.next().await {
+            r.map_err(|r| r.to_string())??;
+        }
+
+        Ok(())
+    })
+}

--- a/zingolib/src/blaze/trial_decryptions.rs
+++ b/zingolib/src/blaze/trial_decryptions.rs
@@ -310,7 +310,7 @@ impl TrialDecryptions {
                     let bsync_data = bsync_data.clone();
                     let transaction_metadata_set = transaction_metadata_set.clone();
                     let detected_transaction_id_sender = detected_transaction_id_sender.clone();
-                    let timestamp = compact_block.time as u64;
+                    let timestamp = compact_block.time;
                     let config = config.clone();
 
                     workers.push(tokio::spawn(async move {
@@ -351,7 +351,7 @@ impl TrialDecryptions {
                             .add_new_note::<D>(
                                 transaction_id,
                                 status,
-                                timestamp,
+                                Some(timestamp),
                                 note,
                                 to,
                                 have_spending_key,

--- a/zingolib/src/blaze/update_notes.rs
+++ b/zingolib/src/blaze/update_notes.rs
@@ -139,7 +139,7 @@ impl UpdateNotes {
                         wallet_transactions_write_unlocked.found_spent_nullifier(
                             transaction_id_spent_in,
                             status,
-                            ts,
+                            Some(ts),
                             maybe_spend_nullifier,
                             transaction_id_spent_from,
                             output_index,

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -205,7 +205,7 @@ impl LightClient {
                             .scan_full_tx(
                                 &transaction,
                                 status,
-                                now() as u32,
+                                Some(now() as u32),
                                 get_price(now(), &price),
                             )
                             .await;
@@ -430,7 +430,7 @@ impl LightClient {
             self.wallet.transactions(),
         );
 
-        // fv believes that sending either a transaction or a txid along the txid_sender or full_transaction_sender will result in a scan.
+        // Fetches full transactions only in the batch currently being processed
         let (fetch_full_transactions_handle, txid_sender, full_transaction_sender) =
             crate::blaze::full_transactions_processor::start(
                 transaction_context.clone(),
@@ -438,20 +438,6 @@ impl LightClient {
                 bsync_data.clone(),
             )
             .await;
-
-        // targetted_rescan to update missing output indices
-        if let Some(latest_block) = self.wallet.blocks.read().await.first() {
-            // collect any outdated transaction record that are incomplete and missing output indexes
-            let result = transaction_context
-                .unindexed_records(BlockHeight::from_u32(latest_block.height as u32))
-                .await;
-            // send those TxIds to the newly created output scanner
-            if let Err(incomplete_txids_and_heights) = result {
-                incomplete_txids_and_heights
-                    .into_iter()
-                    .for_each(|t| txid_sender.send(t).unwrap());
-            }
-        }
 
         // The processor to process Transactions detected by the trial decryptions processor
         let update_notes_processor = UpdateNotes::new(self.wallet.transactions());
@@ -475,7 +461,7 @@ impl LightClient {
                     .read()
                     .await
                     .transaction_size_filter,
-                full_transaction_fetcher_transmitter,
+                full_transaction_fetcher_transmitter.clone(),
             )
             .await;
 
@@ -522,7 +508,15 @@ impl LightClient {
         // 2. Notify the notes updater that the blocks are done updating
         blocks_done_transmitter.send(earliest_block).unwrap();
 
-        // 3. Verify all the downloaded data
+        // 3. Targetted rescan to update transactions with missing information
+        let targetted_rescan_handle = crate::blaze::targetted_rescan::start(
+            self.wallet.blocks.clone(),
+            transaction_context,
+            full_transaction_fetcher_transmitter,
+        )
+        .await;
+
+        // 4. Verify all the downloaded data
         let block_data = bsync_data.clone();
 
         // Wait for everything to finish
@@ -544,6 +538,7 @@ impl LightClient {
             taddr_transactions_handle,
             fetch_compact_blocks_handle,
             fetch_full_transactions_handle,
+            targetted_rescan_handle,
             r1,
         ])
         .await

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -841,7 +841,12 @@ impl LightWallet {
 
             let status = ConfirmationStatus::Pending(submission_height);
             self.transaction_context
-                .scan_full_tx(transaction, status, now() as u32, get_price(now(), &price))
+                .scan_full_tx(
+                    transaction,
+                    status,
+                    Some(now() as u32),
+                    get_price(now(), &price),
+                )
                 .await;
         }
 

--- a/zingolib/src/wallet/transaction_context.rs
+++ b/zingolib/src/wallet/transaction_context.rs
@@ -99,7 +99,7 @@ pub mod decrypt_transaction {
             &self,
             transaction: &Transaction,
             status: ConfirmationStatus,
-            block_time: u32,
+            block_time: Option<u32>, // block_time should only be None when re-scanning a tx that already exists in the wallet
             price: Option<f64>,
         ) {
             // Set up data structures to record scan results
@@ -179,7 +179,7 @@ pub mod decrypt_transaction {
             &self,
             transaction: &Transaction,
             status: ConfirmationStatus,
-            block_time: u32,
+            block_time: Option<u32>,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,
             taddrs_set: &HashSet<String>,
@@ -215,7 +215,7 @@ pub mod decrypt_transaction {
             &self,
             transaction: &Transaction,
             status: ConfirmationStatus,
-            block_time: u32,
+            block_time: Option<u32>,
             taddrs_set: &HashSet<String>,
         ) {
             // Scan all transparent outputs to see if we received any money
@@ -233,7 +233,7 @@ pub mod decrypt_transaction {
                                     transaction.txid(),
                                     output_taddr.clone(),
                                     status,
-                                    block_time as u64,
+                                    block_time,
                                     vout,
                                     n as u32,
                                 );
@@ -299,7 +299,7 @@ pub mod decrypt_transaction {
                     .add_taddr_spent(
                         transaction.txid(),
                         status,
-                        block_time as u64,
+                        block_time,
                         total_transparent_value_spent,
                     );
             }
@@ -364,7 +364,7 @@ pub mod decrypt_transaction {
             &self,
             transaction: &Transaction,
             status: ConfirmationStatus,
-            block_time: u32,
+            block_time: Option<u32>,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,
         ) {
@@ -383,7 +383,7 @@ pub mod decrypt_transaction {
             &self,
             transaction: &Transaction,
             status: ConfirmationStatus,
-            block_time: u32,
+            block_time: Option<u32>,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,
         ) {
@@ -407,7 +407,7 @@ pub mod decrypt_transaction {
             &self,
             transaction: &Transaction,
             status: ConfirmationStatus,
-            block_time: u32,
+            block_time: Option<u32>,
             outgoing_metadatas: &mut Vec<OutgoingTxData>,
             arbitrary_memos_with_txids: &mut Vec<(ParsedMemo, TxId)>,
         ) {
@@ -490,7 +490,7 @@ pub mod decrypt_transaction {
                         .add_pending_note::<D>(
                             transaction.txid(),
                             height,
-                            block_time as u64,
+                            block_time,
                             note.clone(),
                             to,
                             output_index,
@@ -503,7 +503,7 @@ pub mod decrypt_transaction {
                         .update_output_index::<D>(
                             transaction.txid(),
                             status,
-                            block_time as u64,
+                            block_time,
                             note.clone(),
                             output_index,
                         )

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/recording.rs
@@ -46,7 +46,7 @@ impl super::TxMapAndMaybeTrees {
         &mut self,
         spending_txid: TxId,
         status: ConfirmationStatus,
-        timestamp: u32,
+        timestamp: Option<u32>,
         spent_nullifier: PoolNullifier,
         source_txid: TxId,
         output_index: Option<u32>,
@@ -80,7 +80,7 @@ impl super::TxMapAndMaybeTrees {
         &mut self,
         spending_txid: TxId,
         status: ConfirmationStatus,
-        timestamp: u32,
+        timestamp: Option<u32>,
         spent_nullifier: <D::WalletNote as ShieldedNoteInterface>::Nullifier,
         source_txid: TxId,
         output_index: Option<u32>,
@@ -101,7 +101,7 @@ impl super::TxMapAndMaybeTrees {
         // Record this Tx as having spent some funds
         let transaction_metadata = self
             .transaction_records_by_id
-            .create_modify_get_transaction_metadata(&spending_txid, status, timestamp as u64);
+            .create_modify_get_transaction_metadata(&spending_txid, status, timestamp);
 
         if !<D::WalletNote as ShieldedNoteInterface>::Nullifier::get_nullifiers_spent_in_transaction(
             transaction_metadata,


### PR DESCRIPTION
- moves targetted rescan to its own function with tokio tasks and joins handle with other sync tasks
- uses the full tx fetcher sender instead of fetch full tx sender as fetch full tx can only scan transactions in the current batch or will hang
- adds a targetted rescan test where the output index is missing and is recovered
- unifies timestamps in sync functions to u32 which is the original data type from the compact block itself