### PR TITLE
remove transparent fvk from old wallet version ufvk loads

### DIFF
--- a/zingolib/src/wallet/keys/legacy.rs
+++ b/zingolib/src/wallet/keys/legacy.rs
@@ -69,6 +69,8 @@ where
     }
 }
 
+/// Converts a set of full viewing keys to a [`zcash_keys::keys::UnifiedFullViewingKey`].
+/// The transparent viewing key is of the zingolib legacy type [`extended_transparent::ExtendPubKey`].
 pub(crate) fn legacy_fvks_to_ufvk<P: zcash_primitives::consensus::Parameters>(
     orchard_fvk: Option<&orchard::keys::FullViewingKey>,
     sapling_fvk: Option<&sapling_crypto::zip32::DiversifiableFullViewingKey>,
@@ -97,6 +99,8 @@ pub(crate) fn legacy_fvks_to_ufvk<P: zcash_primitives::consensus::Parameters>(
         .map_err(|_| KeyError::KeyDecodingError)
 }
 
+/// Converts a set of spending keys to a [`zcash_keys::keys::UnifiedSpendingKey`].
+/// The transparent spending key is of the zingolib legacy type [`extended_transparent::ExtendPrivKey`].
 pub(crate) fn legacy_sks_to_usk(
     orchard_key: &orchard::keys::SpendingKey,
     sapling_key: &sapling_crypto::zip32::ExtendedSpendingKey,

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -747,24 +747,15 @@ impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
                     Capability::View(fvk) => Some(fvk),
                     _ => None,
                 };
-                let transparent_fvk = match &transparent_capability {
-                    Capability::View(fvk) => Some(fvk),
-                    _ => None,
-                };
 
-                let unified_key_store = if orchard_fvk.is_some()
-                    || sapling_fvk.is_some()
-                    || transparent_fvk.is_some()
-                {
+                let unified_key_store = if orchard_fvk.is_some() || sapling_fvk.is_some() {
                     // In the case of loading from viewing keys:
                     // Create the UFVK from FVKs.
-                    let ufvk = super::legacy::legacy_fvks_to_ufvk(
-                        orchard_fvk,
-                        sapling_fvk,
-                        transparent_fvk,
-                        &input,
-                    )
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+                    let ufvk =
+                        super::legacy::legacy_fvks_to_ufvk(orchard_fvk, sapling_fvk, None, &input)
+                            .map_err(|e| {
+                                io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+                            })?;
                     UnifiedKeyStore::View(Box::new(ufvk))
                 } else if matches!(sapling_capability.clone(), Capability::Spend(_)) {
                     // In the case of loading spending keys:


### PR DESCRIPTION
fixes a bug where the address is derived a layer too deep for t address generation when loading ufvk from old wallet version. this allows shielded viewing to continue to be available when a wallet is loaded from an old ufvk file but transparent will be unsupported due to the key derivation change.