### PR TITLE
fix shield when wallet contains more than one transparent address

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -668,6 +668,39 @@ mod fast {
             NonNegativeAmount::const_from_u64((block_rewards::CANOPY * 4) - expected_fee)
         )
     }
+    #[tokio::test]
+    async fn mine_to_transparent_and_propose_shielding_with_div_addr() {
+        let regtest_network = RegtestNetwork::all_upgrades_active();
+        let (regtest_manager, _cph, faucet, _recipient) =
+            scenarios::faucet_recipient(PoolType::Transparent, regtest_network).await;
+        increase_height_and_wait_for_client(&regtest_manager, &faucet, 1)
+            .await
+            .unwrap();
+        faucet.do_new_address("zto").await.unwrap();
+        let proposal = faucet.propose_shield().await.unwrap();
+        let only_step = proposal.steps().first();
+
+        // Orchard action and dummy, plus 4 transparent inputs
+        let expected_fee = 30_000;
+
+        assert_eq!(proposal.steps().len(), 1);
+        assert_eq!(only_step.transparent_inputs().len(), 4);
+        assert_eq!(
+            only_step.balance().fee_required(),
+            NonNegativeAmount::const_from_u64(expected_fee)
+        );
+        // Only one change item. I guess change could be split between pools?
+        assert_eq!(only_step.balance().proposed_change().len(), 1);
+        assert_eq!(
+            only_step
+                .balance()
+                .proposed_change()
+                .first()
+                .unwrap()
+                .value(),
+            NonNegativeAmount::const_from_u64((block_rewards::CANOPY * 4) - expected_fee)
+        )
+    }
 }
 mod slow {
     use bip0039::Mnemonic;

--- a/zingolib/src/wallet/tx_map/trait_stub_inputsource.rs
+++ b/zingolib/src/wallet/tx_map/trait_stub_inputsource.rs
@@ -54,12 +54,12 @@ impl InputSource for TxMap {
 
     fn get_spendable_transparent_outputs(
         &self,
-        _address: &zcash_primitives::legacy::TransparentAddress,
+        address: &zcash_primitives::legacy::TransparentAddress,
         target_height: zcash_primitives::consensus::BlockHeight,
         _min_confirmations: u32,
     ) -> Result<Vec<zcash_client_backend::wallet::WalletTransparentOutput>, Self::Error> {
         self.transaction_records_by_id
-            .get_spendable_transparent_outputs(_address, target_height, _min_confirmations)
+            .get_spendable_transparent_outputs(address, target_height, _min_confirmations)
             .map_err(TxMapTraitError::InputSource)
     }
 }


### PR DESCRIPTION
There was a bug preventing propose_shield from working when there was more than one transparent address in the wallet.