### PR TITLE
Make value transfers more idiomatic

### DIFF
--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -58,7 +58,7 @@ async fn reorg_changes_incoming_tx_height() {
         }
     );
 
-    let before_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let before_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -93,7 +93,7 @@ async fn reorg_changes_incoming_tx_height() {
         }
     );
 
-    let after_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let after_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(after_reorg_transactions.len(), 1);
     assert_eq!(
@@ -214,7 +214,7 @@ async fn reorg_changes_incoming_tx_index() {
         }
     );
 
-    let before_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let before_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -249,7 +249,7 @@ async fn reorg_changes_incoming_tx_index() {
         }
     );
 
-    let after_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let after_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(after_reorg_transactions.len(), 1);
     assert_eq!(
@@ -369,7 +369,7 @@ async fn reorg_expires_incoming_tx() {
         }
     );
 
-    let before_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let before_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -404,7 +404,7 @@ async fn reorg_expires_incoming_tx() {
         }
     );
 
-    let after_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let after_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(after_reorg_transactions.len(), 0);
 }
@@ -547,7 +547,7 @@ async fn reorg_changes_outgoing_tx_height() {
         }
     );
 
-    let before_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let before_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -661,7 +661,7 @@ async fn reorg_changes_outgoing_tx_height() {
         expected_after_reorg_balance
     );
 
-    let after_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let after_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(after_reorg_transactions.len(), 3);
 
@@ -786,7 +786,7 @@ async fn reorg_expires_outgoing_tx_height() {
     light_client.do_sync(true).await.unwrap();
     assert_eq!(light_client.do_balance().await, expected_initial_balance);
 
-    let before_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let before_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -872,7 +872,7 @@ async fn reorg_expires_outgoing_tx_height() {
     // sent transaction was never mined and has expired.
     assert_eq!(light_client.do_balance().await, expected_initial_balance);
 
-    let after_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let after_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(after_reorg_transactions.len(), 1);
 
@@ -964,7 +964,7 @@ async fn reorg_changes_outgoing_tx_index() {
         }
     );
 
-    let before_reorg_transactions = light_client.sorted_value_transfers(true).await.0;
+    let before_reorg_transactions = light_client.sorted_value_transfers(true).await;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -527,7 +527,7 @@ mod fast {
             let val_tranfers = dbg!(sender.sorted_value_transfers(true).await);
             // This fails, as we don't scan sends to tex correctly yet
             assert_eq!(
-                val_tranfers.0[0].recipient_address().unwrap(),
+                val_tranfers[0].recipient_address().unwrap(),
                 tex_addr_from_first.encode()
             );
         }

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -265,7 +265,7 @@ impl LightClient {
 
     /// Provides a list of ValueTransfers associated with the sender, or containing the string.
     pub async fn messages_containing(&self, filter: Option<&str>) -> ValueTransfers {
-        let mut value_transfers = self.sorted_value_transfers(true).await.0;
+        let mut value_transfers = self.sorted_value_transfers(true).await;
         value_transfers.reverse();
 
         // Filter out VTs where all memos are empty.
@@ -293,7 +293,7 @@ impl LightClient {
             None => value_transfers.retain(|vt| !vt.memos().is_empty()),
         }
 
-        ValueTransfers(value_transfers)
+        value_transfers
     }
 
     /// Provides a list of value transfers sorted
@@ -301,7 +301,7 @@ impl LightClient {
     pub async fn sorted_value_transfers(&self, newer_first: bool) -> ValueTransfers {
         let mut value_transfers = self.value_transfers().await;
         if newer_first {
-            value_transfers.0.reverse();
+            value_transfers.reverse();
         }
         value_transfers
     }
@@ -557,7 +557,7 @@ impl LightClient {
                 }
             };
         }
-        ValueTransfers(value_transfers)
+        ValueTransfers::new(value_transfers)
     }
 
     /// TODO: doc comment
@@ -700,9 +700,9 @@ impl LightClient {
 
     /// TODO: Add Doc Comment Here!
     pub async fn do_total_memobytes_to_address(&self) -> finsight::TotalMemoBytesToAddress {
-        let value_transfers = self.sorted_value_transfers(true).await.0;
+        let value_transfers = self.sorted_value_transfers(true).await;
         let mut memobytes_by_address = HashMap::new();
-        for value_transfer in value_transfers {
+        for value_transfer in &value_transfers {
             if let ValueTransferKind::Sent(SentValueTransfer::Send) = value_transfer.kind() {
                 let address = value_transfer
                     .recipient_address()
@@ -955,9 +955,9 @@ impl LightClient {
     }
 
     async fn value_transfer_by_to_address(&self) -> finsight::ValuesSentToAddress {
-        let value_transfers = self.sorted_value_transfers(false).await.0;
+        let value_transfers = self.sorted_value_transfers(false).await;
         let mut amount_by_address = HashMap::new();
-        for value_transfer in value_transfers {
+        for value_transfer in &value_transfers {
             if let ValueTransferKind::Sent(SentValueTransfer::Send) = value_transfer.kind() {
                 let address = value_transfer
                     .recipient_address()

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -58,35 +58,28 @@ where
     )
     .await;
 
-    assert_eq!(sender.sorted_value_transfers(true).await.0.len(), 3);
+    assert_eq!(sender.sorted_value_transfers(true).await.len(), 3);
 
     assert!(sender
         .sorted_value_transfers(false)
         .await
-        .0
         .iter()
         .any(|vt| { vt.kind() == ValueTransferKind::Received }));
 
     assert!(sender
         .sorted_value_transfers(false)
         .await
-        .0
         .iter()
         .any(|vt| { vt.kind() == ValueTransferKind::Sent(SentValueTransfer::Send) }));
 
-    assert!(sender
-        .sorted_value_transfers(false)
-        .await
-        .0
-        .iter()
-        .any(|vt| {
-            vt.kind()
-                == ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
-                    SelfSendValueTransfer::MemoToSelf,
-                ))
-        }));
+    assert!(sender.sorted_value_transfers(false).await.iter().any(|vt| {
+        vt.kind()
+            == ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
+                SelfSendValueTransfer::MemoToSelf,
+            ))
+    }));
 
-    assert_eq!(recipient.sorted_value_transfers(true).await.0.len(), 1);
+    assert_eq!(recipient.sorted_value_transfers(true).await.len(), 1);
 
     with_assertions::propose_send_bump_sync_all_recipients(
         &mut environment,
@@ -96,18 +89,18 @@ where
     )
     .await;
 
-    assert_eq!(sender.sorted_value_transfers(true).await.0.len(), 4);
+    assert_eq!(sender.sorted_value_transfers(true).await.len(), 4);
     assert_eq!(
-        sender.sorted_value_transfers(true).await.0[0].kind(),
+        sender.sorted_value_transfers(true).await[0].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(SelfSendValueTransfer::Basic))
     );
 
     with_assertions::assure_propose_shield_bump_sync(&mut environment, &sender, false)
         .await
         .unwrap();
-    assert_eq!(sender.sorted_value_transfers(true).await.0.len(), 5);
+    assert_eq!(sender.sorted_value_transfers(true).await.len(), 5);
     assert_eq!(
-        sender.sorted_value_transfers(true).await.0[0].kind(),
+        sender.sorted_value_transfers(true).await[0].kind(),
         ValueTransferKind::Sent(SentValueTransfer::SendToSelf(SelfSendValueTransfer::Shield))
     );
 }

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -679,7 +679,7 @@ pub mod summaries {
 
     /// A wrapper struct for implementing display and json on a vec of value trasnfers
     #[derive(PartialEq, Debug)]
-    pub struct ValueTransfers(pub Vec<ValueTransfer>);
+    pub struct ValueTransfers(Vec<ValueTransfer>);
     impl<'a> std::iter::IntoIterator for &'a ValueTransfers {
         type Item = &'a ValueTransfer;
         type IntoIter = std::slice::Iter<'a, ValueTransfer>;
@@ -711,7 +711,6 @@ pub mod summaries {
 
     impl ValueTransfers {
         /// Creates a new ValueTransfer
-        #[deprecated(since = "1.10.2", note = "never used")]
         pub fn new(value_transfers: Vec<ValueTransfer>) -> Self {
             ValueTransfers(value_transfers)
         }

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -680,15 +680,40 @@ pub mod summaries {
     /// A wrapper struct for implementing display and json on a vec of value trasnfers
     #[derive(PartialEq, Debug)]
     pub struct ValueTransfers(pub Vec<ValueTransfer>);
+    impl<'a> std::iter::IntoIterator for &'a ValueTransfers {
+        type Item = &'a ValueTransfer;
+        type IntoIter = std::slice::Iter<'a, ValueTransfer>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter()
+        }
+    }
+    impl std::ops::Deref for ValueTransfers {
+        type Target = Vec<ValueTransfer>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl std::ops::DerefMut for ValueTransfers {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+    // Implement the Index trait
+    impl std::ops::Index<usize> for ValueTransfers {
+        type Output = ValueTransfer; // The type of the value returned by the index
+
+        fn index(&self, index: usize) -> &Self::Output {
+            &self.0[index] // Forward the indexing operation to the underlying data structure
+        }
+    }
 
     impl ValueTransfers {
         /// Creates a new ValueTransfer
+        #[deprecated(since = "1.10.2", note = "never used")]
         pub fn new(value_transfers: Vec<ValueTransfer>) -> Self {
             ValueTransfers(value_transfers)
-        }
-        /// Implicitly dispatch to the wrapped data
-        pub fn iter(&self) -> std::slice::Iter<ValueTransfer> {
-            self.0.iter()
         }
 
         /// Creates value transfers for all notes in a transaction that are sent to another


### PR DESCRIPTION
This makes `ValueTransfers` implement trait to support an idiomatic interface.

Apart from readability in general it's possible poor ergonomics on this type confused us into writing a bad test:

`fast::tex::send_to_tex`