### PR TITLE
For host x86_64 do not use arm64 android AVD in ci

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -42,7 +42,7 @@ jobs:
   android-ubuntu-integration-test-actions:
     strategy:
       matrix:
-        abi: [ x86_64, x86, arm64-v8a, armeabi-v7a ]
+        abi: [ x86_64, x86 ]
       fail-fast: false
     uses: zingolabs/zingo-mobile/.github/workflows/android-ubuntu-integration-test-ci.yaml@dev
     needs: [create-timestamp, android-build]


### PR DESCRIPTION
logs:
```
INFO    | Found systemPath /usr/local/lib/android/sdk/system-images/android-29/default/arm64-v8a/
PANIC: Avd's CPU Architecture 'arm64' is not supported by the QEMU2 emulator on x86_64 host.
```