### PR TITLE
added testvectors crate to cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "zingo-netutils",
     "zingo-memo",
     "zingo-sync",
+    "testvectors",
 ]
 resolver = "2"
 


### PR DESCRIPTION
Publicises the testvectors crate for consumption by zaino and infrastructure.