### PR TITLE
align default and new in note builder

### DIFF
--- a/zingolib/src/wallet/notes/orchard.rs
+++ b/zingolib/src/wallet/notes/orchard.rs
@@ -224,21 +224,14 @@ pub mod mocks {
         have_spending_key: Option<bool>,
     }
 
-    #[allow(dead_code)] //TODO:  fix this gross hack that I tossed in to silence the language-analyzer false positive
     impl OrchardNoteBuilder {
-        /// blank builder
+        #[allow(dead_code)] //TODO:  fix this gross hack that I tossed in to silence the language-analyzer false positive
+        /// A builder, for a 'blank' note.
+        /// Be aware that two notes generated with
+        /// this function will be identical if built
+        /// with no changes.
         pub fn new() -> Self {
-            OrchardNoteBuilder {
-                diversifier: None,
-                note: None,
-                witnessed_position: None,
-                output_index: None,
-                nullifier: None,
-                spending_tx_status: None,
-                memo: None,
-                is_change: None,
-                have_spending_key: None,
-            }
+            Self::default()
         }
 
         // Methods to set each field
@@ -281,7 +274,17 @@ pub mod mocks {
 
     impl Default for OrchardNoteBuilder {
         fn default() -> Self {
-            let mut builder = OrchardNoteBuilder::new();
+            let mut builder = OrchardNoteBuilder {
+                diversifier: None,
+                note: None,
+                witnessed_position: None,
+                output_index: None,
+                nullifier: None,
+                spending_tx_status: None,
+                memo: None,
+                is_change: None,
+                have_spending_key: None,
+            };
             builder
                 .diversifier(Diversifier::from_bytes([0; 11]))
                 .note(OrchardCryptoNoteBuilder::default())

--- a/zingolib/src/wallet/notes/sapling.rs
+++ b/zingolib/src/wallet/notes/sapling.rs
@@ -240,21 +240,14 @@ pub mod mocks {
         have_spending_key: Option<bool>,
     }
 
-    #[allow(dead_code)] //TODO:  fix this gross hack that I tossed in to silence the language-analyzer false positive
     impl SaplingNoteBuilder {
-        /// blank builder
+        /// A builder, for a 'blank' note.
+        /// Be aware that two notes generated with
+        /// this function will be identical if built
+        /// with no changes.
+        #[allow(dead_code)]
         pub fn new() -> Self {
-            SaplingNoteBuilder {
-                diversifier: None,
-                note: None,
-                witnessed_position: None,
-                output_index: None,
-                nullifier: None,
-                spending_tx_status: None,
-                memo: None,
-                is_change: None,
-                have_spending_key: None,
-            }
+            Self::default()
         }
 
         // Methods to set each field
@@ -297,7 +290,17 @@ pub mod mocks {
 
     impl Default for SaplingNoteBuilder {
         fn default() -> Self {
-            let mut builder = SaplingNoteBuilder::new();
+            let mut builder = SaplingNoteBuilder {
+                diversifier: None,
+                note: None,
+                witnessed_position: None,
+                output_index: None,
+                nullifier: None,
+                spending_tx_status: None,
+                memo: None,
+                is_change: None,
+                have_spending_key: None,
+            };
             builder
                 .diversifier(sapling_crypto::Diversifier([0; 11]))
                 .note(crate::mocks::SaplingCryptoNoteBuilder::default())


### PR DESCRIPTION
It's conventional in Rust for types with both Default implementations and `new` constructors for those functions to be equivalent. I just spent a bunch of time trying to call `SaplingNoteBuilder::new()` and then call all of the build methods to build all the pieces individually, only to discover that I was re-implementing `default()`.