### PR TITLE
Lrz update fix usk to tkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1578,15 +1578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1684,7 @@ dependencies = [
  "bip0039",
  "hex",
  "http",
- "itertools 0.10.5",
+ "itertools",
  "json",
  "log",
  "orchard",
@@ -2318,7 +2309,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes 1.6.0",
  "heck",
- "itertools 0.12.1",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -2338,7 +2329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -4052,7 +4043,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.4.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "bech32",
  "bs58",
@@ -4064,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "base64 0.21.7",
  "bech32",
@@ -4109,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4118,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "bech32",
  "bip32",
@@ -4159,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "aes",
  "bip32",
@@ -4197,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.16.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4219,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "document-features",
  "memuse",
@@ -4410,7 +4401,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#53331a36bf9ec2cea52b9c80063db8e24505daa9"
 dependencies = [
  "base64 0.21.7",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip32"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa13fae8b6255872fd86f7faf4b41168661d7d78609f7bfe6771b85c6739a15b"
+dependencies = [
+ "bs58",
+ "hmac",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1",
+ "sha2 0.10.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +925,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -944,7 +960,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4035,8 +4051,8 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zcash_address"
-version = "0.3.2"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.4.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "bech32",
  "bs58",
@@ -4047,11 +4063,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.12.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.13.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "base64 0.21.7",
  "bech32",
+ "bip32",
  "bls12_381",
  "bs58",
  "byteorder",
@@ -4060,6 +4077,7 @@ dependencies = [
  "group",
  "hdwallet",
  "hex",
+ "hyper-util",
  "incrementalmerkletree",
  "memuse",
  "nom",
@@ -4085,12 +4103,13 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zip32",
+ "zip321",
 ]
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.2.1"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -4098,17 +4117,17 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.2.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.3.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "bech32",
+ "bip32",
  "blake2b_simd",
  "bls12_381",
  "bs58",
  "byteorder",
  "document-features",
  "group",
- "hdwallet",
  "memuse",
  "nonempty",
  "orchard",
@@ -4139,19 +4158,19 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.15.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.16.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "aes",
- "bip0039",
+ "bip32",
  "blake2b_simd",
+ "bs58",
  "byteorder",
  "document-features",
  "equihash",
  "ff",
  "fpe",
  "group",
- "hdwallet",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -4177,8 +4196,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.15.0"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.16.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4199,8 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.1.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=upgrade_prost_and_tonic#be689273796a3ca15b8a673a6cfe7ba3c4d53771"
+version = "0.2.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
 dependencies = [
  "document-features",
  "memuse",
@@ -4386,4 +4405,16 @@ dependencies = [
  "blake2b_simd",
  "memuse",
  "subtle",
+]
+
+[[package]]
+name = "zip321"
+version = "0.1.0"
+source = "git+https://github.com/zingolabs/librustzcash.git?branch=main_zingolib#9db48453e659fb8b276ee19cbd92f3e436f51beb"
+dependencies = [
+ "base64 0.21.7",
+ "nom",
+ "percent-encoding",
+ "zcash_address",
+ "zcash_protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ bip0039 = "0.11"
 orchard = "0.9"
 sapling-crypto = "0.2"
 shardtree = "0.4"
-zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic", features = ["lightwalletd-tonic", "orchard", "transparent-inputs"] }
-zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic", features = ["transparent-inputs", "sapling", "orchard" ] }
+zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib", features = ["lightwalletd-tonic", "orchard", "transparent-inputs"] }
+zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib", features = ["transparent-inputs", "sapling", "orchard" ] }
 zcash_note_encryption = "0.4"
-zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
-zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", tag = "upgrade_prost_and_tonic" }
+zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
+zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", branch = "main_zingolib" }
 zip32 = "0.1"
 
 append-only-vec = { git = "https://github.com/zancas/append-only-vec.git", branch = "add_debug_impl" }

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -242,6 +242,7 @@ impl Command for ParseAddressCommand {
                                 "receivers_available" => receivers_available,
                             }
                         }
+                        Address::Tex(_) => todo!(),
                     }
                 }),
                 4,

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -164,7 +164,7 @@ impl LightWallet {
         ) -> secp256k1::SecretKey {
             hdwallet::ExtendedPrivKey::deserialize(&unified_spend_key.transparent().to_bytes())
                 .expect("This a hack to do a type conversion, and will not fail")
-                .derive_private_key(t_metadata.address_index().into())
+                .derive_private_key(t_metadata.address_index().index().into())
                 // This is unwrapped in librustzcash, so I'm not too worried about it
                 .expect("private key derivation failed")
                 .private_key


### PR DESCRIPTION
solve build error:

error[E0277]: the trait bound `hdwallet::KeyIndex: From<NonHardenedChildIndex>` is not satisfied
   --> zingolib/src/wallet/send.rs:167:64
    |
167 |                 .derive_private_key(t_metadata.address_index().into())
    |                                                                ^^^^ the trait `From<NonHardenedChildIndex>` is not implemented for `hdwallet::KeyIndex`, which is required by `NonHardenedChildIndex: Into<_>`
    |
    = help: the trait `From<u32>` is implemented for `hdwallet::KeyIndex`
    = help: for that trait implementation, expected `u32`, found `NonHardenedChildIndex`
    = note: required for `NonHardenedChildIndex` to implement `Into<hdwallet::KeyIndex>`