### PR TITLE
unify optional dependency crates syntax in manifest file (remove ':dep')

### DIFF
--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -12,9 +12,8 @@ darkside_tests = []
 default = ["sync"]
 deprecations = ["lightclient-deprecated"]
 lightclient-deprecated = []
-tempfile = ["dep:tempfile"]
 test-elevation = ["portpicker", "testvectors", "tempfile", "tempdir"]
-sync = ['dep:zingo-sync']
+sync = ['zingo-sync']
 zaino-test = ['test-elevation']
 
 [dependencies]
@@ -87,7 +86,6 @@ bech32 = { workspace = true }
 
 [dev-dependencies]
 portpicker = { workspace = true }
-tempfile = { workspace = true }
 concat-idents = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
We have to specify `optional = true` anyway