### PR TITLE
Mempool result

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -209,7 +209,8 @@ mod fast {
         .await
         .unwrap();
 
-        LightClient::start_mempool_monitor(recipient.clone());
+        LightClient::start_mempool_monitor(recipient.clone())
+            .expect("should start mempool monitor");
         tokio::time::sleep(Duration::from_secs(5)).await;
 
         let transactions = &recipient.transaction_summaries().await.0;
@@ -3449,7 +3450,8 @@ mod slow {
                 .await
                 .unwrap(),
         );
-        LightClient::start_mempool_monitor(recipient_loaded.clone());
+        LightClient::start_mempool_monitor(recipient_loaded.clone())
+            .expect("should start mempool monitor");
         // This seems to be long enough for the mempool monitor to kick in.
         // One second is insufficient. Even if this fails, this can only ever be
         // a false negative, giving us a balance of 100_000. Still, could be improved.

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -231,7 +231,7 @@ pub fn command_loop(
     let (resp_transmitter, resp_receiver) = channel::<String>();
 
     std::thread::spawn(move || {
-        LightClient::start_mempool_monitor(lightclient.clone());
+        let _ = LightClient::start_mempool_monitor(lightclient.clone());
 
         while let Ok((cmd, args)) = command_receiver.recv() {
             let args: Vec<_> = args.iter().map(|s| s.as_ref()).collect();

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -151,13 +151,13 @@ impl LightClient {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn start_mempool_monitor(lc: Arc<LightClient>) {
+    pub fn start_mempool_monitor(lc: Arc<LightClient>) -> Result<(), ()> {
         if !lc.config.monitor_mempool {
-            return;
+            return Err(());
         }
 
         if lc.mempool_monitor.read().unwrap().is_some() {
-            return;
+            return Err(());
         }
 
         let config = lc.config.clone();
@@ -279,6 +279,7 @@ impl LightClient {
         });
 
         *lc.mempool_monitor.write().unwrap() = Some(h);
+        Ok(())
     }
 
     /// Start syncing in batches with the max size, to manage memory consumption.

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -523,7 +523,8 @@ where
     let check_mempool = !cfg!(feature = "ci");
     if check_mempool {
         for lightclient in [&ref_primary, &ref_secondary, &ref_tertiary] {
-            LightClient::start_mempool_monitor(lightclient.clone());
+            LightClient::start_mempool_monitor(lightclient.clone())
+                .expect("should start mempool monitor");
             dbg!("mm started");
         }
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;

--- a/zingolib/src/wallet/transaction_records_by_id.rs
+++ b/zingolib/src/wallet/transaction_records_by_id.rs
@@ -15,7 +15,6 @@ use crate::wallet::{
 use std::collections::HashMap;
 
 use orchard::note_encryption::OrchardDomain;
-use sapling_crypto::constants::SPENDING_KEY_GENERATOR;
 use sapling_crypto::note_encryption::SaplingDomain;
 
 use zcash_client_backend::wallet::NoteId;


### PR DESCRIPTION
Got 32 failed tests while running `cargo nextest`.
``` bash
------------
     Summary [ 791.275s] 309 tests run: 277 passed (59 slow), 32 failed, 21 skipped
        FAIL [ 107.824s] libtonode-tests::chain_generics chain_generics::simpool_change_10_000_orchard_to_orchard
        FAIL [ 110.085s] libtonode-tests::chain_generics chain_generics::simpool_change_10_000_orchard_to_sapling
        FAIL [ 132.373s] libtonode-tests::chain_generics chain_generics::simpool_change_10_000_orchard_to_transparent
        FAIL [ 107.074s] libtonode-tests::chain_generics chain_generics::simpool_change_10_000_sapling_to_orchard
        FAIL [  85.808s] libtonode-tests::chain_generics chain_generics::simpool_change_10_000_sapling_to_sapling
        FAIL [  85.983s] libtonode-tests::chain_generics chain_generics::simpool_change_10_000_sapling_to_transparent
        FAIL [ 116.079s] libtonode-tests::chain_generics chain_generics::simpool_change_50_000_orchard_to_orchard
        FAIL [  95.346s] libtonode-tests::chain_generics chain_generics::simpool_change_50_000_orchard_to_sapling
        FAIL [  95.879s] libtonode-tests::chain_generics chain_generics::simpool_change_50_000_orchard_to_transparent
        FAIL [  99.074s] libtonode-tests::chain_generics chain_generics::simpool_change_50_000_sapling_to_orchard
        FAIL [  91.380s] libtonode-tests::chain_generics chain_generics::simpool_change_50_000_sapling_to_sapling
        FAIL [ 112.936s] libtonode-tests::chain_generics chain_generics::simpool_change_50_000_sapling_to_transparent
        FAIL [  98.107s] libtonode-tests::chain_generics chain_generics::simpool_change_50_orchard_to_orchard
        FAIL [  99.500s] libtonode-tests::chain_generics chain_generics::simpool_change_50_orchard_to_sapling
        FAIL [ 121.109s] libtonode-tests::chain_generics chain_generics::simpool_change_50_orchard_to_transparent
        FAIL [  97.342s] libtonode-tests::chain_generics chain_generics::simpool_change_50_sapling_to_orchard
        FAIL [  87.854s] libtonode-tests::chain_generics chain_generics::simpool_change_50_sapling_to_sapling
        FAIL [ 102.357s] libtonode-tests::chain_generics chain_generics::simpool_change_50_sapling_to_transparent
        FAIL [ 104.337s] libtonode-tests::chain_generics chain_generics::simpool_change_5_000_orchard_to_orchard
        FAIL [  80.535s] libtonode-tests::chain_generics chain_generics::simpool_change_5_000_orchard_to_sapling
        FAIL [  82.623s] libtonode-tests::chain_generics chain_generics::simpool_change_5_000_orchard_to_transparent
        FAIL [ 256.837s] libtonode-tests::chain_generics chain_generics::simpool_change_5_000_sapling_to_orchard
        FAIL [  77.436s] libtonode-tests::chain_generics chain_generics::simpool_change_5_000_sapling_to_sapling
        FAIL [ 102.143s] libtonode-tests::chain_generics chain_generics::simpool_change_5_000_sapling_to_transparent
        FAIL [ 107.895s] libtonode-tests::chain_generics chain_generics::simpool_zero_value_change_orchard_to_orchard
        FAIL [ 105.800s] libtonode-tests::chain_generics chain_generics::simpool_zero_value_change_orchard_to_sapling
        FAIL [  85.860s] libtonode-tests::chain_generics chain_generics::simpool_zero_value_change_orchard_to_transparent
        FAIL [  85.745s] libtonode-tests::chain_generics chain_generics::simpool_zero_value_change_sapling_to_orchard
        FAIL [  80.358s] libtonode-tests::chain_generics chain_generics::simpool_zero_value_change_sapling_to_transparent
        FAIL [  99.046s] libtonode-tests::chain_generics chain_generics::simpool_zero_value_sapling_to_sapling
        FAIL [  79.244s] libtonode-tests::concrete fast::received_tx_status_pending_to_confirmed_with_mempool_monitor
        FAIL [ 224.787s] libtonode-tests::concrete slow::aborted_resync
error: test run failed
```

Tried running a specific test `simpool_zero_value_sapling_to_sapling` and got:

```bash
--- STDERR:              libtonode-tests::chain_generics chain_generics::simpool_zero_value_sapl
ing_to_sapling ---
[zingolib/src/testutils/chain_generics/fixtures.rs:528:13] "mm started" = "mm started"
[zingolib/src/testutils/chain_generics/fixtures.rs:528:13] "mm started" = "mm started"
[zingolib/src/testutils/chain_generics/fixtures.rs:528:13] "mm started" = "mm started"
thread 'tokio-runtime-worker' panicked at zingolib/src/wallet/transaction_records_by_id.rs:285:1
4:
transaction must exist in wallet
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'chain_generics::simpool_zero_value_sapling_to_sapling' panicked at /home/chona/zingo/zin
golib/dev/zingolib/src/testutils/assertions.rs:44:9:
assertion `left == right` failed
  left: Mempool(BlockHeight(1))
 right: Mempool(BlockHeight(7))

------------
```

**Experiment:**
Added error handling for `start_mempool_monitor'
**Result:**
Nothing changed, same error