### PR TITLE
Explicit Invocation of thiserror::Error macro

### DIFF
--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -10,7 +10,6 @@ use client::client_from_connector;
 use http::{uri::PathAndQuery, Uri};
 use http_body_util::combinators::UnsyncBoxBody;
 use hyper_util::client::legacy::connect::HttpConnector;
-use thiserror::Error;
 use tokio_rustls::rustls::pki_types::{Der, TrustAnchor};
 use tokio_rustls::rustls::{ClientConfig, RootCertStore};
 use tonic::Status;
@@ -26,7 +25,7 @@ pub type UnderlyingService = BoxCloneService<
 >;
 
 #[allow(missing_docs)] // error types document themselves
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum GetClientError {
     #[error("bad uri: invalid scheme")]
     InvalidScheme,

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -36,7 +36,6 @@ pub mod send_with_proposal {
 
     use zcash_primitives::transaction::{Transaction, TxId};
 
-    use thiserror::Error;
     use zingo_status::confirmation_status::ConfirmationStatus;
 
     use crate::lightclient::LightClient;
@@ -44,7 +43,7 @@ pub mod send_with_proposal {
     use crate::wallet::propose::{ProposeSendError, ProposeShieldError};
 
     #[allow(missing_docs)] // error types document themselves
-    #[derive(Clone, Debug, Error)]
+    #[derive(Clone, Debug, thiserror::Error)]
     pub enum TransactionCacheError {
         #[error("No witness trees. This is viewkey watch, not spendkey wallet.")]
         NoSpendCapability,
@@ -55,7 +54,7 @@ pub mod send_with_proposal {
     }
 
     #[allow(missing_docs)] // error types document themselves
-    #[derive(Clone, Debug, Error)]
+    #[derive(Clone, Debug, thiserror::Error)]
     pub enum BroadcastCachedTransactionsError {
         #[error("Cant broadcast: {0:?}")]
         Cache(#[from] TransactionCacheError),
@@ -66,7 +65,7 @@ pub mod send_with_proposal {
     }
 
     #[allow(missing_docs)] // error types document themselves
-    #[derive(Debug, Error)]
+    #[derive(Debug, thiserror::Error)]
     pub enum RecordCachedTransactionsError {
         #[error("Cant record: {0:?}")]
         Cache(#[from] TransactionCacheError),
@@ -77,7 +76,7 @@ pub mod send_with_proposal {
     }
 
     #[allow(missing_docs)] // error types document themselves
-    #[derive(Debug, Error)]
+    #[derive(Debug, thiserror::Error)]
     pub enum CompleteAndBroadcastError {
         #[error("The transaction could not be calculated: {0:?}")]
         BuildTransaction(#[from] crate::wallet::send::BuildTransactionError),
@@ -90,7 +89,7 @@ pub mod send_with_proposal {
     }
 
     #[allow(missing_docs)] // error types document themselves
-    #[derive(Debug, Error)]
+    #[derive(Debug, thiserror::Error)]
     pub enum CompleteAndBroadcastStoredProposalError {
         #[error("No proposal. Call do_propose first.")]
         NoStoredProposal,
@@ -99,7 +98,7 @@ pub mod send_with_proposal {
     }
 
     #[allow(missing_docs)] // error types document themselves
-    #[derive(Debug, Error)]
+    #[derive(Debug, thiserror::Error)]
     pub enum QuickSendError {
         #[error("propose send {0:?}")]
         ProposeSend(#[from] ProposeSendError),
@@ -108,7 +107,7 @@ pub mod send_with_proposal {
     }
 
     #[allow(missing_docs)] // error types document themselves
-    #[derive(Debug, Error)]
+    #[derive(Debug, thiserror::Error)]
     pub enum QuickShieldError {
         #[error("propose shield {0:?}")]
         Propose(#[from] ProposeShieldError),

--- a/zingolib/src/utils/conversion.rs
+++ b/zingolib/src/utils/conversion.rs
@@ -1,14 +1,12 @@
 //! Conversion specific utilities
 
-use thiserror::Error;
-
 use zcash_address::ZcashAddress;
 use zcash_primitives::transaction::{components::amount::NonNegativeAmount, TxId};
 
 use super::error::ConversionError;
 
 #[allow(missing_docs)] // error types document themselves
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum TxIdFromHexEncodedStrError {
     #[error("{0}")]
     Decode(hex::FromHexError),

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -1,12 +1,11 @@
 //! Errors for [`crate::wallet`] and sub-modules
 
-use thiserror::Error;
 use zcash_keys::keys::DerivationError;
 
 use crate::wallet::data::OutgoingTxData;
 
 /// Errors associated with transaction fee calculation
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum FeeError {
     /// Sapling notes spent in a transaction not found in the wallet
     #[error("Sapling nullifier(s) {0:?} for this transaction not found in wallet. Is the wallet fully synced?")]
@@ -33,7 +32,7 @@ pub enum FeeError {
 }
 
 /// Errors associated with balance calculation
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum BalanceError {
     /// failed to retrieve full viewing key
     #[error("failed to retrieve full viewing key.")]
@@ -44,7 +43,7 @@ pub enum BalanceError {
 }
 
 /// Errors associated with balance key derivation
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum KeyError {
     /// Error asociated with standard IO
     #[error("{0}")]

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -2,7 +2,6 @@
 
 use std::{convert::Infallible, num::NonZeroU32, ops::DerefMut as _};
 
-use thiserror::Error;
 use zcash_client_backend::{
     data_api::wallet::input_selection::GreedyInputSelector,
     zip321::{TransactionRequest, Zip321Error},
@@ -42,7 +41,7 @@ fn build_default_giskit(memo: Option<MemoBytes>) -> GISKit {
 }
 
 /// Errors that can result from do_propose
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ProposeSendError {
     /// error in using trait to create spend proposal
     #[error("{0}")]
@@ -69,7 +68,7 @@ pub enum ProposeSendError {
 }
 
 /// Errors that can result from do_propose
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ProposeShieldError {
     /// error in parsed addresses
     #[error("{0}")]

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -89,9 +89,8 @@ impl LightWallet {
     }
 }
 
-use thiserror::Error;
 #[allow(missing_docs)] // error types document themselves
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum BuildTransactionError {
     #[error("No witness trees. This is viewkey watch, not spendkey wallet.")]
     NoSpendCapability,

--- a/zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs
+++ b/zingolib/src/wallet/transaction_records_by_id/trait_inputsource.rs
@@ -19,13 +19,12 @@ use zcash_primitives::{
 use crate::wallet::{notes::OutputInterface, transaction_records_by_id::TransactionRecordsById};
 
 use std::fmt::Debug;
-use thiserror::Error;
 
 use zcash_client_backend::wallet::NoteId;
 use zcash_primitives::transaction::components::amount::BalanceError;
 
 /// Error type used by InputSource trait
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum InputSourceError {
     /// No witness position found for note. Note cannot be spent.
     #[error("No witness position found for note. Note cannot be spent: {0:?}")]

--- a/zingolib/src/wallet/tx_map.rs
+++ b/zingolib/src/wallet/tx_map.rs
@@ -13,7 +13,6 @@ use crate::{
 use getset::{Getters, MutGetters};
 use spending_data::SpendingData;
 use std::{fmt::Debug, sync::Arc};
-use thiserror::Error;
 use zcash_client_backend::wallet::TransparentAddressMetadata;
 use zcash_primitives::legacy::{keys::EphemeralIvk, TransparentAddress};
 
@@ -87,7 +86,7 @@ impl TxMap {
     }
 }
 #[allow(missing_docs)] // error types document themselves
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum TxMapTraitError {
     #[error("No witness trees. This is viewkey watch, not a spendkey wallet.")]
     NoSpendCapability,


### PR DESCRIPTION
    - increases explicitness: Error is a crate, not to be confused with a standard derive trait, like Debug.
    - increased locality: rather than having a use statement in an arbitrary place, this groups error-related code together
    - standardization