### PR TITLE
zaino-test feature

### DIFF
--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -16,6 +16,7 @@ testvectors = []
 tempfile = ["dep:tempfile"]
 default = ["sync"]
 sync = ['dep:zingo-sync']
+zaino-test = ['test-elevation']
 
 [dependencies]
 zingo-memo = { path = "../zingo-memo" }

--- a/zingolib/src/testutils/regtest.rs
+++ b/zingolib/src/testutils/regtest.rs
@@ -203,6 +203,7 @@ pub fn launch_lightwalletd(
     lightwalletd_child
 }
 
+#[cfg(not(feature = "zaino-test"))]
 fn write_zcash_conf(location: &PathBuf) {
     // This is the only data we need to supply *to* the zcashd, the other files are created by zcashd and lightwalletd
     use std::io::Write;

--- a/zingolib/src/testutils/regtest.rs
+++ b/zingolib/src/testutils/regtest.rs
@@ -220,7 +220,10 @@ impl RegtestManager {
         let confs_dir = regtest_dir.join("conf");
         let zcashd_config = confs_dir.join("zcash.conf");
         std::fs::create_dir_all(&confs_dir).expect("Couldn't create dir.");
-        write_zcash_conf(&zcashd_config);
+        #[cfg(not(feature = "zaino-test"))]
+        {
+            write_zcash_conf(&zcashd_config);
+        }
         let bin_dir = super::paths::get_bin_dir();
         std::fs::create_dir_all(&bin_dir).expect("Couldn't create dir.");
         let cli_bin = bin_dir.join("zcash-cli");


### PR DESCRIPTION
Adds zaino-test feature, conditionally removes a single line of code in zingolib::testutils::regtest.rs.

This is required for zaino-testutils to be able to write its own zcashd conf files for integration tests.

- This PR is work towards https://github.com/zingolabs/zaino/issues/48