### PR TITLE
Investigate send to tex

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -504,11 +504,27 @@ mod fast {
                 .propose_send(transaction_request_to_faucet_tex)
                 .await
                 .unwrap();
+            assert_eq!(
+                sender
+                    .wallet
+                    .wallet_capability()
+                    .get_rejection_addresses()
+                    .len(),
+                0
+            );
             assert_eq!(proposal_with_faucet_tex.steps().len(), 2usize);
             let _sent_txids_according_to_broadcast = sender
                 .complete_and_broadcast_stored_proposal()
                 .await
                 .unwrap();
+            assert_eq!(
+                sender
+                    .wallet
+                    .wallet_capability()
+                    .get_rejection_addresses()
+                    .len(),
+                1
+            );
             let _txids = sender
                 .wallet
                 .transactions()

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -525,6 +525,11 @@ mod fast {
                     .len(),
                 1
             );
+            dbg!(sender.wallet.wallet_capability().get_rejection_addresses());
+            dbg!(sender
+                .wallet
+                .wallet_capability()
+                .transparent_child_addresses());
             let _txids = sender
                 .wallet
                 .transactions()
@@ -546,7 +551,7 @@ mod fast {
             );
             let val_tranfers = sender.sorted_value_transfers(true).await;
             // This fails, as we don't scan sends to tex correctly yet
-            let first_vt = dbg!(val_tranfers[0].clone());
+            let first_vt = val_tranfers[0].clone();
             assert_eq!(
                 first_vt.recipient_address().unwrap(),
                 tex_addr_from_faucet_first_taddr.encode()

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -491,16 +491,20 @@ mod fast {
             let (ref _regtest_manager, _cph, ref faucet, sender, _txid) =
                 scenarios::orchard_funded_recipient(5_000_000).await;
 
-            let tex_addr_from_first = first_taddr_to_tex(faucet);
-            let payment = vec![Payment::without_memo(
-                tex_addr_from_first.clone(),
+            let tex_addr_from_faucet_first_taddr = first_taddr_to_tex(faucet);
+            let payment_to_faucet_tex = vec![Payment::without_memo(
+                tex_addr_from_faucet_first_taddr.clone(),
                 NonNegativeAmount::from_u64(100_000).unwrap(),
             )];
 
-            let transaction_request = TransactionRequest::new(payment).unwrap();
+            let transaction_request_to_faucet_tex =
+                TransactionRequest::new(payment_to_faucet_tex).unwrap();
 
-            let proposal = sender.propose_send(transaction_request).await.unwrap();
-            assert_eq!(proposal.steps().len(), 2usize);
+            let proposal_with_faucet_tex = sender
+                .propose_send(transaction_request_to_faucet_tex)
+                .await
+                .unwrap();
+            assert_eq!(proposal_with_faucet_tex.steps().len(), 2usize);
             let _sent_txids_according_to_broadcast = sender
                 .complete_and_broadcast_stored_proposal()
                 .await
@@ -529,7 +533,7 @@ mod fast {
             let first_vt = dbg!(val_tranfers[0].clone());
             assert_eq!(
                 first_vt.recipient_address().unwrap(),
-                tex_addr_from_first.encode()
+                tex_addr_from_faucet_first_taddr.encode()
             );
             panic!("The first value transfer is the receipt from the faucet!!");
         }

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -524,12 +524,14 @@ mod fast {
                     .len(),
                 3usize
             );
-            let val_tranfers = dbg!(sender.sorted_value_transfers(true).await);
+            let val_tranfers = sender.sorted_value_transfers(true).await;
             // This fails, as we don't scan sends to tex correctly yet
+            let first_vt = dbg!(val_tranfers[0].clone());
             assert_eq!(
-                val_tranfers[0].recipient_address().unwrap(),
+                first_vt.recipient_address().unwrap(),
                 tex_addr_from_first.encode()
             );
+            panic!("The first value transfer is the receipt from the faucet!!");
         }
     }
 

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -518,7 +518,7 @@ pub mod summaries {
 
     /// A value transfer is a note group abstraction.
     /// A group of all notes sent to a specific address in a transaction.
-    #[derive(PartialEq)]
+    #[derive(Clone, PartialEq)]
     pub struct ValueTransfer {
         txid: TxId,
         datetime: u64,


### PR DESCRIPTION
Builds on #1564 which makes value_transfers easier to use.

Why does the first value transfer of sender (which should be a receipt) have a `recipient_address`?

Should it?   Has this already been fixed on @fluidvanadium 's feature branch?