### PR TITLE
specify version info in the rust-toolchain.toml, and not elsewhere

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Install protoc
         run: sudo apt-get install protobuf-compiler

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Install nextest
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
This README indicates that the rust-toolchain.toml file will be used:

https://github.com/actions-rust-lang/setup-rust-toolchain?tab=readme-ov-file#inputs