### PR TITLE
changed all runners to ziserv-2 (self-hosted)

### DIFF
--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ziserv-2
     if: github.event.pull_request.draft == false
     steps:
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: cargo-checkmate

--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -11,9 +11,9 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: taiki-e/cache-cargo-install-action@v2
-        with:
-          tool: cargo-checkmate
+      # - uses: taiki-e/cache-cargo-install-action@v2
+      #   with:
+      #     tool: cargo-checkmate
 
   cargo-checkmate:
     name: Cargo checkmate
@@ -26,9 +26,9 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: taiki-e/cache-cargo-install-action@v2
-        with:
-          tool: cargo-checkmate
+      # - uses: taiki-e/cache-cargo-install-action@v2
+      #   with:
+      #     tool: cargo-checkmate
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -6,6 +6,8 @@ jobs:
   cache-checkmate:
     name: Cache checkmate
     runs-on: ziserv-2
+    container:
+      image: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Cache checkmate
     runs-on: ziserv-2
     container:
-      image: ubuntu-latest
+      image: rust:bullseye
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -5,7 +5,7 @@ on: [workflow_call]
 jobs:
   cache-checkmate:
     name: Cache checkmate
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     if: github.event.pull_request.draft == false
     steps:
       - uses: taiki-e/cache-cargo-install-action@v2
@@ -18,7 +18,7 @@ jobs:
       matrix:
         phase: [build, check, clippy, doc, format]
     needs: cache-checkmate
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     if: github.event.pull_request.draft == false
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -11,7 +11,7 @@ jobs:
 
   reject-trailing-whitespace:
     name: Reject trailing whitespace
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
   reject-trailing-whitespace:
     name: Reject trailing whitespace
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
 
   run-doc-tests:
     name: Run doc tests
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     if: github.event.pull_request.draft == false
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   coverage:
     name: Coverage
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     env:
       RUSTFLAGS: -D warnings
     container:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build test artifacts
     container:
       image: zingodevops/ci-build:004
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     if: github.event.pull_request.draft == false
     env:
       RUSTFLAGS: -D warnings
@@ -44,7 +44,7 @@ jobs:
 
   run-tests:
     name: Run tests
-    runs-on: ubuntu-22.04
+    runs-on: ziserv-2
     if: github.event.pull_request.draft == false
     needs: build-test-artifacts
     env:


### PR DESCRIPTION
We got a new server and a nice Kubernetes managed actions runner.
This should be pretty fast... I intend on bench marking this.

This PR isn't intended to be merged as of now, but I didn't mark it as a draft cause that would prevent the actions to trigger.