### PR TITLE
Lrz update replace address with zcash address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4043,7 +4043,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.4.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "bech32",
  "bs58",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "base64 0.21.7",
  "bech32",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "bech32",
  "bip32",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "aes",
  "bip32",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "document-features",
  "memuse",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#4487437e069e9e31a7bef9f0bbad3a0f34f7ff25"
 dependencies = [
  "base64 0.21.7",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4043,7 +4043,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.4.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "bech32",
  "bs58",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "base64 0.21.7",
  "bech32",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "bech32",
  "bip32",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "aes",
  "bip32",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "document-features",
  "memuse",
@@ -4401,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#eb7caef5735ca918151955a376dc19863975f5c3"
 dependencies = [
  "base64 0.21.7",
  "nom",

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -12,7 +12,6 @@ use std::convert::TryInto;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
 use zcash_address::unified::{Container, Encoding, Ufvk};
-use zcash_client_backend::address::Address;
 use zcash_primitives::consensus::Parameters;
 use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 use zcash_primitives::transaction::fees::zip317::MINIMUM_FEE;
@@ -177,79 +176,80 @@ impl Command for InterruptCommand {
     }
 }
 
-struct ParseAddressCommand {}
-impl Command for ParseAddressCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r#"
-            Parse an address
-            Usage:
-            parse_address [address]
+// FIXME: re-implement this command or remove
+// struct ParseAddressCommand {}
+// impl Command for ParseAddressCommand {
+//     fn help(&self) -> &'static str {
+//         indoc! {r#"
+//             Parse an address
+//             Usage:
+//             parse_address [address]
 
-            Example
-            parse_address tmSwk8bjXdCgBvpS8Kybk5nUyE21QFcDqre
-        "#}
-    }
+//             Example
+//             parse_address tmSwk8bjXdCgBvpS8Kybk5nUyE21QFcDqre
+//         "#}
+//     }
 
-    fn short_help(&self) -> &'static str {
-        "Parse an address"
-    }
+//     fn short_help(&self) -> &'static str {
+//         "Parse an address"
+//     }
 
-    fn exec(&self, args: &[&str], _lightclient: &LightClient) -> String {
-        match args.len() {
-            1 => json::stringify_pretty(
-                [
-                    crate::config::ChainType::Mainnet,
-                    crate::config::ChainType::Testnet,
-                    crate::config::ChainType::Regtest(
-                        crate::config::RegtestNetwork::all_upgrades_active(),
-                    ),
-                ]
-                .iter()
-                .find_map(|chain| Address::decode(chain, args[0]).zip(Some(chain)))
-                .map(|(recipient_address, chain_name)| {
-                    let chain_name_string = match chain_name {
-                        crate::config::ChainType::Mainnet => "main",
-                        crate::config::ChainType::Testnet => "test",
-                        crate::config::ChainType::Regtest(_) => "regtest",
-                    };
+//     fn exec(&self, args: &[&str], _lightclient: &LightClient) -> String {
+//         match args.len() {
+//             1 => json::stringify_pretty(
+//                 [
+//                     crate::config::ChainType::Mainnet,
+//                     crate::config::ChainType::Testnet,
+//                     crate::config::ChainType::Regtest(
+//                         crate::config::RegtestNetwork::all_upgrades_active(),
+//                     ),
+//                 ]
+//                 .iter()
+//                 .find_map(|chain| Address::decode(chain, args[0]).zip(Some(chain)))
+//                 .map(|(recipient_address, chain_name)| {
+//                     let chain_name_string = match chain_name {
+//                         crate::config::ChainType::Mainnet => "main",
+//                         crate::config::ChainType::Testnet => "test",
+//                         crate::config::ChainType::Regtest(_) => "regtest",
+//                     };
 
-                    match recipient_address {
-                        Address::Sapling(_) => object! {
-                            "status" => "success",
-                            "chain_name" => chain_name_string,
-                            "address_kind" => "sapling",
-                        },
-                        Address::Transparent(_) => object! {
-                            "status" => "success",
-                            "chain_name" => chain_name_string,
-                            "address_kind" => "transparent",
-                        },
-                        Address::Unified(ua) => {
-                            let mut receivers_available = vec![];
-                            if ua.orchard().is_some() {
-                                receivers_available.push("orchard")
-                            }
-                            if ua.sapling().is_some() {
-                                receivers_available.push("sapling")
-                            }
-                            if ua.transparent().is_some() {
-                                receivers_available.push("transparent")
-                            }
-                            object! {
-                                "status" => "success",
-                                "chain_name" => chain_name_string,
-                                "address_kind" => "unified",
-                                "receivers_available" => receivers_available,
-                            }
-                        }
-                    }
-                }),
-                4,
-            ),
-            _ => self.help().to_string(),
-        }
-    }
-}
+//                     match recipient_address {
+//                         Address::Sapling(_) => object! {
+//                             "status" => "success",
+//                             "chain_name" => chain_name_string,
+//                             "address_kind" => "sapling",
+//                         },
+//                         Address::Transparent(_) => object! {
+//                             "status" => "success",
+//                             "chain_name" => chain_name_string,
+//                             "address_kind" => "transparent",
+//                         },
+//                         Address::Unified(ua) => {
+//                             let mut receivers_available = vec![];
+//                             if ua.orchard().is_some() {
+//                                 receivers_available.push("orchard")
+//                             }
+//                             if ua.sapling().is_some() {
+//                                 receivers_available.push("sapling")
+//                             }
+//                             if ua.transparent().is_some() {
+//                                 receivers_available.push("transparent")
+//                             }
+//                             object! {
+//                                 "status" => "success",
+//                                 "chain_name" => chain_name_string,
+//                                 "address_kind" => "unified",
+//                                 "receivers_available" => receivers_available,
+//                             }
+//                         }
+//                     }
+//                 }),
+//                 4,
+//             ),
+//             _ => self.help().to_string(),
+//         }
+//     }
+// }
 
 struct ParseViewKeyCommand {}
 impl Command for ParseViewKeyCommand {
@@ -623,16 +623,15 @@ impl Command for SpendableBalanceCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        let (address, zennies_for_zingo) =
-            match parse_spendable_balance_args(args, &lightclient.config.chain) {
-                Ok(address_and_zennies) => address_and_zennies,
-                Err(e) => {
-                    return format!(
-                        "Error: {}\nTry 'help spendablebalance' for correct usage and examples.",
-                        e
-                    );
-                }
-            };
+        let (address, zennies_for_zingo) = match parse_spendable_balance_args(args) {
+            Ok(address_and_zennies) => address_and_zennies,
+            Err(e) => {
+                return format!(
+                    "Error: {}\nTry 'help spendablebalance' for correct usage and examples.",
+                    e
+                );
+            }
+        };
         RT.block_on(async move {
             match lightclient
                 .get_spendable_shielded_balance(address, zennies_for_zingo)
@@ -836,7 +835,7 @@ impl Command for SendCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        let receivers = match utils::parse_send_args(args, &lightclient.config().chain) {
+        let receivers = match utils::parse_send_args(args) {
             Ok(receivers) => receivers,
             Err(e) => {
                 return format!(
@@ -900,16 +899,15 @@ impl Command for SendAllCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        let (address, zennies_for_zingo, memo) =
-            match utils::parse_send_all_args(args, &lightclient.config().chain) {
-                Ok(parse_results) => parse_results,
-                Err(e) => {
-                    return format!(
-                        "Error: {}\nTry 'help sendall' for correct usage and examples.",
-                        e
-                    )
-                }
-            };
+        let (address, zennies_for_zingo, memo) = match utils::parse_send_all_args(args) {
+            Ok(parse_results) => parse_results,
+            Err(e) => {
+                return format!(
+                    "Error: {}\nTry 'help sendall' for correct usage and examples.",
+                    e
+                )
+            }
+        };
         RT.block_on(async move {
             match lightclient
                 .propose_send_all(address, zennies_for_zingo, memo)
@@ -961,7 +959,7 @@ impl Command for QuickSendCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        let receivers = match utils::parse_send_args(args, &lightclient.config().chain) {
+        let receivers = match utils::parse_send_args(args) {
             Ok(receivers) => receivers,
             Err(e) => {
                 return format!(
@@ -1709,7 +1707,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         ("syncstatus", Box::new(SyncStatusCommand {})),
         ("encryptmessage", Box::new(EncryptMessageCommand {})),
         ("decryptmessage", Box::new(DecryptMessageCommand {})),
-        ("parse_address", Box::new(ParseAddressCommand {})),
+        // ("parse_address", Box::new(ParseAddressCommand {})),
         ("parse_viewkey", Box::new(ParseViewKeyCommand {})),
         ("interrupt_sync_after_batch", Box::new(InterruptCommand {})),
         ("changeserver", Box::new(ChangeServerCommand {})),

--- a/zingolib/src/data.rs
+++ b/zingolib/src/data.rs
@@ -4,10 +4,10 @@ pub mod witness_trees;
 
 /// transforming data related to the destination of a send.
 pub mod receivers {
+    use zcash_address::ZcashAddress;
     use zcash_client_backend::zip321::Payment;
     use zcash_client_backend::zip321::TransactionRequest;
     use zcash_client_backend::zip321::Zip321Error;
-    use zcash_keys::address;
     use zcash_primitives::memo::MemoBytes;
     use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
@@ -17,14 +17,14 @@ pub mod receivers {
     /// The superficial representation of the the consumer's intended receiver
     #[derive(Clone, Debug, PartialEq)]
     pub struct Receiver {
-        pub(crate) recipient_address: address::Address,
+        pub(crate) recipient_address: ZcashAddress,
         pub(crate) amount: NonNegativeAmount,
         pub(crate) memo: Option<MemoBytes>,
     }
     impl Receiver {
         /// Create a new Receiver
         pub fn new(
-            recipient_address: address::Address,
+            recipient_address: ZcashAddress,
             amount: NonNegativeAmount,
             memo: Option<MemoBytes>,
         ) -> Self {
@@ -37,14 +37,16 @@ pub mod receivers {
     }
     impl From<Receiver> for Payment {
         fn from(receiver: Receiver) -> Self {
-            Self {
-                recipient_address: receiver.recipient_address,
-                amount: receiver.amount,
-                memo: receiver.memo,
-                label: None,
-                message: None,
-                other_params: vec![],
-            }
+            // FIXME: handle without_memo cases and remove unwrap
+            Payment::new(
+                receiver.recipient_address,
+                receiver.amount,
+                receiver.memo,
+                None,
+                None,
+                vec![],
+            )
+            .unwrap()
         }
     }
 

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -1,5 +1,6 @@
 //! LightClient function do_propose generates a proposal to send to specified addresses.
 
+use zcash_address::ZcashAddress;
 use zcash_client_backend::zip321::TransactionRequest;
 use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
@@ -7,7 +8,6 @@ use crate::config::ZENNIES_FOR_ZINGO_AMOUNT;
 use crate::config::ZENNIES_FOR_ZINGO_DONATION_ADDRESS;
 use crate::wallet::propose::{ProposeSendError, ProposeShieldError};
 
-use crate::config::ChainType;
 use crate::data::proposal::ProportionalFeeProposal;
 use crate::data::proposal::ProportionalFeeShieldProposal;
 use crate::data::proposal::ZingoProposal;
@@ -17,11 +17,8 @@ use crate::lightclient::LightClient;
 
 fn append_zingo_zenny_receiver(receivers: &mut Vec<Receiver>) {
     let dev_donation_receiver = Receiver::new(
-        crate::utils::conversion::address_from_str(
-            ZENNIES_FOR_ZINGO_DONATION_ADDRESS,
-            &ChainType::Mainnet,
-        )
-        .expect("Hard coded str"),
+        crate::utils::conversion::address_from_str(ZENNIES_FOR_ZINGO_DONATION_ADDRESS)
+            .expect("Hard coded str"),
         NonNegativeAmount::from_u64(ZENNIES_FOR_ZINGO_AMOUNT).expect("Hard coded u64."),
         None,
     );
@@ -49,7 +46,7 @@ impl LightClient {
     /// Creates and stores a proposal for sending all shielded funds to a given address.
     pub async fn propose_send_all(
         &self,
-        address: zcash_keys::address::Address,
+        address: ZcashAddress,
         zennies_for_zingo: bool,
         memo: Option<zcash_primitives::memo::MemoBytes>,
     ) -> Result<ProportionalFeeProposal, ProposeSendError> {
@@ -83,7 +80,7 @@ impl LightClient {
     // TODO: move spendable balance and create proposal to wallet layer
     pub async fn get_spendable_shielded_balance(
         &self,
-        address: zcash_keys::address::Address,
+        address: ZcashAddress,
         zennies_for_zingo: bool,
     ) -> Result<NonNegativeAmount, ProposeSendError> {
         let confirmed_shielded_balance = self

--- a/zingolib/src/mocks.rs
+++ b/zingolib/src/mocks.rs
@@ -350,18 +350,17 @@ pub mod proposal {
     use sapling_crypto::value::NoteValue;
 
     use sapling_crypto::Rseed;
+    use zcash_address::ZcashAddress;
     use zcash_client_backend::fees::TransactionBalance;
     use zcash_client_backend::proposal::{Proposal, ShieldedInputs, Step, StepOutput};
     use zcash_client_backend::wallet::{ReceivedNote, WalletTransparentOutput};
     use zcash_client_backend::zip321::{Payment, TransactionRequest};
     use zcash_client_backend::{PoolType, ShieldedProtocol};
-    use zcash_keys::address::Address;
     use zcash_primitives::consensus::BlockHeight;
     use zcash_primitives::transaction::{
         components::amount::NonNegativeAmount, fees::zip317::FeeRule,
     };
 
-    use crate::config::{ChainType, RegtestNetwork};
     use zcash_client_backend::wallet::NoteId;
 
     use crate::utils::conversion::address_from_str;
@@ -572,7 +571,7 @@ pub mod proposal {
     /// let payment = PaymentBuilder::default().build();
     /// ````
     pub struct PaymentBuilder {
-        recipient_address: Option<Address>,
+        recipient_address: Option<ZcashAddress>,
         amount: Option<NonNegativeAmount>,
     }
 
@@ -585,7 +584,7 @@ pub mod proposal {
             }
         }
 
-        build_method!(recipient_address, Address);
+        build_method!(recipient_address, ZcashAddress);
         build_method!(amount, NonNegativeAmount);
 
         /// Builds after all fields have been set.
@@ -603,11 +602,7 @@ pub mod proposal {
             let mut builder = Self::new();
             builder
                 .recipient_address(
-                    address_from_str(
-                        crate::testvectors::REG_O_ADDR_FROM_ABANDONART,
-                        &ChainType::Regtest(RegtestNetwork::all_upgrades_active()),
-                    )
-                    .unwrap(),
+                    address_from_str(crate::testvectors::REG_O_ADDR_FROM_ABANDONART).unwrap(),
                 )
                 .amount(NonNegativeAmount::from_u64(100_000).unwrap());
             builder

--- a/zingolib/src/utils/conversion.rs
+++ b/zingolib/src/utils/conversion.rs
@@ -2,10 +2,8 @@
 
 use thiserror::Error;
 
-use zcash_client_backend::address::Address;
+use zcash_address::ZcashAddress;
 use zcash_primitives::transaction::{components::amount::NonNegativeAmount, TxId};
-
-use crate::config::ChainType;
 
 use super::error::ConversionError;
 
@@ -29,10 +27,9 @@ pub fn txid_from_hex_encoded_str(txid: &str) -> Result<TxId, TxIdFromHexEncodedS
     Ok(TxId::from_bytes(txid_bytes))
 }
 
-/// Convert a &str to an Address
-pub fn address_from_str(address: &str, chain: &ChainType) -> Result<Address, ConversionError> {
-    Address::decode(chain, address)
-        .ok_or_else(|| ConversionError::InvalidAddress(address.to_string()))
+/// Convert a &str to a ZcashAddress
+pub fn address_from_str(address: &str) -> Result<ZcashAddress, ConversionError> {
+    Ok(ZcashAddress::try_from_encoded(address)?)
 }
 
 /// Convert a valid u64 into Zatoshis.

--- a/zingolib/src/utils/error.rs
+++ b/zingolib/src/utils/error.rs
@@ -3,27 +3,25 @@
 use std::fmt;
 
 /// The error type for conversion errors.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum ConversionError {
     /// Failed to decode hex
     DecodeHexFailed(hex::FromHexError),
     /// Invalid string length
     InvalidStringLength,
     /// Invalid recipient address
-    InvalidAddress(String),
+    InvalidAddress(#[from] zcash_address::ParseError),
     /// Amount is outside the valid range of zatoshis
     OutsideValidRange,
 }
-
-impl std::error::Error for ConversionError {}
 
 impl fmt::Display for ConversionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ConversionError::DecodeHexFailed(e) => write!(f, "failed to decode hex. {}", e),
             ConversionError::InvalidStringLength => write!(f, "invalid string length"),
-            ConversionError::InvalidAddress(address) => {
-                write!(f, "invalid recipient address. {}", address)
+            ConversionError::InvalidAddress(e) => {
+                write!(f, "invalid recipient address. {}", e)
             }
             ConversionError::OutsideValidRange => {
                 write!(f, "amount is outside the valid range of zatoshis")

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -282,8 +282,8 @@ pub(crate) fn change_memo_from_transaction_request(request: &TransactionRequest)
 mod tests {
     use std::str::FromStr;
 
-    use crate::config::ChainType;
-    use zcash_client_backend::{address::Address, zip321::TransactionRequest};
+    use zcash_address::ZcashAddress;
+    use zcash_client_backend::zip321::TransactionRequest;
     use zcash_primitives::{
         memo::{Memo, MemoBytes},
         transaction::components::amount::NonNegativeAmount,
@@ -295,12 +295,12 @@ mod tests {
     fn test_build_request() {
         let amount_1 = NonNegativeAmount::const_from_u64(20000);
         let recipient_address_1 =
-            Address::decode(&ChainType::Testnet, "utest17wwv8nuvdnpjsxtu6ndz6grys5x8wphcwtzmg75wkx607c7cue9qz5kfraqzc7k9dfscmylazj4nkwazjj26s9rhyjxm0dcqm837ykgh2suv0at9eegndh3kvtfjwp3hhhcgk55y9d2ys56zkw8aaamcrv9cy0alj0ndvd0wll4gxhrk9y4yy9q9yg8yssrencl63uznqnkv7mk3w05").unwrap();
+            ZcashAddress::try_from_encoded("utest17wwv8nuvdnpjsxtu6ndz6grys5x8wphcwtzmg75wkx607c7cue9qz5kfraqzc7k9dfscmylazj4nkwazjj26s9rhyjxm0dcqm837ykgh2suv0at9eegndh3kvtfjwp3hhhcgk55y9d2ys56zkw8aaamcrv9cy0alj0ndvd0wll4gxhrk9y4yy9q9yg8yssrencl63uznqnkv7mk3w05").unwrap();
         let memo_1 = None;
 
         let amount_2 = NonNegativeAmount::const_from_u64(20000);
         let recipient_address_2 =
-            Address::decode(&ChainType::Testnet, "utest17wwv8nuvdnpjsxtu6ndz6grys5x8wphcwtzmg75wkx607c7cue9qz5kfraqzc7k9dfscmylazj4nkwazjj26s9rhyjxm0dcqm837ykgh2suv0at9eegndh3kvtfjwp3hhhcgk55y9d2ys56zkw8aaamcrv9cy0alj0ndvd0wll4gxhrk9y4yy9q9yg8yssrencl63uznqnkv7mk3w05").unwrap();
+            ZcashAddress::try_from_encoded("utest17wwv8nuvdnpjsxtu6ndz6grys5x8wphcwtzmg75wkx607c7cue9qz5kfraqzc7k9dfscmylazj4nkwazjj26s9rhyjxm0dcqm837ykgh2suv0at9eegndh3kvtfjwp3hhhcgk55y9d2ys56zkw8aaamcrv9cy0alj0ndvd0wll4gxhrk9y4yy9q9yg8yssrencl63uznqnkv7mk3w05").unwrap();
         let memo_2 = Some(MemoBytes::from(
             Memo::from_str("the lake wavers along the beach").expect("string can memofy"),
         ));


### PR DESCRIPTION
fix build error:

error[E0616]: field `recipient_address` of struct `zcash_client_backend::zip321::Payment` is private
   --> zingolib/src/wallet/send.rs:261:50
    |
261 |         .filter_map(|(_, payment)| match payment.recipient_address {
    |                                                  ^^^^^^^^^^^^^^^^^ private field
    |
help: a method `recipient_address` also exists, call it with parentheses
    |
261 |         .filter_map(|(_, payment)| match payment.recipient_address() {
    |            