### PR TITLE
Lrz update remove get unspent tx outputs

### DIFF
--- a/zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs
+++ b/zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs
@@ -4,22 +4,14 @@ use orchard::note_encryption::OrchardDomain;
 use sapling_crypto::note_encryption::SaplingDomain;
 use zcash_client_backend::{
     data_api::{InputSource, SpendableNotes},
-    wallet::{ReceivedNote, WalletTransparentOutput},
+    wallet::ReceivedNote,
     ShieldedProtocol,
 };
-use zcash_primitives::{
-    legacy::Script,
-    transaction::{
-        components::{amount::NonNegativeAmount, TxOut},
-        fees::zip317::MARGINAL_FEE,
-        TxId,
-    },
+use zcash_primitives::transaction::{
+    components::amount::NonNegativeAmount, fees::zip317::MARGINAL_FEE, TxId,
 };
 
-use crate::wallet::{
-    notes::{query::OutputSpendStatusQuery, OutputInterface},
-    transaction_records_by_id::TransactionRecordsById,
-};
+use crate::wallet::transaction_records_by_id::TransactionRecordsById;
 
 // error type
 use std::fmt::Debug;
@@ -289,77 +281,20 @@ impl InputSource for TransactionRecordsById {
     ) -> Result<Option<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
         unimplemented!()
     }
-    /// Returns a list of unspent transparent UTXOs that appear in the chain at heights up to and
-    /// including `max_height`.
-    /// IMPL: Implemented and tested. address is unused, we select all outputs available to the wallet.
-    /// IMPL: _address skipped because Zingo uses 1 account.
-    fn get_unspent_transparent_outputs(
-        &self,
-        // I don't understand what this argument is for. Is the Trait's intent to only shield
-        // utxos from one address at a time? Is this needed?
-        _address: &zcash_primitives::legacy::TransparentAddress,
-        max_height: zcash_primitives::consensus::BlockHeight,
-        exclude: &[zcash_primitives::transaction::components::OutPoint],
-    ) -> Result<Vec<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
-        self.values()
-            .filter_map(|transaction_record| {
-                transaction_record
-                    .status
-                    .get_confirmed_height()
-                    .map(|height| (transaction_record, height))
-                    .filter(|(_, height)| height <= &max_height)
-            })
-            .flat_map(|(transaction_record, confirmed_height)| {
-                transaction_record
-                    .transparent_outputs
-                    .iter()
-                    .filter(|output| {
-                        exclude
-                            .iter()
-                            .all(|excluded| excluded != &output.to_outpoint())
-                    })
-                    .filter(|output| {
-                        output.spend_status_query(OutputSpendStatusQuery::only_unspent())
-                    })
-                    .filter_map(move |output| {
-                        let value = match NonNegativeAmount::from_u64(output.value)
-                            .map_err(InputSourceError::InvalidValue)
-                        {
-                            Ok(v) => v,
-                            Err(e) => return Some(Err(e)),
-                        };
-
-                        let script_pubkey = Script(output.script.clone());
-                        Ok(WalletTransparentOutput::from_parts(
-                            output.to_outpoint(),
-                            TxOut {
-                                value,
-                                script_pubkey,
-                            },
-                            confirmed_height,
-                        ))
-                        .transpose()
-                    })
-            })
-            .collect()
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use proptest::{prop_assert_eq, proptest};
-    use zcash_client_backend::{data_api::InputSource as _, ShieldedProtocol};
+    use zcash_client_backend::ShieldedProtocol;
     use zcash_primitives::{
-        consensus::BlockHeight, legacy::TransparentAddress,
-        transaction::components::amount::NonNegativeAmount,
+        consensus::BlockHeight, transaction::components::amount::NonNegativeAmount,
     };
     use zip32::AccountId;
 
     use crate::wallet::{
         notes::orchard::mocks::OrchardNoteBuilder,
-        transaction_record::mocks::{
-            nine_note_transaction_record_default, TransactionRecordBuilder,
-        },
+        transaction_record::mocks::TransactionRecordBuilder,
         transaction_records_by_id::TransactionRecordsById,
     };
 
@@ -437,52 +372,5 @@ mod tests {
 
             prop_assert_eq!(spendable_notes.sapling().len() + spendable_notes.orchard().len(), expected_len);
         }
-    }
-
-    #[test]
-    fn get_unspent_transparent_outputs() {
-        let mut transaction_records_by_id = TransactionRecordsById::new();
-        transaction_records_by_id.insert_transaction_record(nine_note_transaction_record_default());
-
-        let transparent_output = transaction_records_by_id
-            .0
-            .values()
-            .next()
-            .unwrap()
-            .transparent_outputs
-            .first()
-            .unwrap();
-        let record_height = transaction_records_by_id
-            .0
-            .values()
-            .next()
-            .unwrap()
-            .status
-            .get_confirmed_height();
-
-        let selected_outputs = transaction_records_by_id
-            .get_unspent_transparent_outputs(
-                &TransparentAddress::ScriptHash([0; 20]),
-                BlockHeight::from_u32(10),
-                &[],
-            )
-            .unwrap();
-        assert_eq!(selected_outputs.len(), 1);
-        assert_eq!(
-            selected_outputs.first().unwrap().outpoint(),
-            &transparent_output.to_outpoint()
-        );
-        assert_eq!(
-            selected_outputs.first().unwrap().txout().value.into_u64(),
-            transparent_output.value
-        );
-        assert_eq!(
-            selected_outputs.first().unwrap().txout().script_pubkey.0,
-            transparent_output.script
-        );
-        assert_eq!(
-            Some(selected_outputs.first().unwrap().height()),
-            record_height
-        )
     }
 }

--- a/zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs
+++ b/zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs
@@ -51,15 +51,4 @@ impl InputSource for TxMapAndMaybeTrees {
     ) -> Result<Option<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
         unimplemented!()
     }
-
-    fn get_unspent_transparent_outputs(
-        &self,
-        address: &zcash_primitives::legacy::TransparentAddress,
-        max_height: zcash_primitives::consensus::BlockHeight,
-        exclude: &[zcash_primitives::transaction::components::OutPoint],
-    ) -> Result<Vec<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
-        self.transaction_records_by_id
-            .get_unspent_transparent_outputs(address, max_height, exclude)
-            .map_err(TxMapAndMaybeTreesTraitError::InputSource)
-    }
 }


### PR DESCRIPTION
solves build errors:

error[E0407]: method get_unspent_transparent_outputs is not a member of trait InputSource
   --> zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs:296:5
    |
296 |       fn get_unspent_transparent_outputs(
    |       ^  ------------------------------- help: there is an associated function with a similar name: get_unspent_transparent_output
    |  |
    | |
297 | |         &self,
298 | |         // I don't understand what this argument is for. Is the Trait's intent to only shield
299 | |         // utxos from one address at a time? Is this needed?
...   |
344 | |             .collect()
345 | |     }
    | |^ not a member of trait InputSource

error[E0407]: method get_unspent_transparent_outputs is not a member of trait InputSource
  --> zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs:55:5
   |
55 |       fn get_unspent_transparent_outputs(
   |       ^  ------------------------------- help: there is an associated function with a similar name: get_unspent_transparent_output
   |  |
   | |
56 | |         &self,
57 | |         address: &zcash_primitives::legacy::TransparentAddress,
58 | |         max_height: zcash_primitives::consensus::BlockHeight,
...  |
63 | |             .map_err(TxMapAndMaybeTreesTraitError::InputSource)
64 | |     }
   | |^ not a member of trait InputSource
   
   AND
   
   error[E0308]: mismatched types
   --> zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs:339:29
    |
333 |                         Ok(WalletTransparentOutput::from_parts(
    |                            ----------------------------------- arguments to this function are incorrect
...
339 |                             confirmed_height,
    |                             ^^^^^^^^^^^^^^^^ expected Option<BlockHeight>, found BlockHeight
    |
    = note: expected enum std::option::Option<BlockHeight>
             found struct BlockHeight
note: associated function defined here
   --> /home/oscar/.cargo/git/checkouts/librustzcash-2a71d81ac8756eb7/53331a3/zcash_client_backend/src/wallet.rs:270:12
    |
270 |     pub fn from_parts(
    |            ^^^^^^^^^^
help: try wrapping the expression in Some
    |
339 |                             Some(confirmed_height),
    |                             +++++                +
   
    AND
   
    error[E0599]: no method named get_unspent_transparent_outputs found for struct TransactionRecordsById in the current scope
   --> zingolib/src/wallet/tx_map_and_maybe_trees/trait_stub_inputsource.rs:62:14
    |
61  | /         self.transaction_records_by_id
62  | |             .get_unspent_transparent_outputs(address, max_height, exclude)
    | |-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: zingolib/src/wallet/transaction_records_by_id.rs:35:1
    |
35  |   pub struct TransactionRecordsById(pub HashMap<TxId, TransactionRecord>);
    |   --------------------------------- method get_unspent_transparent_outputs not found for this struct
    |
help: there is a method get_unspent_transparent_output with a similar name, but with different arguments
   --> /home/oscar/.cargo/git/checkouts/librustzcash-2a71d81ac8756eb7/53331a3/zcash_client_backend/src/data_api.rs:764:5
    |
764 | /     fn get_unspent_transparent_output(
765 | |         &self,
766 | |         outpoint: &OutPoint,
767 | |     ) -> Result<Option, Self::Error> {
    | |_______________________________________________^