### PR TITLE
Fix for error: use of undeclared crate or module `zingo_sync`

### DIFF
--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -14,6 +14,9 @@ test-elevation = ["portpicker", "testvectors", "tempfile", "tempdir"]
 testvectors = []
 tempfile = ["dep:tempfile"]
 sync = [ "dep:zingo-sync" ]
+default = ["zingo-sync"]
+zingo-sync = ['dep:zingo-sync']
+
 
 [dependencies]
 zingo-memo = { path = "../zingo-memo" }


### PR DESCRIPTION
When compiling from source per README, I cant compile. Verified on both my pi and linux pc.

## Steps to reproduce

``` bash
 git clone --recurse-submodules https://github.com/zingolabs/zingolib.git
 cd zingolib
 cargo build --release --package zingo-cli
```

## Error
![error](https://github.com/user-attachments/assets/f2bbc996-dbec-4bbb-81a5-aa09cdafb143)

## Fix

#### in Cargo.toml

``` markdown
default = ["zingo-sync"]
zingo-sync = ['dep:zingo-sync']
```