### PR TITLE
Support donation addresses for light wallet servers

### DIFF
--- a/zingo-testutils/proto/service.proto
+++ b/zingo-testutils/proto/service.proto
@@ -70,6 +70,7 @@ message LightdInfo {
     uint64 estimatedHeight = 12;        // less than tip height if zcashd is syncing
     string zcashdBuild = 13;            // example: "v4.1.1-877212414"
     string zcashdSubversion = 14;       // example: "/MagicBean:4.1.1/"
+    string donationAddress = 15;        // Zcash donation UA address
 }
 
 // TransparentAddressBlockFilter restricts the results to the given address

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -71,6 +71,7 @@ impl LightClient {
             Ok(i) => {
                 let o = object! {
                     "version" => i.version,
+                    "zcash_version" => i.zcashd_build,
                     "git_commit" => i.git_commit,
                     "server_uri" => self.get_server_uri().to_string(),
                     "vendor" => i.vendor,
@@ -78,7 +79,8 @@ impl LightClient {
                     "chain_name" => i.chain_name,
                     "sapling_activation_height" => i.sapling_activation_height,
                     "consensus_branch_id" => i.consensus_branch_id,
-                    "latest_block_height" => i.block_height
+                    "latest_block_height" => i.block_height,
+                    "donation_address" => i.donation_address,
                 };
                 o.pretty(2)
             }


### PR DESCRIPTION
Suggestion: Rather than pointing zingolib to a tag on a librustzcash fork ("zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2"), can you create a branch so that contributions can be merged into zainolabs' fork? See the Cargo.toml in this pull for an example. Once this is done I can update this PR to point back at the zingolabs fork of LRZ.

Light wallet servers will soon be advertising Zcash donation addresses via their LightdInfo gRPC endpoints, this patch to zingolib allows its dependent projects to support it.

Related PRs:
- [Lightwalletd #506](https://github.com/zcash/lightwalletd/pull/506)
- [Zaino #185](https://github.com/zingolabs/zaino/pull/185)
- [Librustzcash #1707](https://github.com/zcash/librustzcash/pull/1707)