### PR TITLE
Lrz update remove get unspent tx outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1578,15 +1578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1684,7 @@ dependencies = [
  "bip0039",
  "hex",
  "http",
- "itertools 0.10.5",
+ "itertools",
  "json",
  "log",
  "orchard",
@@ -2318,7 +2309,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes 1.6.0",
  "heck",
- "itertools 0.12.1",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -2338,7 +2329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -4052,7 +4043,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.4.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "bech32",
  "bs58",
@@ -4064,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "base64 0.21.7",
  "bech32",
@@ -4109,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4118,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "bech32",
  "bip32",
@@ -4159,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "aes",
  "bip32",
@@ -4197,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4219,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "document-features",
  "memuse",
@@ -4410,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "base64 0.21.7",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip32"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa13fae8b6255872fd86f7faf4b41168661d7d78609f7bfe6771b85c6739a15b"
+dependencies = [
+ "bs58",
+ "hmac",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1",
+ "sha2 0.10.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +925,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -944,7 +960,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4035,8 +4051,8 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zcash_address"
-version = "0.3.2"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.4.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "bech32",
  "bs58",
@@ -4047,11 +4063,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.12.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.13.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "base64 0.21.7",
  "bech32",
+ "bip32",
  "bls12_381",
  "bs58",
  "byteorder",
@@ -4060,6 +4077,7 @@ dependencies = [
  "group",
  "hdwallet",
  "hex",
+ "hyper-util",
  "incrementalmerkletree",
  "memuse",
  "nom",
@@ -4085,12 +4103,13 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zip32",
+ "zip321",
 ]
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.2.1"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4098,17 +4117,17 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.3.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "bech32",
+ "bip32",
  "blake2b_simd",
  "bls12_381",
  "bs58",
  "byteorder",
  "document-features",
  "group",
- "hdwallet",
  "memuse",
  "nonempty",
  "orchard",
@@ -4139,19 +4158,19 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.15.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.16.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "aes",
- "bip0039",
+ "bip32",
  "blake2b_simd",
+ "bs58",
  "byteorder",
  "document-features",
  "equihash",
  "ff",
  "fpe",
  "group",
- "hdwallet",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -4177,8 +4196,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.15.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.16.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4199,8 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.1.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.2.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "document-features",
  "memuse",
@@ -4386,4 +4405,16 @@ dependencies = [
  "blake2b_simd",
  "memuse",
  "subtle",
+]
+
+[[package]]
+name = "zip321"
+version = "0.1.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+dependencies = [
+ "base64 0.21.7",
+ "nom",
+ "percent-encoding",
+ "zcash_address",
+ "zcash_protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ bip0039 = "0.11"
 orchard = "0.9"
 sapling-crypto = "0.2"
 shardtree = "0.4"
-zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic", features = ["lightwalletd-tonic", "orchard", "transparent-inputs"] }
-zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic", features = ["transparent-inputs", "sapling", "orchard" ] }
+zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib", features = ["lightwalletd-tonic", "orchard", "transparent-inputs"] }
+zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib", features = ["transparent-inputs", "sapling", "orchard" ] }
 zcash_note_encryption = "0.4"
-zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
+zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
 zip32 = "0.1"
 
 append-only-vec = { git = "https://github.com/zancas/append-only-vec.git", branch = "add_debug_impl" }

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -242,6 +242,7 @@ impl Command for ParseAddressCommand {
                                 "receivers_available" => receivers_available,
                             }
                         }
+                        Address::Tex(_) => todo!(),
                     }
                 }),
                 4,

--- a/zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs
+++ b/zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs
@@ -4,22 +4,14 @@ use orchard::note_encryption::OrchardDomain;
 use sapling_crypto::note_encryption::SaplingDomain;
 use zcash_client_backend::{
     data_api::{InputSource, SpendableNotes},
-    wallet::{ReceivedNote, WalletTransparentOutput},
+    wallet::ReceivedNote,
     ShieldedProtocol,
 };
-use zcash_primitives::{
-    legacy::Script,
-    transaction::{
-        components::{amount::NonNegativeAmount, TxOut},
-        fees::zip317::MARGINAL_FEE,
-        TxId,
-    },
+use zcash_primitives::transaction::{
+    components::amount::NonNegativeAmount, fees::zip317::MARGINAL_FEE, TxId,
 };
 
-use crate::wallet::{
-    notes::{query::OutputSpendStatusQuery, OutputInterface},
-    transaction_records_by_id::TransactionRecordsById,
-};
+use crate::wallet::transaction_records_by_id::TransactionRecordsById;
 
 // error type
 use std::fmt::Debug;
@@ -289,77 +281,20 @@ impl InputSource for TransactionRecordsById {
     ) -> Result<Option<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
         unimplemented!()
     }
-    /// Returns a list of unspent transparent UTXOs that appear in the chain at heights up to and
-    /// including `max_height`.
-    /// IMPL: Implemented and tested. address is unused, we select all outputs available to the wallet.
-    /// IMPL: _address skipped because Zingo uses 1 account.
-    fn get_unspent_transparent_outputs(
-        &self,
-        // I don't understand what this argument is for. Is the Trait's intent to only shield
-        // utxos from one address at a time? Is this needed?
-        _address: &zcash_primitives::legacy::TransparentAddress,
-        max_height: zcash_primitives::consensus::BlockHeight,
-        exclude: &[zcash_primitives::transaction::components::OutPoint],
-    ) -> Result<Vec<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
-        self.values()
-            .filter_map(|transaction_record| {
-                transaction_record
-                    .status
-                    .get_confirmed_height()
-                    .map(|height| (transaction_record, height))
-                    .filter(|(_, height)| height <= &max_height)
-            })
-            .flat_map(|(transaction_record, confirmed_height)| {
-                transaction_record
-                    .transparent_outputs
-                    .iter()
-                    .filter(|output| {
-                        exclude
-                            .iter()
-                            .all(|excluded| excluded != &output.to_outpoint())
-                    })
-                    .filter(|output| {
-                        output.spend_status_query(OutputSpendStatusQuery::only_unspent())
-                    })
-                    .filter_map(move |output| {
-                        let value = match NonNegativeAmount::from_u64(output.value)
-                            .map_err(InputSourceError::InvalidValue)
-                        {
-                            Ok(v) => v,
-                            Err(e) => return Some(Err(e)),
-                        };
-
-                        let script_pubkey = Script(output.script.clone());
-                        Ok(WalletTransparentOutput::from_parts(
-                            output.to_outpoint(),
-                            TxOut {
-                                value,
-                                script_pubkey,
-                            },
-                            confirmed_height,
-                        ))
-                        .transpose()
-                    })
-            })
-            .collect()
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use proptest::{prop_assert_eq, proptest};
-    use zcash_client_backend::{data_api::InputSource as _, ShieldedProtocol};
+    use zcash_client_backend::ShieldedProtocol;
     use zcash_primitives::{
-        consensus::BlockHeight, legacy::TransparentAddress,
-        transaction::components::amount::NonNegativeAmount,
+        consensus::BlockHeight, transaction::components::amount::NonNegativeAmount,
     };
     use zip32::AccountId;
 
     use crate::wallet::{
         notes::orchard::mocks::OrchardNoteBuilder,
-        transaction_record::mocks::{
-            nine_note_transaction_record_default, TransactionRecordBuilder,
-        },
+        transaction_record::mocks::TransactionRecordBuilder,
         transaction_records_by_id::TransactionRecordsById,
     };
 
@@ -437,52 +372,5 @@ mod tests {
 
             prop_assert_eq!(spendable_notes.sapling().len() + spendable_notes.orchard().len(), expected_len);
         }
-    }
-
-    #[test]
-    fn get_unspent_transparent_outputs() {
-        let mut transaction_records_by_id = TransactionRecordsById::new();
-        transaction_records_by_id.insert_transaction_record(nine_note_transaction_record_default());
-
-        let transparent_output = transaction_records_by_id
-            .0
-            .values()
-            .next()
-            .unwrap()
-            .transparent_outputs
-            .first()
-            .unwrap();
-        let record_height = transaction_records_by_id
-            .0
-            .values()
-            .next()
-            .unwrap()
-            .status
-            .get_confirmed_height();
-
-        let selected_outputs = transaction_records_by_id
-            .get_unspent_transparent_outputs(
-                &TransparentAddress::ScriptHash([0; 20]),
-                BlockHeight::from_u32(10),
-                &[],
-            )
-            .unwrap();
-        assert_eq!(selected_outputs.len(), 1);
-        assert_eq!(
-            selected_outputs.first().unwrap().outpoint(),
-            &transparent_output.to_outpoint()
-        );
-        assert_eq!(
-            selected_outputs.first().unwrap().txout().value.into_u64(),
-            transparent_output.value
-        );
-        assert_eq!(
-            selected_outputs.first().unwrap().txout().script_pubkey.0,
-            transparent_output.script
-        );
-        assert_eq!(
-            Some(selected_outputs.first().unwrap().height()),
-            record_height
-        )
     }
 }

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs
@@ -51,15 +51,4 @@ impl InputSource for TxMapAndMaybeTrees {
     ) -> Result<Option<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
         unimplemented!()
     }
-
-    fn get_unspent_transparent_outputs(
-        &self,
-        address: &zcash_primitives::legacy::TransparentAddress,
-        max_height: zcash_primitives::consensus::BlockHeight,
-        exclude: &[zcash_primitives::transaction::components::OutPoint],
-    ) -> Result<Vec<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
-        self.transaction_records_by_id
-            .get_unspent_transparent_outputs(address, max_height, exclude)
-            .map_err(TxMapAndMaybeTreesTraitError::InputSource)
-    }
 }


### PR DESCRIPTION
solves build errors:

error[E0407]: method `get_unspent_transparent_outputs` is not a member of trait `InputSource`
   --> zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs:296:5
    |
296 |       fn get_unspent_transparent_outputs(
    |       ^  ------------------------------- help: there is an associated function with a similar name: `get_unspent_transparent_output`
    |  _____|
    | |
297 | |         &self,
298 | |         // I don't understand what this argument is for. Is the Trait's intent to only shield
299 | |         // utxos from one address at a time? Is this needed?
...   |
344 | |             .collect()
345 | |     }
    | |_____^ not a member of trait `InputSource`
    
    AND

error[E0407]: method `get_unspent_transparent_outputs` is not a member of trait `InputSource`
  --> zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs:55:5
   |
55 |       fn get_unspent_transparent_outputs(
   |       ^  ------------------------------- help: there is an associated function with a similar name: `get_unspent_transparent_output`
   |  _____|
   | |
56 | |         &self,
57 | |         address: &zcash_primitives::legacy::TransparentAddress,
58 | |         max_height: zcash_primitives::consensus::BlockHeight,
...  |
63 | |             .map_err(TxMapAndMaybeTreesTraitError::InputSource)
64 | |     }
   | |_____^ not a member of trait `InputSource`
   
   AND
   
   error[E0308]: mismatched types
   --> zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs:339:29
    |
333 |                         Ok(WalletTransparentOutput::from_parts(
    |                            ----------------------------------- arguments to this function are incorrect
...
339 |                             confirmed_height,
    |                             ^^^^^^^^^^^^^^^^ expected `Option<BlockHeight>`, found `BlockHeight`
    |
    = note: expected enum `std::option::Option<BlockHeight>`
             found struct `BlockHeight`
note: associated function defined here
   --> /home/oscar/.cargo/git/checkouts/librustzcash-2a71d81ac8756eb7/53331a3/zcash_client_backend/src/wallet.rs:270:12
    |
270 |     pub fn from_parts(
    |            ^^^^^^^^^^
help: try wrapping the expression in `Some`
    |
339 |                             Some(confirmed_height),
    |                             +++++                +
    
    AND
    
    error[E0599]: no method named `get_unspent_transparent_outputs` found for struct `TransactionRecordsById` in the current scope
   --> zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs:62:14
    |
61  | /         self.transaction_records_by_id
62  | |             .get_unspent_transparent_outputs(address, max_height, exclude)
    | |_____________-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: zingolib/src/wallet/transaction_records_by_id.rs:35:1
    |
35  |   pub struct TransactionRecordsById(pub HashMap<TxId, TransactionRecord>);
    |   --------------------------------- method `get_unspent_transparent_outputs` not found for this struct
    |
help: there is a method `get_unspent_transparent_output` with a similar name, but with different arguments
   --> /home/oscar/.cargo/git/checkouts/librustzcash-2a71d81ac8756eb7/53331a3/zcash_client_backend/src/data_api.rs:764:5
    |
764 | /     fn get_unspent_transparent_output(
765 | |         &self,
766 | |         _outpoint: &OutPoint,
767 | |     ) -> Result<Option<WalletTransparentOutput>, Self::Error> {
    | |_____________________________________________________________^