### PR TITLE
add nu6 network variant as todo

### DIFF
--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -665,6 +665,7 @@ impl RegtestNetwork {
                 self.activation_heights
                     .get_activation_height(NetworkUpgrade::Nu5),
             ),
+            NetworkUpgrade::Nu6 => todo!(),
         }
     }
 }
@@ -709,6 +710,7 @@ impl ActivationHeights {
             NetworkUpgrade::Heartwood => self.heartwood,
             NetworkUpgrade::Canopy => self.canopy,
             NetworkUpgrade::Nu5 => self.orchard,
+            NetworkUpgrade::Nu6 => todo!(),
         }
     }
 }


### PR DESCRIPTION
solve build error:

error[E0004]: non-exhaustive patterns: `NetworkUpgrade::Nu6` not covered
   --> zingolib/src/config.rs:643:15
    |
643 |         match nu {
    |               ^^ pattern `NetworkUpgrade::Nu6` not covered
    |
note: `NetworkUpgrade` defined here
   --> /home/oscar/.cargo/git/checkouts/librustzcash-2a71d81ac8756eb7/53331a3/components/zcash_protocol/src/consensus.rs:425:1
    |
425 | pub enum NetworkUpgrade {
    | ^^^^^^^^^^^^^^^^^^^^^^^
...
453 |     Nu6,
    |     --- not covered
    = note: the matched value is of type `NetworkUpgrade`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
667 ~             ),
668 ~             NetworkUpgrade::Nu6 => todo!(),
    |

error[E0004]: non-exhaustive patterns: `NetworkUpgrade::Nu6` not covered
   --> zingolib/src/config.rs:705:15
    |
705 |         match network_upgrade {
    |               ^^^^^^^^^^^^^^^ pattern `NetworkUpgrade::Nu6` not covered
    |
note: `NetworkUpgrade` defined here
   --> /home/oscar/.cargo/git/checkouts/librustzcash-2a71d81ac8756eb7/53331a3/components/zcash_protocol/src/consensus.rs:425:1
    |
425 | pub enum NetworkUpgrade {
    | ^^^^^^^^^^^^^^^^^^^^^^^
...
453 |     Nu6,
    |     --- not covered
    = note: the matched value is of type `NetworkUpgrade`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
711 ~             NetworkUpgrade::Nu5 => self.orchard,
712 ~             NetworkUpgrade::Nu6 => todo!(),
    |