### PR TITLE
set nextest install action to v2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,10 @@ jobs:
           toolchain: stable
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+          version: 0.9.78
 
       - name: Install protoc
         run: sudo apt-get install protobuf-compiler


### PR DESCRIPTION
I explicitly set nextest to be the version that I am running locally.
Running CI to check for non-breaking update.