### PR TITLE
Nightly CI fixed with the new flows of zingo-mobile

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -32,14 +32,14 @@ jobs:
     strategy:
       matrix:
         arch: [ x86_64, x86, arm64-v8a, armeabi-v7a ]
-    uses: zingolabs/zingo-mobile/.github/workflows/android-build.yaml
+    uses: zingolabs/zingo-mobile/.github/workflows/android-build.yaml@dev
     needs: create-cache-key
     with:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
       arch: ${{ matrix.arch }}
 
   android-test:
-    uses: zingolabs/zingo-mobile/.github/workflows/android-test.yaml
+    uses: zingolabs/zingo-mobile/.github/workflows/android-test.yaml@dev
     needs: [ create-timestamp, android-build ]
     with:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
@@ -50,7 +50,7 @@ jobs:
       matrix:
         abi: [ x86_64, x86, arm64-v8a, armeabi-v7a ]
       fail-fast: false
-    uses: zingolabs/zingo-mobile/.github/workflows/android-macos-integration-test.yaml
+    uses: zingolabs/zingo-mobile/.github/workflows/android-macos-integration-test.yaml@dev
     needs: [ android-test ]
     with:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
@@ -58,13 +58,13 @@ jobs:
       abi: ${{ matrix.abi }}
 
   ios-build:
-    uses: zingolabs/zingo-mobile/.github/workflows/ios-build.yaml
+    uses: zingolabs/zingo-mobile/.github/workflows/ios-build.yaml@dev
     needs: create-cache-key
     with:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
        
   ios-integration-test:
-    uses: zingolabs/zingo-mobile/.github/workflows/ios-integration-test.yaml
+    uses: zingolabs/zingo-mobile/.github/workflows/ios-integration-test.yaml@dev
     needs: [ create-timestamp, ios-build ]
     with:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -28,26 +28,44 @@ jobs:
   create-cache-key:
     uses: zingolabs/zingo-mobile/.github/workflows/create-cache-key.yaml@dev
 
-  build-android:
+  android-build:
     strategy:
       matrix:
         arch: [ x86_64, x86, arm64-v8a, armeabi-v7a ]
-      fail-fast: false
-    uses: zingolabs/zingo-mobile/.github/workflows/build.yaml@dev
+    uses: zingolabs/zingo-mobile/.github/workflows/android-build.yaml
     needs: create-cache-key
     with:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
       arch: ${{ matrix.arch }}
 
-  integration-test-android:
+  android-test:
+    uses: zingolabs/zingo-mobile/.github/workflows/android-test.yaml
+    needs: [ create-timestamp, android-build ]
+    with:
+      timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
+      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
+
+  android-macos-integration-test:
     strategy:
       matrix:
         abi: [ x86_64, x86, arm64-v8a, armeabi-v7a ]
       fail-fast: false
-    uses: zingolabs/zingo-mobile/.github/workflows/integration-test.yaml@dev
-    needs: [ create-timestamp, create-cache-key, build-android ]
+    uses: zingolabs/zingo-mobile/.github/workflows/android-macos-integration-test.yaml
+    needs: [ android-test ]
     with:
       timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
       abi: ${{ matrix.abi }}
 
+  ios-build:
+    uses: zingolabs/zingo-mobile/.github/workflows/ios-build.yaml
+    needs: create-cache-key
+    with:
+      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
+       
+  ios-integration-test:
+    uses: zingolabs/zingo-mobile/.github/workflows/ios-integration-test.yaml
+    needs: [ create-timestamp, ios-build ]
+    with:
+      timestamp: ${{ needs.create-timestamp.outputs.timestamp }}
+      cache-key: ${{ needs.create-cache-key.outputs.cache-key }}

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -62,7 +62,7 @@ jobs:
     needs: create-cache-key
     with:
       cache-key: ${{ needs.create-cache-key.outputs.cache-key }}
-       
+
   ios-integration-test:
     uses: zingolabs/zingo-mobile/.github/workflows/ios-integration-test.yaml@dev
     needs: [ create-timestamp, ios-build ]


### PR DESCRIPTION
We changed some of the CI flows of zingo-mobile, name & structure... and we need to update the zingolib CI nightly according to that.