### PR TITLE
fix zingocli viewkey

### DIFF
--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -37,15 +37,16 @@ pub fn build_clap_app() -> clap::ArgMatches {
             .arg(Arg::new("chain")
                 .long("chain").short('c')
                 .help(r#"What chain to expect, if it's not inferable from the server URI. One of "mainnet", "testnet", or "regtest""#))
-            .arg(Arg::new("from")
-                .short('f')
-                .short_alias('s')
-                .long("from")
-                .alias("seed")
-                .alias("viewing-key")
-                .value_name("from")
+            .arg(Arg::new("seed")
+                .short('s')
+                .long("seed")
+                .value_name("SEED")
                 .value_parser(parse_seed)
-                .help("Create a new wallet with the given key. Can be a 24-word seed phrase or a viewkey. Will fail if wallet already exists"))
+                .help("Create a new wallet with the given 24-word seed phrase. Will fail if wallet already exists"))
+            .arg(Arg::new("viewkey`")
+                .long("viewkey")
+                .value_name("UFVK")
+                .help("Create a new wallet with the given encoded unified full viewing key. Will fail if wallet already exists"))
             .arg(Arg::new("birthday")
                 .long("birthday")
                 .value_name("birthday")
@@ -295,7 +296,17 @@ impl ConfigTemplate {
         } else {
             None
         };
-        let from = matches.get_one::<String>("from");
+        let seed = matches.get_one::<String>("seed");
+        let viewkey = matches.get_one::<String>("viewkey");
+        let from = if seed.is_some() && viewkey.is_some() {
+            return Err("Cannot load a wallet from both seed phrase and viewkey!".to_string());
+        } else if seed.is_some() {
+            seed
+        } else if viewkey.is_some() {
+            viewkey
+        } else {
+            None
+        };
         let maybe_birthday = matches
             .get_one::<u32>("birthday")
             .map(|bday| bday.to_string());

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -102,7 +102,7 @@ fn parse_ufvk(s: &str) -> Result<String, String> {
         if count == 1 {
             Ok(s)
         } else {
-            Err(format!("Encoded UFVK should not contain whitespace!"))
+            Err("Encoded UFVK should not contain whitespace!".to_string())
         }
     } else {
         Err("Unexpected failure to parse String!!".to_string())

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -40,12 +40,13 @@ pub fn build_clap_app() -> clap::ArgMatches {
             .arg(Arg::new("seed")
                 .short('s')
                 .long("seed")
-                .value_name("SEED")
+                .value_name("SEED PHRASE")
                 .value_parser(parse_seed)
                 .help("Create a new wallet with the given 24-word seed phrase. Will fail if wallet already exists"))
-            .arg(Arg::new("viewkey`")
+            .arg(Arg::new("viewkey")
                 .long("viewkey")
                 .value_name("UFVK")
+                .value_parser(parse_ufvk)
                 .help("Create a new wallet with the given encoded unified full viewing key. Will fail if wallet already exists"))
             .arg(Arg::new("birthday")
                 .long("birthday")
@@ -89,6 +90,19 @@ fn parse_seed(s: &str) -> Result<String, String> {
             Ok(s)
         } else {
             Err(format!("Expected 24 words, but received: {}.", count))
+        }
+    } else {
+        Err("Unexpected failure to parse String!!".to_string())
+    }
+}
+/// Parse encoded UFVK to String and check for whitespaces
+fn parse_ufvk(s: &str) -> Result<String, String> {
+    if let Ok(s) = s.parse::<String>() {
+        let count = s.split_whitespace().count();
+        if count == 1 {
+            Ok(s)
+        } else {
+            Err(format!("Encoded UFVK should not contain whitespace!"))
         }
     } else {
         Err("Unexpected failure to parse String!!".to_string())
@@ -283,6 +297,7 @@ fn short_circuit_on_help(params: Vec<String>) {
 impl ConfigTemplate {
     fn fill(matches: clap::ArgMatches) -> Result<Self, String> {
         let is_regtest = matches.get_flag("regtest"); // Begin short_circuit section
+
         let params = if let Some(vals) = matches.get_many::<String>("extra_args") {
             vals.cloned().collect()
         } else {


### PR DESCRIPTION
this fixes an error when creating a wallet from UFVK in zingocli due to the viewing key not having 24 words (it was passed through seed phrase checks)