### PR TITLE
Kill lightwalletd instead of waiting for it

### DIFF
--- a/zingolib/src/testutils/regtest.rs
+++ b/zingolib/src/testutils/regtest.rs
@@ -58,7 +58,7 @@ impl Drop for ChildProcessHandler {
                 } else {
                     log::debug!("zcashd successfully shut down")
                 };
-                if let Err(e) = self.lightwalletd.wait() {
+                if let Err(e) = self.lightwalletd.kill() {
                     log::warn!("lightwalletd cannot be awaited: {e}")
                 } else {
                     log::debug!("lightwalletd successfully shut down")


### PR DESCRIPTION
This PR modifies the `Drop` impl for `ChildProcessHandler` to kill the `lightwalletd` process instead of waiting for it.