### PR TITLE
Ring v16 dependency removed

### DIFF
--- a/zingo-netutils/Cargo.toml
+++ b/zingo-netutils/Cargo.toml
@@ -17,7 +17,7 @@ thiserror.workspace = true
 tokio-rustls.workspace = true
 tonic.workspace = true
 tower.workspace = true
-webpki-roots = "0.21.0"
+webpki-roots = "0.25"
 zcash_client_backend.workspace = true
 
 [features]

--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -95,7 +95,7 @@ impl GrpcConnector {
             if uri.scheme_str() == Some("https") {
                 let mut root_store = RootCertStore::empty();
                 //webpki uses a different struct for TrustAnchor
-                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|anchor_ref| {
+                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|anchor_ref| {
                     TrustAnchor {
                         subject: Der::from_slice(anchor_ref.subject),
                         subject_public_key_info: Der::from_slice(anchor_ref.spki),


### PR DESCRIPTION
Finally I removed `ring v16` as a dependency from `zingolib`. 
With this fix I can build `zingo-pc` for `Windows arm64`.

If this is correct I can close this PR: https://github.com/zingolabs/zingolib/pull/1318