### PR TITLE
Restore order for value_transfers and messages

### DIFF
--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -58,7 +58,7 @@ async fn reorg_changes_incoming_tx_height() {
         }
     );
 
-    let before_reorg_transactions = light_client.value_transfers().await.0;
+    let before_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -93,7 +93,7 @@ async fn reorg_changes_incoming_tx_height() {
         }
     );
 
-    let after_reorg_transactions = light_client.value_transfers().await.0;
+    let after_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(after_reorg_transactions.len(), 1);
     assert_eq!(
@@ -214,7 +214,7 @@ async fn reorg_changes_incoming_tx_index() {
         }
     );
 
-    let before_reorg_transactions = light_client.value_transfers().await.0;
+    let before_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -249,7 +249,7 @@ async fn reorg_changes_incoming_tx_index() {
         }
     );
 
-    let after_reorg_transactions = light_client.value_transfers().await.0;
+    let after_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(after_reorg_transactions.len(), 1);
     assert_eq!(
@@ -369,7 +369,7 @@ async fn reorg_expires_incoming_tx() {
         }
     );
 
-    let before_reorg_transactions = light_client.value_transfers().await.0;
+    let before_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -404,7 +404,7 @@ async fn reorg_expires_incoming_tx() {
         }
     );
 
-    let after_reorg_transactions = light_client.value_transfers().await.0;
+    let after_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(after_reorg_transactions.len(), 0);
 }
@@ -547,7 +547,7 @@ async fn reorg_changes_outgoing_tx_height() {
         }
     );
 
-    let before_reorg_transactions = light_client.value_transfers().await.0;
+    let before_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -597,11 +597,11 @@ async fn reorg_changes_outgoing_tx_height() {
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
 
-    println!("{:?}", light_client.value_transfers().await);
+    println!("{:?}", light_client.value_transfers(true).await);
 
     assert_eq!(
         light_client
-            .value_transfers()
+            .value_transfers(true)
             .await
             .iter()
             .find_map(|v| match v.kind() {
@@ -661,18 +661,18 @@ async fn reorg_changes_outgoing_tx_height() {
         expected_after_reorg_balance
     );
 
-    let after_reorg_transactions = light_client.value_transfers().await.0;
+    let after_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(after_reorg_transactions.len(), 3);
 
-    println!("{:?}", light_client.value_transfers().await);
+    println!("{:?}", light_client.value_transfers(true).await);
 
     // FIXME: This test is broken because if this issue
     // https://github.com/zingolabs/zingolib/issues/622
     // verify that the reorged transaction is in the new height
     // assert_eq!(
     //     light_client
-    //         .list_value_transfers()
+    //         .list_value_transfers(true)
     //         .await
     //         .into_iter()
     //         .find_map(|v| match v.kind {
@@ -786,7 +786,7 @@ async fn reorg_expires_outgoing_tx_height() {
     light_client.do_sync(true).await.unwrap();
     assert_eq!(light_client.do_balance().await, expected_initial_balance);
 
-    let before_reorg_transactions = light_client.value_transfers().await.0;
+    let before_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -829,10 +829,10 @@ async fn reorg_expires_outgoing_tx_height() {
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
 
-    println!("{:?}", light_client.value_transfers().await);
+    println!("{:?}", light_client.value_transfers(true).await);
 
     let send_height = light_client
-        .value_transfers()
+        .value_transfers(true)
         .await
         .iter()
         .find_map(|v| match v.kind() {
@@ -872,18 +872,18 @@ async fn reorg_expires_outgoing_tx_height() {
     // sent transaction was never mined and has expired.
     assert_eq!(light_client.do_balance().await, expected_initial_balance);
 
-    let after_reorg_transactions = light_client.value_transfers().await.0;
+    let after_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(after_reorg_transactions.len(), 1);
 
-    println!("{:?}", light_client.value_transfers().await);
+    println!("{:?}", light_client.value_transfers(true).await);
 
     // FIXME: This test is broken because if this issue
     // https://github.com/zingolabs/zingolib/issues/622
     // verify that the reorged transaction is in the new height
     // assert_eq!(
     //     light_client
-    //         .list_value_transfers()
+    //         .list_value_transfers(true)
     //         .await
     //         .into_iter()
     //         .find_map(|v| match v.kind {
@@ -964,7 +964,7 @@ async fn reorg_changes_outgoing_tx_index() {
         }
     );
 
-    let before_reorg_transactions = light_client.value_transfers().await.0;
+    let before_reorg_transactions = light_client.value_transfers(true).await.0;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -1016,7 +1016,7 @@ async fn reorg_changes_outgoing_tx_index() {
 
     assert_eq!(
         light_client
-            .value_transfers()
+            .value_transfers(true)
             .await
             .iter()
             .find_map(|v| match v.kind() {
@@ -1039,7 +1039,7 @@ async fn reorg_changes_outgoing_tx_index() {
     );
 
     println!("pre re-org value transfers:");
-    println!("{}", light_client.value_transfers().await);
+    println!("{}", light_client.value_transfers(true).await);
     println!("pre re-org tx summaries:");
     println!("{}", light_client.transaction_summaries().await);
 
@@ -1087,7 +1087,7 @@ async fn reorg_changes_outgoing_tx_index() {
         expected_after_reorg_balance
     );
 
-    let after_reorg_transactions = light_client.value_transfers().await;
+    let after_reorg_transactions = light_client.value_transfers(true).await;
 
     println!("post re-org value transfers:");
     println!("{}", after_reorg_transactions);
@@ -1102,7 +1102,7 @@ async fn reorg_changes_outgoing_tx_index() {
     // verify that the reorged transaction is in the new height
     // assert_eq!(
     //     light_client
-    //         .list_value_transfers()
+    //         .list_value_transfers(true)
     //         .await
     //         .into_iter()
     //         .find_map(|v| match v.kind {

--- a/darkside-tests/tests/network_interruption_tests.rs
+++ b/darkside-tests/tests/network_interruption_tests.rs
@@ -197,7 +197,7 @@ async fn shielded_note_marked_as_change_test() {
         json::stringify_pretty(scenario.get_lightclient(0).do_list_notes(true).await, 4)
     );
     println!("do list tx summaries:");
-    dbg!(scenario.get_lightclient(0).value_transfers().await);
+    dbg!(scenario.get_lightclient(0).value_transfers(true).await);
 
     // assert the balance is correct
     assert_eq!(

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -160,7 +160,7 @@ mod fast {
             .await
             .unwrap();
 
-        let value_transfers = &recipient.value_transfers().await;
+        let value_transfers = &recipient.value_transfers(true).await;
 
         dbg!(value_transfers);
 
@@ -355,8 +355,12 @@ mod fast {
             .messages_containing(Some(&charlie.encode(&recipient.config().chain)))
             .await;
 
-        let all_vts = &recipient.value_transfers().await;
+        let all_vts = &recipient.value_transfers(true).await;
         let all_messages = &recipient.messages_containing(None).await;
+
+        for vt in all_vts.0.iter() {
+            dbg!(vt.blockheight());
+        }
 
         assert_eq!(value_transfers_bob.0.len(), 3);
         assert_eq!(value_transfers_charlie.0.len(), 2);
@@ -435,7 +439,7 @@ mod fast {
                     .len(),
                 3usize
             );
-            let val_tranfers = dbg!(sender.value_transfers().await);
+            let val_tranfers = dbg!(sender.value_transfers(true).await);
             // This fails, as we don't scan sends to tex correctly yet
             assert_eq!(
                 val_tranfers.0[0].recipient_address().unwrap(),
@@ -972,7 +976,7 @@ mod slow {
         );
         println!(
             "{}",
-            JsonValue::from(recipient.value_transfers().await).pretty(4)
+            JsonValue::from(recipient.value_transfers(true).await).pretty(4)
         );
     }
     #[tokio::test]
@@ -1391,7 +1395,7 @@ mod slow {
         println!("{}", recipient.do_list_transactions().await.pretty(2));
         println!(
             "{}",
-            JsonValue::from(recipient.value_transfers().await).pretty(2)
+            JsonValue::from(recipient.value_transfers(true).await).pretty(2)
         );
         recipient.do_rescan().await.unwrap();
         println!(
@@ -1401,7 +1405,7 @@ mod slow {
         println!("{}", recipient.do_list_transactions().await.pretty(2));
         println!(
             "{}",
-            JsonValue::from(recipient.value_transfers().await).pretty(2)
+            JsonValue::from(recipient.value_transfers(true).await).pretty(2)
         );
         // TODO: Add asserts!
     }
@@ -1824,7 +1828,7 @@ mod slow {
 
         println!(
             "{}",
-            JsonValue::from(faucet.value_transfers().await).pretty(4)
+            JsonValue::from(faucet.value_transfers(true).await).pretty(4)
         );
         println!(
             "{}",
@@ -2441,10 +2445,10 @@ mod slow {
                 .await
                 .unwrap();
             let pre_rescan_transactions = recipient.do_list_transactions().await;
-            let pre_rescan_summaries = recipient.value_transfers().await;
+            let pre_rescan_summaries = recipient.value_transfers(true).await;
             recipient.do_rescan().await.unwrap();
             let post_rescan_transactions = recipient.do_list_transactions().await;
-            let post_rescan_summaries = recipient.value_transfers().await;
+            let post_rescan_summaries = recipient.value_transfers(true).await;
             assert_eq!(pre_rescan_transactions, post_rescan_transactions);
             assert_eq!(pre_rescan_summaries, post_rescan_summaries);
             let mut outgoing_metadata = pre_rescan_transactions
@@ -3731,7 +3735,7 @@ mod slow {
         zingolib::testutils::increase_server_height(&regtest_manager, 1).await;
 
         let _synciiyur = recipient.do_sync(false).await;
-        // let summ_sim = recipient.list_value_transfers().await;
+        // let summ_sim = recipient.list_value_transfers(true).await;
         let bala_sim = recipient.do_balance().await;
 
         recipient.clear_state().await;
@@ -3750,10 +3754,10 @@ mod slow {
             }
         }
 
-        // let summ_int = recipient.list_value_transfers().await;
+        // let summ_int = recipient.list_value_transfers(true).await;
         // let bala_int = recipient.do_balance().await;
         let _synciiyur = recipient.do_sync(false).await;
-        // let summ_syn = recipient.list_value_transfers().await;
+        // let summ_syn = recipient.list_value_transfers(true).await;
         let bala_syn = recipient.do_balance().await;
 
         dbg!(

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -432,7 +432,7 @@ mod fast {
             let val_tranfers = dbg!(sender.value_transfers().await);
             // This fails, as we don't scan sends to tex correctly yet
             assert_eq!(
-                val_tranfers.0[2].recipient_address().unwrap(),
+                val_tranfers.0[0].recipient_address().unwrap(),
                 tex_addr_from_first.encode()
             );
         }

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -348,12 +348,25 @@ mod fast {
         let value_transfers_charlie = &recipient
             .messages_containing(Some(&charlie.encode(&recipient.config().chain)))
             .await;
-        let all_vts = &recipient.messages_containing(None).await;
 
-        println!("ALL VTS");
-        dbg!(all_vts);
+        let all_vts = &recipient.value_transfers().await;
+        let all_messages = &recipient.messages_containing(None).await;
+
         assert_eq!(value_transfers_bob.0.len(), 3);
         assert_eq!(value_transfers_charlie.0.len(), 2);
+
+        // Also asserting the order now (sorry juanky)
+        // ALL MESSAGES (First one should be the oldest one)
+        assert!(all_messages
+            .0
+            .windows(2)
+            .all(|pair| { pair[0].blockheight() <= pair[1].blockheight() }));
+
+        // ALL VTS (First one should be the most recent one)
+        assert!(all_vts
+            .0
+            .windows(2)
+            .all(|pair| { pair[0].blockheight() >= pair[1].blockheight() }));
     }
 
     pub mod tex {

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -173,6 +173,18 @@ mod fast {
             && vt.recipient_address() == Some(ZENNIES_FOR_ZINGO_REGTEST_ADDRESS)));
     }
 
+    /// Test sending and receiving messages between three parties.
+    ///
+    /// This test case consists of the following sequence of events:
+    ///
+    /// 1. Alice sends a message to Bob.
+    /// 2. Alice sends another message to Bob.
+    /// 3. Bob sends a message to Alice.
+    /// 4. Alice sends a message to Charlie.
+    /// 5. Charlie sends a message to Alice.
+    ///
+    /// After the messages are sent, the test checks that the `messages_containing` method
+    /// returns the expected messages for each party in the correct order.
     #[tokio::test]
     async fn message_thread() {
         let (regtest_manager, _cph, faucet, recipient, _txid) =
@@ -204,12 +216,6 @@ mod fast {
                 false,
             )
             .unwrap();
-
-        println!(
-            "Addresses: {}, {}",
-            alice,
-            bob.encode(&faucet.config().chain),
-        );
 
         let alice_to_bob = TransactionRequest::new(vec![Payment::new(
             ZcashAddress::from_str(&bob.encode(&faucet.config().chain)).unwrap(),

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1278,7 +1278,7 @@ impl Command for ValueTransfersCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        if !args.len() > 1 {
+        if args.len() > 1 {
             return "Error: invalid arguments\nTry 'help valuetransfers' for correct usage and examples"
                 .to_string();
         }

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1269,7 +1269,7 @@ impl Command for ValueTransfersCommand {
             A value transfer is a group of all notes to a specific receiver in a transaction.
 
             Usage:
-            valuetransfers
+            valuetransfers [bool]
         "#}
     }
 
@@ -1278,12 +1278,18 @@ impl Command for ValueTransfersCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &LightClient) -> String {
-        if !args.is_empty() {
+        if !args.len() > 1 {
             return "Error: invalid arguments\nTry 'help valuetransfers' for correct usage and examples"
                 .to_string();
         }
 
-        RT.block_on(async move { format!("{}", lightclient.value_transfers().await) })
+        let newer_first = args
+            .first()
+            .map(|s| s.parse())
+            .unwrap_or(Ok(true))
+            .unwrap_or(true);
+
+        RT.block_on(async move { format!("{}", lightclient.value_transfers(newer_first).await) })
     }
 }
 

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -271,7 +271,6 @@ impl LightClient {
     pub async fn messages_containing(&self, filter: Option<&str>) -> ValueTransfers {
         let mut value_transfers = self.value_transfers().await.0;
         value_transfers.reverse();
-
         match filter {
             Some(s) => {
                 value_transfers.retain(|vt| {
@@ -303,7 +302,7 @@ impl LightClient {
         let mut value_transfers: Vec<ValueTransfer> = Vec::new();
         let transaction_summaries = self.transaction_summaries().await;
 
-        for tx in transaction_summaries.iter() {
+        for tx in transaction_summaries.iter().rev() {
             match tx.kind() {
                 TransactionKind::Sent(SendType::Send) => {
                     // create 1 sent value transfer for each non-self recipient address

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -269,7 +269,7 @@ impl LightClient {
 
     /// Provides a list of ValueTransfers associated with the sender, or containing the string
     pub async fn messages_containing(&self, filter: Option<&str>) -> ValueTransfers {
-        let mut value_transfers = self.value_transfers().await.0;
+        let mut value_transfers = self.value_transfers(true).await.0;
         value_transfers.reverse();
         match filter {
             Some(s) => {
@@ -298,11 +298,17 @@ impl LightClient {
 
     /// Provides a list of value transfers related to this capability
     /// A value transfer is a group of all notes to a specific receiver in a transaction.
-    pub async fn value_transfers(&self) -> ValueTransfers {
+    pub async fn value_transfers(&self, newer_first: bool) -> ValueTransfers {
         let mut value_transfers: Vec<ValueTransfer> = Vec::new();
-        let transaction_summaries = self.transaction_summaries().await;
+        let summaries = self.transaction_summaries().await;
 
-        for tx in transaction_summaries.iter().rev() {
+        let transaction_summaries = if newer_first {
+            Box::new(summaries.iter().rev()) as Box<dyn Iterator<Item = &TransactionSummary>>
+        } else {
+            Box::new(summaries.iter()) as Box<dyn Iterator<Item = &TransactionSummary>>
+        };
+
+        for tx in transaction_summaries {
             match tx.kind() {
                 TransactionKind::Sent(SendType::Send) => {
                     // create 1 sent value transfer for each non-self recipient address
@@ -551,7 +557,7 @@ impl LightClient {
 
     /// TODO: doc comment
     pub async fn value_transfers_json_string(&self) -> String {
-        json::JsonValue::from(self.value_transfers().await).pretty(2)
+        json::JsonValue::from(self.value_transfers(true).await).pretty(2)
     }
 
     /// Provides a list of transaction summaries related to this wallet in order of blockheight
@@ -689,7 +695,7 @@ impl LightClient {
 
     /// TODO: Add Doc Comment Here!
     pub async fn do_total_memobytes_to_address(&self) -> finsight::TotalMemoBytesToAddress {
-        let value_transfers = self.value_transfers().await.0;
+        let value_transfers = self.value_transfers(true).await.0;
         let mut memobytes_by_address = HashMap::new();
         for value_transfer in value_transfers {
             if let ValueTransferKind::Sent(SentValueTransfer::Send) = value_transfer.kind() {
@@ -947,7 +953,7 @@ impl LightClient {
     }
 
     async fn value_transfer_by_to_address(&self) -> finsight::ValuesSentToAddress {
-        let value_transfers = self.value_transfers().await.0;
+        let value_transfers = self.value_transfers(true).await.0;
         let mut amount_by_address = HashMap::new();
         for value_transfer in value_transfers {
             if let ValueTransferKind::Sent(SentValueTransfer::Send) = value_transfer.kind() {

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -58,24 +58,24 @@ where
     )
     .await;
 
-    assert_eq!(sender.value_transfers().await.0.len(), 3);
+    assert_eq!(sender.value_transfers(true).await.0.len(), 3);
     assert_eq!(
-        sender.value_transfers().await.0[0].kind(),
+        sender.value_transfers(true).await.0[0].kind(),
         ValueTransferKind::Sent(SentValueTransfer::Send)
     );
     assert_eq!(
-        sender.value_transfers().await.0[1].kind(),
+        sender.value_transfers(true).await.0[1].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
             SelfSendValueTransfer::MemoToSelf
         ))
     );
     assert_eq!(
-        sender.value_transfers().await.0[2].kind(),
+        sender.value_transfers(true).await.0[2].kind(),
         ValueTransferKind::Received
     );
-    assert_eq!(recipient.value_transfers().await.0.len(), 1);
+    assert_eq!(recipient.value_transfers(true).await.0.len(), 1);
     assert_eq!(
-        recipient.value_transfers().await.0[0].kind(),
+        recipient.value_transfers(true).await.0[0].kind(),
         ValueTransferKind::Received
     );
 
@@ -87,18 +87,18 @@ where
     )
     .await;
 
-    assert_eq!(sender.value_transfers().await.0.len(), 4);
+    assert_eq!(sender.value_transfers(true).await.0.len(), 4);
     assert_eq!(
-        sender.value_transfers().await.0[0].kind(),
+        sender.value_transfers(true).await.0[0].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(SelfSendValueTransfer::Basic))
     );
 
     with_assertions::assure_propose_shield_bump_sync(&mut environment, &sender, false)
         .await
         .unwrap();
-    assert_eq!(sender.value_transfers().await.0.len(), 5);
+    assert_eq!(sender.value_transfers(true).await.0.len(), 5);
     assert_eq!(
-        sender.value_transfers().await.0[0].kind(),
+        sender.value_transfers(true).await.0[0].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(SelfSendValueTransfer::Shield))
     );
 }

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -57,20 +57,21 @@ where
         false,
     )
     .await;
+
     assert_eq!(sender.value_transfers().await.0.len(), 3);
     assert_eq!(
         sender.value_transfers().await.0[0].kind(),
-        ValueTransferKind::Received
-    );
-    assert_eq!(
-        sender.value_transfers().await.0[1].kind(),
         ValueTransferKind::Sent(SentValueTransfer::Send)
     );
     assert_eq!(
-        sender.value_transfers().await.0[2].kind(),
+        sender.value_transfers().await.0[1].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
             SelfSendValueTransfer::MemoToSelf
         ))
+    );
+    assert_eq!(
+        sender.value_transfers().await.0[2].kind(),
+        ValueTransferKind::Received
     );
     assert_eq!(recipient.value_transfers().await.0.len(), 1);
     assert_eq!(
@@ -85,9 +86,10 @@ where
         false,
     )
     .await;
+
     assert_eq!(sender.value_transfers().await.0.len(), 4);
     assert_eq!(
-        sender.value_transfers().await.0[3].kind(),
+        sender.value_transfers().await.0[0].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(SelfSendValueTransfer::Basic))
     );
 
@@ -96,7 +98,7 @@ where
         .unwrap();
     assert_eq!(sender.value_transfers().await.0.len(), 5);
     assert_eq!(
-        sender.value_transfers().await.0[4].kind(),
+        sender.value_transfers().await.0[0].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(SelfSendValueTransfer::Shield))
     );
 }


### PR DESCRIPTION
This PR fixes `value_transfers` and `messages_containing`, as they had the inverse order... sorry @juanky201271. It also adds more assertions.