### PR TITLE
Fix minor bugs

### DIFF
--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -43,8 +43,8 @@ async fn sync_mainnet_test() {
         .await
         .unwrap();
 
-    dbg!(lightclient.wallet.wallet_blocks);
-    dbg!(lightclient.wallet.nullifier_map);
+    // dbg!(lightclient.wallet.wallet_blocks);
+    // dbg!(lightclient.wallet.nullifier_map);
     dbg!(lightclient.wallet.sync_state);
 }
 

--- a/zingo-sync/src/scan.rs
+++ b/zingo-sync/src/scan.rs
@@ -173,7 +173,19 @@ where
     .await
     .unwrap();
 
-    let scan_data = scan_compact_blocks(compact_blocks, parameters, ufvks, initial_scan_data)?;
+    let consensus_parameters_clone = parameters.clone();
+    let ufvks_clone = ufvks.clone();
+    let scan_data = tokio::task::spawn_blocking(move || {
+        scan_compact_blocks(
+            compact_blocks,
+            &consensus_parameters_clone,
+            &ufvks_clone,
+            initial_scan_data,
+        )
+    })
+    .await
+    .unwrap()?;
+    // let scan_data = scan_compact_blocks(compact_blocks, parameters, ufvks, initial_scan_data)?;
 
     let ScanData {
         nullifiers,

--- a/zingo-sync/src/scan.rs
+++ b/zingo-sync/src/scan.rs
@@ -40,7 +40,7 @@ struct InitialScanData {
 impl InitialScanData {
     async fn new<P>(
         fetch_request_sender: mpsc::UnboundedSender<FetchRequest>,
-        parameters: &P,
+        consensus_parameters: &P,
         first_block: &CompactBlock,
         previous_wallet_block: Option<WalletBlock>,
     ) -> Result<Self, ()>
@@ -84,7 +84,7 @@ impl InitialScanData {
                         .unwrap(),
                 )
             } else {
-                let sapling_activation_height = parameters
+                let sapling_activation_height = consensus_parameters
                     .activation_height(NetworkUpgrade::Sapling)
                     .expect("should have some sapling activation height");
 

--- a/zingo-sync/src/scan/compact_blocks.rs
+++ b/zingo-sync/src/scan/compact_blocks.rs
@@ -158,6 +158,7 @@ where
 
 // checks height and hash continuity of a batch of compact blocks.
 // takes the last wallet compact block of the adjacent lower scan range, if available.
+// TODO: remove option and revisit scanner flow to use the last block of previously scanned batch to check continuity
 fn check_continuity(
     compact_blocks: &[CompactBlock],
     previous_compact_block: Option<&WalletBlock>,

--- a/zingo-sync/src/scan/compact_blocks.rs
+++ b/zingo-sync/src/scan/compact_blocks.rs
@@ -18,7 +18,7 @@ use zcash_primitives::{
 use crate::{
     keys::{KeyId, ScanningKeyOps, ScanningKeys},
     primitives::{NullifierMap, OutputId, WalletBlock},
-    witness::ShardTreeData,
+    witness::WitnessData,
 };
 
 use self::runners::{BatchRunners, DecryptedOutput};
@@ -48,7 +48,7 @@ where
     let mut nullifiers = NullifierMap::new();
     let mut relevant_txids: HashSet<TxId> = HashSet::new();
     let mut decrypted_note_data = DecryptedNoteData::new();
-    let mut shard_tree_data = ShardTreeData::new(
+    let mut witness_data = WitnessData::new(
         Position::from(u64::from(initial_scan_data.sapling_initial_tree_size)),
         Position::from(u64::from(initial_scan_data.orchard_initial_tree_size)),
     );
@@ -77,7 +77,7 @@ where
 
             collect_nullifiers(&mut nullifiers, block.height(), transaction).unwrap();
 
-            shard_tree_data.sapling_leaves_and_retentions.extend(
+            witness_data.sapling_leaves_and_retentions.extend(
                 calculate_sapling_leaves_and_retentions(
                     &transaction.outputs,
                     block.height(),
@@ -86,7 +86,7 @@ where
                 )
                 .unwrap(),
             );
-            shard_tree_data.orchard_leaves_and_retentions.extend(
+            witness_data.orchard_leaves_and_retentions.extend(
                 calculate_orchard_leaves_and_retentions(
                     &transaction.actions,
                     block.height(),
@@ -135,7 +135,7 @@ where
         wallet_blocks,
         relevant_txids,
         decrypted_note_data,
-        shard_tree_data,
+        witness_data,
     })
 }
 

--- a/zingo-sync/src/scan/task.rs
+++ b/zingo-sync/src/scan/task.rs
@@ -187,10 +187,8 @@ where
                 if let Some(worker) = self.idle_worker() {
                     if let Some(scan_task) = sync::state::create_scan_task(wallet).unwrap() {
                         worker.add_scan_task(scan_task).unwrap();
-                    } else {
-                        if wallet.get_sync_state().unwrap().scan_complete() {
-                            self.state.shutdown();
-                        }
+                    } else if wallet.get_sync_state().unwrap().scan_complete() {
+                        self.state.shutdown();
                     }
                 }
             }

--- a/zingo-sync/src/sync.rs
+++ b/zingo-sync/src/sync.rs
@@ -383,8 +383,8 @@ where
         outpoints,
         wallet_blocks,
         wallet_transactions,
-        sapling_located_tree_data,
-        orchard_located_tree_data,
+        sapling_located_trees,
+        orchard_located_trees,
     } = scan_results;
 
     wallet.append_wallet_blocks(wallet_blocks).unwrap();
@@ -394,7 +394,7 @@ where
     wallet.append_nullifiers(nullifiers).unwrap();
     wallet.append_outpoints(outpoints).unwrap();
     wallet
-        .update_shard_trees(sapling_located_tree_data, orchard_located_tree_data)
+        .update_shard_trees(sapling_located_trees, orchard_located_trees)
         .unwrap();
     // TODO: add trait to save wallet data to persistance for in-memory wallets
 

--- a/zingo-sync/src/sync.rs
+++ b/zingo-sync/src/sync.rs
@@ -255,7 +255,7 @@ async fn process_mempool_stream_response<W>(
     W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints,
 {
     // TODO: replace this unwrap_or_else with proper error handling
-    match mempool_stream_response.unwrap_or_else(|_| None) {
+    match mempool_stream_response.unwrap_or(None) {
         Some(raw_transaction) => {
             let block_height =
                 BlockHeight::from_u32(u32::try_from(raw_transaction.height).unwrap());

--- a/zingo-sync/src/sync.rs
+++ b/zingo-sync/src/sync.rs
@@ -380,10 +380,11 @@ where
 {
     let ScanResults {
         nullifiers,
+        outpoints,
         wallet_blocks,
         wallet_transactions,
-        shard_tree_data,
-        outpoints,
+        sapling_located_tree_data,
+        orchard_located_tree_data,
     } = scan_results;
 
     wallet.append_wallet_blocks(wallet_blocks).unwrap();
@@ -392,7 +393,9 @@ where
         .unwrap();
     wallet.append_nullifiers(nullifiers).unwrap();
     wallet.append_outpoints(outpoints).unwrap();
-    wallet.update_shard_trees(shard_tree_data).unwrap();
+    wallet
+        .update_shard_trees(sapling_located_tree_data, orchard_located_tree_data)
+        .unwrap();
     // TODO: add trait to save wallet data to persistance for in-memory wallets
 
     Ok(())

--- a/zingo-sync/src/sync.rs
+++ b/zingo-sync/src/sync.rs
@@ -108,7 +108,7 @@ where
     // TODO: invalidate any pending transactions after eviction height (40 below best chain height?)
     // TODO: implement an option for continuous scanning where it doesnt exit when complete
 
-    let mut interval = tokio::time::interval(Duration::from_millis(100));
+    let mut interval = tokio::time::interval(Duration::from_millis(30));
     loop {
         tokio::select! {
             Some((scan_range, scan_results)) = scan_results_receiver.recv() => {

--- a/zingo-sync/src/sync.rs
+++ b/zingo-sync/src/sync.rs
@@ -71,15 +71,15 @@ where
     }
     let ufvks = wallet.get_unified_full_viewing_keys().unwrap();
 
-    transparent::update_addresses_and_locators(
-        consensus_parameters,
-        wallet,
-        fetch_request_sender.clone(),
-        &ufvks,
-        wallet_height,
-        chain_height,
-    )
-    .await;
+    // transparent::update_addresses_and_locators(
+    //     consensus_parameters,
+    //     wallet,
+    //     fetch_request_sender.clone(),
+    //     &ufvks,
+    //     wallet_height,
+    //     chain_height,
+    // )
+    // .await;
 
     state::update_scan_ranges(
         wallet_height,
@@ -99,15 +99,16 @@ where
     );
     scanner.spawn_workers();
 
-    // setup the initial mempool stream
-    let mut mempool_stream = client::get_mempool_transaction_stream(fetch_request_sender.clone())
-        .await
-        .unwrap();
+    // // setup the initial mempool stream
+    // let mut mempool_stream = client::get_mempool_transaction_stream(fetch_request_sender.clone())
+    //     .await
+    //     .unwrap();
 
     // TODO: consider what happens when there is no verification range i.e. all ranges already scanned
     // TODO: invalidate any pending transactions after eviction height (40 below best chain height?)
+    // TODO: implement an option for continuous scanning where it doesnt exit when complete
 
-    let mut interval = tokio::time::interval(Duration::from_millis(30));
+    let mut interval = tokio::time::interval(Duration::from_millis(100));
     loop {
         tokio::select! {
             Some((scan_range, scan_results)) = scan_results_receiver.recv() => {
@@ -124,20 +125,20 @@ where
                 .unwrap();
             }
 
-            mempool_stream_response = mempool_stream.message() => {
-                process_mempool_stream_response(
-                    consensus_parameters,
-                    fetch_request_sender.clone(),
-                    &ufvks,
-                    wallet,
-                    mempool_stream_response,
-                    &mut mempool_stream)
-                .await;
+            // mempool_stream_response = mempool_stream.message() => {
+            //     process_mempool_stream_response(
+            //         consensus_parameters,
+            //         fetch_request_sender.clone(),
+            //         &ufvks,
+            //         wallet,
+            //         mempool_stream_response,
+            //         &mut mempool_stream)
+            //     .await;
 
-                // reset interval to ensure all mempool transactions have been scanned before sync completes.
-                // if a full interval passes without receiving a transaction from the mempool we can safely finish sync.
-                interval.reset();
-            }
+            //     // reset interval to ensure all mempool transactions have been scanned before sync completes.
+            //     // if a full interval passes without receiving a transaction from the mempool we can safely finish sync.
+            //     interval.reset();
+            // }
 
             _update_scanner = interval.tick() => {
                 scanner.update(wallet).await;
@@ -257,7 +258,8 @@ async fn process_mempool_stream_response<W>(
 ) where
     W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints,
 {
-    match mempool_stream_response.unwrap() {
+    // TODO: replace this unwrap_or_else with proper error handling
+    match mempool_stream_response.unwrap_or_else(|_| None) {
         Some(raw_transaction) => {
             let block_height =
                 BlockHeight::from_u32(u32::try_from(raw_transaction.height).unwrap());
@@ -351,6 +353,7 @@ async fn process_mempool_stream_response<W>(
             *mempool_stream = client::get_mempool_transaction_stream(fetch_request_sender.clone())
                 .await
                 .unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
     }
 }

--- a/zingo-sync/src/traits.rs
+++ b/zingo-sync/src/traits.rs
@@ -3,20 +3,15 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 
-use incrementalmerkletree::Level;
 use orchard::tree::MerkleHashOrchard;
-use shardtree::LocatedPrunableTree;
-use zcash_client_backend::{
-    data_api::{ORCHARD_SHARD_HEIGHT, SAPLING_SHARD_HEIGHT},
-    keys::UnifiedFullViewingKey,
-};
+use zcash_client_backend::keys::UnifiedFullViewingKey;
 use zcash_primitives::consensus::BlockHeight;
 use zcash_primitives::transaction::TxId;
 use zcash_primitives::zip32::AccountId;
 
 use crate::keys::transparent::TransparentAddressId;
 use crate::primitives::{NullifierMap, OutPointMap, SyncState, WalletBlock, WalletTransaction};
-use crate::witness::{LocatedTreeData, ShardTrees, WitnessData};
+use crate::witness::{LocatedTreeData, ShardTrees};
 
 // TODO: clean up interface and move many default impls out of traits. consider merging to a simplified SyncWallet interface.
 

--- a/zingo-sync/src/traits.rs
+++ b/zingo-sync/src/traits.rs
@@ -16,7 +16,7 @@ use zcash_primitives::zip32::AccountId;
 
 use crate::keys::transparent::TransparentAddressId;
 use crate::primitives::{NullifierMap, OutPointMap, SyncState, WalletBlock, WalletTransaction};
-use crate::witness::{LocatedTreeData, ShardTreeData, ShardTrees};
+use crate::witness::{LocatedTreeData, ShardTrees, WitnessData};
 
 // TODO: clean up interface and move many default impls out of traits. consider merging to a simplified SyncWallet interface.
 
@@ -232,18 +232,18 @@ pub trait SyncShardTrees: SyncWallet {
     /// Update wallet shard trees with new shard tree data
     fn update_shard_trees(
         &mut self,
-        sapling_located_tree_data: Vec<LocatedTreeData<sapling_crypto::Node>>,
-        orchard_located_tree_data: Vec<LocatedTreeData<MerkleHashOrchard>>,
+        sapling_located_trees: Vec<LocatedTreeData<sapling_crypto::Node>>,
+        orchard_located_trees: Vec<LocatedTreeData<MerkleHashOrchard>>,
     ) -> Result<(), Self::Error> {
         let shard_trees = self.get_shard_trees_mut()?;
 
-        for tree in sapling_located_tree_data.into_iter() {
+        for tree in sapling_located_trees.into_iter() {
             shard_trees
                 .sapling_mut()
                 .insert_tree(tree.subtree, tree.checkpoints)
                 .unwrap();
         }
-        for tree in orchard_located_tree_data.into_iter() {
+        for tree in orchard_located_trees.into_iter() {
             shard_trees
                 .orchard_mut()
                 .insert_tree(tree.subtree, tree.checkpoints)

--- a/zingo-sync/src/witness.rs
+++ b/zingo-sync/src/witness.rs
@@ -1,17 +1,20 @@
 //! Module for stucts and types associated with witness construction
 
+use std::collections::BTreeMap;
+
 use getset::{Getters, MutGetters};
 use incrementalmerkletree::{Position, Retention};
 use orchard::tree::MerkleHashOrchard;
-use sapling_crypto::Node;
-use shardtree::{store::memory::MemoryShardStore, ShardTree};
+use shardtree::{store::memory::MemoryShardStore, LocatedPrunableTree, ShardTree};
+use zcash_client_backend::data_api::{ORCHARD_SHARD_HEIGHT, SAPLING_SHARD_HEIGHT};
 use zcash_primitives::consensus::BlockHeight;
 
 const NOTE_COMMITMENT_TREE_DEPTH: u8 = 32;
 const SHARD_HEIGHT: u8 = 16;
 const MAX_CHECKPOINTS: usize = 100;
+const LOCATED_TREE_SIZE: usize = 128;
 
-type SaplingShardStore = MemoryShardStore<Node, BlockHeight>;
+type SaplingShardStore = MemoryShardStore<sapling_crypto::Node, BlockHeight>;
 type OrchardShardStore = MemoryShardStore<MerkleHashOrchard, BlockHeight>;
 
 /// Shard tree wallet data struct
@@ -41,10 +44,10 @@ impl Default for ShardTrees {
 }
 
 /// Required data for updating [`shardtree::ShardTree`]
-pub struct ShardTreeData {
+pub(crate) struct ShardTreeData {
     pub(crate) sapling_initial_position: Position,
     pub(crate) orchard_initial_position: Position,
-    pub(crate) sapling_leaves_and_retentions: Vec<(Node, Retention<BlockHeight>)>,
+    pub(crate) sapling_leaves_and_retentions: Vec<(sapling_crypto::Node, Retention<BlockHeight>)>,
     pub(crate) orchard_leaves_and_retentions: Vec<(MerkleHashOrchard, Retention<BlockHeight>)>,
 }
 
@@ -58,4 +61,67 @@ impl ShardTreeData {
             orchard_leaves_and_retentions: Vec::new(),
         }
     }
+}
+
+// TODO: add more batch insertion results as they become relavent
+/// TODO
+pub struct LocatedTreeData<H> {
+    /// TODO
+    pub subtree: LocatedPrunableTree<H>,
+    /// TODO
+    pub checkpoints: BTreeMap<BlockHeight, Position>,
+}
+
+fn create_located_trees<H>(
+    initial_position: Position,
+    leaves_and_retentions: Vec<(H, Retention<BlockHeight>)>,
+    located_tree_level: incrementalmerkletree::Level,
+) -> Result<Vec<LocatedTreeData<H>>, ()>
+where
+    H: Copy + PartialEq + incrementalmerkletree::Hashable + Sync + Send,
+{
+    // let ShardTreeData {
+    //     sapling_initial_position,
+    //     orchard_initial_position,
+    //     sapling_leaves_and_retentions,
+    //     orchard_leaves_and_retentions,
+    // } = shard_tree_data;
+    //TODO: Play with numbers. Is it more efficient to
+    // build larger trees to allow for more pruning to
+    // happen in parallel before insertion?
+    // Is it better to build smaller trees so that more
+    // trees can be built in parallel at the same time?
+    // Is inserting trees more efficient if trees are
+    // a power of 2 size? Is it more efficient if they
+    // are 'aligned' so that the initial_position is
+    // a multiple of tree size? All unanswered questions
+    // that want to be benchmarked.
+
+    let (sender, receiver) = crossbeam_channel::unbounded();
+    rayon::scope_fifo(|scope| {
+        for (i, chunk) in leaves_and_retentions.chunks(LOCATED_TREE_SIZE).enumerate() {
+            let sender = sender.clone();
+            scope.spawn_fifo(move |_scope| {
+                let start_position = initial_position + ((i * LOCATED_TREE_SIZE) as u64);
+                let tree = LocatedPrunableTree::from_iter(
+                    start_position..(start_position + chunk.len() as u64),
+                    located_tree_level,
+                    // incrementalmerkletree::Level::from(SAPLING_SHARD_HEIGHT),
+                    chunk.iter().copied(),
+                );
+                sender.send(tree).unwrap();
+            })
+        }
+    });
+
+    let mut located_tree_data = Vec::new();
+    for tree in receiver.iter() {
+        let tree = tree.unwrap();
+        located_tree_data.push(LocatedTreeData {
+            subtree: tree.subtree,
+            checkpoints: tree.checkpoints,
+        });
+    }
+
+    Ok(located_tree_data)
 }


### PR DESCRIPTION
Sync should be much more finely tuned with this PR

fixes:
1. to fix tokio polling being CPU-starved. moves located tree construction to scanning and uses spawn_blocking to keep rayon tasks in a separate thread pool to the main tokio thread
2. fixes a bug where workers may be shutdown before scan is complete
3. moves the point where a worker is a set to be scanning to fix a bug where workers are assigned multiple tasks
4. fixes a mempool panic, more work to be done on mempool in following PR