### PR TITLE
add tex address arm as todo

### DIFF
--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -242,6 +242,7 @@ impl Command for ParseAddressCommand {
                                 "receivers_available" => receivers_available,
                             }
                         }
+                        Address::Tex(_) => todo!(),
                     }
                 }),
                 4,


### PR DESCRIPTION
solves this build error:

error[E0004]: non-exhaustive patterns: `zcash_client_backend::address::Address::Tex(_)` not covered
   --> zingolib/src/commands.rs:216:27
    |
216 |                     match recipient_address {
    |                           ^^^^^^^^^^^^^^^^^ pattern `zcash_client_backend::address::Address::Tex(_)` not covered
    |
note: `zcash_client_backend::address::Address` defined here
   --> /home/oscar/.cargo/git/checkouts/librustzcash-2a71d81ac8756eb7/53331a3/zcash_keys/src/address.rs:295:1
    |
295 | pub enum Address {
    | ^^^^^^^^^^^^^^^^
...
311 |     Tex([u8; 20]),
    |     --- not covered
    = note: the matched value is of type `zcash_client_backend::address::Address`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
244 ~                         },
245 +                         zcash_client_backend::address::Address::Tex(_) => todo!()
    |