### PR TITLE
Wallet save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,6 +2291,7 @@ dependencies = [
  "futures",
  "incrementalmerkletree",
  "json",
+ "jubjub",
  "memuse",
  "orchard",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,6 +2286,7 @@ name = "pepper-sync"
 version = "0.1.0"
 dependencies = [
  "base58",
+ "byteorder",
  "crossbeam-channel",
  "futures",
  "incrementalmerkletree",
@@ -2302,6 +2303,7 @@ dependencies = [
  "tracing",
  "zcash_address",
  "zcash_client_backend",
+ "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
@@ -4602,6 +4604,7 @@ dependencies = [
 name = "zingo-status"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "zcash_primitives",
 ]
 

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -201,7 +201,7 @@ async fn sent_transaction_reorged_into_mempool() {
         serde_json::to_string_pretty(&light_client.do_balance().await).unwrap()
     );
     let mut loaded_client =
-        zingolib::testutils::lightclient::new_client_from_save_buffer(&light_client)
+        zingolib::testutils::lightclient::new_client_from_save_buffer(&mut light_client)
             .await
             .unwrap();
     loaded_client.sync_and_await().await.unwrap();

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -2641,7 +2641,14 @@ mod slow {
         assert_eq!(balance.spendable_sapling_balance.unwrap(), value);
 
         {
-            let recipient_sapling_address = *recipient.wallet.lock().await.unified_addresses[0]
+            let recipient_sapling_address = *recipient
+                .wallet
+                .lock()
+                .await
+                .unified_addresses
+                .values()
+                .next()
+                .unwrap()
                 .sapling()
                 .unwrap();
             let transactions = &recipient.wallet.lock().await.wallet_transactions;

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -1006,7 +1006,7 @@ mod fast {
         let seed_phrase = Mnemonic::<bip0039::English>::from_entropy([1; 32])
             .unwrap()
             .to_string();
-        let recipient1 = client_builder
+        let mut recipient1 = client_builder
             .build_client(seed_phrase, 0, false, regtest_network)
             .await;
         let base_transparent_receiver = "tmS9nbexug7uT8x1cMTLP1ABEyKXpMjR5F1";
@@ -2232,11 +2232,14 @@ mod slow {
         let recipient_to_faucet_amount = 5_000u64;
         // check start state
         faucet.sync_and_await().await.unwrap();
-        let wallet_height = faucet.do_wallet_last_scanned_height().await;
-        assert_eq!(
-            wallet_height.as_fixed_point_u64(0).unwrap(),
-            BASE_HEIGHT as u64
-        );
+        let wallet_fully_scanned_height = faucet
+            .wallet
+            .lock()
+            .await
+            .sync_state
+            .fully_scanned_height()
+            .unwrap();
+        assert_eq!(wallet_fully_scanned_height, BASE_HEIGHT.into());
         let three_blocks_reward = block_rewards::CANOPY
             .checked_mul(BASE_HEIGHT as u64)
             .unwrap();
@@ -2629,7 +2632,8 @@ mod slow {
                 .lock()
                 .await
                 .sync_state
-                .fully_scanned_height(),
+                .fully_scanned_height()
+                .unwrap(),
             4.into()
         );
 

--- a/libtonode-tests/tests/wallet.rs
+++ b/libtonode-tests/tests/wallet.rs
@@ -191,10 +191,16 @@ mod load_wallet {
 
         // Without sync push server forward 2 blocks
         zingolib::testutils::increase_server_height(&regtest_manager, 2).await;
-        let client_wallet_height = faucet.do_wallet_last_scanned_height().await;
+        let client_fully_scanned_height = faucet
+            .wallet
+            .lock()
+            .await
+            .sync_state
+            .fully_scanned_height()
+            .unwrap();
 
         // Verify that wallet is still back at 6.
-        assert_eq!(client_wallet_height.as_fixed_point_u64(0).unwrap(), 8);
+        assert_eq!(client_fully_scanned_height, 8.into());
 
         // Interrupt generating send
         from_inputs::quick_send(

--- a/pepper-sync/Cargo.toml
+++ b/pepper-sync/Cargo.toml
@@ -26,6 +26,9 @@ incrementalmerkletree.workspace = true
 shardtree.workspace = true
 zip32.workspace = true
 
+# Cryptography
+jubjub.workspace = true
+
 # Async
 futures.workspace = true
 tokio.workspace = true

--- a/pepper-sync/Cargo.toml
+++ b/pepper-sync/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 default = [ "wallet_essentials" ]
 # utility not necessary for the sync engine but essential for wallets using pepper_sync::primitives for wallet functionality
-wallet_essentials = []
+wallet_essentials = [ "dep:byteorder", "dep:zcash_encoding" ]
 
 [dependencies]
 # Zingo
@@ -15,6 +15,7 @@ zingo-memo = { path = "../zingo-memo" }
 zingo-status = { path = "../zingo-status" }
 
 # Zcash
+zcash_encoding = { workspace = true, optional = true }
 zcash_client_backend.workspace = true
 zcash_primitives.workspace = true
 zcash_note_encryption.workspace = true
@@ -47,6 +48,9 @@ thiserror.workspace = true
 
 # JSON
 json.workspace = true
+
+# Read write
+byteorder = { workspace = true, optional = true }
 
 # temp
 zcash_address.workspace = true

--- a/pepper-sync/Cargo.toml
+++ b/pepper-sync/Cargo.toml
@@ -16,7 +16,7 @@ zingo-status = { path = "../zingo-status" }
 
 # Zcash
 zcash_encoding = { workspace = true, optional = true }
-zcash_client_backend.workspace = true
+zcash_client_backend = { workspace = true, features = [ "unstable-serialization" ] }
 zcash_primitives.workspace = true
 zcash_note_encryption.workspace = true
 zcash_keys.workspace = true

--- a/pepper-sync/src/keys.rs
+++ b/pepper-sync/src/keys.rs
@@ -25,7 +25,6 @@ pub struct KeyId {
     pub account_id: zcash_primitives::zip32::AccountId,
     /// Scope
     pub scope: Scope,
-    // TODO: add address index and unified address recovery
 }
 
 pub mod transparent;

--- a/pepper-sync/src/keys/transparent.rs
+++ b/pepper-sync/src/keys/transparent.rs
@@ -87,6 +87,22 @@ impl From<TransparentScope> for TransparentKeyScope {
     }
 }
 
+impl TryFrom<u8> for TransparentScope {
+    type Error = std::io::Error;
+
+    fn try_from(value: u8) -> std::io::Result<Self> {
+        match value {
+            0 => Ok(TransparentScope::External),
+            1 => Ok(TransparentScope::Internal),
+            2 => Ok(TransparentScope::Refund),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }
+    }
+}
+
 pub(crate) fn derive_address<P>(
     consensus_parameters: &P,
     account_pubkey: &AccountPubKey,

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -192,6 +192,7 @@ where
                 )
                 .await
                 .unwrap();
+                wallet_guard.set_save_flag().unwrap();
 
                 // allow tasks outside the sync engine access to the wallet data
                 drop(wallet_guard);
@@ -237,6 +238,7 @@ where
     }
 
     let sync_status = sync_status(&*wallet_guard).await;
+    wallet_guard.set_save_flag().unwrap();
 
     drop(wallet_guard);
     drop(scanner);

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -174,6 +174,7 @@ where
         .get_sync_state()
         .unwrap()
         .highest_scanned_height()
+        .expect("scan ranges must be non-empty")
         + 1;
     let mut interval = tokio::time::interval(Duration::from_millis(50));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -607,8 +608,12 @@ where
     W: SyncWallet + SyncBlocks + SyncNullifiers + SyncTransactions,
 {
     let sync_state = wallet.get_sync_state().unwrap();
-    let fully_scanned_height = sync_state.fully_scanned_height();
-    let highest_scanned_height = sync_state.highest_scanned_height();
+    let fully_scanned_height = sync_state
+        .fully_scanned_height()
+        .expect("scan ranges must be non-empty");
+    let highest_scanned_height = sync_state
+        .highest_scanned_height()
+        .expect("scan ranges must be non-empty");
     let sync_start_height = sync_state.initial_sync_state.sync_start_height;
 
     let scanned_block_range_bounds = sync_state

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -94,7 +94,10 @@ pub(super) async fn update_scan_ranges(
     )?;
     set_chain_tip_scan_range(consensus_parameters, sync_state, chain_height)?;
 
-    let verification_height = sync_state.highest_scanned_height() + 1;
+    let verification_height = sync_state
+        .highest_scanned_height()
+        .expect("scan ranges must be non-empty")
+        + 1;
     if verification_height <= chain_height {
         set_verify_scan_range(sync_state, verification_height, VerifyEnd::VerifyLowest);
     }
@@ -111,7 +114,10 @@ fn merge_scanned_ranges(sync_state: &mut SyncState) {
         .enumerate()
         .filter(|(_, scan_range)| {
             scan_range.priority() == ScanPriority::Scanned
-                && scan_range.block_range().end - 1 <= sync_state.fully_scanned_height()
+                && scan_range.block_range().end - 1
+                    <= sync_state
+                        .fully_scanned_height()
+                        .expect("scan ranges must be non-empty")
         })
         .collect::<Vec<_>>();
 
@@ -649,7 +655,11 @@ pub(super) async fn set_initial_state<W>(
 ) where
     W: SyncWallet + SyncBlocks,
 {
-    let fully_scanned_height = wallet.get_sync_state().unwrap().fully_scanned_height();
+    let fully_scanned_height = wallet
+        .get_sync_state()
+        .unwrap()
+        .fully_scanned_height()
+        .expect("scan ranges must be non-empty");
     let (sync_start_sapling_tree_size, sync_start_orchard_tree_size) = final_tree_sizes(
         consensus_parameters,
         fetch_request_sender.clone(),

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -242,7 +242,6 @@ impl SyncState {
 }
 
 /// Sync modes.
-#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncMode {
     /// Sync is not running.

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -100,23 +100,6 @@ impl Default for InitialSyncState {
     }
 }
 
-#[cfg(feature = "wallet_essentials")]
-impl InitialSyncState {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-        writer.write_u32::<LittleEndian>(self.sync_start_height.into())?;
-        self.sync_tree_bounds.write(&mut writer)?;
-        writer.write_u32::<LittleEndian>(self.total_blocks_to_scan)?;
-        writer.write_u32::<LittleEndian>(self.total_sapling_outputs_to_scan)?;
-        writer.write_u32::<LittleEndian>(self.total_orchard_outputs_to_scan)
-    }
-}
-
 /// Encapsulates the current state of sync
 #[derive(Debug, Clone)]
 pub struct SyncState {
@@ -254,8 +237,7 @@ impl SyncState {
                 w.write_u32::<LittleEndian>(locator.0.into())?;
                 locator.1.write(w)
             },
-        )?;
-        self.initial_sync_state.write(&mut writer)
+        )
     }
 }
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -13,11 +13,15 @@ use std::{
     },
 };
 
-use incrementalmerkletree::Position;
+use incrementalmerkletree::{Hashable, Position};
 use orchard::tree::MerkleHashOrchard;
-use shardtree::{store::memory::MemoryShardStore, ShardTree};
+use shardtree::{
+    store::{memory::MemoryShardStore, Checkpoint, ShardStore},
+    ShardTree,
+};
 use zcash_client_backend::{
     data_api::scanning::{ScanPriority, ScanRange},
+    serialization::shardtree::write_shard,
     PoolType, ShieldedProtocol,
 };
 use zcash_keys::{address::UnifiedAddress, encoding::encode_payment_address};
@@ -26,6 +30,7 @@ use zcash_primitives::{
     consensus::{self, BlockHeight, NetworkConstants, Parameters},
     legacy::Script,
     memo::Memo,
+    merkle_tree::HashSer,
     transaction::{
         components::{amount::NonNegativeAmount, OutPoint},
         TxId,
@@ -92,6 +97,23 @@ impl InitialSyncState {
 impl Default for InitialSyncState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl InitialSyncState {
+    fn serialized_version() -> u8 {
+        1
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        writer.write_u32::<LittleEndian>(self.sync_start_height.into())?;
+        self.sync_tree_bounds.write(&mut writer)?;
+        writer.write_u32::<LittleEndian>(self.total_blocks_to_scan)?;
+        writer.write_u32::<LittleEndian>(self.total_sapling_outputs_to_scan)?;
+        writer.write_u32::<LittleEndian>(self.total_orchard_outputs_to_scan)
     }
 }
 
@@ -200,6 +222,41 @@ impl SyncState {
 impl Default for SyncState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl SyncState {
+    fn serialized_version() -> u8 {
+        1
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        Vector::write(&mut writer, self.scan_ranges(), |w, scan_range| {
+            w.write_u32::<LittleEndian>(scan_range.block_range().start.into())?;
+            w.write_u32::<LittleEndian>(scan_range.block_range().end.into())?;
+            w.write_u8(scan_range.priority() as u8)
+        })?;
+        Vector::write(&mut writer, &self.sapling_shard_ranges, |w, shard_range| {
+            w.write_u32::<LittleEndian>(shard_range.start.into())?;
+            w.write_u32::<LittleEndian>(shard_range.end.into())
+        })?;
+        Vector::write(&mut writer, &self.orchard_shard_ranges, |w, shard_range| {
+            w.write_u32::<LittleEndian>(shard_range.start.into())?;
+            w.write_u32::<LittleEndian>(shard_range.end.into())
+        })?;
+        Vector::write(
+            &mut writer,
+            &self.locators.iter().collect::<Vec<_>>(),
+            |w, &locator| {
+                w.write_u32::<LittleEndian>(locator.0.into())?;
+                locator.1.write(w)
+            },
+        )?;
+
+        Ok(())
     }
 }
 
@@ -433,6 +490,36 @@ impl NullifierMap {
 impl Default for NullifierMap {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl NullifierMap {
+    fn serialized_version() -> u8 {
+        1
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        Vector::write(
+            &mut writer,
+            &self.sapling.iter().collect::<Vec<_>>(),
+            |w, (&nullifier, &locator)| {
+                w.write_all(nullifier.as_ref())?;
+                w.write_u32::<LittleEndian>(locator.0.into())?;
+                locator.1.write(w)
+            },
+        )?;
+        Vector::write(
+            &mut writer,
+            &self.orchard.iter().collect::<Vec<_>>(),
+            |w, (&nullifier, &locator)| {
+                w.write_all(&nullifier.to_bytes())?;
+                w.write_u32::<LittleEndian>(locator.0.into())?;
+                locator.1.write(w)
+            },
+        )
     }
 }
 
@@ -1356,6 +1443,128 @@ impl ShardTrees {
 impl Default for ShardTrees {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl ShardTrees {
+    fn serialized_version() -> u8 {
+        1
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        Self::write_shardtree(&mut writer, &mut self.sapling)?;
+        Self::write_shardtree(&mut writer, &mut self.orchard)?;
+
+        Ok(())
+    }
+
+    /// Write memory-backed shardstore, represented tree.
+    fn write_shardtree<
+        H: Hashable + Clone + Eq + HashSer,
+        C: Ord + std::fmt::Debug + Copy,
+        W: Write,
+        const DEPTH: u8,
+        const SHARD_HEIGHT: u8,
+    >(
+        mut writer: W,
+        tree: &mut shardtree::ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>,
+    ) -> std::io::Result<()>
+    where
+        u32: From<C>,
+    {
+        fn write_shards<W, H, C>(
+            mut writer: W,
+            store: &MemoryShardStore<H, C>,
+        ) -> std::io::Result<()>
+        where
+            H: Hashable + Clone + Eq + HashSer,
+            C: Ord + std::fmt::Debug + Copy,
+            W: Write,
+        {
+            let roots = store.get_shard_roots().expect("Infallible");
+            Vector::write(&mut writer, &roots, |w, root| {
+                w.write_u8(root.level().into())?;
+                w.write_u64::<LittleEndian>(root.index())?;
+                let shard = store
+                    .get_shard(*root)
+                    .expect("Infallible")
+                    .expect("cannot find root that shard store claims to have");
+                write_shard(w, shard.root())?; // s.root returns &Tree
+                Ok(())
+            })?;
+            Ok(())
+        }
+
+        fn write_checkpoints<W, Cid>(
+            mut writer: W,
+            checkpoints: &[(Cid, Checkpoint)],
+        ) -> std::io::Result<()>
+        where
+            W: Write,
+            Cid: Ord + std::fmt::Debug + Copy,
+            u32: From<Cid>,
+        {
+            Vector::write(
+                &mut writer,
+                checkpoints,
+                |mut w, (checkpoint_id, checkpoint)| {
+                    w.write_u32::<LittleEndian>(u32::from(*checkpoint_id))?;
+                    match checkpoint.tree_state() {
+                        shardtree::store::TreeState::Empty => w.write_u8(0),
+                        shardtree::store::TreeState::AtPosition(pos) => {
+                            w.write_u8(1)?;
+                            w.write_u64::<LittleEndian>(<u64 as From<Position>>::from(pos))
+                        }
+                    }?;
+                    Vector::write(
+                        &mut w,
+                        &checkpoint.marks_removed().iter().collect::<Vec<_>>(),
+                        |w, mark| {
+                            w.write_u64::<LittleEndian>(<u64 as From<Position>>::from(**mark))
+                        },
+                    )
+                },
+            )?;
+            Ok(())
+        }
+
+        // Replace original tree with empty tree, and mutate new version into store.
+        let mut store = std::mem::replace(
+            tree,
+            shardtree::ShardTree::new(MemoryShardStore::empty(), 0),
+        )
+        .into_store();
+        macro_rules! write_with_error_handling {
+            ($writer: ident, $from: ident) => {
+                if let Err(e) = $writer(&mut writer, &$from) {
+                    *tree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+                    return Err(e);
+                }
+            };
+        }
+        // Write located prunable trees
+        write_with_error_handling!(write_shards, store);
+        let mut checkpoints = Vec::new();
+        store
+            .with_checkpoints(
+                MAX_VERIFICATION_WINDOW as usize,
+                |checkpoint_id, checkpoint| {
+                    checkpoints.push((*checkpoint_id, checkpoint.clone()));
+                    Ok(())
+                },
+            )
+            .expect("Infallible");
+        // Write checkpoints
+        write_with_error_handling!(write_checkpoints, checkpoints);
+        let cap = store.get_cap().expect("Infallible");
+        // Write cap
+        write_with_error_handling!(write_shard, cap);
+        *tree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+
+        Ok(())
     }
 }
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -137,41 +137,34 @@ impl SyncState {
     }
 
     /// Returns the block height at which all blocks equal to and below this height are scanned.
-    ///
-    /// Will panic if called before scan ranges are updated for the first time.
-    pub fn fully_scanned_height(&self) -> BlockHeight {
+    /// Returns `None` if `self.scan_ranges` is empty.
+    pub fn fully_scanned_height(&self) -> Option<BlockHeight> {
         if let Some(scan_range) = self
             .scan_ranges
             .iter()
             .find(|scan_range| scan_range.priority() != ScanPriority::Scanned)
         {
-            scan_range.block_range().start - 1
+            Some(scan_range.block_range().start - 1)
         } else {
             self.scan_ranges
                 .last()
-                .expect("scan ranges always non-empty")
-                .block_range()
-                .end
-                - 1
+                .map(|range| range.block_range().end - 1)
         }
     }
 
     /// Returns the highest block height that has been scanned.
-    ///
     /// If no scan ranges have been scanned, returns the block below the wallet birthday.
-    /// Will panic if called before scan ranges are updated for the first time.
-    pub fn highest_scanned_height(&self) -> BlockHeight {
+    /// Returns `None` if `self.scan_ranges` is empty.
+    pub fn highest_scanned_height(&self) -> Option<BlockHeight> {
         if let Some(last_scanned_range) = self
             .scan_ranges
             .iter()
             .filter(|scan_range| scan_range.priority() == ScanPriority::Scanned)
             .last()
         {
-            last_scanned_range.block_range().end - 1
+            Some(last_scanned_range.block_range().end - 1)
         } else {
-            self.wallet_birthday()
-                .expect("scan ranges always non-empty")
-                - 1
+            self.wallet_birthday().map(|birthday| birthday - 1)
         }
     }
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -6,6 +6,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
+    io::Read,
     ops::Range,
     sync::{
         atomic::{self, AtomicU8},
@@ -212,6 +213,11 @@ impl Default for SyncState {
 impl SyncState {
     fn serialized_version() -> u8 {
         0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        todo!()
     }
 
     /// Serialize into `writer`
@@ -482,6 +488,11 @@ impl NullifierMap {
         0
     }
 
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        todo!()
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
         writer.write_u8(Self::serialized_version())?;
@@ -551,8 +562,18 @@ impl WalletBlock {
 
 #[cfg(feature = "wallet_essentials")]
 impl WalletBlock {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        todo!()
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
         writer.write_u32::<LittleEndian>(self.block_height.into())?;
         writer.write_all(&self.block_hash.0)?;
         writer.write_all(&self.prev_hash.0)?;
@@ -685,6 +706,11 @@ impl WalletTransaction {
 impl WalletTransaction {
     fn serialized_version() -> u8 {
         0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        todo!()
     }
 
     /// Serialize into `writer`
@@ -1435,6 +1461,11 @@ impl ShardTrees {
         0
     }
 
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        todo!()
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
         writer.write_u8(Self::serialized_version())?;
@@ -1555,9 +1586,18 @@ impl ShardTrees {
 
 #[cfg(feature = "wallet_essentials")]
 mod read_write {
-    use std::io::Write;
+    use std::io::{Read, Write};
 
-    use byteorder::{LittleEndian, WriteBytesExt};
+    use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+
+    pub(super) fn read_string<R: Read>(mut reader: R) -> std::io::Result<String> {
+        let str_len = reader.read_u64::<LittleEndian>()?;
+        let mut str_bytes = vec![0; str_len as usize];
+        reader.read_exact(&mut str_bytes)?;
+
+        String::from_utf8(str_bytes)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
+    }
 
     pub(super) fn write_string<W: Write>(mut writer: W, str: &str) -> std::io::Result<()> {
         writer.write_u64::<LittleEndian>(str.len() as u64)?;

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -40,26 +40,10 @@ use crate::{
     witness,
 };
 
-#[cfg(feature = "wallet_essentials")]
-use {
-    crate::keys::transparent::TransparentScope,
-    byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt},
-    incrementalmerkletree::Hashable,
-    read_write::read_string,
-    read_write::write_string,
-    shardtree::{
-        store::{Checkpoint, ShardStore},
-        LocatedPrunableTree,
-    },
-    std::io::Read,
-    std::io::Write,
-    zcash_address::ZcashAddress,
-    zcash_client_backend::serialization::shardtree::{read_shard, write_shard},
-    zcash_encoding::{Optional, Vector},
-    zcash_primitives::{merkle_tree::HashSer, transaction::Transaction},
-};
-
 pub mod traits;
+
+#[cfg(feature = "wallet_essentials")]
+pub mod serialization;
 
 /// Block height and txid of relevant transactions that have yet to be scanned. These may be added due to transparent
 /// output/spend discovery or for targetted rescan.
@@ -214,91 +198,6 @@ impl Default for SyncState {
     }
 }
 
-#[cfg(feature = "wallet_essentials")]
-impl SyncState {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-        let scan_ranges = Vector::read(&mut reader, |r| {
-            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let priority = match r.read_u8()? {
-                0 => Ok(ScanPriority::Ignored),
-                1 => Ok(ScanPriority::Scanned),
-                2 => Ok(ScanPriority::Historic),
-                3 => Ok(ScanPriority::OpenAdjacent),
-                4 => Ok(ScanPriority::FoundNote),
-                5 => Ok(ScanPriority::ChainTip),
-                6 => Ok(ScanPriority::Verify),
-                _ => Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "invalid scan priority",
-                )),
-            }?;
-
-            Ok(ScanRange::from_parts(start..end, priority))
-        })?;
-        let sapling_shard_ranges = Vector::read(&mut reader, |r| {
-            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-
-            Ok(start..end)
-        })?;
-        let orchard_shard_ranges = Vector::read(&mut reader, |r| {
-            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-
-            Ok(start..end)
-        })?;
-        let locators = Vector::read(&mut reader, |r| {
-            let block_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let txid = TxId::read(r)?;
-
-            Ok((block_height, txid))
-        })?
-        .into_iter()
-        .collect::<BTreeSet<_>>();
-
-        Ok(Self {
-            scan_ranges,
-            sapling_shard_ranges,
-            orchard_shard_ranges,
-            locators,
-            initial_sync_state: InitialSyncState::new(),
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-        Vector::write(&mut writer, self.scan_ranges(), |w, scan_range| {
-            w.write_u32::<LittleEndian>(scan_range.block_range().start.into())?;
-            w.write_u32::<LittleEndian>(scan_range.block_range().end.into())?;
-            w.write_u8(scan_range.priority() as u8)
-        })?;
-        Vector::write(&mut writer, &self.sapling_shard_ranges, |w, shard_range| {
-            w.write_u32::<LittleEndian>(shard_range.start.into())?;
-            w.write_u32::<LittleEndian>(shard_range.end.into())
-        })?;
-        Vector::write(&mut writer, &self.orchard_shard_ranges, |w, shard_range| {
-            w.write_u32::<LittleEndian>(shard_range.start.into())?;
-            w.write_u32::<LittleEndian>(shard_range.end.into())
-        })?;
-        Vector::write(
-            &mut writer,
-            &self.locators.iter().collect::<Vec<_>>(),
-            |w, &locator| {
-                w.write_u32::<LittleEndian>(locator.0.into())?;
-                locator.1.write(w)
-            },
-        )
-    }
-}
-
 /// Sync modes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncMode {
@@ -344,38 +243,6 @@ pub struct TreeBounds {
     pub sapling_final_tree_size: u32,
     pub orchard_initial_tree_size: u32,
     pub orchard_final_tree_size: u32,
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl TreeBounds {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-        let sapling_initial_tree_size = reader.read_u32::<LittleEndian>()?;
-        let sapling_final_tree_size = reader.read_u32::<LittleEndian>()?;
-        let orchard_initial_tree_size = reader.read_u32::<LittleEndian>()?;
-        let orchard_final_tree_size = reader.read_u32::<LittleEndian>()?;
-
-        Ok(Self {
-            sapling_initial_tree_size,
-            sapling_final_tree_size,
-            orchard_initial_tree_size,
-            orchard_final_tree_size,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-        writer.write_u32::<LittleEndian>(self.sapling_initial_tree_size)?;
-        writer.write_u32::<LittleEndian>(self.sapling_final_tree_size)?;
-        writer.write_u32::<LittleEndian>(self.orchard_initial_tree_size)?;
-        writer.write_u32::<LittleEndian>(self.orchard_final_tree_size)
-    }
 }
 
 /// A snapshot of the current state of sync. Useful for displaying the status of sync to a user / consumer.
@@ -552,74 +419,6 @@ impl Default for NullifierMap {
     }
 }
 
-#[cfg(feature = "wallet_essentials")]
-impl NullifierMap {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-
-        let sapling = Vector::read(&mut reader, |mut r| {
-            let mut nullifier_bytes = [0u8; 32];
-            r.read_exact(&mut nullifier_bytes)?;
-            let nullifier =
-                sapling_crypto::Nullifier::from_slice(&nullifier_bytes).map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("failed to read nullifier. {e}"),
-                    )
-                })?;
-            let locator_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let locator_txid = TxId::read(&mut r)?;
-
-            Ok((nullifier, (locator_height, locator_txid)))
-        })?
-        .into_iter()
-        .collect::<BTreeMap<_, _>>();
-
-        let orchard = Vector::read(&mut reader, |mut r| {
-            let mut nullifier_bytes = [0u8; 32];
-            r.read_exact(&mut nullifier_bytes)?;
-            let nullifier = orchard::note::Nullifier::from_bytes(&nullifier_bytes)
-                .expect("nullifier bytes should be valid");
-            let locator_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let locator_txid = TxId::read(&mut r)?;
-
-            Ok((nullifier, (locator_height, locator_txid)))
-        })?
-        .into_iter()
-        .collect::<BTreeMap<_, _>>();
-
-        Ok(NullifierMap { sapling, orchard })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-        Vector::write(
-            &mut writer,
-            &self.sapling.iter().collect::<Vec<_>>(),
-            |w, (&nullifier, &locator)| {
-                w.write_all(nullifier.as_ref())?;
-                w.write_u32::<LittleEndian>(locator.0.into())?;
-                locator.1.write(w)
-            },
-        )?;
-        Vector::write(
-            &mut writer,
-            &self.orchard.iter().collect::<Vec<_>>(),
-            |w, (&nullifier, &locator)| {
-                w.write_all(&nullifier.to_bytes())?;
-                w.write_u32::<LittleEndian>(locator.0.into())?;
-                locator.1.write(w)
-            },
-        )
-    }
-}
-
 /// Wallet block data
 #[derive(Debug, Clone)]
 pub struct WalletBlock {
@@ -660,46 +459,6 @@ impl WalletBlock {
     /// Tree size bounds
     pub fn tree_bounds(&self) -> TreeBounds {
         self.tree_bounds
-    }
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl WalletBlock {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-        let block_height = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
-        let mut block_hash = BlockHash([0u8; 32]);
-        reader.read_exact(&mut block_hash.0)?;
-        let mut prev_hash = BlockHash([0u8; 32]);
-        reader.read_exact(&mut prev_hash.0)?;
-        let time = reader.read_u32::<LittleEndian>()?;
-        let txids = Vector::read(&mut reader, |r| TxId::read(r))?;
-        let tree_bounds = TreeBounds::read(&mut reader)?;
-
-        Ok(Self {
-            block_height,
-            block_hash,
-            prev_hash,
-            time,
-            txids,
-            tree_bounds,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-        writer.write_u32::<LittleEndian>(self.block_height.into())?;
-        writer.write_all(&self.block_hash.0)?;
-        writer.write_all(&self.prev_hash.0)?;
-        writer.write_u32::<LittleEndian>(self.time)?;
-        Vector::write(&mut writer, self.txids(), |w, txid| txid.write(w))?;
-        self.tree_bounds.write(&mut writer)
     }
 }
 
@@ -822,74 +581,6 @@ impl WalletTransaction {
 
 #[cfg(feature = "wallet_essentials")]
 impl WalletTransaction {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(
-        mut reader: R,
-        consensus_parameters: &impl consensus::Parameters,
-    ) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-        let txid = TxId::read(&mut reader)?;
-        let status = ConfirmationStatus::read(&mut reader)?;
-        let transaction = Transaction::read(
-            &mut reader,
-            consensus::BranchId::for_height(consensus_parameters, status.get_height()),
-        )?;
-        let datetime = reader.read_u32::<LittleEndian>()?;
-        let transparent_coins = Vector::read(&mut reader, |r| TransparentCoin::read(r))?;
-        let sapling_notes = Vector::read(&mut reader, |r| SaplingNote::read(r))?;
-        let orchard_notes = Vector::read(&mut reader, |r| OrchardNote::read(r))?;
-        let outgoing_sapling_notes = Vector::read(&mut reader, |r| {
-            OutgoingSaplingNote::read(r, consensus_parameters)
-        })?;
-        let outgoing_orchard_notes = Vector::read(&mut reader, |r| {
-            OutgoingOrchardNote::read(r, consensus_parameters)
-        })?;
-
-        Ok(Self {
-            txid,
-            status,
-            transaction,
-            datetime,
-            transparent_coins,
-            sapling_notes,
-            orchard_notes,
-            outgoing_sapling_notes,
-            outgoing_orchard_notes,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(
-        &self,
-        mut writer: W,
-        consensus_parameters: &impl consensus::Parameters,
-    ) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-        self.txid.write(&mut writer)?;
-        self.status.write(&mut writer)?;
-        self.transaction.write(&mut writer)?;
-        writer.write_u32::<LittleEndian>(self.datetime)?;
-        Vector::write(&mut writer, self.transparent_coins(), |w, output| {
-            output.write(w)
-        })?;
-        Vector::write(&mut writer, self.sapling_notes(), |w, output| {
-            output.write(w)
-        })?;
-        Vector::write(&mut writer, self.orchard_notes(), |w, output| {
-            output.write(w)
-        })?;
-        Vector::write(&mut writer, self.outgoing_sapling_notes(), |w, output| {
-            output.write(w, consensus_parameters)
-        })?;
-        Vector::write(&mut writer, self.outgoing_orchard_notes(), |w, output| {
-            output.write(w, consensus_parameters)
-        })
-    }
-
     /// Returns the total value sent to receivers, including value explicitly sent to the wallet own addresses but
     /// excluding change.
     pub fn total_value_sent(&self) -> u64 {
@@ -985,6 +676,29 @@ pub trait OutputInterface: Sized {
     fn transaction_outputs(transaction: &WalletTransaction) -> &[Self];
 }
 
+/// Provides a common API for all shielded output types.
+pub trait NoteInterface: OutputInterface {
+    /// Decrypted note type.
+    type ZcashNote;
+    /// Nullifier type.
+    type Nullifier: Copy;
+
+    /// Note's associated shielded protocol.
+    const SHIELDED_PROTOCOL: ShieldedProtocol;
+
+    /// Decrypted note with recipient and value
+    fn note(&self) -> &Self::ZcashNote;
+
+    /// Derived nullifier
+    fn nullifier(&self) -> Option<Self::Nullifier>;
+
+    /// Commitment tree leaf position
+    fn position(&self) -> Option<Position>;
+
+    /// Memo
+    fn memo(&self) -> &Memo;
+}
+
 ///  Transparent coin (output) with metadata relevant to the wallet.
 #[derive(Debug, Clone)]
 pub struct TransparentCoin {
@@ -1050,85 +764,6 @@ impl OutputInterface for TransparentCoin {
     }
 }
 
-#[cfg(feature = "wallet_essentials")]
-impl TransparentCoin {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-
-        let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
-
-        let account_id = zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?)
-            .expect("only valid account ids written");
-        let scope = TransparentScope::try_from(reader.read_u8()?)?;
-        let address_index = reader.read_u32::<LittleEndian>()?;
-
-        let address = read_string(&mut reader)?;
-        let script = Script::read(&mut reader)?;
-        let value = NonNegativeAmount::from_u64(reader.read_u64::<LittleEndian>()?)
-            .expect("only valid values written");
-        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
-
-        Ok(Self {
-            output_id: OutputId { txid, output_index },
-            key_id: TransparentAddressId::new(account_id, scope, address_index),
-            address,
-            value,
-            script,
-            spending_transaction,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-
-        self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
-
-        writer.write_u32::<LittleEndian>(self.key_id.account_id().into())?;
-        writer.write_u8(self.key_id.scope() as u8)?;
-        writer.write_u32::<LittleEndian>(self.key_id.address_index())?;
-
-        write_string(&mut writer, &self.address)?;
-        self.script.write(&mut writer)?;
-        writer.write_u64::<LittleEndian>(self.value())?;
-        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
-            txid.write(w)
-        })?;
-
-        Ok(())
-    }
-}
-
-/// Provides a common API for all shielded output types.
-pub trait NoteInterface: OutputInterface + Sized {
-    /// Decrypted note type.
-    type ZcashNote;
-    /// Nullifier type.
-    type Nullifier: Copy;
-
-    /// Note's associated shielded protocol.
-    const SHIELDED_PROTOCOL: ShieldedProtocol;
-
-    /// Decrypted note with recipient and value
-    fn note(&self) -> &Self::ZcashNote;
-
-    /// Derived nullifier
-    fn nullifier(&self) -> Option<Self::Nullifier>;
-
-    /// Commitment tree leaf position
-    fn position(&self) -> Option<Position>;
-
-    /// Memo
-    fn memo(&self) -> &Memo;
-}
-
 /// Wallet note, shielded output with metadata relevant to the wallet.
 #[derive(Debug, Clone)]
 pub struct WalletNote<N, Nf: Copy> {
@@ -1147,13 +782,6 @@ pub struct WalletNote<N, Nf: Copy> {
     /// Transaction ID of transaction this output was spent.
     /// If `None`, output is not spent.
     pub(crate) spending_transaction: Option<TxId>,
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl<N, Nf: Copy> WalletNote<N, Nf> {
-    fn serialized_version() -> u8 {
-        0
-    }
 }
 
 /// Sapling note.
@@ -1196,7 +824,7 @@ impl OutputInterface for SaplingNote {
 
 impl NoteInterface for SaplingNote {
     type ZcashNote = sapling_crypto::Note;
-    type Nullifier = sapling_crypto::Nullifier;
+    type Nullifier = Self::Input;
 
     const SHIELDED_PROTOCOL: ShieldedProtocol = ShieldedProtocol::Sapling;
 
@@ -1214,130 +842,6 @@ impl NoteInterface for SaplingNote {
 
     fn memo(&self) -> &Memo {
         &self.memo
-    }
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl SaplingNote {
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-
-        let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
-
-        let account_id =
-            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to read account id. {e}"),
-                )
-            })?;
-        let scope = match reader.read_u8()? {
-            0 => Ok(zip32::Scope::External),
-            1 => Ok(zip32::Scope::Internal),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "invalid scope value",
-            )),
-        }?;
-
-        let mut address_bytes = [0u8; 43];
-        reader.read_exact(&mut address_bytes)?;
-        let recipient =
-            sapling_crypto::PaymentAddress::from_bytes(&address_bytes).ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "failed to read payment address",
-                )
-            })?;
-        let value = sapling_crypto::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
-        let rseed_zip212 = reader.read_u8()?;
-        let mut rseed_bytes = [0u8; 32];
-        reader.read_exact(&mut rseed_bytes)?;
-        let rseed = match rseed_zip212 {
-            0 => sapling_crypto::Rseed::BeforeZip212(
-                jubjub::Fr::from_bytes(&rseed_bytes).expect("should read valid jubjub bytes"),
-            ),
-            1 => sapling_crypto::Rseed::AfterZip212(rseed_bytes),
-            _ => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "invalid rseed zip212 byte",
-                ))
-            }
-        };
-
-        let nullifier = Optional::read(&mut reader, |r| {
-            let mut nullifier_bytes = [0u8; 32];
-            r.read_exact(&mut nullifier_bytes)?;
-
-            sapling_crypto::Nullifier::from_slice(&nullifier_bytes).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to read nullifier. {e}"),
-                )
-            })
-        })?;
-        let position = Optional::read(&mut reader, |r| {
-            Ok(Position::from(r.read_u64::<LittleEndian>()?))
-        })?;
-        let mut memo_bytes = [0u8; 512];
-        reader.read_exact(&mut memo_bytes)?;
-        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to read memo. {e}"),
-            )
-        })?;
-
-        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
-
-        Ok(Self {
-            output_id: OutputId::new(txid, output_index),
-            key_id: KeyId::from_parts(account_id, scope),
-            note: sapling_crypto::Note::from_parts(recipient, value, rseed),
-            nullifier,
-            position,
-            memo,
-            spending_transaction,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-
-        self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
-
-        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
-        writer.write_u8(self.key_id.scope as u8)?;
-
-        writer.write_all(&self.note.recipient().to_bytes())?;
-        writer.write_u64::<LittleEndian>(self.value())?;
-        match self.note.rseed() {
-            sapling_crypto::Rseed::BeforeZip212(fr) => {
-                writer.write_u8(0)?;
-                writer.write_all(&fr.to_bytes())?;
-            }
-            sapling_crypto::Rseed::AfterZip212(bytes) => {
-                writer.write_u8(1)?;
-                writer.write_all(bytes)?;
-            }
-        }
-
-        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
-            w.write_all(nullifier.as_ref())
-        })?;
-        Optional::write(&mut writer, self.position, |w, position| {
-            w.write_u64::<LittleEndian>(position.into())
-        })?;
-        writer.write_all(self.memo.encode().as_array())?;
-
-        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
-            txid.write(w)
-        })
     }
 }
 
@@ -1402,107 +906,6 @@ impl NoteInterface for OrchardNote {
     }
 }
 
-#[cfg(feature = "wallet_essentials")]
-impl OrchardNote {
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-
-        let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
-
-        let account_id =
-            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to read account id. {e}"),
-                )
-            })?;
-        let scope = match reader.read_u8()? {
-            0 => Ok(zip32::Scope::External),
-            1 => Ok(zip32::Scope::Internal),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "invalid scope value",
-            )),
-        }?;
-
-        let mut address_bytes = [0u8; 43];
-        reader.read_exact(&mut address_bytes)?;
-        let recipient = orchard::Address::from_raw_address_bytes(&address_bytes)
-            .expect("should be a valid address");
-        let value = orchard::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
-        let mut rho_bytes = [0u8; 32];
-        reader.read_exact(&mut rho_bytes)?;
-        let rho = orchard::note::Rho::from_bytes(&rho_bytes).expect("should be valid rho bytes");
-        let mut rseed_bytes = [0u8; 32];
-        reader.read_exact(&mut rseed_bytes)?;
-        let rseed = orchard::note::RandomSeed::from_bytes(rseed_bytes, &rho)
-            .expect("should be valid random seed bytes");
-
-        let nullifier = Optional::read(&mut reader, |r| {
-            let mut nullifier_bytes = [0u8; 32];
-            r.read_exact(&mut nullifier_bytes)?;
-
-            Ok(orchard::note::Nullifier::from_bytes(&nullifier_bytes)
-                .expect("should be valid nullfiier bytes"))
-        })?;
-        let position = Optional::read(&mut reader, |r| {
-            Ok(Position::from(r.read_u64::<LittleEndian>()?))
-        })?;
-        let mut memo_bytes = [0u8; 512];
-        reader.read_exact(&mut memo_bytes)?;
-        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to read memo. {e}"),
-            )
-        })?;
-
-        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
-
-        Ok(Self {
-            output_id: OutputId::new(txid, output_index),
-            key_id: KeyId::from_parts(account_id, scope),
-            note: orchard::note::Note::from_parts(recipient, value, rho, rseed)
-                .expect("should be a valid orchard note"),
-            nullifier,
-            position,
-            memo,
-            spending_transaction,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-
-        self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
-
-        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
-        writer.write_u8(self.key_id.scope as u8)?;
-
-        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
-        writer.write_u64::<LittleEndian>(self.value())?;
-        writer.write_all(&self.note.rho().to_bytes())?;
-        writer.write_all(self.note.rseed().as_bytes())?;
-
-        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
-            w.write_all(&nullifier.to_bytes())
-        })?;
-        Optional::write(&mut writer, self.position, |w, position| {
-            w.write_u64::<LittleEndian>(position.into())
-        })?;
-        writer.write_all(self.memo.encode().as_array())?;
-        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
-            txid.write(w)
-        })?;
-
-        Ok(())
-    }
-}
-
 /// Provides a common API for all outgoing note types.
 pub trait OutgoingNoteInterface: Sized {
     /// Decrypted note type.
@@ -1553,13 +956,6 @@ pub struct OutgoingNote<N> {
     pub(crate) memo: Memo,
     /// Recipient's full unified address from encoded memo.
     pub(crate) recipient_unified_address: Option<UnifiedAddress>,
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl<N> OutgoingNote<N> {
-    fn serialized_version() -> u8 {
-        0
-    }
 }
 
 /// Outgoing sapling note.
@@ -1614,141 +1010,6 @@ impl OutgoingNoteInterface for OutgoingSaplingNote {
     }
 }
 
-#[cfg(feature = "wallet_essentials")]
-impl OutgoingSaplingNote {
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(
-        mut reader: R,
-        consensus_parameters: &impl consensus::Parameters,
-    ) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-
-        let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
-
-        let account_id =
-            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to read account id. {e}"),
-                )
-            })?;
-        let scope = match reader.read_u8()? {
-            0 => Ok(zip32::Scope::External),
-            1 => Ok(zip32::Scope::Internal),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "invalid scope value",
-            )),
-        }?;
-
-        let mut address_bytes = [0u8; 43];
-        reader.read_exact(&mut address_bytes)?;
-        let recipient =
-            sapling_crypto::PaymentAddress::from_bytes(&address_bytes).ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "failed to read payment address",
-                )
-            })?;
-        let value = sapling_crypto::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
-        let rseed_zip212 = reader.read_u8()?;
-        let mut rseed_bytes = [0u8; 32];
-        reader.read_exact(&mut rseed_bytes)?;
-        let rseed = match rseed_zip212 {
-            0 => sapling_crypto::Rseed::BeforeZip212(
-                jubjub::Fr::from_bytes(&rseed_bytes).expect("should read valid jubjub bytes"),
-            ),
-            1 => sapling_crypto::Rseed::AfterZip212(rseed_bytes),
-            _ => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "invalid rseed zip212 byte",
-                ))
-            }
-        };
-
-        let mut memo_bytes = [0u8; 512];
-        reader.read_exact(&mut memo_bytes)?;
-        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to read memo. {e}"),
-            )
-        })?;
-
-        let recipient_unified_address = Optional::read(&mut reader, |r| {
-            let encoded_address = read_string(r)?;
-
-            // TODO: surely there is a more straightforward way to decode unified address from string
-            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
-                .unwrap()
-                .convert_if_network::<read_write::UnifiedAddress>(
-                    consensus_parameters.network_type(),
-                )
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("failed to convert recipient unified address. {e}"),
-                    )
-                })?
-                .0;
-
-            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to convert recipient unified address. {e}"),
-                )
-            })
-        })?;
-
-        Ok(Self {
-            output_id: OutputId::new(txid, output_index),
-            key_id: KeyId::from_parts(account_id, scope),
-            note: sapling_crypto::Note::from_parts(recipient, value, rseed),
-            memo,
-            recipient_unified_address,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(
-        &self,
-        mut writer: W,
-        consensus_parameters: &impl consensus::Parameters,
-    ) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-
-        self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
-
-        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
-        writer.write_u8(self.key_id.scope as u8)?;
-
-        writer.write_all(&self.note.recipient().to_bytes())?;
-        writer.write_u64::<LittleEndian>(self.value())?;
-        match self.note.rseed() {
-            sapling_crypto::Rseed::BeforeZip212(fr) => {
-                writer.write_u8(1)?;
-                writer.write_all(&fr.to_bytes())?;
-            }
-            sapling_crypto::Rseed::AfterZip212(bytes) => {
-                writer.write_u8(2)?;
-                writer.write_all(bytes)?;
-            }
-        }
-
-        writer.write_all(self.memo.encode().as_array())?;
-        Optional::write(
-            &mut writer,
-            self.recipient_unified_address.as_ref(),
-            |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
-        )?;
-
-        Ok(())
-    }
-}
-
 /// Outgoing orchard note.
 pub type OutgoingOrchardNote = OutgoingNote<orchard::Note>;
 
@@ -1795,121 +1056,6 @@ impl OutgoingNoteInterface for OutgoingOrchardNote {
 
     fn transaction_outgoing_notes(transaction: &WalletTransaction) -> &[Self] {
         &transaction.outgoing_orchard_notes
-    }
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl OutgoingOrchardNote {
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(
-        mut reader: R,
-        consensus_parameters: &impl consensus::Parameters,
-    ) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-
-        let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
-
-        let account_id =
-            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to read account id. {e}"),
-                )
-            })?;
-        let scope = match reader.read_u8()? {
-            0 => Ok(zip32::Scope::External),
-            1 => Ok(zip32::Scope::Internal),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "invalid scope value",
-            )),
-        }?;
-
-        let mut address_bytes = [0u8; 43];
-        reader.read_exact(&mut address_bytes)?;
-        let recipient = orchard::Address::from_raw_address_bytes(&address_bytes)
-            .expect("should be a valid address");
-        let value = orchard::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
-        let mut rho_bytes = [0u8; 32];
-        reader.read_exact(&mut rho_bytes)?;
-        let rho = orchard::note::Rho::from_bytes(&rho_bytes).expect("should be valid rho bytes");
-        let mut rseed_bytes = [0u8; 32];
-        reader.read_exact(&mut rseed_bytes)?;
-        let rseed = orchard::note::RandomSeed::from_bytes(rseed_bytes, &rho)
-            .expect("should be valid random seed bytes");
-
-        let mut memo_bytes = [0u8; 512];
-        reader.read_exact(&mut memo_bytes)?;
-        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to read memo. {e}"),
-            )
-        })?;
-
-        let recipient_unified_address = Optional::read(&mut reader, |r| {
-            let encoded_address = read_string(r)?;
-
-            // TODO: surely there is a more straightforward way to decode unified address from string
-            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
-                .unwrap()
-                .convert_if_network::<read_write::UnifiedAddress>(
-                    consensus_parameters.network_type(),
-                )
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("failed to convert recipient unified address. {e}"),
-                    )
-                })?
-                .0;
-
-            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to convert recipient unified address. {e}"),
-                )
-            })
-        })?;
-
-        Ok(Self {
-            output_id: OutputId::new(txid, output_index),
-            key_id: KeyId::from_parts(account_id, scope),
-            note: orchard::note::Note::from_parts(recipient, value, rho, rseed)
-                .expect("should be a valid orchard note"),
-            memo,
-            recipient_unified_address,
-        })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(
-        &self,
-        mut writer: W,
-        consensus_parameters: &impl consensus::Parameters,
-    ) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-
-        self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
-
-        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
-        writer.write_u8(self.key_id.scope as u8)?;
-
-        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
-        writer.write_u64::<LittleEndian>(self.value())?;
-        writer.write_all(&self.note.rho().to_bytes())?;
-        writer.write_all(self.note.rseed().as_bytes())?;
-
-        writer.write_all(self.memo.encode().as_array())?;
-        Optional::write(
-            &mut writer,
-            self.recipient_unified_address.as_ref(),
-            |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
-        )?;
-
-        Ok(())
     }
 }
 
@@ -1960,227 +1106,5 @@ impl ShardTrees {
 impl Default for ShardTrees {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl ShardTrees {
-    fn serialized_version() -> u8 {
-        0
-    }
-
-    /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
-        let sapling = Self::read_shardtree(&mut reader)?;
-        let orchard = Self::read_shardtree(&mut reader)?;
-
-        Ok(Self { sapling, orchard })
-    }
-
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-        Self::write_shardtree(&mut writer, &mut self.sapling)?;
-        Self::write_shardtree(&mut writer, &mut self.orchard)?;
-
-        Ok(())
-    }
-
-    fn read_shardtree<
-        H: Hashable + Clone + HashSer + Eq,
-        C: Ord + std::fmt::Debug + Copy + From<u32>,
-        R: Read,
-        const DEPTH: u8,
-        const SHARD_HEIGHT: u8,
-    >(
-        mut reader: R,
-    ) -> std::io::Result<shardtree::ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>> {
-        let shards = Vector::read(&mut reader, |r| {
-            let level = incrementalmerkletree::Level::from(r.read_u8()?);
-            let index = r.read_u64::<LittleEndian>()?;
-            let root_addr = incrementalmerkletree::Address::from_parts(level, index);
-            let shard = read_shard(r)?;
-            Ok(LocatedPrunableTree::from_parts(root_addr, shard))
-        })?;
-        let mut store = MemoryShardStore::empty();
-        for shard in shards {
-            store.put_shard(shard).expect("Infallible");
-        }
-        let checkpoints = Vector::read(&mut reader, |r| {
-            let checkpoint_id = C::from(r.read_u32::<LittleEndian>()?);
-            let tree_state = match r.read_u8()? {
-                0 => shardtree::store::TreeState::Empty,
-                1 => shardtree::store::TreeState::AtPosition(Position::from(
-                    r.read_u64::<LittleEndian>()?,
-                )),
-                otherwise => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!(
-                            "failed to read TreeState. expected boolean value, found {otherwise}"
-                        ),
-                    ))
-                }
-            };
-            let marks_removed =
-                Vector::read(r, |r| r.read_u64::<LittleEndian>().map(Position::from))?;
-            Ok((
-                checkpoint_id,
-                Checkpoint::from_parts(tree_state, marks_removed.into_iter().collect()),
-            ))
-        })?;
-        for (checkpoint_id, checkpoint) in checkpoints {
-            store
-                .add_checkpoint(checkpoint_id, checkpoint)
-                .expect("Infallible");
-        }
-        store.put_cap(read_shard(reader)?).expect("Infallible");
-
-        Ok(shardtree::ShardTree::new(
-            store,
-            MAX_VERIFICATION_WINDOW as usize,
-        ))
-    }
-
-    /// Write memory-backed shardstore, represented tree.
-    fn write_shardtree<
-        H: Hashable + Clone + Eq + HashSer,
-        C: Ord + std::fmt::Debug + Copy,
-        W: Write,
-        const DEPTH: u8,
-        const SHARD_HEIGHT: u8,
-    >(
-        mut writer: W,
-        shardtree: &mut shardtree::ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>,
-    ) -> std::io::Result<()>
-    where
-        u32: From<C>,
-    {
-        fn write_shards<W, H, C>(
-            mut writer: W,
-            store: &MemoryShardStore<H, C>,
-        ) -> std::io::Result<()>
-        where
-            H: Hashable + Clone + Eq + HashSer,
-            C: Ord + std::fmt::Debug + Copy,
-            W: Write,
-        {
-            let roots = store.get_shard_roots().expect("Infallible");
-            Vector::write(&mut writer, &roots, |w, root| {
-                w.write_u8(root.level().into())?;
-                w.write_u64::<LittleEndian>(root.index())?;
-                let shard = store
-                    .get_shard(*root)
-                    .expect("Infallible")
-                    .expect("cannot find root that shard store claims to have");
-                write_shard(w, shard.root())
-            })
-        }
-
-        fn write_checkpoints<W, Cid>(
-            mut writer: W,
-            checkpoints: &[(Cid, Checkpoint)],
-        ) -> std::io::Result<()>
-        where
-            W: Write,
-            Cid: Ord + std::fmt::Debug + Copy,
-            u32: From<Cid>,
-        {
-            Vector::write(
-                &mut writer,
-                checkpoints,
-                |mut w, (checkpoint_id, checkpoint)| {
-                    w.write_u32::<LittleEndian>(u32::from(*checkpoint_id))?;
-                    match checkpoint.tree_state() {
-                        shardtree::store::TreeState::Empty => w.write_u8(0),
-                        shardtree::store::TreeState::AtPosition(pos) => {
-                            w.write_u8(1)?;
-                            w.write_u64::<LittleEndian>(<u64 as From<Position>>::from(pos))
-                        }
-                    }?;
-                    Vector::write(
-                        &mut w,
-                        &checkpoint.marks_removed().iter().collect::<Vec<_>>(),
-                        |w, mark| {
-                            w.write_u64::<LittleEndian>(<u64 as From<Position>>::from(**mark))
-                        },
-                    )
-                },
-            )
-        }
-
-        // Replace original tree with empty tree, and mutate new version into store.
-        let mut store = std::mem::replace(
-            shardtree,
-            shardtree::ShardTree::new(MemoryShardStore::empty(), 0),
-        )
-        .into_store();
-
-        macro_rules! write_with_error_handling {
-            ($writer: ident, $from: ident) => {
-                if let Err(e) = $writer(&mut writer, &$from) {
-                    *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
-                    return Err(e);
-                }
-            };
-        }
-
-        // Write located prunable trees
-        write_with_error_handling!(write_shards, store);
-
-        // Write checkpoints
-        let mut checkpoints = Vec::new();
-        store
-            .with_checkpoints(
-                MAX_VERIFICATION_WINDOW as usize,
-                |checkpoint_id, checkpoint| {
-                    checkpoints.push((*checkpoint_id, checkpoint.clone()));
-                    Ok(())
-                },
-            )
-            .expect("Infallible");
-        write_with_error_handling!(write_checkpoints, checkpoints);
-
-        // Write cap
-        let cap = store.get_cap().expect("Infallible");
-        write_with_error_handling!(write_shard, cap);
-
-        *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
-
-        Ok(())
-    }
-}
-
-#[cfg(feature = "wallet_essentials")]
-mod read_write {
-    use std::io::{Read, Write};
-
-    use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-
-    pub(super) fn read_string<R: Read>(mut reader: R) -> std::io::Result<String> {
-        let str_len = reader.read_u64::<LittleEndian>()?;
-        let mut str_bytes = vec![0; str_len as usize];
-        reader.read_exact(&mut str_bytes)?;
-
-        String::from_utf8(str_bytes)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
-    }
-
-    pub(super) fn write_string<W: Write>(mut writer: W, str: &str) -> std::io::Result<()> {
-        writer.write_u64::<LittleEndian>(str.len() as u64)?;
-        writer.write_all(str.as_bytes())
-    }
-
-    pub(super) struct UnifiedAddress(pub(super) zcash_address::unified::Address);
-
-    impl zcash_address::TryFromRawAddress for UnifiedAddress {
-        type Error = std::convert::Infallible;
-
-        fn try_from_raw_unified(
-            ua: zcash_address::unified::Address,
-        ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
-            Ok(UnifiedAddress(ua))
-        }
     }
 }

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -23,7 +23,7 @@ use zcash_client_backend::{
 use zcash_keys::{address::UnifiedAddress, encoding::encode_payment_address};
 use zcash_primitives::{
     block::BlockHash,
-    consensus::{BlockHeight, NetworkConstants, Parameters},
+    consensus::{self, BlockHeight, NetworkConstants, Parameters},
     legacy::Script,
     memo::Memo,
     transaction::{
@@ -38,6 +38,14 @@ use crate::{
     keys::{self, transparent::TransparentAddressId, KeyId},
     sync::MAX_VERIFICATION_WINDOW,
     witness,
+};
+
+#[cfg(feature = "wallet_essentials")]
+use {
+    byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt},
+    read_write::write_string,
+    std::io::Write,
+    zcash_encoding::{Optional, Vector},
 };
 
 pub mod traits;
@@ -241,6 +249,19 @@ pub struct TreeBounds {
     pub sapling_final_tree_size: u32,
     pub orchard_initial_tree_size: u32,
     pub orchard_final_tree_size: u32,
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl TreeBounds {
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_u32::<LittleEndian>(self.sapling_initial_tree_size)?;
+        writer.write_u32::<LittleEndian>(self.sapling_final_tree_size)?;
+        writer.write_u32::<LittleEndian>(self.orchard_initial_tree_size)?;
+        writer.write_u32::<LittleEndian>(self.orchard_final_tree_size)?;
+
+        Ok(())
+    }
 }
 
 /// A snapshot of the current state of sync. Useful for displaying the status of sync to a user / consumer.
@@ -458,6 +479,21 @@ impl WalletBlock {
     }
 }
 
+#[cfg(feature = "wallet_essentials")]
+impl WalletBlock {
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u32::<LittleEndian>(self.block_height.into())?;
+        writer.write_all(&self.block_hash.0)?;
+        writer.write_all(&self.prev_hash.0)?;
+        writer.write_u32::<LittleEndian>(self.time)?;
+        Vector::write(&mut writer, self.txids(), |w, txid| txid.write(w))?;
+        self.tree_bounds.write(&mut writer)?;
+
+        Ok(())
+    }
+}
+
 /// Wallet transaction
 pub struct WalletTransaction {
     pub(crate) txid: TxId,
@@ -577,6 +613,38 @@ impl WalletTransaction {
 
 #[cfg(feature = "wallet_essentials")]
 impl WalletTransaction {
+    fn serialized_version() -> u8 {
+        1
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(
+        &self,
+        mut writer: W,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        self.txid.write(&mut writer)?;
+        self.transaction.write(&mut writer)?;
+        self.status.write(&mut writer)?;
+        writer.write_u32::<LittleEndian>(self.datetime)?;
+        Vector::write(&mut writer, self.transparent_coins(), |w, output| {
+            output.write(w)
+        })?;
+        Vector::write(&mut writer, self.sapling_notes(), |w, output| {
+            output.write(w)
+        })?;
+        Vector::write(&mut writer, self.orchard_notes(), |w, output| {
+            output.write(w)
+        })?;
+        Vector::write(&mut writer, self.outgoing_sapling_notes(), |w, output| {
+            output.write(w, consensus_parameters)
+        })?;
+        Vector::write(&mut writer, self.outgoing_orchard_notes(), |w, output| {
+            output.write(w, consensus_parameters)
+        })
+    }
+
     /// Returns the total value sent to receivers, including value explicitly sent to the wallet own addresses but
     /// excluding change.
     pub fn total_value_sent(&self) -> u64 {
@@ -650,6 +718,13 @@ pub struct WalletNote<N, Nf: Copy> {
     /// Transaction ID of transaction this output was spent.
     /// If `None`, output is not spent.
     pub(crate) spending_transaction: Option<TxId>,
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl<N, Nf: Copy> WalletNote<N, Nf> {
+    fn serialized_version() -> u8 {
+        1
+    }
 }
 
 /// Provides a common API for all output types.
@@ -757,6 +832,34 @@ impl OutputInterface for TransparentCoin {
     }
 }
 
+#[cfg(feature = "wallet_essentials")]
+impl TransparentCoin {
+    fn serialized_version() -> u8 {
+        1
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id().into())?;
+        writer.write_u8(self.key_id.scope() as u8)?;
+        writer.write_u32::<LittleEndian>(self.key_id.address_index())?;
+
+        write_string(&mut writer, &self.address)?;
+        self.script.write(&mut writer)?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
+            txid.write(w)
+        })?;
+
+        Ok(())
+    }
+}
+
 /// Provides a common API for all shielded output types.
 pub trait NoteInterface: OutputInterface + Sized {
     /// Decrypted note type.
@@ -838,6 +941,78 @@ impl NoteInterface for SaplingNote {
 
     fn memo(&self) -> &Memo {
         &self.memo
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl SaplingNote {
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        match self.note.rseed() {
+            sapling_crypto::Rseed::BeforeZip212(fr) => {
+                writer.write_u8(1)?;
+                writer.write_all(&fr.to_bytes())?;
+            }
+            sapling_crypto::Rseed::AfterZip212(bytes) => {
+                writer.write_u8(2)?;
+                writer.write_all(bytes)?;
+            }
+        }
+
+        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
+            w.write_all(nullifier.as_ref())
+        })?;
+        Optional::write(&mut writer, self.position, |w, position| {
+            w.write_u64::<LittleEndian>(position.into())
+        })?;
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
+            txid.write(w)
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl OrchardNote {
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        writer.write_all(&self.note.rho().to_bytes())?;
+        writer.write_all(self.note.rseed().as_bytes())?;
+
+        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
+            w.write_all(&nullifier.to_bytes())
+        })?;
+        Optional::write(&mut writer, self.position, |w, position| {
+            w.write_u64::<LittleEndian>(position.into())
+        })?;
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
+            txid.write(w)
+        })?;
+
+        Ok(())
     }
 }
 
@@ -954,6 +1129,13 @@ pub struct OutgoingNote<N> {
     pub(crate) recipient_unified_address: Option<UnifiedAddress>,
 }
 
+#[cfg(feature = "wallet_essentials")]
+impl<N> OutgoingNote<N> {
+    fn serialized_version() -> u8 {
+        1
+    }
+}
+
 /// Outgoing sapling note.
 pub type OutgoingSaplingNote = OutgoingNote<sapling_crypto::Note>;
 
@@ -1006,6 +1188,46 @@ impl OutgoingNoteInterface for OutgoingSaplingNote {
     }
 }
 
+#[cfg(feature = "wallet_essentials")]
+impl OutgoingSaplingNote {
+    /// Serialize into `writer`
+    pub fn write<W: Write>(
+        &self,
+        mut writer: W,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        match self.note.rseed() {
+            sapling_crypto::Rseed::BeforeZip212(fr) => {
+                writer.write_u8(1)?;
+                writer.write_all(&fr.to_bytes())?;
+            }
+            sapling_crypto::Rseed::AfterZip212(bytes) => {
+                writer.write_u8(2)?;
+                writer.write_all(bytes)?;
+            }
+        }
+
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(
+            &mut writer,
+            self.recipient_unified_address.as_ref(),
+            |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
+        )?;
+
+        Ok(())
+    }
+}
+
 /// Outgoing orchard note.
 pub type OutgoingOrchardNote = OutgoingNote<orchard::Note>;
 
@@ -1052,6 +1274,38 @@ impl OutgoingNoteInterface for OutgoingOrchardNote {
 
     fn transaction_outgoing_notes(transaction: &WalletTransaction) -> &[Self] {
         &transaction.outgoing_orchard_notes
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl OutgoingOrchardNote {
+    /// Serialize into `writer`
+    pub fn write<W: Write>(
+        &self,
+        mut writer: W,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        writer.write_all(&self.note.rho().to_bytes())?;
+        writer.write_all(self.note.rseed().as_bytes())?;
+
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(
+            &mut writer,
+            self.recipient_unified_address.as_ref(),
+            |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
+        )?;
+
+        Ok(())
     }
 }
 
@@ -1102,5 +1356,17 @@ impl ShardTrees {
 impl Default for ShardTrees {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+mod read_write {
+    use std::io::Write;
+
+    use byteorder::{LittleEndian, WriteBytesExt};
+
+    pub(super) fn write_string<W: Write>(mut writer: W, str: &str) -> std::io::Result<()> {
+        writer.write_u64::<LittleEndian>(str.len() as u64)?;
+        writer.write_all(str.as_bytes())
     }
 }

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -6,7 +6,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
-    io::Read,
     ops::Range,
     sync::{
         atomic::{self, AtomicU8},
@@ -14,50 +13,50 @@ use std::{
     },
 };
 
-use incrementalmerkletree::{Hashable, Position};
+use incrementalmerkletree::Position;
 use orchard::tree::MerkleHashOrchard;
-use read_write::read_string;
-use shardtree::{
-    store::{memory::MemoryShardStore, Checkpoint, ShardStore},
-    LocatedPrunableTree, ShardTree,
-};
-use zcash_address::ZcashAddress;
+use shardtree::{store::memory::MemoryShardStore, ShardTree};
 use zcash_client_backend::{
     data_api::scanning::{ScanPriority, ScanRange},
-    serialization::shardtree::{read_shard, write_shard},
     PoolType, ShieldedProtocol,
 };
 use zcash_keys::{address::UnifiedAddress, encoding::encode_payment_address};
 use zcash_primitives::{
     block::BlockHash,
-    consensus::{self, BlockHeight, BranchId, NetworkConstants, Parameters},
+    consensus::{self, BlockHeight},
     legacy::Script,
     memo::Memo,
-    merkle_tree::HashSer,
     transaction::{
         components::{amount::NonNegativeAmount, OutPoint},
-        Transaction, TxId,
+        TxId,
     },
 };
 
 use zingo_status::confirmation_status::ConfirmationStatus;
 
 use crate::{
-    keys::{
-        self,
-        transparent::{TransparentAddressId, TransparentScope},
-        KeyId,
-    },
+    keys::{self, transparent::TransparentAddressId, KeyId},
     sync::MAX_VERIFICATION_WINDOW,
     witness,
 };
 
 #[cfg(feature = "wallet_essentials")]
 use {
+    crate::keys::transparent::TransparentScope,
     byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt},
+    incrementalmerkletree::Hashable,
+    read_write::read_string,
     read_write::write_string,
+    shardtree::{
+        store::{Checkpoint, ShardStore},
+        LocatedPrunableTree,
+    },
+    std::io::Read,
     std::io::Write,
+    zcash_address::ZcashAddress,
+    zcash_client_backend::serialization::shardtree::{read_shard, write_shard},
     zcash_encoding::{Optional, Vector},
+    zcash_primitives::{merkle_tree::HashSer, transaction::Transaction},
 };
 
 pub mod traits;
@@ -837,7 +836,7 @@ impl WalletTransaction {
         let status = ConfirmationStatus::read(&mut reader)?;
         let transaction = Transaction::read(
             &mut reader,
-            BranchId::for_height(consensus_parameters, status.get_height()),
+            consensus::BranchId::for_height(consensus_parameters, status.get_height()),
         )?;
         let datetime = reader.read_u32::<LittleEndian>()?;
         let transparent_coins = Vector::read(&mut reader, |r| TransparentCoin::read(r))?;
@@ -1530,12 +1529,12 @@ pub trait OutgoingNoteInterface: Sized {
     /// Encoded recipient address recorded in note on chain (single receiver).
     fn encoded_recipient<P>(&self, parameters: &P) -> String
     where
-        P: Parameters + NetworkConstants;
+        P: consensus::Parameters + consensus::NetworkConstants;
 
     /// Encoded recipient unified address as given by recipient and recorded in an encoded memo (all original receivers).
     fn encoded_recipient_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
     where
-        P: Parameters + NetworkConstants;
+        P: consensus::Parameters + consensus::NetworkConstants;
 
     /// Outgoing notes within `transaction`.
     fn transaction_outgoing_notes(transaction: &WalletTransaction) -> &[Self];
@@ -1593,7 +1592,7 @@ impl OutgoingNoteInterface for OutgoingSaplingNote {
 
     fn encoded_recipient<P>(&self, consensus_parameters: &P) -> String
     where
-        P: Parameters + NetworkConstants,
+        P: consensus::Parameters + consensus::NetworkConstants,
     {
         encode_payment_address(
             consensus_parameters.hrp_sapling_payment_address(),
@@ -1603,7 +1602,7 @@ impl OutgoingNoteInterface for OutgoingSaplingNote {
 
     fn encoded_recipient_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
     where
-        P: Parameters + NetworkConstants,
+        P: consensus::Parameters + consensus::NetworkConstants,
     {
         self.recipient_unified_address
             .as_ref()
@@ -1780,14 +1779,14 @@ impl OutgoingNoteInterface for OutgoingOrchardNote {
 
     fn encoded_recipient<P>(&self, parameters: &P) -> String
     where
-        P: Parameters + NetworkConstants,
+        P: consensus::Parameters + consensus::NetworkConstants,
     {
         keys::encode_orchard_receiver(parameters, &self.note().recipient()).unwrap()
     }
 
     fn encoded_recipient_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
     where
-        P: Parameters + NetworkConstants,
+        P: consensus::Parameters + consensus::NetworkConstants,
     {
         self.recipient_unified_address
             .as_ref()
@@ -2174,6 +2173,7 @@ mod read_write {
     }
 
     pub(super) struct UnifiedAddress(pub(super) zcash_address::unified::Address);
+
     impl zcash_address::TryFromRawAddress for UnifiedAddress {
         type Error = std::convert::Infallible;
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -300,6 +300,22 @@ impl TreeBounds {
         0
     }
 
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let sapling_initial_tree_size = reader.read_u32::<LittleEndian>()?;
+        let sapling_final_tree_size = reader.read_u32::<LittleEndian>()?;
+        let orchard_initial_tree_size = reader.read_u32::<LittleEndian>()?;
+        let orchard_final_tree_size = reader.read_u32::<LittleEndian>()?;
+
+        Ok(Self {
+            sapling_initial_tree_size,
+            sapling_final_tree_size,
+            orchard_initial_tree_size,
+            orchard_final_tree_size,
+        })
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_u8(Self::serialized_version())?;
@@ -568,7 +584,24 @@ impl WalletBlock {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        todo!()
+        let _version = reader.read_u8()?;
+        let block_height = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
+        let mut block_hash = BlockHash([0u8; 32]);
+        reader.read_exact(&mut block_hash.0)?;
+        let mut prev_hash = BlockHash([0u8; 32]);
+        reader.read_exact(&mut prev_hash.0)?;
+        let time = reader.read_u32::<LittleEndian>()?;
+        let txids = Vector::read(&mut reader, |r| TxId::read(r))?;
+        let tree_bounds = TreeBounds::read(&mut reader)?;
+
+        Ok(Self {
+            block_height,
+            block_hash,
+            prev_hash,
+            time,
+            txids,
+            tree_bounds,
+        })
     }
 
     /// Serialize into `writer`
@@ -579,9 +612,7 @@ impl WalletBlock {
         writer.write_all(&self.prev_hash.0)?;
         writer.write_u32::<LittleEndian>(self.time)?;
         Vector::write(&mut writer, self.txids(), |w, txid| txid.write(w))?;
-        self.tree_bounds.write(&mut writer)?;
-
-        Ok(())
+        self.tree_bounds.write(&mut writer)
     }
 }
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -103,7 +103,7 @@ impl Default for InitialSyncState {
 #[cfg(feature = "wallet_essentials")]
 impl InitialSyncState {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 
     /// Serialize into `writer`
@@ -228,7 +228,7 @@ impl Default for SyncState {
 #[cfg(feature = "wallet_essentials")]
 impl SyncState {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 
     /// Serialize into `writer`
@@ -255,8 +255,7 @@ impl SyncState {
                 locator.1.write(w)
             },
         )?;
-
-        Ok(())
+        self.initial_sync_state.write(&mut writer)
     }
 }
 
@@ -310,14 +309,17 @@ pub struct TreeBounds {
 
 #[cfg(feature = "wallet_essentials")]
 impl TreeBounds {
+    fn serialized_version() -> u8 {
+        0
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
         writer.write_u32::<LittleEndian>(self.sapling_initial_tree_size)?;
         writer.write_u32::<LittleEndian>(self.sapling_final_tree_size)?;
         writer.write_u32::<LittleEndian>(self.orchard_initial_tree_size)?;
-        writer.write_u32::<LittleEndian>(self.orchard_final_tree_size)?;
-
-        Ok(())
+        writer.write_u32::<LittleEndian>(self.orchard_final_tree_size)
     }
 }
 
@@ -496,7 +498,7 @@ impl Default for NullifierMap {
 #[cfg(feature = "wallet_essentials")]
 impl NullifierMap {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 
     /// Serialize into `writer`
@@ -701,7 +703,7 @@ impl WalletTransaction {
 #[cfg(feature = "wallet_essentials")]
 impl WalletTransaction {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 
     /// Serialize into `writer`
@@ -810,7 +812,7 @@ pub struct WalletNote<N, Nf: Copy> {
 #[cfg(feature = "wallet_essentials")]
 impl<N, Nf: Copy> WalletNote<N, Nf> {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 }
 
@@ -922,7 +924,7 @@ impl OutputInterface for TransparentCoin {
 #[cfg(feature = "wallet_essentials")]
 impl TransparentCoin {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 
     /// Serialize into `writer`
@@ -1219,7 +1221,7 @@ pub struct OutgoingNote<N> {
 #[cfg(feature = "wallet_essentials")]
 impl<N> OutgoingNote<N> {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 }
 
@@ -1449,7 +1451,7 @@ impl Default for ShardTrees {
 #[cfg(feature = "wallet_essentials")]
 impl ShardTrees {
     fn serialized_version() -> u8 {
-        1
+        0
     }
 
     /// Serialize into `writer`
@@ -1492,10 +1494,8 @@ impl ShardTrees {
                     .get_shard(*root)
                     .expect("Infallible")
                     .expect("cannot find root that shard store claims to have");
-                write_shard(w, shard.root())?; // s.root returns &Tree
-                Ok(())
-            })?;
-            Ok(())
+                write_shard(w, shard.root())
+            })
         }
 
         fn write_checkpoints<W, Cid>(
@@ -1527,8 +1527,7 @@ impl ShardTrees {
                         },
                     )
                 },
-            )?;
-            Ok(())
+            )
         }
 
         // Replace original tree with empty tree, and mutate new version into store.
@@ -1537,6 +1536,7 @@ impl ShardTrees {
             shardtree::ShardTree::new(MemoryShardStore::empty(), 0),
         )
         .into_store();
+
         macro_rules! write_with_error_handling {
             ($writer: ident, $from: ident) => {
                 if let Err(e) = $writer(&mut writer, &$from) {
@@ -1545,8 +1545,11 @@ impl ShardTrees {
                 }
             };
         }
+
         // Write located prunable trees
         write_with_error_handling!(write_shards, store);
+
+        // Write checkpoints
         let mut checkpoints = Vec::new();
         store
             .with_checkpoints(
@@ -1557,11 +1560,12 @@ impl ShardTrees {
                 },
             )
             .expect("Infallible");
-        // Write checkpoints
         write_with_error_handling!(write_checkpoints, checkpoints);
-        let cap = store.get_cap().expect("Infallible");
+
         // Write cap
+        let cap = store.get_cap().expect("Infallible");
         write_with_error_handling!(write_shard, cap);
+
         *tree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
 
         Ok(())

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -16,32 +16,38 @@ use std::{
 
 use incrementalmerkletree::{Hashable, Position};
 use orchard::tree::MerkleHashOrchard;
+use read_write::read_string;
 use shardtree::{
     store::{memory::MemoryShardStore, Checkpoint, ShardStore},
-    ShardTree,
+    LocatedPrunableTree, ShardTree,
 };
+use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::scanning::{ScanPriority, ScanRange},
-    serialization::shardtree::write_shard,
+    serialization::shardtree::{read_shard, write_shard},
     PoolType, ShieldedProtocol,
 };
 use zcash_keys::{address::UnifiedAddress, encoding::encode_payment_address};
 use zcash_primitives::{
     block::BlockHash,
-    consensus::{self, BlockHeight, NetworkConstants, Parameters},
+    consensus::{self, BlockHeight, BranchId, NetworkConstants, Parameters},
     legacy::Script,
     memo::Memo,
     merkle_tree::HashSer,
     transaction::{
         components::{amount::NonNegativeAmount, OutPoint},
-        TxId,
+        Transaction, TxId,
     },
 };
 
 use zingo_status::confirmation_status::ConfirmationStatus;
 
 use crate::{
-    keys::{self, transparent::TransparentAddressId, KeyId},
+    keys::{
+        self,
+        transparent::{TransparentAddressId, TransparentScope},
+        KeyId,
+    },
     sync::MAX_VERIFICATION_WINDOW,
     witness,
 };
@@ -217,7 +223,54 @@ impl SyncState {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        todo!()
+        let _version = reader.read_u8()?;
+        let scan_ranges = Vector::read(&mut reader, |r| {
+            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let priority = match r.read_u8()? {
+                0 => Ok(ScanPriority::Ignored),
+                1 => Ok(ScanPriority::Scanned),
+                2 => Ok(ScanPriority::Historic),
+                3 => Ok(ScanPriority::OpenAdjacent),
+                4 => Ok(ScanPriority::FoundNote),
+                5 => Ok(ScanPriority::ChainTip),
+                6 => Ok(ScanPriority::Verify),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid scan priority",
+                )),
+            }?;
+
+            Ok(ScanRange::from_parts(start..end, priority))
+        })?;
+        let sapling_shard_ranges = Vector::read(&mut reader, |r| {
+            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+
+            Ok(start..end)
+        })?;
+        let orchard_shard_ranges = Vector::read(&mut reader, |r| {
+            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+
+            Ok(start..end)
+        })?;
+        let locators = Vector::read(&mut reader, |r| {
+            let block_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let txid = TxId::read(r)?;
+
+            Ok((block_height, txid))
+        })?
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+        Ok(Self {
+            scan_ranges,
+            sapling_shard_ranges,
+            orchard_shard_ranges,
+            locators,
+            initial_sync_state: InitialSyncState::new(),
+        })
     }
 
     /// Serialize into `writer`
@@ -472,8 +525,10 @@ impl From<OutputId> for OutPoint {
 /// Binary tree map of nullifiers from transaction spends or actions
 #[derive(Debug)]
 pub struct NullifierMap {
-    pub(crate) sapling: BTreeMap<sapling_crypto::Nullifier, Locator>,
-    pub(crate) orchard: BTreeMap<orchard::note::Nullifier, Locator>,
+    /// Sapling nullifer map
+    pub sapling: BTreeMap<sapling_crypto::Nullifier, Locator>,
+    /// Orchard nullifer map
+    pub orchard: BTreeMap<orchard::note::Nullifier, Locator>,
 }
 
 impl NullifierMap {
@@ -506,7 +561,40 @@ impl NullifierMap {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        todo!()
+        let _version = reader.read_u8()?;
+
+        let sapling = Vector::read(&mut reader, |mut r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+            let nullifier =
+                sapling_crypto::Nullifier::from_slice(&nullifier_bytes).map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("failed to read nullifier. {e}"),
+                    )
+                })?;
+            let locator_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let locator_txid = TxId::read(&mut r)?;
+
+            Ok((nullifier, (locator_height, locator_txid)))
+        })?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+        let orchard = Vector::read(&mut reader, |mut r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+            let nullifier = orchard::note::Nullifier::from_bytes(&nullifier_bytes)
+                .expect("nullifier bytes should be valid");
+            let locator_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let locator_txid = TxId::read(&mut r)?;
+
+            Ok((nullifier, (locator_height, locator_txid)))
+        })?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+        Ok(NullifierMap { sapling, orchard })
     }
 
     /// Serialize into `writer`
@@ -619,8 +707,8 @@ impl WalletBlock {
 /// Wallet transaction
 pub struct WalletTransaction {
     pub(crate) txid: TxId,
-    pub(crate) transaction: zcash_primitives::transaction::Transaction,
     pub(crate) status: ConfirmationStatus,
+    pub(crate) transaction: zcash_primitives::transaction::Transaction,
     pub(crate) datetime: u32,
     pub(crate) transparent_coins: Vec<TransparentCoin>,
     pub(crate) sapling_notes: Vec<SaplingNote>,
@@ -635,14 +723,14 @@ impl WalletTransaction {
         self.txid
     }
 
-    /// [`zcash_primitives::transaction::Transaction`]
-    pub fn transaction(&self) -> &zcash_primitives::transaction::Transaction {
-        &self.transaction
-    }
-
     /// Confirmation status
     pub fn status(&self) -> ConfirmationStatus {
         self.status
+    }
+
+    /// [`zcash_primitives::transaction::Transaction`]
+    pub fn transaction(&self) -> &zcash_primitives::transaction::Transaction {
+        &self.transaction
     }
 
     /// Datetime. In form of seconds since unix epoch.
@@ -740,8 +828,39 @@ impl WalletTransaction {
     }
 
     /// Deserialize into `reader`
-    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        todo!()
+    pub fn read<R: Read>(
+        mut reader: R,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let txid = TxId::read(&mut reader)?;
+        let status = ConfirmationStatus::read(&mut reader)?;
+        let transaction = Transaction::read(
+            &mut reader,
+            BranchId::for_height(consensus_parameters, status.get_height()),
+        )?;
+        let datetime = reader.read_u32::<LittleEndian>()?;
+        let transparent_coins = Vector::read(&mut reader, |r| TransparentCoin::read(r))?;
+        let sapling_notes = Vector::read(&mut reader, |r| SaplingNote::read(r))?;
+        let orchard_notes = Vector::read(&mut reader, |r| OrchardNote::read(r))?;
+        let outgoing_sapling_notes = Vector::read(&mut reader, |r| {
+            OutgoingSaplingNote::read(r, consensus_parameters)
+        })?;
+        let outgoing_orchard_notes = Vector::read(&mut reader, |r| {
+            OutgoingOrchardNote::read(r, consensus_parameters)
+        })?;
+
+        Ok(Self {
+            txid,
+            status,
+            transaction,
+            datetime,
+            transparent_coins,
+            sapling_notes,
+            orchard_notes,
+            outgoing_sapling_notes,
+            outgoing_orchard_notes,
+        })
     }
 
     /// Serialize into `writer`
@@ -752,8 +871,8 @@ impl WalletTransaction {
     ) -> std::io::Result<()> {
         writer.write_u8(Self::serialized_version())?;
         self.txid.write(&mut writer)?;
-        self.transaction.write(&mut writer)?;
         self.status.write(&mut writer)?;
+        self.transaction.write(&mut writer)?;
         writer.write_u32::<LittleEndian>(self.datetime)?;
         Vector::write(&mut writer, self.transparent_coins(), |w, output| {
             output.write(w)
@@ -824,33 +943,6 @@ impl std::fmt::Debug for WalletTransaction {
             .field("outgoing_sapling_notes", &self.outgoing_sapling_notes)
             .field("outgoing_orchard_notes", &self.outgoing_orchard_notes)
             .finish()
-    }
-}
-
-/// Wallet note, shielded output with metadata relevant to the wallet.
-#[derive(Debug, Clone)]
-pub struct WalletNote<N, Nf: Copy> {
-    /// Output ID.
-    pub(crate) output_id: OutputId,
-    /// Identifier for key used to decrypt output.
-    pub(crate) key_id: KeyId,
-    /// Decrypted note with recipient and value.
-    pub(crate) note: N,
-    /// Derived nullifier.
-    pub(crate) nullifier: Option<Nf>, //TODO: syncing without nullifier deriving key
-    /// Commitment tree leaf position.
-    pub(crate) position: Option<Position>,
-    /// Memo.
-    pub(crate) memo: Memo,
-    /// Transaction ID of transaction this output was spent.
-    /// If `None`, output is not spent.
-    pub(crate) spending_transaction: Option<TxId>,
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl<N, Nf: Copy> WalletNote<N, Nf> {
-    fn serialized_version() -> u8 {
-        0
     }
 }
 
@@ -965,6 +1057,34 @@ impl TransparentCoin {
         0
     }
 
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id = zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?)
+            .expect("only valid account ids written");
+        let scope = TransparentScope::try_from(reader.read_u8()?)?;
+        let address_index = reader.read_u32::<LittleEndian>()?;
+
+        let address = read_string(&mut reader)?;
+        let script = Script::read(&mut reader)?;
+        let value = NonNegativeAmount::from_u64(reader.read_u64::<LittleEndian>()?)
+            .expect("only valid values written");
+        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
+
+        Ok(Self {
+            output_id: OutputId { txid, output_index },
+            key_id: TransparentAddressId::new(account_id, scope, address_index),
+            address,
+            value,
+            script,
+            spending_transaction,
+        })
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
         writer.write_u8(Self::serialized_version())?;
@@ -1008,6 +1128,33 @@ pub trait NoteInterface: OutputInterface + Sized {
 
     /// Memo
     fn memo(&self) -> &Memo;
+}
+
+/// Wallet note, shielded output with metadata relevant to the wallet.
+#[derive(Debug, Clone)]
+pub struct WalletNote<N, Nf: Copy> {
+    /// Output ID.
+    pub(crate) output_id: OutputId,
+    /// Identifier for key used to decrypt output.
+    pub(crate) key_id: KeyId,
+    /// Decrypted note with recipient and value.
+    pub(crate) note: N,
+    /// Derived nullifier.
+    pub(crate) nullifier: Option<Nf>, //TODO: syncing without nullifier deriving key
+    /// Commitment tree leaf position.
+    pub(crate) position: Option<Position>,
+    /// Memo.
+    pub(crate) memo: Memo,
+    /// Transaction ID of transaction this output was spent.
+    /// If `None`, output is not spent.
+    pub(crate) spending_transaction: Option<TxId>,
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl<N, Nf: Copy> WalletNote<N, Nf> {
+    fn serialized_version() -> u8 {
+        0
+    }
 }
 
 /// Sapling note.
@@ -1073,6 +1220,91 @@ impl NoteInterface for SaplingNote {
 
 #[cfg(feature = "wallet_essentials")]
 impl SaplingNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient =
+            sapling_crypto::PaymentAddress::from_bytes(&address_bytes).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "failed to read payment address",
+                )
+            })?;
+        let value = sapling_crypto::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let rseed_zip212 = reader.read_u8()?;
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = match rseed_zip212 {
+            0 => sapling_crypto::Rseed::BeforeZip212(
+                jubjub::Fr::from_bytes(&rseed_bytes).expect("should read valid jubjub bytes"),
+            ),
+            1 => sapling_crypto::Rseed::AfterZip212(rseed_bytes),
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid rseed zip212 byte",
+                ))
+            }
+        };
+
+        let nullifier = Optional::read(&mut reader, |r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+
+            sapling_crypto::Nullifier::from_slice(&nullifier_bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read nullifier. {e}"),
+                )
+            })
+        })?;
+        let position = Optional::read(&mut reader, |r| {
+            Ok(Position::from(r.read_u64::<LittleEndian>()?))
+        })?;
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: sapling_crypto::Note::from_parts(recipient, value, rseed),
+            nullifier,
+            position,
+            memo,
+            spending_transaction,
+        })
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
         writer.write_u8(Self::serialized_version())?;
@@ -1087,11 +1319,11 @@ impl SaplingNote {
         writer.write_u64::<LittleEndian>(self.value())?;
         match self.note.rseed() {
             sapling_crypto::Rseed::BeforeZip212(fr) => {
-                writer.write_u8(1)?;
+                writer.write_u8(0)?;
                 writer.write_all(&fr.to_bytes())?;
             }
             sapling_crypto::Rseed::AfterZip212(bytes) => {
-                writer.write_u8(2)?;
+                writer.write_u8(1)?;
                 writer.write_all(bytes)?;
             }
         }
@@ -1103,43 +1335,10 @@ impl SaplingNote {
             w.write_u64::<LittleEndian>(position.into())
         })?;
         writer.write_all(self.memo.encode().as_array())?;
+
         Optional::write(&mut writer, self.spending_transaction, |w, txid| {
             txid.write(w)
-        })?;
-
-        Ok(())
-    }
-}
-
-#[cfg(feature = "wallet_essentials")]
-impl OrchardNote {
-    /// Serialize into `writer`
-    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
-        writer.write_u8(Self::serialized_version())?;
-
-        self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
-
-        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
-        writer.write_u8(self.key_id.scope as u8)?;
-
-        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
-        writer.write_u64::<LittleEndian>(self.value())?;
-        writer.write_all(&self.note.rho().to_bytes())?;
-        writer.write_all(self.note.rseed().as_bytes())?;
-
-        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
-            w.write_all(&nullifier.to_bytes())
-        })?;
-        Optional::write(&mut writer, self.position, |w, position| {
-            w.write_u64::<LittleEndian>(position.into())
-        })?;
-        writer.write_all(self.memo.encode().as_array())?;
-        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
-            txid.write(w)
-        })?;
-
-        Ok(())
+        })
     }
 }
 
@@ -1201,6 +1400,107 @@ impl NoteInterface for OrchardNote {
 
     fn memo(&self) -> &Memo {
         &self.memo
+    }
+}
+
+#[cfg(feature = "wallet_essentials")]
+impl OrchardNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient = orchard::Address::from_raw_address_bytes(&address_bytes)
+            .expect("should be a valid address");
+        let value = orchard::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let mut rho_bytes = [0u8; 32];
+        reader.read_exact(&mut rho_bytes)?;
+        let rho = orchard::note::Rho::from_bytes(&rho_bytes).expect("should be valid rho bytes");
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = orchard::note::RandomSeed::from_bytes(rseed_bytes, &rho)
+            .expect("should be valid random seed bytes");
+
+        let nullifier = Optional::read(&mut reader, |r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+
+            Ok(orchard::note::Nullifier::from_bytes(&nullifier_bytes)
+                .expect("should be valid nullfiier bytes"))
+        })?;
+        let position = Optional::read(&mut reader, |r| {
+            Ok(Position::from(r.read_u64::<LittleEndian>()?))
+        })?;
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: orchard::note::Note::from_parts(recipient, value, rho, rseed)
+                .expect("should be a valid orchard note"),
+            nullifier,
+            position,
+            memo,
+            spending_transaction,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        writer.write_all(&self.note.rho().to_bytes())?;
+        writer.write_all(self.note.rseed().as_bytes())?;
+
+        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
+            w.write_all(&nullifier.to_bytes())
+        })?;
+        Optional::write(&mut writer, self.position, |w, position| {
+            w.write_u64::<LittleEndian>(position.into())
+        })?;
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
+            txid.write(w)
+        })?;
+
+        Ok(())
     }
 }
 
@@ -1317,6 +1617,101 @@ impl OutgoingNoteInterface for OutgoingSaplingNote {
 
 #[cfg(feature = "wallet_essentials")]
 impl OutgoingSaplingNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(
+        mut reader: R,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient =
+            sapling_crypto::PaymentAddress::from_bytes(&address_bytes).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "failed to read payment address",
+                )
+            })?;
+        let value = sapling_crypto::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let rseed_zip212 = reader.read_u8()?;
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = match rseed_zip212 {
+            0 => sapling_crypto::Rseed::BeforeZip212(
+                jubjub::Fr::from_bytes(&rseed_bytes).expect("should read valid jubjub bytes"),
+            ),
+            1 => sapling_crypto::Rseed::AfterZip212(rseed_bytes),
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid rseed zip212 byte",
+                ))
+            }
+        };
+
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let recipient_unified_address = Optional::read(&mut reader, |r| {
+            let encoded_address = read_string(r)?;
+
+            // TODO: surely there is a more straightforward way to decode unified address from string
+            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
+                .unwrap()
+                .convert_if_network::<read_write::UnifiedAddress>(
+                    consensus_parameters.network_type(),
+                )
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("failed to convert recipient unified address. {e}"),
+                    )
+                })?
+                .0;
+
+            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to convert recipient unified address. {e}"),
+                )
+            })
+        })?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: sapling_crypto::Note::from_parts(recipient, value, rseed),
+            memo,
+            recipient_unified_address,
+        })
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(
         &self,
@@ -1406,6 +1801,89 @@ impl OutgoingNoteInterface for OutgoingOrchardNote {
 
 #[cfg(feature = "wallet_essentials")]
 impl OutgoingOrchardNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(
+        mut reader: R,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient = orchard::Address::from_raw_address_bytes(&address_bytes)
+            .expect("should be a valid address");
+        let value = orchard::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let mut rho_bytes = [0u8; 32];
+        reader.read_exact(&mut rho_bytes)?;
+        let rho = orchard::note::Rho::from_bytes(&rho_bytes).expect("should be valid rho bytes");
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = orchard::note::RandomSeed::from_bytes(rseed_bytes, &rho)
+            .expect("should be valid random seed bytes");
+
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let recipient_unified_address = Optional::read(&mut reader, |r| {
+            let encoded_address = read_string(r)?;
+
+            // TODO: surely there is a more straightforward way to decode unified address from string
+            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
+                .unwrap()
+                .convert_if_network::<read_write::UnifiedAddress>(
+                    consensus_parameters.network_type(),
+                )
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("failed to convert recipient unified address. {e}"),
+                    )
+                })?
+                .0;
+
+            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to convert recipient unified address. {e}"),
+                )
+            })
+        })?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: orchard::note::Note::from_parts(recipient, value, rho, rseed)
+                .expect("should be a valid orchard note"),
+            memo,
+            recipient_unified_address,
+        })
+    }
+
     /// Serialize into `writer`
     pub fn write<W: Write>(
         &self,
@@ -1494,7 +1972,11 @@ impl ShardTrees {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        todo!()
+        let _version = reader.read_u8()?;
+        let sapling = Self::read_shardtree(&mut reader)?;
+        let orchard = Self::read_shardtree(&mut reader)?;
+
+        Ok(Self { sapling, orchard })
     }
 
     /// Serialize into `writer`
@@ -1506,6 +1988,62 @@ impl ShardTrees {
         Ok(())
     }
 
+    fn read_shardtree<
+        H: Hashable + Clone + HashSer + Eq,
+        C: Ord + std::fmt::Debug + Copy + From<u32>,
+        R: Read,
+        const DEPTH: u8,
+        const SHARD_HEIGHT: u8,
+    >(
+        mut reader: R,
+    ) -> std::io::Result<shardtree::ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>> {
+        let shards = Vector::read(&mut reader, |r| {
+            let level = incrementalmerkletree::Level::from(r.read_u8()?);
+            let index = r.read_u64::<LittleEndian>()?;
+            let root_addr = incrementalmerkletree::Address::from_parts(level, index);
+            let shard = read_shard(r)?;
+            Ok(LocatedPrunableTree::from_parts(root_addr, shard))
+        })?;
+        let mut store = MemoryShardStore::empty();
+        for shard in shards {
+            store.put_shard(shard).expect("Infallible");
+        }
+        let checkpoints = Vector::read(&mut reader, |r| {
+            let checkpoint_id = C::from(r.read_u32::<LittleEndian>()?);
+            let tree_state = match r.read_u8()? {
+                0 => shardtree::store::TreeState::Empty,
+                1 => shardtree::store::TreeState::AtPosition(Position::from(
+                    r.read_u64::<LittleEndian>()?,
+                )),
+                otherwise => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "failed to read TreeState. expected boolean value, found {otherwise}"
+                        ),
+                    ))
+                }
+            };
+            let marks_removed =
+                Vector::read(r, |r| r.read_u64::<LittleEndian>().map(Position::from))?;
+            Ok((
+                checkpoint_id,
+                Checkpoint::from_parts(tree_state, marks_removed.into_iter().collect()),
+            ))
+        })?;
+        for (checkpoint_id, checkpoint) in checkpoints {
+            store
+                .add_checkpoint(checkpoint_id, checkpoint)
+                .expect("Infallible");
+        }
+        store.put_cap(read_shard(reader)?).expect("Infallible");
+
+        Ok(shardtree::ShardTree::new(
+            store,
+            MAX_VERIFICATION_WINDOW as usize,
+        ))
+    }
+
     /// Write memory-backed shardstore, represented tree.
     fn write_shardtree<
         H: Hashable + Clone + Eq + HashSer,
@@ -1515,7 +2053,7 @@ impl ShardTrees {
         const SHARD_HEIGHT: u8,
     >(
         mut writer: W,
-        tree: &mut shardtree::ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>,
+        shardtree: &mut shardtree::ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>,
     ) -> std::io::Result<()>
     where
         u32: From<C>,
@@ -1575,7 +2113,7 @@ impl ShardTrees {
 
         // Replace original tree with empty tree, and mutate new version into store.
         let mut store = std::mem::replace(
-            tree,
+            shardtree,
             shardtree::ShardTree::new(MemoryShardStore::empty(), 0),
         )
         .into_store();
@@ -1583,7 +2121,7 @@ impl ShardTrees {
         macro_rules! write_with_error_handling {
             ($writer: ident, $from: ident) => {
                 if let Err(e) = $writer(&mut writer, &$from) {
-                    *tree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+                    *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
                     return Err(e);
                 }
             };
@@ -1609,7 +2147,7 @@ impl ShardTrees {
         let cap = store.get_cap().expect("Infallible");
         write_with_error_handling!(write_shard, cap);
 
-        *tree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+        *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
 
         Ok(())
     }
@@ -1633,5 +2171,16 @@ mod read_write {
     pub(super) fn write_string<W: Write>(mut writer: W, str: &str) -> std::io::Result<()> {
         writer.write_u64::<LittleEndian>(str.len() as u64)?;
         writer.write_all(str.as_bytes())
+    }
+
+    pub(super) struct UnifiedAddress(pub(super) zcash_address::unified::Address);
+    impl zcash_address::TryFromRawAddress for UnifiedAddress {
+        type Error = std::convert::Infallible;
+
+        fn try_from_raw_unified(
+            ua: zcash_address::unified::Address,
+        ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
+            Ok(UnifiedAddress(ua))
+        }
     }
 }

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -1,0 +1,1081 @@
+//! Serialization and de-serialization of wallet structs in [`crate::wallet`] including utilities.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io::{Read, Write},
+};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+
+use incrementalmerkletree::{Hashable, Position};
+use shardtree::{
+    store::{memory::MemoryShardStore, Checkpoint, ShardStore, TreeState},
+    LocatedPrunableTree, ShardTree,
+};
+use zcash_address::ZcashAddress;
+use zcash_client_backend::{
+    data_api::scanning::{ScanPriority, ScanRange},
+    serialization::shardtree::{read_shard, write_shard},
+};
+use zcash_encoding::{Optional, Vector};
+use zcash_primitives::{
+    block::BlockHash,
+    consensus::{self, BlockHeight},
+    legacy::Script,
+    memo::Memo,
+    merkle_tree::HashSer,
+    transaction::{components::amount::NonNegativeAmount, Transaction, TxId},
+};
+
+use zingo_status::confirmation_status::ConfirmationStatus;
+
+use crate::{
+    keys::{
+        transparent::{TransparentAddressId, TransparentScope},
+        KeyId,
+    },
+    sync::MAX_VERIFICATION_WINDOW,
+};
+
+use super::{
+    InitialSyncState, NullifierMap, OrchardNote, OutgoingNote, OutgoingNoteInterface,
+    OutgoingOrchardNote, OutgoingSaplingNote, OutputId, OutputInterface, SaplingNote, ShardTrees,
+    SyncState, TransparentCoin, TreeBounds, WalletBlock, WalletNote, WalletTransaction,
+};
+
+fn read_string<R: Read>(mut reader: R) -> std::io::Result<String> {
+    let str_len = reader.read_u64::<LittleEndian>()?;
+    let mut str_bytes = vec![0; str_len as usize];
+    reader.read_exact(&mut str_bytes)?;
+
+    String::from_utf8(str_bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
+}
+
+fn write_string<W: Write>(mut writer: W, str: &str) -> std::io::Result<()> {
+    writer.write_u64::<LittleEndian>(str.len() as u64)?;
+    writer.write_all(str.as_bytes())
+}
+
+struct UnifiedAddressConverter(zcash_address::unified::Address);
+
+impl zcash_address::TryFromRawAddress for UnifiedAddressConverter {
+    type Error = std::convert::Infallible;
+
+    fn try_from_raw_unified(
+        ua: zcash_address::unified::Address,
+    ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
+        Ok(UnifiedAddressConverter(ua))
+    }
+}
+
+impl SyncState {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let scan_ranges = Vector::read(&mut reader, |r| {
+            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let priority = match r.read_u8()? {
+                0 => Ok(ScanPriority::Ignored),
+                1 => Ok(ScanPriority::Scanned),
+                2 => Ok(ScanPriority::Historic),
+                3 => Ok(ScanPriority::OpenAdjacent),
+                4 => Ok(ScanPriority::FoundNote),
+                5 => Ok(ScanPriority::ChainTip),
+                6 => Ok(ScanPriority::Verify),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid scan priority",
+                )),
+            }?;
+
+            Ok(ScanRange::from_parts(start..end, priority))
+        })?;
+        let sapling_shard_ranges = Vector::read(&mut reader, |r| {
+            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+
+            Ok(start..end)
+        })?;
+        let orchard_shard_ranges = Vector::read(&mut reader, |r| {
+            let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+
+            Ok(start..end)
+        })?;
+        let locators = Vector::read(&mut reader, |r| {
+            let block_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let txid = TxId::read(r)?;
+
+            Ok((block_height, txid))
+        })?
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+        Ok(Self {
+            scan_ranges,
+            sapling_shard_ranges,
+            orchard_shard_ranges,
+            locators,
+            initial_sync_state: InitialSyncState::new(),
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        Vector::write(&mut writer, self.scan_ranges(), |w, scan_range| {
+            w.write_u32::<LittleEndian>(scan_range.block_range().start.into())?;
+            w.write_u32::<LittleEndian>(scan_range.block_range().end.into())?;
+            w.write_u8(scan_range.priority() as u8)
+        })?;
+        Vector::write(&mut writer, &self.sapling_shard_ranges, |w, shard_range| {
+            w.write_u32::<LittleEndian>(shard_range.start.into())?;
+            w.write_u32::<LittleEndian>(shard_range.end.into())
+        })?;
+        Vector::write(&mut writer, &self.orchard_shard_ranges, |w, shard_range| {
+            w.write_u32::<LittleEndian>(shard_range.start.into())?;
+            w.write_u32::<LittleEndian>(shard_range.end.into())
+        })?;
+        Vector::write(
+            &mut writer,
+            &self.locators.iter().collect::<Vec<_>>(),
+            |w, &locator| {
+                w.write_u32::<LittleEndian>(locator.0.into())?;
+                locator.1.write(w)
+            },
+        )
+    }
+}
+
+impl TreeBounds {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let sapling_initial_tree_size = reader.read_u32::<LittleEndian>()?;
+        let sapling_final_tree_size = reader.read_u32::<LittleEndian>()?;
+        let orchard_initial_tree_size = reader.read_u32::<LittleEndian>()?;
+        let orchard_final_tree_size = reader.read_u32::<LittleEndian>()?;
+
+        Ok(Self {
+            sapling_initial_tree_size,
+            sapling_final_tree_size,
+            orchard_initial_tree_size,
+            orchard_final_tree_size,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        writer.write_u32::<LittleEndian>(self.sapling_initial_tree_size)?;
+        writer.write_u32::<LittleEndian>(self.sapling_final_tree_size)?;
+        writer.write_u32::<LittleEndian>(self.orchard_initial_tree_size)?;
+        writer.write_u32::<LittleEndian>(self.orchard_final_tree_size)
+    }
+}
+
+impl NullifierMap {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let sapling = Vector::read(&mut reader, |mut r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+            let nullifier =
+                sapling_crypto::Nullifier::from_slice(&nullifier_bytes).map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("failed to read nullifier. {e}"),
+                    )
+                })?;
+            let locator_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let locator_txid = TxId::read(&mut r)?;
+
+            Ok((nullifier, (locator_height, locator_txid)))
+        })?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+        let orchard = Vector::read(&mut reader, |mut r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+            let nullifier = orchard::note::Nullifier::from_bytes(&nullifier_bytes)
+                .expect("nullifier bytes should be valid");
+            let locator_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let locator_txid = TxId::read(&mut r)?;
+
+            Ok((nullifier, (locator_height, locator_txid)))
+        })?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+        Ok(NullifierMap { sapling, orchard })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        Vector::write(
+            &mut writer,
+            &self.sapling.iter().collect::<Vec<_>>(),
+            |w, (&nullifier, &locator)| {
+                w.write_all(nullifier.as_ref())?;
+                w.write_u32::<LittleEndian>(locator.0.into())?;
+                locator.1.write(w)
+            },
+        )?;
+        Vector::write(
+            &mut writer,
+            &self.orchard.iter().collect::<Vec<_>>(),
+            |w, (&nullifier, &locator)| {
+                w.write_all(&nullifier.to_bytes())?;
+                w.write_u32::<LittleEndian>(locator.0.into())?;
+                locator.1.write(w)
+            },
+        )
+    }
+}
+
+impl WalletBlock {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let block_height = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
+        let mut block_hash = BlockHash([0u8; 32]);
+        reader.read_exact(&mut block_hash.0)?;
+        let mut prev_hash = BlockHash([0u8; 32]);
+        reader.read_exact(&mut prev_hash.0)?;
+        let time = reader.read_u32::<LittleEndian>()?;
+        let txids = Vector::read(&mut reader, |r| TxId::read(r))?;
+        let tree_bounds = TreeBounds::read(&mut reader)?;
+
+        Ok(Self {
+            block_height,
+            block_hash,
+            prev_hash,
+            time,
+            txids,
+            tree_bounds,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        writer.write_u32::<LittleEndian>(self.block_height.into())?;
+        writer.write_all(&self.block_hash.0)?;
+        writer.write_all(&self.prev_hash.0)?;
+        writer.write_u32::<LittleEndian>(self.time)?;
+        Vector::write(&mut writer, self.txids(), |w, txid| txid.write(w))?;
+        self.tree_bounds.write(&mut writer)
+    }
+}
+
+impl WalletTransaction {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(
+        mut reader: R,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let txid = TxId::read(&mut reader)?;
+        let status = ConfirmationStatus::read(&mut reader)?;
+        let transaction = Transaction::read(
+            &mut reader,
+            consensus::BranchId::for_height(consensus_parameters, status.get_height()),
+        )?;
+        let datetime = reader.read_u32::<LittleEndian>()?;
+        let transparent_coins = Vector::read(&mut reader, |r| TransparentCoin::read(r))?;
+        let sapling_notes = Vector::read(&mut reader, |r| SaplingNote::read(r))?;
+        let orchard_notes = Vector::read(&mut reader, |r| OrchardNote::read(r))?;
+        let outgoing_sapling_notes = Vector::read(&mut reader, |r| {
+            OutgoingSaplingNote::read(r, consensus_parameters)
+        })?;
+        let outgoing_orchard_notes = Vector::read(&mut reader, |r| {
+            OutgoingOrchardNote::read(r, consensus_parameters)
+        })?;
+
+        Ok(Self {
+            txid,
+            status,
+            transaction,
+            datetime,
+            transparent_coins,
+            sapling_notes,
+            orchard_notes,
+            outgoing_sapling_notes,
+            outgoing_orchard_notes,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(
+        &self,
+        mut writer: W,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        self.txid.write(&mut writer)?;
+        self.status.write(&mut writer)?;
+        self.transaction.write(&mut writer)?;
+        writer.write_u32::<LittleEndian>(self.datetime)?;
+        Vector::write(&mut writer, self.transparent_coins(), |w, output| {
+            output.write(w)
+        })?;
+        Vector::write(&mut writer, self.sapling_notes(), |w, output| {
+            output.write(w)
+        })?;
+        Vector::write(&mut writer, self.orchard_notes(), |w, output| {
+            output.write(w)
+        })?;
+        Vector::write(&mut writer, self.outgoing_sapling_notes(), |w, output| {
+            output.write(w, consensus_parameters)
+        })?;
+        Vector::write(&mut writer, self.outgoing_orchard_notes(), |w, output| {
+            output.write(w, consensus_parameters)
+        })
+    }
+}
+
+impl TransparentCoin {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id = zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?)
+            .expect("only valid account ids written");
+        let scope = TransparentScope::try_from(reader.read_u8()?)?;
+        let address_index = reader.read_u32::<LittleEndian>()?;
+
+        let address = read_string(&mut reader)?;
+        let script = Script::read(&mut reader)?;
+        let value = NonNegativeAmount::from_u64(reader.read_u64::<LittleEndian>()?)
+            .expect("only valid values written");
+        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
+
+        Ok(Self {
+            output_id: OutputId { txid, output_index },
+            key_id: TransparentAddressId::new(account_id, scope, address_index),
+            address,
+            value,
+            script,
+            spending_transaction,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id().into())?;
+        writer.write_u8(self.key_id.scope() as u8)?;
+        writer.write_u32::<LittleEndian>(self.key_id.address_index())?;
+
+        write_string(&mut writer, &self.address)?;
+        self.script.write(&mut writer)?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
+            txid.write(w)
+        })?;
+
+        Ok(())
+    }
+}
+
+impl<N, Nf: Copy> WalletNote<N, Nf> {
+    fn serialized_version() -> u8 {
+        0
+    }
+}
+
+impl SaplingNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient =
+            sapling_crypto::PaymentAddress::from_bytes(&address_bytes).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "failed to read payment address",
+                )
+            })?;
+        let value = sapling_crypto::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let rseed_zip212 = reader.read_u8()?;
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = match rseed_zip212 {
+            0 => sapling_crypto::Rseed::BeforeZip212(
+                jubjub::Fr::from_bytes(&rseed_bytes).expect("should read valid jubjub bytes"),
+            ),
+            1 => sapling_crypto::Rseed::AfterZip212(rseed_bytes),
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid rseed zip212 byte",
+                ))
+            }
+        };
+
+        let nullifier = Optional::read(&mut reader, |r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+
+            sapling_crypto::Nullifier::from_slice(&nullifier_bytes).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read nullifier. {e}"),
+                )
+            })
+        })?;
+        let position = Optional::read(&mut reader, |r| {
+            Ok(Position::from(r.read_u64::<LittleEndian>()?))
+        })?;
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: sapling_crypto::Note::from_parts(recipient, value, rseed),
+            nullifier,
+            position,
+            memo,
+            spending_transaction,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        match self.note.rseed() {
+            sapling_crypto::Rseed::BeforeZip212(fr) => {
+                writer.write_u8(0)?;
+                writer.write_all(&fr.to_bytes())?;
+            }
+            sapling_crypto::Rseed::AfterZip212(bytes) => {
+                writer.write_u8(1)?;
+                writer.write_all(bytes)?;
+            }
+        }
+
+        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
+            w.write_all(nullifier.as_ref())
+        })?;
+        Optional::write(&mut writer, self.position, |w, position| {
+            w.write_u64::<LittleEndian>(position.into())
+        })?;
+        writer.write_all(self.memo.encode().as_array())?;
+
+        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
+            txid.write(w)
+        })
+    }
+}
+
+impl OrchardNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient = orchard::Address::from_raw_address_bytes(&address_bytes)
+            .expect("should be a valid address");
+        let value = orchard::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let mut rho_bytes = [0u8; 32];
+        reader.read_exact(&mut rho_bytes)?;
+        let rho = orchard::note::Rho::from_bytes(&rho_bytes).expect("should be valid rho bytes");
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = orchard::note::RandomSeed::from_bytes(rseed_bytes, &rho)
+            .expect("should be valid random seed bytes");
+
+        let nullifier = Optional::read(&mut reader, |r| {
+            let mut nullifier_bytes = [0u8; 32];
+            r.read_exact(&mut nullifier_bytes)?;
+
+            Ok(orchard::note::Nullifier::from_bytes(&nullifier_bytes)
+                .expect("should be valid nullfiier bytes"))
+        })?;
+        let position = Optional::read(&mut reader, |r| {
+            Ok(Position::from(r.read_u64::<LittleEndian>()?))
+        })?;
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let spending_transaction = Optional::read(&mut reader, TxId::read)?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: orchard::note::Note::from_parts(recipient, value, rho, rseed)
+                .expect("should be a valid orchard note"),
+            nullifier,
+            position,
+            memo,
+            spending_transaction,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        writer.write_all(&self.note.rho().to_bytes())?;
+        writer.write_all(self.note.rseed().as_bytes())?;
+
+        Optional::write(&mut writer, self.nullifier, |w, nullifier| {
+            w.write_all(&nullifier.to_bytes())
+        })?;
+        Optional::write(&mut writer, self.position, |w, position| {
+            w.write_u64::<LittleEndian>(position.into())
+        })?;
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(&mut writer, self.spending_transaction, |w, txid| {
+            txid.write(w)
+        })?;
+
+        Ok(())
+    }
+}
+
+impl<N> OutgoingNote<N> {
+    fn serialized_version() -> u8 {
+        0
+    }
+}
+
+impl OutgoingSaplingNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(
+        mut reader: R,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient =
+            sapling_crypto::PaymentAddress::from_bytes(&address_bytes).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "failed to read payment address",
+                )
+            })?;
+        let value = sapling_crypto::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let rseed_zip212 = reader.read_u8()?;
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = match rseed_zip212 {
+            0 => sapling_crypto::Rseed::BeforeZip212(
+                jubjub::Fr::from_bytes(&rseed_bytes).expect("should read valid jubjub bytes"),
+            ),
+            1 => sapling_crypto::Rseed::AfterZip212(rseed_bytes),
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid rseed zip212 byte",
+                ))
+            }
+        };
+
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let recipient_unified_address = Optional::read(&mut reader, |r| {
+            let encoded_address = read_string(r)?;
+
+            // TODO: surely there is a more straightforward way to decode unified address from string
+            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
+                .unwrap()
+                .convert_if_network::<UnifiedAddressConverter>(consensus_parameters.network_type())
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("failed to convert recipient unified address. {e}"),
+                    )
+                })?
+                .0;
+
+            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to convert recipient unified address. {e}"),
+                )
+            })
+        })?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: sapling_crypto::Note::from_parts(recipient, value, rseed),
+            memo,
+            recipient_unified_address,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(
+        &self,
+        mut writer: W,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        match self.note.rseed() {
+            sapling_crypto::Rseed::BeforeZip212(fr) => {
+                writer.write_u8(1)?;
+                writer.write_all(&fr.to_bytes())?;
+            }
+            sapling_crypto::Rseed::AfterZip212(bytes) => {
+                writer.write_u8(2)?;
+                writer.write_all(bytes)?;
+            }
+        }
+
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(
+            &mut writer,
+            self.recipient_unified_address.as_ref(),
+            |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
+        )?;
+
+        Ok(())
+    }
+}
+
+impl OutgoingOrchardNote {
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(
+        mut reader: R,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+
+        let txid = TxId::read(&mut reader)?;
+        let output_index = reader.read_u16::<LittleEndian>()?;
+
+        let account_id =
+            zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to read account id. {e}"),
+                )
+            })?;
+        let scope = match reader.read_u8()? {
+            0 => Ok(zip32::Scope::External),
+            1 => Ok(zip32::Scope::Internal),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid scope value",
+            )),
+        }?;
+
+        let mut address_bytes = [0u8; 43];
+        reader.read_exact(&mut address_bytes)?;
+        let recipient = orchard::Address::from_raw_address_bytes(&address_bytes)
+            .expect("should be a valid address");
+        let value = orchard::value::NoteValue::from_raw(reader.read_u64::<LittleEndian>()?);
+        let mut rho_bytes = [0u8; 32];
+        reader.read_exact(&mut rho_bytes)?;
+        let rho = orchard::note::Rho::from_bytes(&rho_bytes).expect("should be valid rho bytes");
+        let mut rseed_bytes = [0u8; 32];
+        reader.read_exact(&mut rseed_bytes)?;
+        let rseed = orchard::note::RandomSeed::from_bytes(rseed_bytes, &rho)
+            .expect("should be valid random seed bytes");
+
+        let mut memo_bytes = [0u8; 512];
+        reader.read_exact(&mut memo_bytes)?;
+        let memo = Memo::from_bytes(&memo_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to read memo. {e}"),
+            )
+        })?;
+
+        let recipient_unified_address = Optional::read(&mut reader, |r| {
+            let encoded_address = read_string(r)?;
+
+            // TODO: surely there is a more straightforward way to decode unified address from string
+            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
+                .unwrap()
+                .convert_if_network::<UnifiedAddressConverter>(consensus_parameters.network_type())
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("failed to convert recipient unified address. {e}"),
+                    )
+                })?
+                .0;
+
+            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("failed to convert recipient unified address. {e}"),
+                )
+            })
+        })?;
+
+        Ok(Self {
+            output_id: OutputId::new(txid, output_index),
+            key_id: KeyId::from_parts(account_id, scope),
+            note: orchard::note::Note::from_parts(recipient, value, rho, rseed)
+                .expect("should be a valid orchard note"),
+            memo,
+            recipient_unified_address,
+        })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(
+        &self,
+        mut writer: W,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+
+        self.output_id.txid().write(&mut writer)?;
+        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+
+        writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
+        writer.write_u8(self.key_id.scope as u8)?;
+
+        writer.write_all(&self.note.recipient().to_raw_address_bytes())?;
+        writer.write_u64::<LittleEndian>(self.value())?;
+        writer.write_all(&self.note.rho().to_bytes())?;
+        writer.write_all(self.note.rseed().as_bytes())?;
+
+        writer.write_all(self.memo.encode().as_array())?;
+        Optional::write(
+            &mut writer,
+            self.recipient_unified_address.as_ref(),
+            |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
+        )?;
+
+        Ok(())
+    }
+}
+
+impl ShardTrees {
+    fn serialized_version() -> u8 {
+        0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let sapling = Self::read_shardtree(&mut reader)?;
+        let orchard = Self::read_shardtree(&mut reader)?;
+
+        Ok(Self { sapling, orchard })
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&mut self, mut writer: W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        Self::write_shardtree(&mut writer, &mut self.sapling)?;
+        Self::write_shardtree(&mut writer, &mut self.orchard)?;
+
+        Ok(())
+    }
+
+    fn read_shardtree<
+        H: Hashable + Clone + HashSer + Eq,
+        C: Ord + std::fmt::Debug + Copy + From<u32>,
+        R: Read,
+        const DEPTH: u8,
+        const SHARD_HEIGHT: u8,
+    >(
+        mut reader: R,
+    ) -> std::io::Result<ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>> {
+        let shards = Vector::read(&mut reader, |r| {
+            let level = incrementalmerkletree::Level::from(r.read_u8()?);
+            let index = r.read_u64::<LittleEndian>()?;
+            let root_addr = incrementalmerkletree::Address::from_parts(level, index);
+            let shard = read_shard(r)?;
+            Ok(LocatedPrunableTree::from_parts(root_addr, shard))
+        })?;
+        let mut store = MemoryShardStore::empty();
+        for shard in shards {
+            store.put_shard(shard).expect("Infallible");
+        }
+        let checkpoints = Vector::read(&mut reader, |r| {
+            let checkpoint_id = C::from(r.read_u32::<LittleEndian>()?);
+            let tree_state = match r.read_u8()? {
+                0 => TreeState::Empty,
+                1 => TreeState::AtPosition(Position::from(r.read_u64::<LittleEndian>()?)),
+                otherwise => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "failed to read TreeState. expected boolean value, found {otherwise}"
+                        ),
+                    ))
+                }
+            };
+            let marks_removed =
+                Vector::read(r, |r| r.read_u64::<LittleEndian>().map(Position::from))?;
+            Ok((
+                checkpoint_id,
+                Checkpoint::from_parts(tree_state, marks_removed.into_iter().collect()),
+            ))
+        })?;
+        for (checkpoint_id, checkpoint) in checkpoints {
+            store
+                .add_checkpoint(checkpoint_id, checkpoint)
+                .expect("Infallible");
+        }
+        store.put_cap(read_shard(reader)?).expect("Infallible");
+
+        Ok(shardtree::ShardTree::new(
+            store,
+            MAX_VERIFICATION_WINDOW as usize,
+        ))
+    }
+
+    /// Write memory-backed shardstore, represented tree.
+    fn write_shardtree<
+        H: Hashable + Clone + Eq + HashSer,
+        C: Ord + std::fmt::Debug + Copy,
+        W: Write,
+        const DEPTH: u8,
+        const SHARD_HEIGHT: u8,
+    >(
+        mut writer: W,
+        shardtree: &mut ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>,
+    ) -> std::io::Result<()>
+    where
+        u32: From<C>,
+    {
+        fn write_shards<W, H, C>(
+            mut writer: W,
+            store: &MemoryShardStore<H, C>,
+        ) -> std::io::Result<()>
+        where
+            H: Hashable + Clone + Eq + HashSer,
+            C: Ord + std::fmt::Debug + Copy,
+            W: Write,
+        {
+            let roots = store.get_shard_roots().expect("Infallible");
+            Vector::write(&mut writer, &roots, |w, root| {
+                w.write_u8(root.level().into())?;
+                w.write_u64::<LittleEndian>(root.index())?;
+                let shard = store
+                    .get_shard(*root)
+                    .expect("Infallible")
+                    .expect("cannot find root that shard store claims to have");
+                write_shard(w, shard.root())
+            })
+        }
+
+        fn write_checkpoints<W, Cid>(
+            mut writer: W,
+            checkpoints: &[(Cid, Checkpoint)],
+        ) -> std::io::Result<()>
+        where
+            W: Write,
+            Cid: Ord + std::fmt::Debug + Copy,
+            u32: From<Cid>,
+        {
+            Vector::write(
+                &mut writer,
+                checkpoints,
+                |mut w, (checkpoint_id, checkpoint)| {
+                    w.write_u32::<LittleEndian>(u32::from(*checkpoint_id))?;
+                    match checkpoint.tree_state() {
+                        shardtree::store::TreeState::Empty => w.write_u8(0),
+                        shardtree::store::TreeState::AtPosition(pos) => {
+                            w.write_u8(1)?;
+                            w.write_u64::<LittleEndian>(<u64 as From<Position>>::from(pos))
+                        }
+                    }?;
+                    Vector::write(
+                        &mut w,
+                        &checkpoint.marks_removed().iter().collect::<Vec<_>>(),
+                        |w, mark| {
+                            w.write_u64::<LittleEndian>(<u64 as From<Position>>::from(**mark))
+                        },
+                    )
+                },
+            )
+        }
+
+        // Replace original tree with empty tree, and mutate new version into store.
+        let mut store = std::mem::replace(
+            shardtree,
+            shardtree::ShardTree::new(MemoryShardStore::empty(), 0),
+        )
+        .into_store();
+
+        macro_rules! write_with_error_handling {
+            ($writer: ident, $from: ident) => {
+                if let Err(e) = $writer(&mut writer, &$from) {
+                    *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+                    return Err(e);
+                }
+            };
+        }
+
+        // Write located prunable trees
+        write_with_error_handling!(write_shards, store);
+
+        // Write checkpoints
+        let mut checkpoints = Vec::new();
+        store
+            .with_checkpoints(
+                MAX_VERIFICATION_WINDOW as usize,
+                |checkpoint_id, checkpoint| {
+                    checkpoints.push((*checkpoint_id, checkpoint.clone()));
+                    Ok(())
+                },
+            )
+            .expect("Infallible");
+        write_with_error_handling!(write_checkpoints, checkpoints);
+
+        // Write cap
+        let cap = store.get_cap().expect("Infallible");
+        write_with_error_handling!(write_shard, cap);
+
+        *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+
+        Ok(())
+    }
+}

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -192,7 +192,6 @@ impl NullifierMap {
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
         let _version = reader.read_u8()?;
-
         let sapling = Vector::read(&mut reader, |mut r| {
             let mut nullifier_bytes = [0u8; 32];
             r.read_exact(&mut nullifier_bytes)?;

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -45,6 +45,13 @@ pub trait SyncWallet {
     fn get_transparent_addresses_mut(
         &mut self,
     ) -> Result<&mut BTreeMap<TransparentAddressId, String>, Self::Error>;
+
+    /// Aids in-memory wallets to only save when the wallet state has changed by setting a flag to mark that save is
+    /// required.
+    /// Persitance wallets may use the default implementation.
+    fn set_save_flag(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 /// Trait for interfacing [`crate::wallet::WalletBlock`]s with wallet data

--- a/zingo-status/Cargo.toml
+++ b/zingo-status/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 zcash_primitives = { workspace = true }
+byteorder = { workspace = true }

--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -1,7 +1,7 @@
 //! If a note is confirmed, it is:
 //!  Confirmed === on-record on-chain at BlockHeight
 
-use std::io::Write;
+use std::io::{Read, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -219,6 +219,24 @@ impl ConfirmationStatus {
 
     fn serialized_version() -> u8 {
         0
+    }
+
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let _version = reader.read_u8()?;
+        let status = reader.read_u8()?;
+        let block_height = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
+
+        match status {
+            0 => Ok(Self::Calculated(block_height)),
+            1 => Ok(Self::Transmitted(block_height)),
+            2 => Ok(Self::Mempool(block_height)),
+            3 => Ok(Self::Confirmed(block_height)),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "failed to read status",
+            )),
+        }
     }
 
     /// Serialize into `writer`

--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -1,6 +1,10 @@
 //! If a note is confirmed, it is:
 //!  Confirmed === on-record on-chain at BlockHeight
 
+use std::io::Write;
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+
 use zcash_primitives::consensus::BlockHeight;
 
 /// Transaction confirmation states. Every transaction record includes exactly one of these variants.
@@ -211,6 +215,24 @@ impl ConfirmationStatus {
             Self::Transmitted(self_height) => *self_height,
             Self::Confirmed(self_height) => *self_height,
         }
+    }
+
+    fn serialized_version() -> u8 {
+        1
+    }
+
+    /// Serialize into `writer`
+    pub fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_u8(Self::serialized_version())?;
+        writer.write_u8(match self {
+            Self::Calculated(_) => 0,
+            Self::Transmitted(_) => 1,
+            Self::Mempool(_) => 2,
+            Self::Confirmed(_) => 3,
+        })?;
+        writer.write_u32::<LittleEndian>(self.get_height().into())?;
+
+        Ok(())
     }
 }
 

--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -218,7 +218,7 @@ impl ConfirmationStatus {
     }
 
     fn serialized_version() -> u8 {
-        1
+        0
     }
 
     /// Serialize into `writer`
@@ -230,9 +230,7 @@ impl ConfirmationStatus {
             Self::Mempool(_) => 2,
             Self::Confirmed(_) => 3,
         })?;
-        writer.write_u32::<LittleEndian>(self.get_height().into())?;
-
-        Ok(())
+        writer.write_u32::<LittleEndian>(self.get_height().into())
     }
 }
 

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -196,6 +196,11 @@ fn start_interactive(
             _ => (),
         }
 
+        match send_command("save".to_string(), vec!["check".to_string()]) {
+            check if check.starts_with("Error:") => eprintln!("{check}"),
+            _ => (),
+        }
+
         let readline = rl.readline(&format!(
             "({}) Block:{} (type 'help') >> ",
             chain_name, height
@@ -540,7 +545,7 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) {
         }
 
         command_transmitter
-            .send(("save".to_string(), vec!["shutdown".to_string()]))
+            .send(("quit".to_string(), vec![]))
             .unwrap();
         match resp_receiver.recv() {
             Ok(s) => println!("{}", s),

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -484,6 +484,9 @@ pub fn startup(
         println!("{}", update);
     }
 
+    let update = commands::do_user_command("save", &["run"], &mut lightclient);
+    println!("{}", update);
+
     // Start the command loop
     let (command_transmitter, resp_receiver) = command_loop(lightclient);
 
@@ -533,6 +536,16 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) {
                 );
                 eprintln!("{}", e);
                 error!("{}", e);
+            }
+        }
+
+        command_transmitter
+            .send(("save".to_string(), vec!["shutdown".to_string()]))
+            .unwrap();
+        match resp_receiver.recv() {
+            Ok(s) => println!("{}", s),
+            Err(e) => {
+                eprintln!("{}", e);
             }
         }
     }

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -23,7 +23,7 @@ mod error;
 mod utils;
 
 lazy_static! {
-    static ref RT: Runtime = tokio::runtime::Runtime::new().unwrap();
+    pub static ref RT: Runtime = tokio::runtime::Runtime::new().unwrap();
 }
 
 /// This command interface is used both by cli and also consumers.

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -2,7 +2,7 @@
 //! upgrade-or-replace
 
 use crate::data::proposal;
-use crate::lightclient::sync::SyncPollReport;
+use crate::utils::PollReport;
 use crate::wallet::keys::unified::UnifiedKeyStore;
 use crate::{lightclient::LightClient, wallet};
 use indoc::indoc;
@@ -375,7 +375,7 @@ impl Command for SyncCommand {
 
     fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
         if args.len() != 1 {
-            return "Error: sync command expects 1 argument. Type \"sync help\" for usage."
+            return "Error: sync command expects 1 argument. Type \"help sync\" for usage."
                 .to_string();
         }
 
@@ -403,14 +403,14 @@ impl Command for SyncCommand {
                 })
                 .pretty(2),
             "poll" => match lightclient.poll_sync() {
-                SyncPollReport::NoHandle => "Sync task has not been launched.".to_string(),
-                SyncPollReport::NotReady => "Sync task is not complete.".to_string(),
-                SyncPollReport::Ready(result) => match result {
+                PollReport::NoHandle => "Sync task has not been launched.".to_string(),
+                PollReport::NotReady => "Sync task is not complete.".to_string(),
+                PollReport::Ready(result) => match result {
                     Ok(sync_result) => sync_result.to_string(),
                     Err(e) => format!("Error: {e}"),
                 },
             },
-            _ => "Error: invalid sub-command. Type \"sync help\" for usage.".to_string(),
+            _ => "Error: invalid sub-command. Type \"help sync\" for usage.".to_string(),
         }
     }
 }
@@ -1760,6 +1760,55 @@ impl Command for CoinsCommand {
     }
 }
 
+struct SaveCommand {}
+impl Command for SaveCommand {
+    fn help(&self) -> &'static str {
+        indoc! {r#"
+            Launches a save task which saves the wallet to persistance when the wallet state changes.
+            Not intended to be called manually.
+
+            usage:
+            save run
+            save check
+            save shutdown
+
+        "#}
+    }
+
+    fn short_help(&self) -> &'static str {
+        "Launches a save task. Not intended to be called manually."
+    }
+
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+        if args.len() != 1 {
+            return "Error: save command expects 1 argument. Type \"help save\" for usage."
+                .to_string();
+        }
+
+        match args[0] {
+            "run" => {
+                RT.block_on(async move { lightclient.save_task().await });
+                "Launching save task...".to_string()
+            }
+            "check" => match RT.block_on(async move { lightclient.check_save_error().await }) {
+                Ok(_) => "".to_string(),
+                Err(e) => {
+                    format!("Error: save failed. {}\nRestarting save task...", e)
+                }
+            },
+            "shutdown" => {
+                match RT.block_on(async move { lightclient.shutdown_save_task().await }) {
+                    Ok(_) => "".to_string(),
+                    Err(e) => {
+                        format!("Error: save failed. {}", e)
+                    }
+                }
+            }
+            _ => "Error: invalid sub-command. Type \"help save\" for usage.".to_string(),
+        }
+    }
+}
+
 struct QuitCommand {}
 impl Command for QuitCommand {
     fn help(&self) -> &'static str {
@@ -1816,26 +1865,6 @@ impl Command for QuitCommand {
     }
 }
 
-struct DeprecatedNoCommand {}
-impl Command for DeprecatedNoCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r#"
-            This command has been deprecated.
-            Usage:
-            dont
-
-        "#}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Deprecated command."
-    }
-
-    fn exec(&self, _args: &[&str], _lightclient: &mut LightClient) -> String {
-        ".deprecated.".to_string()
-    }
-}
-
 /// TODO: Add Doc Comment Here!
 pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
     let mut entries: Vec<(&'static str, Box<dyn Command>)> = vec![
@@ -1868,7 +1897,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         ("updatecurrentprice", Box::new(UpdateCurrentPriceCommand {})),
         ("send", Box::new(SendCommand {})),
         ("shield", Box::new(ShieldCommand {})),
-        ("save", Box::new(DeprecatedNoCommand {})),
+        ("save", Box::new(SaveCommand {})),
         ("quit", Box::new(QuitCommand {})),
         ("notes", Box::new(NotesCommand {})),
         ("coins", Box::new(CoinsCommand {})),

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1798,7 +1798,7 @@ impl Command for SaveCommand {
             },
             "shutdown" => {
                 match RT.block_on(async move { lightclient.shutdown_save_task().await }) {
-                    Ok(_) => "".to_string(),
+                    Ok(_) => "Save task shutdown successfully.".to_string(),
                     Err(e) => {
                         format!("Error: save failed. {}", e)
                     }
@@ -1825,6 +1825,8 @@ impl Command for QuitCommand {
     }
 
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+        let save_shutdown = do_user_command("save", &["shutdown"], lightclient);
+
         // before shutting down, shut down all child processes..
         // ...but only if the network being used is regtest.
         let o = RT.block_on(async move { lightclient.do_info().await });
@@ -1861,7 +1863,7 @@ impl Command for QuitCommand {
                     .expect("error while killing regtest-spawned processes!");
             }
         }
-        "quit".to_string()
+        format!("{}\nZingo CLI quit successfully.", save_shutdown)
     }
 }
 

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -1586,22 +1586,21 @@ struct HeightCommand {}
 impl Command for HeightCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
-            Get the latest block height that the wallet is at.
+            Returns the blockchain height at the time the wallet last requested the latest block height from the server.
+
             Usage:
             height
-
-            Pass 'true' (default) to sync to the server to get the latest block height. Pass 'false' to get the latest height in the wallet without checking with the server.
 
         "#}
     }
 
     fn short_help(&self) -> &'static str {
-        "Get the latest block height that the wallet is at"
+        "Returns the blockchain height at the time the wallet last requested the latest block height from the server."
     }
 
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
         RT.block_on(async move {
-            object! { "height" => lightclient.do_wallet_last_scanned_height().await}.pretty(2)
+            object! { "height" => json::JsonValue::from(lightclient.wallet.lock().await.sync_state.wallet_height().map(u32::from).unwrap_or(0))}.pretty(2)
         })
     }
 }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -2,10 +2,7 @@
 
 use json::{array, object, JsonValue};
 use log::error;
-use pepper_sync::{
-    error::SyncError,
-    wallet::{SyncMode, SyncResult},
-};
+use pepper_sync::{error::SyncError, wallet::SyncResult};
 use serde::Serialize;
 use std::sync::{atomic::AtomicU8, Arc};
 use tokio::{
@@ -159,19 +156,6 @@ pub struct AccountBackupInfo {
     pub account_index: u32,
 }
 
-#[derive(Default)]
-struct ZingoSaveBuffer {
-    pub buffer: Arc<RwLock<Vec<u8>>>,
-}
-
-impl ZingoSaveBuffer {
-    fn new(buffer: Vec<u8>) -> Self {
-        ZingoSaveBuffer {
-            buffer: Arc::new(RwLock::new(buffer)),
-        }
-    }
-}
-
 /// Balances that may be presented to a user in a wallet app.
 /// The goal is to present a user-friendly and useful view of what the user has or can soon expect
 /// *without* requiring the user to understand the details of the Zcash protocol.
@@ -247,7 +231,6 @@ pub struct LightClient {
     sync_mode: Arc<AtomicU8>,
     sync_handle: Option<JoinHandle<Result<SyncResult, SyncError>>>,
     latest_proposal: Arc<RwLock<Option<ZingoProposal>>>, // TODO: move to wallet
-    save_buffer: ZingoSaveBuffer,                        // TODO: move save buffer to wallet itself?
 }
 
 /// all the wonderfully intertwined ways to conjure a LightClient
@@ -266,7 +249,7 @@ pub mod instantiation {
 
     use crate::config::ZingoConfig;
 
-    use super::{LightClient, ZingoSaveBuffer};
+    use super::LightClient;
     use crate::wallet::{LightWallet, WalletBase};
 
     impl LightClient {
@@ -285,7 +268,6 @@ pub mod instantiation {
                 sync_mode: Arc::new(AtomicU8::new(SyncMode::NotRunning as u8)),
                 sync_handle: None,
                 latest_proposal: Arc::new(RwLock::new(None)),
-                save_buffer: ZingoSaveBuffer::new(buffer),
             })
         }
 
@@ -324,7 +306,7 @@ pub mod instantiation {
                 ));
                 }
             }
-            let mut lightclient = LightClient::create_from_wallet_async(
+            let lightclient = LightClient::create_from_wallet_async(
                 config.clone(),
                 LightWallet::new(
                     config.chain,
@@ -337,10 +319,7 @@ pub mod instantiation {
             )
             .await?;
 
-            lightclient
-                .save_internal_rust()
-                .await
-                .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+            lightclient.wallet.lock().await.save_required = true;
 
             debug!("Created new wallet!");
 
@@ -370,19 +349,16 @@ pub mod instantiation {
 
         fn create_with_new_wallet(config: &ZingoConfig, height: u64) -> io::Result<Self> {
             Runtime::new().unwrap().block_on(async move {
-                let mut l =
+                let lightclient =
                     LightClient::create_unconnected(config, WalletBase::FreshEntropy, height)
                         .await?;
 
                 debug!("Created new wallet with a new seed!");
                 debug!("Created LightClient to {}", &config.get_lightwalletd_uri());
 
-                // Save
-                l.save_internal_rust()
-                    .await
-                    .map_err(|s| io::Error::new(ErrorKind::PermissionDenied, s))?;
+                lightclient.wallet.lock().await.save_required = true;
 
-                Ok(l)
+                Ok(lightclient)
             })
         }
 
@@ -476,17 +452,13 @@ impl LightClient {
             transparent: addr_type.contains('t'),
         };
 
-        let new_address = self
-            .wallet
-            .lock()
-            .await
-            .generate_unified_address(desired_receivers)
-            .map_err(|e| e.to_string())?;
-
-        // FIXME: zingo2, rework wallet save to save while the wallet guard is acquired
-        if SyncMode::from_atomic_u8(self.sync_mode.clone()) == SyncMode::NotRunning {
-            self.save_internal_rust().await?;
-        }
+        let new_address = {
+            let mut wallet = self.wallet.lock().await;
+            wallet.save_required = true;
+            wallet
+                .generate_unified_address(desired_receivers)
+                .map_err(|e| e.to_string())?
+        };
 
         Ok(array![new_address.encode(&self.config.chain)])
     }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -483,6 +483,7 @@ impl LightClient {
             .generate_unified_address(desired_receivers)
             .map_err(|e| e.to_string())?;
 
+        // FIXME: zingo2, rework wallet save to save while the wallet guard is acquired
         if SyncMode::from_atomic_u8(self.sync_mode.clone()) == SyncMode::NotRunning {
             self.save_internal_rust().await?;
         }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -4,7 +4,10 @@ use json::{array, object, JsonValue};
 use log::error;
 use pepper_sync::{error::SyncError, wallet::SyncResult};
 use serde::Serialize;
-use std::sync::{atomic::AtomicU8, Arc};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU8},
+    Arc,
+};
 use tokio::{
     sync::{Mutex, RwLock},
     task::JoinHandle,
@@ -230,6 +233,8 @@ pub struct LightClient {
     pub wallet: Arc<Mutex<LightWallet>>,
     sync_mode: Arc<AtomicU8>,
     sync_handle: Option<JoinHandle<Result<SyncResult, SyncError>>>,
+    save_active: Arc<AtomicBool>,
+    save_handle: Option<JoinHandle<std::io::Result<()>>>,
     latest_proposal: Arc<RwLock<Option<ZingoProposal>>>, // TODO: move to wallet
 }
 
@@ -239,7 +244,10 @@ pub mod instantiation {
     use pepper_sync::wallet::SyncMode;
     use std::{
         io::{self, Error, ErrorKind},
-        sync::{atomic::AtomicU8, Arc},
+        sync::{
+            atomic::{AtomicBool, AtomicU8},
+            Arc,
+        },
     };
     use tokio::{
         runtime::Runtime,
@@ -267,6 +275,8 @@ pub mod instantiation {
                 wallet: Arc::new(Mutex::new(wallet)),
                 sync_mode: Arc::new(AtomicU8::new(SyncMode::NotRunning as u8)),
                 sync_handle: None,
+                save_active: Arc::new(AtomicBool::new(false)),
+                save_handle: None,
                 latest_proposal: Arc::new(RwLock::new(None)),
             })
         }
@@ -319,8 +329,6 @@ pub mod instantiation {
             )
             .await?;
 
-            lightclient.wallet.lock().await.save_required = true;
-
             debug!("Created new wallet!");
 
             Ok(lightclient)
@@ -355,8 +363,6 @@ pub mod instantiation {
 
                 debug!("Created new wallet with a new seed!");
                 debug!("Created LightClient to {}", &config.get_lightwalletd_uri());
-
-                lightclient.wallet.lock().await.save_required = true;
 
                 Ok(lightclient)
             })

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -272,7 +272,7 @@ pub mod instantiation {
         /// This is the fundamental invocation of a LightClient. It lives in an asynchronous runtime.
         pub async fn create_from_wallet_async(
             config: ZingoConfig,
-            wallet: LightWallet,
+            mut wallet: LightWallet,
         ) -> io::Result<Self> {
             let mut buffer: Vec<u8> = vec![];
             wallet.write(&mut buffer, &config.chain).await?;
@@ -321,7 +321,7 @@ pub mod instantiation {
                 ));
                 }
             }
-            let lightclient = LightClient::create_from_wallet_async(
+            let mut lightclient = LightClient::create_from_wallet_async(
                 config.clone(),
                 LightWallet::new(
                     config.chain,
@@ -367,8 +367,9 @@ pub mod instantiation {
 
         fn create_with_new_wallet(config: &ZingoConfig, height: u64) -> io::Result<Self> {
             Runtime::new().unwrap().block_on(async move {
-                let l = LightClient::create_unconnected(config, WalletBase::FreshEntropy, height)
-                    .await?;
+                let mut l =
+                    LightClient::create_unconnected(config, WalletBase::FreshEntropy, height)
+                        .await?;
 
                 debug!("Created new wallet with a new seed!");
                 debug!("Created LightClient to {}", &config.get_lightwalletd_uri());

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -275,7 +275,7 @@ pub mod instantiation {
             wallet: LightWallet,
         ) -> io::Result<Self> {
             let mut buffer: Vec<u8> = vec![];
-            wallet.write(&mut buffer).await?;
+            wallet.write(&mut buffer, &config.chain).await?;
             Ok(LightClient {
                 config,
                 wallet: Arc::new(Mutex::new(wallet)),

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -2,7 +2,10 @@
 
 use json::{array, object, JsonValue};
 use log::error;
-use pepper_sync::{error::SyncError, wallet::SyncResult};
+use pepper_sync::{
+    error::SyncError,
+    wallet::{SyncMode, SyncResult},
+};
 use serde::Serialize;
 use std::sync::{atomic::AtomicU8, Arc};
 use tokio::{
@@ -465,7 +468,7 @@ impl LightClient {
     }
 
     /// Generates a new unified address from the given `addr_type`.
-    pub async fn do_new_address(&self, addr_type: &str) -> Result<JsonValue, String> {
+    pub async fn do_new_address(&mut self, addr_type: &str) -> Result<JsonValue, String> {
         //TODO: Placeholder interface
         let desired_receivers = ReceiverSelection {
             sapling: addr_type.contains('z'),
@@ -480,7 +483,9 @@ impl LightClient {
             .generate_unified_address(desired_receivers)
             .map_err(|e| e.to_string())?;
 
-        // self.save_internal_rust().await?;
+        if SyncMode::from_atomic_u8(self.sync_mode.clone()) == SyncMode::NotRunning {
+            self.save_internal_rust().await?;
+        }
 
         Ok(array![new_address.encode(&self.config.chain)])
     }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -452,13 +452,11 @@ impl LightClient {
             transparent: addr_type.contains('t'),
         };
 
-        let new_address = {
-            let mut wallet = self.wallet.lock().await;
-            wallet.save_required = true;
-            wallet
-                .generate_unified_address(desired_receivers)
-                .map_err(|e| e.to_string())?
-        };
+        let mut wallet = self.wallet.lock().await;
+        let new_address = wallet
+            .generate_unified_address(desired_receivers)
+            .map_err(|e| e.to_string())?;
+        wallet.save_required = true;
 
         Ok(array![new_address.encode(&self.config.chain)])
     }

--- a/zingolib/src/lightclient/describe.rs
+++ b/zingolib/src/lightclient/describe.rs
@@ -217,14 +217,6 @@ impl LightClient {
     }
 
     /// TODO: Add Doc Comment Here!
-    // TODO: remove
-    pub async fn do_wallet_last_scanned_height(&self) -> JsonValue {
-        json::JsonValue::from(u32::from(
-            self.wallet.lock().await.sync_state.fully_scanned_height(),
-        ))
-    }
-
-    /// TODO: Add Doc Comment Here!
     pub fn get_server(&self) -> std::sync::RwLockReadGuard<http::Uri> {
         self.config.lightwalletd_uri.read().unwrap()
     }

--- a/zingolib/src/lightclient/read.rs
+++ b/zingolib/src/lightclient/read.rs
@@ -18,7 +18,7 @@ impl LightClient {
         config: &ZingoConfig, // TODO: take owned config not reference
         mut reader: R,
     ) -> io::Result<Self> {
-        let wallet = LightWallet::read_internal(&mut reader, config.chain).await?;
+        let wallet = LightWallet::read(&mut reader, config.chain)?;
 
         let lc = LightClient::create_from_wallet_async(config.clone(), wallet).await?;
 

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -41,10 +41,10 @@ impl LightClient {
     /// write down the state of the lightclient as a `Vec<u8>`
     pub async fn save_internal_buffer(&self) -> ZingoLibResult<Vec<u8>> {
         let mut buffer: Vec<u8> = vec![];
-        self.wallet
-            .lock()
-            .await
-            .write(&mut buffer)
+        let wallet = self.wallet.lock().await;
+        let network = wallet.network;
+        wallet
+            .write(&mut buffer, &network)
             .await
             .map_err(ZingoLibError::InternalWriteBufferError)?;
         (self.save_buffer.buffer.write().await).clone_from(&buffer);

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -16,7 +16,7 @@ impl LightClient {
     //        SAVE METHODS
 
     /// Called internally at sync checkpoints to save state. Should not be called midway through sync.
-    pub(super) async fn save_internal_rust(&self) -> ZingoLibResult<bool> {
+    pub(super) async fn save_internal_rust(&mut self) -> ZingoLibResult<bool> {
         match self.save_internal_buffer().await {
             Ok(_vu8) => {
                 // Save_internal_buffer ran without error. At this point, we assume that the save buffer is good to go. Depending on operating system, we may be able to write it to disk. (Otherwise, we wait for the FFI to offer save export.
@@ -39,9 +39,9 @@ impl LightClient {
     }
 
     /// write down the state of the lightclient as a `Vec<u8>`
-    pub async fn save_internal_buffer(&self) -> ZingoLibResult<Vec<u8>> {
+    pub async fn save_internal_buffer(&mut self) -> ZingoLibResult<Vec<u8>> {
         let mut buffer: Vec<u8> = vec![];
-        let wallet = self.wallet.lock().await;
+        let mut wallet = self.wallet.lock().await;
         let network = wallet.network;
         wallet
             .write(&mut buffer, &network)

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -1,54 +1,80 @@
 //! LightClient saves internally when it gets to a checkpoint. If has filesystem access, it saves to file at those points. otherwise, it passes the save buffer to the FFI.
 
+use futures::FutureExt as _;
 use log::error;
 
-use std::{
-    fs::{remove_file, File},
-    io::Write,
-    path::PathBuf,
-};
+use std::{borrow::BorrowMut as _, fs::remove_file, path::PathBuf, sync::atomic};
 
 use super::LightClient;
-use crate::error::ZingoLibError;
+use crate::{
+    error::ZingoLibError,
+    utils::{self, PollReport},
+};
 
 impl LightClient {
-    /// If the wallet state has changed since last save, serializes the wallet and returns the wallet bytes.
-    /// Returns `Ok(None)` if the wallet state has not changed and save is not required.
-    /// Returns error if serialization fails.
-    ///
-    /// Intended to be called from a save task which calls `save` in a loop, awaiting the wallet lock and checking
-    /// `save_required` status, writing the returned wallet bytes to persistance.
-    // FIXME: zingo-cli needs a save task
-    pub async fn save(&self) -> std::io::Result<Option<Vec<u8>>> {
-        let mut wallet_bytes: Vec<u8> = vec![];
-        {
-            let mut wallet = self.wallet.lock().await;
-            if wallet.save_required {
-                let network = wallet.network;
-                wallet.write(&mut wallet_bytes, &network).await?;
-                wallet.save_required = false;
+    pub async fn save_task(&mut self) {
+        self.save_active.store(true, atomic::Ordering::Release);
+        let save_active = self.save_active.clone();
+        let wallet = self.wallet.clone();
+        let wallet_path = self.config.get_wallet_path();
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let save_handle = tokio::spawn(async move {
+            loop {
+                interval.tick().await;
+                if let Some(wallet_bytes) = wallet.lock().await.save().await? {
+                    utils::write_to_path(&wallet_path, wallet_bytes).await?
+                }
+                if !save_active.load(atomic::Ordering::Acquire) {
+                    return Ok(());
+                }
             }
-        }
+        });
+        self.save_handle = Some(save_handle);
+    }
 
-        if wallet_bytes.is_empty() {
-            Ok(None)
+    /// Polls the save task, returning [`self::PollReport`].
+    fn poll_save_task(&mut self) -> PollReport<(), std::io::Error> {
+        if let Some(mut save_handle) = self.save_handle.take() {
+            if let Some(save_result) = save_handle.borrow_mut().now_or_never() {
+                PollReport::Ready(save_result.expect("task panicked"))
+            } else {
+                self.save_handle = Some(save_handle);
+                PollReport::NotReady
+            }
         } else {
-            Ok(Some(wallet_bytes))
+            PollReport::NoHandle
         }
     }
 
-    /// Persists the `wallet_bytes` returned from [`crate::lightclient::LightClient::save`] to the wallet path specified
-    /// in `self.config`.
-    pub async fn persist_wallet_bytes(&self, wallet_bytes: Vec<u8>) -> std::io::Result<()> {
-        let mut file = File::create(self.config.get_wallet_path())?;
-        file.write_all(&wallet_bytes)
+    /// Checks the save task handle in case of failure.
+    /// On save task failure, restarts the save task and returns the error.
+    pub async fn check_save_error(&mut self) -> std::io::Result<()> {
+        match self.poll_save_task() {
+            PollReport::Ready(save_result) => {
+                if save_result.is_err() {
+                    self.save_task().await;
+                }
+                save_result
+            }
+            _ => Ok(()),
+        }
     }
 
-    /// Calls `save` in a runtime and returns an empty buffer in the case save was not required.
+    pub async fn shutdown_save_task(&mut self) -> std::io::Result<()> {
+        self.save_active.store(false, atomic::Ordering::Release);
+        if let Some(save_handle) = self.save_handle.take() {
+            save_handle.await.expect("task panicked")
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Calls [`crate::wallet::LightWallet::save`] in a runtime and returns an empty buffer in the case save was not required.
     // FIXME: zingo2, this is kept in to make zingomobile integration easier but should be moved into zingo-mobile
     pub fn export_save_buffer_runtime(&mut self) -> Result<Vec<u8>, String> {
         crate::commands::RT.block_on(async move {
-            match self.save().await {
+            match self.wallet.lock().await.save().await {
                 Ok(Some(wallet_bytes)) => Ok(wallet_bytes),
                 Ok(None) => Ok(vec![]),
                 Err(e) => Err(e.to_string()),

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -13,6 +13,10 @@ use crate::{
 
 impl LightClient {
     pub async fn save_task(&mut self) {
+        if self.save_active.load(atomic::Ordering::Acquire) {
+            return;
+        }
+
         self.save_active.store(true, atomic::Ordering::Release);
         let save_active = self.save_active.clone();
         let wallet = self.wallet.clone();

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -9,42 +9,46 @@ use std::{
 };
 
 use super::LightClient;
-use crate::{error::ZingoLibError, wallet::LightWallet};
+use crate::error::ZingoLibError;
 
 impl LightClient {
     /// If the wallet state has changed since last save, serializes the wallet and returns the wallet bytes.
-    /// For OSs that are not iOS and Android, also persists the wallet bytes to file.
     /// Returns `Ok(None)` if the wallet state has not changed and save is not required.
-    /// Returns error if serialization or persistance fails.
+    /// Returns error if serialization fails.
     ///
-    /// Intended to be called from a save task which calls `save` repeatedly.
+    /// Intended to be called from a save task which calls `save` in a loop, awaiting the wallet lock and checking
+    /// `save_required` status, writing the returned wallet bytes to persistance.
     // FIXME: zingo-cli needs a save task
-    pub async fn save(&self, wallet: &mut LightWallet) -> std::io::Result<Option<Vec<u8>>> {
-        let mut buffer: Vec<u8> = vec![];
-        if wallet.save_required {
-            let network = wallet.network;
-            wallet.write(&mut buffer, &network).await?;
-            wallet.save_required = false;
+    pub async fn save(&self) -> std::io::Result<Option<Vec<u8>>> {
+        let mut wallet_bytes: Vec<u8> = vec![];
+        {
+            let mut wallet = self.wallet.lock().await;
+            if wallet.save_required {
+                let network = wallet.network;
+                wallet.write(&mut wallet_bytes, &network).await?;
+                wallet.save_required = false;
+            }
         }
 
-        #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        if !buffer.is_empty() {
-            let mut file = File::create(self.config.get_wallet_path())?;
-            file.write_all(&buffer)?;
-        }
-
-        if buffer.is_empty() {
+        if wallet_bytes.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(buffer))
+            Ok(Some(wallet_bytes))
         }
+    }
+
+    /// Persists the `wallet_bytes` returned from [`crate::lightclient::LightClient::save`] to the wallet path specified
+    /// in `self.config`.
+    pub async fn persist_wallet_bytes(&self, wallet_bytes: Vec<u8>) -> std::io::Result<()> {
+        let mut file = File::create(self.config.get_wallet_path())?;
+        file.write_all(&wallet_bytes)
     }
 
     /// Calls `save` in a runtime and returns an empty buffer in the case save was not required.
     // FIXME: zingo2, this is kept in to make zingomobile integration easier but should be moved into zingo-mobile
     pub fn export_save_buffer_runtime(&mut self) -> Result<Vec<u8>, String> {
         crate::commands::RT.block_on(async move {
-            match self.save(&mut *self.wallet.lock().await).await {
+            match self.save().await {
                 Ok(Some(wallet_bytes)) => Ok(wallet_bytes),
                 Ok(None) => Ok(vec![]),
                 Err(e) => Err(e.to_string()),

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -5,90 +5,51 @@ use log::error;
 use std::{
     fs::{remove_file, File},
     io::Write,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
-use tokio::runtime::Runtime;
 
 use super::LightClient;
-use crate::error::{ZingoLibError, ZingoLibResult};
+use crate::{error::ZingoLibError, wallet::LightWallet};
 
 impl LightClient {
-    //        SAVE METHODS
-
-    /// Called internally at sync checkpoints to save state. Should not be called midway through sync.
-    pub(super) async fn save_internal_rust(&mut self) -> ZingoLibResult<bool> {
-        match self.save_internal_buffer().await {
-            Ok(_vu8) => {
-                // Save_internal_buffer ran without error. At this point, we assume that the save buffer is good to go. Depending on operating system, we may be able to write it to disk. (Otherwise, we wait for the FFI to offer save export.
-
-                #[cfg(not(any(target_os = "ios", target_os = "android")))]
-                {
-                    self.rust_write_save_buffer_to_file().await?;
-                    Ok(true)
-                }
-                #[cfg(any(target_os = "ios", target_os = "android"))]
-                {
-                    Ok(false)
-                }
-            }
-            Err(err) => {
-                error!("{}", err);
-                Err(err)
-            }
-        }
-    }
-
-    /// write down the state of the lightclient as a `Vec<u8>`
-    pub async fn save_internal_buffer(&mut self) -> ZingoLibResult<Vec<u8>> {
+    /// If the wallet state has changed since last save, serializes the wallet and returns the wallet bytes.
+    /// For OSs that are not iOS and Android, also persists the wallet bytes to file.
+    /// Returns `Ok(None)` if the wallet state has not changed and save is not required.
+    /// Returns error if serialization or persistance fails.
+    ///
+    /// Intended to be called from a save task which calls `save` repeatedly.
+    // FIXME: zingo-cli needs a save task
+    pub async fn save(&self, wallet: &mut LightWallet) -> std::io::Result<Option<Vec<u8>>> {
         let mut buffer: Vec<u8> = vec![];
-        let mut wallet = self.wallet.lock().await;
-        let network = wallet.network;
-        wallet
-            .write(&mut buffer, &network)
-            .await
-            .map_err(ZingoLibError::InternalWriteBufferError)?;
-        (self.save_buffer.buffer.write().await).clone_from(&buffer);
-        Ok(buffer)
-    }
-
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
-    /// If possible, write to disk.
-    async fn rust_write_save_buffer_to_file(&self) -> ZingoLibResult<()> {
-        {
-            let read_buffer = self.save_buffer.buffer.read().await;
-            if !read_buffer.is_empty() {
-                LightClient::write_to_file(self.config.get_wallet_path(), &read_buffer)
-                    .map_err(ZingoLibError::WriteFileError)?;
-                Ok(())
-            } else {
-                ZingoLibError::EmptySaveBuffer.handle()
-            }
+        if wallet.save_required {
+            let network = wallet.network;
+            wallet.write(&mut buffer, &network).await?;
+            wallet.save_required = false;
         }
-    }
 
-    #[cfg(not(any(target_os = "ios", target_os = "android")))]
-    fn write_to_file(path: Box<Path>, buffer: &[u8]) -> std::io::Result<()> {
-        let mut file = File::create(path)?;
-        file.write_all(buffer)?;
-        Ok(())
-    }
+        #[cfg(not(any(target_os = "ios", target_os = "android")))]
+        if !buffer.is_empty() {
+            let mut file = File::create(self.config.get_wallet_path())?;
+            file.write_all(&buffer)?;
+        }
 
-    /// TODO: Add Doc Comment Here!
-    pub async fn export_save_buffer_async(&self) -> ZingoLibResult<Vec<u8>> {
-        let read_buffer = self.save_buffer.buffer.read().await;
-        if !read_buffer.is_empty() {
-            Ok(read_buffer.clone())
+        if buffer.is_empty() {
+            Ok(None)
         } else {
-            ZingoLibError::EmptySaveBuffer.handle()
+            Ok(Some(buffer))
         }
     }
 
-    /// This function is the sole correct way to ask LightClient to save.
-    pub fn export_save_buffer_runtime(&self) -> Result<Vec<u8>, String> {
-        Runtime::new()
-            .unwrap()
-            .block_on(async move { self.export_save_buffer_async().await })
-            .map_err(String::from)
+    /// Calls `save` in a runtime and returns an empty buffer in the case save was not required.
+    // FIXME: zingo2, this is kept in to make zingomobile integration easier but should be moved into zingo-mobile
+    pub fn export_save_buffer_runtime(&mut self) -> Result<Vec<u8>, String> {
+        crate::commands::RT.block_on(async move {
+            match self.save(&mut *self.wallet.lock().await).await {
+                Ok(Some(wallet_bytes)) => Ok(wallet_bytes),
+                Ok(None) => Ok(vec![]),
+                Err(e) => Err(e.to_string()),
+            }
+        })
     }
 
     /// Only relevant in non-mobile, this function removes the save file.

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -103,6 +103,9 @@ pub mod send_with_proposal {
         ) -> Result<NonEmpty<TxId>, CompleteAndBroadcastError> {
             let mut wallet = self.wallet.lock().await;
             let calculated_txids = wallet.create_transactions(proposal).await?;
+
+            // FIXME: zingo2, save wallet here in case send fails and tx is lost
+
             let broadcast_result = wallet
                 .broadcast_calculated_transactions(self.get_server_uri(), calculated_txids)
                 .await;

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -102,21 +102,9 @@ pub mod send_with_proposal {
             &self,
             proposal: &Proposal<zip317::FeeRule, NoteRef>,
         ) -> Result<NonEmpty<TxId>, CompleteAndBroadcastError> {
-            if self.sync_mode() == SyncMode::Running {
-                self.pause_sync();
-            }
-
-            let calculated_txids = {
-                let mut wallet = self.wallet.lock().await;
-                wallet.save_required = true;
-                wallet.create_transactions(proposal).await?
-            };
-            // drop wallet lock to allow the save task to acquire it with the sync engine paused.
-
             let mut wallet = self.wallet.lock().await;
-            if self.sync_mode() == SyncMode::Paused {
-                self.resume_sync();
-            }
+            let calculated_txids = wallet.create_transactions(proposal).await?;
+            wallet.save_required = true;
             let broadcast_result = wallet
                 .broadcast_calculated_transactions(self.get_server_uri(), calculated_txids)
                 .await;

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -101,11 +101,14 @@ pub mod send_with_proposal {
             &self,
             proposal: &Proposal<zip317::FeeRule, NoteRef>,
         ) -> Result<NonEmpty<TxId>, CompleteAndBroadcastError> {
+            let calculated_txids = {
+                let mut wallet = self.wallet.lock().await;
+                wallet.save_required = true;
+                wallet.create_transactions(proposal).await?
+            };
+            // drop wallet lock to allow save task to acquire it.
+
             let mut wallet = self.wallet.lock().await;
-            let calculated_txids = wallet.create_transactions(proposal).await?;
-
-            // FIXME: zingo2, save wallet here in case send fails and tx is lost
-
             let broadcast_result = wallet
                 .broadcast_calculated_transactions(self.get_server_uri(), calculated_txids)
                 .await;

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -19,6 +19,7 @@ pub mod send_with_proposal {
 
     use nonempty::NonEmpty;
 
+    use pepper_sync::wallet::SyncMode;
     use zcash_client_backend::proposal::Proposal;
     use zcash_client_backend::wallet::NoteId;
     use zcash_client_backend::zip321::TransactionRequest;
@@ -101,14 +102,21 @@ pub mod send_with_proposal {
             &self,
             proposal: &Proposal<zip317::FeeRule, NoteRef>,
         ) -> Result<NonEmpty<TxId>, CompleteAndBroadcastError> {
+            if self.sync_mode() == SyncMode::Running {
+                self.pause_sync();
+            }
+
             let calculated_txids = {
                 let mut wallet = self.wallet.lock().await;
                 wallet.save_required = true;
                 wallet.create_transactions(proposal).await?
             };
-            // drop wallet lock to allow save task to acquire it.
+            // drop wallet lock to allow the save task to acquire it with the sync engine paused.
 
             let mut wallet = self.wallet.lock().await;
+            if self.sync_mode() == SyncMode::Paused {
+                self.resume_sync();
+            }
             let broadcast_result = wallet
                 .broadcast_calculated_transactions(self.get_server_uri(), calculated_txids)
                 .await;

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -19,7 +19,6 @@ pub mod send_with_proposal {
 
     use nonempty::NonEmpty;
 
-    use pepper_sync::wallet::SyncMode;
     use zcash_client_backend::proposal::Proposal;
     use zcash_client_backend::wallet::NoteId;
     use zcash_client_backend::zip321::TransactionRequest;

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -8,6 +8,8 @@ use pepper_sync::error::SyncError;
 use pepper_sync::wallet::SyncMode;
 use zingo_netutils::GetClientError;
 
+use crate::utils::PollReport;
+
 use super::error::LightClientError;
 use super::LightClient;
 use super::SyncResult;
@@ -57,17 +59,17 @@ impl LightClient {
             .store(SyncMode::Running as u8, atomic::Ordering::Release);
     }
 
-    /// Polls the sync task, returning [`self::SyncPollReport`].
-    pub fn poll_sync(&mut self) -> SyncPollReport {
+    /// Polls the sync task, returning [`self::PollReport`].
+    pub fn poll_sync(&mut self) -> PollReport<SyncResult, SyncError> {
         if let Some(mut sync_handle) = self.sync_handle.take() {
             if let Some(sync_result) = sync_handle.borrow_mut().now_or_never() {
-                SyncPollReport::Ready(sync_result.expect("task panicked"))
+                PollReport::Ready(sync_result.expect("task panicked"))
             } else {
                 self.sync_handle = Some(sync_handle);
-                SyncPollReport::NotReady
+                PollReport::NotReady
             }
         } else {
-            SyncPollReport::NoHandle
+            PollReport::NoHandle
         }
     }
 
@@ -94,16 +96,6 @@ impl LightClient {
         self.rescan().await?;
         self.await_sync().await
     }
-}
-
-/// Returned from [`crate::lightclient::LightClient::poll_sync`].
-pub enum SyncPollReport {
-    /// Sync task has not been launched.
-    NoHandle,
-    /// Sync task is not complete.
-    NotReady,
-    /// Sync task has completed successfully or failed.
-    Ready(Result<SyncResult, SyncError>),
 }
 
 #[cfg(test)]

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -44,12 +44,14 @@ impl LightClient {
     }
 
     /// Pause the sync engine, releasing the wallet lock until [`crate::lightclient::LightClient::resume_sync`] is called.
+    // FIXME: zingo2, error if not running
     pub fn pause_sync(&self) {
         self.sync_mode
             .store(SyncMode::Paused as u8, atomic::Ordering::Release);
     }
 
     /// Resume scanning after [`crate::lightclient::LightClient::pause_sync`] has been called.
+    // FIXME: zingo2, error if not running
     pub fn resume_sync(&self) {
         self.sync_mode
             .store(SyncMode::Running as u8, atomic::Ordering::Release);

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -277,8 +277,15 @@ pub async fn sync_to_target_height(
 ) -> Result<(), LightClientError> {
     // sync first so ranges exist for the `fully_scanned_height` call
     client.sync_and_await().await?;
-    while u32::from(client.wallet.lock().await.sync_state.fully_scanned_height())
-        < target_block_height
+    while u32::from(
+        client
+            .wallet
+            .lock()
+            .await
+            .sync_state
+            .fully_scanned_height()
+            .unwrap(),
+    ) < target_block_height
     {
         tokio::time::sleep(Duration::from_millis(500)).await;
         client.sync_and_await().await?;

--- a/zingolib/src/testutils/chain_generics/conduct_chain.rs
+++ b/zingolib/src/testutils/chain_generics/conduct_chain.rs
@@ -45,7 +45,7 @@ pub trait ConductChain {
 
         LightClient::create_from_wallet_async(
             config,
-            LightWallet::unsafe_from_buffer(network, data).await,
+            LightWallet::unsafe_from_buffer(network, data),
         )
         .await
         .unwrap()

--- a/zingolib/src/testutils/lightclient.rs
+++ b/zingolib/src/testutils/lightclient.rs
@@ -8,11 +8,13 @@ use zcash_primitives::transaction::TxId;
 pub async fn new_client_from_save_buffer(
     template_client: &mut LightClient,
 ) -> std::io::Result<LightClient> {
-    template_client.wallet.lock().await.save_required = true;
-    let wallet_bytes = template_client
-        .save()
-        .await?
-        .expect("forced save_required true");
+    let mut wallet_bytes: Vec<u8> = vec![];
+    template_client
+        .wallet
+        .lock()
+        .await
+        .write(&mut wallet_bytes, &template_client.config.chain)
+        .await?;
 
     LightClient::read_wallet_from_buffer_async(template_client.config(), wallet_bytes.as_slice())
         .await

--- a/zingolib/src/testutils/lightclient.rs
+++ b/zingolib/src/testutils/lightclient.rs
@@ -9,7 +9,7 @@ use zcash_primitives::transaction::TxId;
 
 /// Create a lightclient from the buffer of another
 pub async fn new_client_from_save_buffer(
-    template_client: &LightClient,
+    template_client: &mut LightClient,
 ) -> Result<LightClient, ZingoLibError> {
     let buffer = template_client.save_internal_buffer().await?;
 

--- a/zingolib/src/testutils/lightclient.rs
+++ b/zingolib/src/testutils/lightclient.rs
@@ -8,14 +8,14 @@ use zcash_primitives::transaction::TxId;
 pub async fn new_client_from_save_buffer(
     template_client: &mut LightClient,
 ) -> std::io::Result<LightClient> {
-    let mut wallet = template_client.wallet.lock().await;
-    wallet.save_required = true;
-    let buffer = template_client
-        .save(&mut wallet)
+    template_client.wallet.lock().await.save_required = true;
+    let wallet_bytes = template_client
+        .save()
         .await?
         .expect("forced save_required true");
 
-    LightClient::read_wallet_from_buffer_async(template_client.config(), buffer.as_slice()).await
+    LightClient::read_wallet_from_buffer_async(template_client.config(), wallet_bytes.as_slice())
+        .await
 }
 /// gets the first address that will allow a sender to send to a specific pool, as a string
 /// calling \[0] on json may panic? not sure -fv

--- a/zingolib/src/testutils/lightclient.rs
+++ b/zingolib/src/testutils/lightclient.rs
@@ -1,21 +1,21 @@
 //! This mod is mostly to take inputs, raw data amd convert it into lightclient actions
 //! (obviously) in a test environment.
-use crate::{
-    error::ZingoLibError,
-    lightclient::{describe::UAReceivers, LightClient},
-};
+use crate::lightclient::{describe::UAReceivers, LightClient};
 use zcash_client_backend::{PoolType, ShieldedProtocol};
 use zcash_primitives::transaction::TxId;
 
 /// Create a lightclient from the buffer of another
 pub async fn new_client_from_save_buffer(
     template_client: &mut LightClient,
-) -> Result<LightClient, ZingoLibError> {
-    let buffer = template_client.save_internal_buffer().await?;
+) -> std::io::Result<LightClient> {
+    let mut wallet = template_client.wallet.lock().await;
+    wallet.save_required = true;
+    let buffer = template_client
+        .save(&mut wallet)
+        .await?
+        .expect("forced save_required true");
 
-    LightClient::read_wallet_from_buffer_async(template_client.config(), buffer.as_slice())
-        .await
-        .map_err(ZingoLibError::CantReadWallet)
+    LightClient::read_wallet_from_buffer_async(template_client.config(), buffer.as_slice()).await
 }
 /// gets the first address that will allow a sender to send to a specific pool, as a string
 /// calling \[0] on json may panic? not sure -fv

--- a/zingolib/src/utils.rs
+++ b/zingolib/src/utils.rs
@@ -31,11 +31,14 @@ macro_rules! build_push_list {
     };
 }
 
+use std::path::Path;
+
 pub(crate) use build_method;
 #[cfg(any(test, feature = "test-elevation"))]
 pub(crate) use build_method_push;
 #[cfg(any(test, feature = "test-elevation"))]
 pub(crate) use build_push_list;
+use tokio::io::AsyncWriteExt as _;
 use zcash_primitives::consensus::NetworkConstants;
 
 /// Take a P2PKH taddr and interpret it as a tex addr
@@ -48,4 +51,20 @@ pub fn interpret_taddr_as_tex_addr(
         &taddr_bytes,
     )
     .unwrap()
+}
+
+/// Writes `bytes` to file at `path`.
+pub(crate) async fn write_to_path(path: &Path, bytes: Vec<u8>) -> std::io::Result<()> {
+    let mut file = tokio::fs::File::create(path).await?;
+    file.write_all(&bytes).await
+}
+
+/// Return type for fns that poll the status of task handles.
+pub enum PollReport<T, E> {
+    /// Task has not been launched.
+    NoHandle,
+    /// Task is not complete.
+    NotReady,
+    /// Task has completed successfully or failed.
+    Ready(Result<T, E>),
 }

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -216,6 +216,12 @@ pub struct LightWallet {
     pub price: Arc<RwLock<WalletZecPriceInfo>>,
     /// Progress of an outgoing transaction
     send_progress: Arc<RwLock<SendProgress>>,
+    /// Boolean for tracking whether the wallet state has changed since last save.
+    ///
+    /// When wallet state is changed due to sync, send or creating addresses, this will be set to `true` automatically.
+    /// Calling [`crate::lightclient::LightClient::save`] will serialize (and in some cases persist) the wallet and
+    /// reset `save_required` to false.
+    pub save_required: bool,
 }
 
 impl LightWallet {
@@ -363,6 +369,7 @@ impl LightWallet {
             transparent_addresses,
             unified_addresses,
             network,
+            save_required: false,
         })
     }
 

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -178,19 +178,24 @@ impl WalletBase {
 }
 
 /// In-memory wallet data struct
+///
+/// The `mnemonic` can be `None` in the case of a wallet created directly from UFVKs or USKs.
+///
+/// As no relevant transactions related to this wallet will exist below the wallet's birthday, sync will start from
+/// `birthday` block height.
+///
+/// When wallet state is changed due to sync, send or creating addresses, `save_required` will be set to `true`
+/// automatically. Calling [`crate::wallet::LightWallet::save`] will serialize the wallet and reset `save_required`
+/// to false, returning the bytes to be persisted. Also see [`crate::lightclient::LightClient::save_task`] and related
+/// methods for a save task implementation.
 pub struct LightWallet {
     /// Network type
     pub network: ChainType,
     /// The seed for the wallet, stored as a zip339 Mnemonic, and the account index.
-    /// Can be `None` in case of wallet without spending capability
-    /// or created directly from spending keys.
     // TODO: we seem to support generating keys for a single account of choice which is stored here, this should be
     // reworked to support multiple accounts during sync integration
     mnemonic: Option<(Mnemonic, u32)>,
     /// The block height at which the wallet was created.
-    ///
-    /// As no relevant transactions related to this wallet will exist below the wallet's birthday, sync will start from
-    /// this block height.
     pub birthday: BlockHeight,
     /// Unified key store
     pub unified_key_store: UnifiedKeyStore,
@@ -217,10 +222,6 @@ pub struct LightWallet {
     /// Progress of an outgoing transaction
     send_progress: Arc<RwLock<SendProgress>>,
     /// Boolean for tracking whether the wallet state has changed since last save.
-    ///
-    /// When wallet state is changed due to sync, send or creating addresses, this will be set to `true` automatically.
-    /// Calling [`crate::lightclient::LightClient::save`] will serialize (and in some cases persist) the wallet and
-    /// reset `save_required` to false.
     pub save_required: bool,
 }
 

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -369,7 +369,7 @@ impl LightWallet {
             transparent_addresses,
             unified_addresses,
             network,
-            save_required: false,
+            save_required: true,
         })
     }
 
@@ -395,6 +395,25 @@ impl LightWallet {
 
         p.is_send_in_progress = false;
         p.last_result = Some(result);
+    }
+
+    /// If the wallet state has changed since last save, serializes the wallet and returns the wallet bytes.
+    /// Returns `Ok(None)` if the wallet state has not changed and save is not required.
+    /// Returns error if serialization fails.
+    ///
+    /// Intended to be called from a save task which calls `save` in a loop, awaiting the wallet lock and checking
+    /// `self.save_required` status, writing the returned wallet bytes to persistance.
+    // FIXME: zingo-cli needs a save task
+    pub async fn save(&mut self) -> std::io::Result<Option<Vec<u8>>> {
+        if self.save_required {
+            let network = self.network;
+            let mut wallet_bytes: Vec<u8> = vec![];
+            self.write(&mut wallet_bytes, &network).await?;
+            self.save_required = false;
+            Ok(Some(wallet_bytes))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -180,25 +180,25 @@ impl WalletBase {
 
 /// In-memory wallet data struct
 pub struct LightWallet {
-    /// The block height at which the wallet was created.
-    ///
-    /// As no relevant transactions related to this wallet will exist below the wallet's birthday, sync will start from
-    /// this block height.
-    pub birthday: BlockHeight,
+    /// Network type
+    pub network: ChainType,
     /// The seed for the wallet, stored as a zip339 Mnemonic, and the account index.
     /// Can be `None` in case of wallet without spending capability
     /// or created directly from spending keys.
     // TODO: we seem to support generating keys for a single account of choice which is stored here, this should be
     // reworked to support multiple accounts during sync integration
     mnemonic: Option<(Mnemonic, u32)>,
-    /// Wallet options
-    pub wallet_options: Arc<RwLock<WalletOptions>>, // TODO: revisit options
-    /// Progress of an outgoing transaction
-    send_progress: Arc<RwLock<SendProgress>>,
-    /// The current price of ZEC. (time_fetched, price in USD)
-    pub price: Arc<RwLock<WalletZecPriceInfo>>,
+    /// The block height at which the wallet was created.
+    ///
+    /// As no relevant transactions related to this wallet will exist below the wallet's birthday, sync will start from
+    /// this block height.
+    pub birthday: BlockHeight,
     /// Unified key store
     pub unified_key_store: UnifiedKeyStore,
+    /// Unified_addresses
+    pub unified_addresses: AppendOnlyVec<UnifiedAddress>,
+    /// Transparent addresses
+    pub transparent_addresses: BTreeMap<TransparentAddressId, String>,
     /// Wallet blocks
     pub wallet_blocks: BTreeMap<BlockHeight, WalletBlock>,
     /// Wallet transactions
@@ -211,12 +211,12 @@ pub struct LightWallet {
     pub shard_trees: ShardTrees,
     /// Sync state
     pub sync_state: SyncState,
-    /// Transparent addresses
-    pub transparent_addresses: BTreeMap<TransparentAddressId, String>,
-    /// Unified_addresses
-    pub unified_addresses: AppendOnlyVec<UnifiedAddress>,
-    /// Network type
-    pub network: ChainType,
+    /// Wallet options
+    pub wallet_options: Arc<RwLock<WalletOptions>>, // TODO: revisit options
+    /// The current price of ZEC. (time_fetched, price in USD)
+    pub price: Arc<RwLock<WalletZecPriceInfo>>,
+    /// Progress of an outgoing transaction
+    send_progress: Arc<RwLock<SendProgress>>,
 }
 
 impl LightWallet {

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -79,6 +79,7 @@ pub enum MemoDownloadOption {
 }
 
 /// TODO: Add Doc Comment Here!
+// FIXME: zingo2 re-implement options
 #[derive(Debug, Clone, Copy)]
 pub struct WalletOptions {
     pub(crate) download_memos: MemoDownloadOption,

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -2,10 +2,9 @@
 //! from a source outside of the code-base e.g. a wallet-file.
 //! TODO: Add Mod Description Here
 
-use append_only_vec::AppendOnlyVec;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use error::{KeyError, WalletError};
-use keys::unified::UnifiedKeyStore;
+use keys::unified::{UnifiedAddressId, UnifiedKeyStore};
 use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
 use zcash_primitives::memo::Memo;
 use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
@@ -196,7 +195,7 @@ pub struct LightWallet {
     /// Unified key store
     pub unified_key_store: UnifiedKeyStore,
     /// Unified_addresses
-    pub unified_addresses: AppendOnlyVec<UnifiedAddress>,
+    pub unified_addresses: BTreeMap<UnifiedAddressId, UnifiedAddress>,
     /// Transparent addresses
     pub transparent_addresses: BTreeMap<TransparentAddressId, String>,
     /// Wallet blocks
@@ -321,26 +320,32 @@ impl LightWallet {
             }
         };
 
-        let unified_addresses = AppendOnlyVec::new();
-        unified_addresses.push(unified_key_store.generate_unified_address(
-            0,
+        let first_address_index = 0;
+        let first_unified_address = unified_key_store.generate_unified_address(
+            first_address_index,
             unified_key_store.can_view(),
             false,
-        )?);
+        )?;
+        let mut unified_addresses = BTreeMap::new();
+        unified_addresses.insert(
+            UnifiedAddressId {
+                account_id: zip32::AccountId::ZERO,
+                address_index: first_address_index,
+            },
+            first_unified_address.clone(),
+        );
 
         let mut transparent_addresses = BTreeMap::new();
-        unified_addresses.iter().for_each(|unified_address| {
-            if let Some(transparent_address) = unified_address.transparent() {
-                transparent_addresses.insert(
-                    TransparentAddressId::new(
-                        zip32::AccountId::ZERO,
-                        TransparentScope::External,
-                        0,
-                    ),
-                    transparent::encode_address(&network, *transparent_address),
-                );
-            }
-        });
+        if let Some(transparent_address) = first_unified_address.transparent() {
+            transparent_addresses.insert(
+                TransparentAddressId::new(
+                    zip32::AccountId::ZERO,
+                    TransparentScope::External,
+                    first_address_index,
+                ),
+                transparent::encode_address(&network, *transparent_address),
+            );
+        }
 
         Ok(Self {
             mnemonic,

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -55,7 +55,7 @@ impl LightWallet {
     /// Returns wallet addresses in a JSON array
     pub async fn do_addresses(&self, subset: UAReceivers) -> JsonValue {
         let mut objectified_addresses = Vec::new();
-        for address in self.unified_addresses.iter() {
+        for address in self.unified_addresses.values() {
             let local_address = match subset {
                 UAReceivers::Orchard => zcash_keys::address::UnifiedAddress::from_receivers(
                     address.orchard().copied(),
@@ -776,7 +776,7 @@ mod test {
         /// zingolib includes derivations of further addresses.
         /// ZingoMobile uses one address.
         pub fn get_first_ua(&self) -> Result<zcash_keys::address::UnifiedAddress, ()> {
-            Ok(self.unified_addresses.iter().next().ok_or(())?.clone())
+            Ok(self.unified_addresses.values().next().ok_or(())?.clone())
         }
 
         #[allow(clippy::result_unit_err)]

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -61,6 +61,7 @@ impl LightWallet {
             Some(m) => m.0.clone().into_entropy(),
             None => vec![],
         };
+
         Vector::write(&mut writer, &seed_bytes, |w, byte| w.write_u8(*byte))?;
         if let Some(m) = &self.mnemonic {
             writer.write_u32::<LittleEndian>(m.1)?;

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -33,7 +33,7 @@ use crate::wallet::traits::ReadableWriteable;
 use crate::wallet::WalletOptions;
 use crate::wallet::{utils, SendProgress};
 
-use super::keys::unified::{ReceiverSelection, WalletCapability};
+use super::keys::unified::{ReceiverSelection, UnifiedAddressId, WalletCapability};
 
 use super::LightWallet;
 use super::{
@@ -69,11 +69,12 @@ impl LightWallet {
         self.unified_key_store.write(&mut writer, self.network)?;
 
         // TODO: consider whether its worth tracking receiver selections. if so, we need to store them in encoded memos.
-        // FIXME: write ua ID also
         Vector::write(
             &mut writer,
-            &self.unified_addresses.values().collect::<Vec<_>>(),
-            |w, address| {
+            &self.unified_addresses.iter().collect::<Vec<_>>(),
+            |w, (address_id, address)| {
+                w.write_u32::<LittleEndian>(address_id.account_id.into())?;
+                w.write_u32::<LittleEndian>(address_id.address_index)?;
                 ReceiverSelection {
                     orchard: address.orchard().is_some(),
                     sapling: address.sapling().is_some(),
@@ -335,18 +336,24 @@ impl LightWallet {
         let birthday = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
         let unified_key_store = UnifiedKeyStore::read(&mut reader, network)?;
 
-        let receiver_selections = Vector::read(&mut reader, |r| ReceiverSelection::read(r, ()))?;
+        let unified_addresses = Vector::read(&mut reader, |r| {
+            let account_id = zip32::AccountId::try_from(r.read_u32::<LittleEndian>()?)
+                .expect("only valid account ids are stored");
+            let address_index = r.read_u32::<LittleEndian>()?;
+            let receivers = ReceiverSelection::read(r, ())?;
 
-        // FIXME: read ua ID also
-        let unified_addresses = BTreeMap::new();
-        // let unified_addresses = receiver_selections
-        //     .into_iter()
-        //     .enumerate()
-        //     .map(|(address_index, receivers)| {
-        //         unified_key_store.generate_unified_address(address_index as u32, receivers, false)
-        //     })
-        //     .collect::<Result<Vec<_>, KeyError>>()
-        //     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            Ok((
+                UnifiedAddressId {
+                    account_id,
+                    address_index,
+                },
+                unified_key_store
+                    .generate_unified_address(address_index, receivers, false)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            ))
+        })?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
 
         let mut transparent_addresses = BTreeMap::new();
         for scope in [

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -43,13 +43,13 @@ impl LightWallet {
         32 // FIXME: double check this is correctly incremented before sync integration is complete
     }
 
-    /// TODO: Add Doc Comment Here!
+    /// Serialize into `writer`
+    // FIXME: remove arc mutex on price and options and make sync fn
     pub async fn write<W: Write>(
         &mut self,
         mut writer: W,
         consensus_parameters: &impl consensus::Parameters,
     ) -> io::Result<()> {
-        // TODO: version can be u8
         writer.write_u64::<LittleEndian>(Self::serialized_version())?;
         self.unified_key_store.write(&mut writer, self.network)?;
 
@@ -125,50 +125,36 @@ impl LightWallet {
         self.sync_state.write(&mut writer)
     }
 
-    /// This is a Wallet constructor.  It is the internal function called by 2 LightWallet
-    /// read procedures, by reducing its visibility we constrain possible uses.
-    /// Each type that can be deserialized has an associated serialization version.  Our
-    /// convention is to omit the type e.g. "wallet" from the local variable ident, and
-    /// make explicit (via ident) which variable refers to a value deserialized from
-    /// some source ("external") and which is represented as a source-code constant
-    /// ("internal").
-    pub async fn read_internal<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
-        let external_version = reader.read_u64::<LittleEndian>()?;
-        if external_version > Self::serialized_version() {
-            let e = format!(
-                "Don't know how to read wallet version {}. Do you have the latest version?\n{}",
-                external_version,
-                "Note: wallet files from zecwallet or beta zingo are not compatible"
-            );
-            error!("{}", e);
-            return Err(io::Error::new(ErrorKind::InvalidData, e));
+    /// Deserialize into `reader`
+    pub fn read<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
+        let version = reader.read_u64::<LittleEndian>()?;
+        info!("Reading wallet version {}", version);
+        match version {
+            ..32 => Self::read_v0(reader, network, version),
+            32 => Self::read_v32(reader, network),
+            _ => {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "Failed to read wallet version {}. Do you have the latest version?\n{}",
+                        version,
+                        "Note: wallet files from zecwallet or beta zingo are not compatible"
+                    ),
+                ));
+            }
         }
+    }
 
-        info!("Reading wallet version {}", external_version);
+    fn read_v0<R: Read>(mut reader: R, network: ChainType, version: u64) -> io::Result<Self> {
+        let mut wallet_capability = WalletCapability::read(&mut reader, network)?;
 
-        let mut wallet_capability = None;
-        let mut _transactions = None;
-        if external_version < 31 {
-            wallet_capability = Some(WalletCapability::read(&mut reader, network)?);
+        let mut _blocks = Vector::read(&mut reader, |r| BlockData::read(r))?;
 
-            let mut _blocks = Vector::read(&mut reader, |r| BlockData::read(r))?;
-
-            _transactions = if external_version <= 14 {
-                Some(TxMap::read_old(
-                    &mut reader,
-                    wallet_capability
-                        .as_ref()
-                        .expect("wallet capability should exist for versions pre-31"),
-                )?)
-            } else {
-                Some(TxMap::read(
-                    &mut reader,
-                    wallet_capability
-                        .as_ref()
-                        .expect("wallet capability should exist for versions pre-31"),
-                )?)
-            };
-        }
+        let _transactions = if version <= 14 {
+            TxMap::read_old(&mut reader, &wallet_capability)?
+        } else {
+            TxMap::read(&mut reader, &wallet_capability)?
+        };
 
         let chain_name = utils::read_string(&mut reader)?;
 
@@ -182,7 +168,7 @@ impl LightWallet {
             ));
         }
 
-        let wallet_options = if external_version <= 23 {
+        let wallet_options = if version <= 23 {
             WalletOptions::default()
         } else {
             WalletOptions::read(&mut reader)?
@@ -195,35 +181,33 @@ impl LightWallet {
                 .expect("should never overflow"),
         );
 
-        if external_version <= 22 {
-            let _sapling_tree_verified = if external_version <= 12 {
+        if version <= 22 {
+            let _sapling_tree_verified = if version <= 12 {
                 true
             } else {
                 reader.read_u8()? == 1
             };
         }
 
-        if external_version < 31 {
-            let _verified_tree = if external_version <= 21 {
-                None
-            } else {
-                Optional::read(&mut reader, |r| {
-                    use prost::Message;
+        let _verified_tree = if version <= 21 {
+            None
+        } else {
+            Optional::read(&mut reader, |r| {
+                use prost::Message;
 
-                    let buf = Vector::read(r, |r| r.read_u8())?;
-                    TreeState::decode(&buf[..])
-                        .map_err(|e| io::Error::new(ErrorKind::InvalidData, e.to_string()))
-                })?
-            };
-        }
+                let buf = Vector::read(r, |r| r.read_u8())?;
+                TreeState::decode(&buf[..])
+                    .map_err(|e| io::Error::new(ErrorKind::InvalidData, e.to_string()))
+            })?
+        };
 
-        let price = if external_version <= 13 {
+        let price = if version <= 13 {
             WalletZecPriceInfo::default()
         } else {
             WalletZecPriceInfo::read(&mut reader)?
         };
 
-        let _orchard_anchor_height_pairs = if external_version == 25 {
+        let _orchard_anchor_height_pairs = if version == 25 {
             Vector::read(&mut reader, |r| {
                 let mut anchor_bytes = [0; 32];
                 r.read_exact(&mut anchor_bytes)?;
@@ -240,7 +224,7 @@ impl LightWallet {
 
         let seed_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
         let mnemonic = if !seed_bytes.is_empty() {
-            let account_index = if external_version >= 28 {
+            let account_index = if version >= 28 {
                 reader.read_u32::<LittleEndian>()?
             } else {
                 0
@@ -259,12 +243,9 @@ impl LightWallet {
         // UnifiedSpendingKey is initially incomplete for old wallet versions.
         // This is due to the legacy transparent extended private key (ExtendedPrivKey) not containing all information required for BIP0032.
         // There is also the issue that the legacy transparent private key is derived an extra level to the external scope.
-        if external_version < 29 {
+        if version < 29 {
             if let Some(mnemonic) = mnemonic.as_ref() {
-                wallet_capability
-                    .as_mut()
-                    .expect("wallet capability should exist for versions pre-31")
-                    .unified_key_store = UnifiedKeyStore::Spend(Box::new(
+                wallet_capability.unified_key_store = UnifiedKeyStore::Spend(Box::new(
                     UnifiedSpendingKey::from_seed(
                         &network,
                         &mnemonic.0.to_seed(""),
@@ -280,11 +261,7 @@ impl LightWallet {
                         )
                     })?,
                 ));
-            } else if let UnifiedKeyStore::Spend(_) = &wallet_capability
-                .as_ref()
-                .expect("wallet capability should exist for versions pre-31")
-                .unified_key_store
-            {
+            } else if let UnifiedKeyStore::Spend(_) = &wallet_capability.unified_key_store {
                 return Err(io::Error::new(
                     ErrorKind::Other,
                     "loading from legacy spending keys with no seed phrase to recover",
@@ -292,14 +269,7 @@ impl LightWallet {
             }
         }
 
-        let unified_key_store = if external_version >= 31 {
-            UnifiedKeyStore::read(&mut reader, network)?
-            // FIXME: sync integration, check write matches read for v31
-        } else {
-            wallet_capability
-                .expect("wallet capability should exist for versions pre-31")
-                .unified_key_store
-        };
+        let unified_key_store = wallet_capability.unified_key_store;
 
         info!("Keys in this wallet:");
         match &unified_key_store {
@@ -322,11 +292,7 @@ impl LightWallet {
             UnifiedKeyStore::Empty => info!("  - no keys found"),
         }
 
-        if external_version >= 31 {
-            // FIXME: sync integration, load new wallet format
-        } else {
-            // FIXME: sync integration, add locators for targetted rescan
-        }
+        // FIXME: sync integration, add locators for targetted rescan
 
         let lw = Self {
             mnemonic,
@@ -347,6 +313,10 @@ impl LightWallet {
         };
 
         Ok(lw)
+    }
+
+    fn read_v32<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
+        todo!()
     }
 }
 

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -1,9 +1,11 @@
 //! This mod contains write and read functionality of impl LightWallet
-use append_only_vec::AppendOnlyVec;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use log::{error, info};
-use pepper_sync::keys::transparent::TransparentScope;
+use log::info;
+use pepper_sync::{
+    keys::transparent::{self, TransparentAddressId, TransparentScope},
+    wallet::{NullifierMap, OutputId, ShardTrees, SyncState, WalletBlock, WalletTransaction},
+};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zip32::AccountId;
 
@@ -20,7 +22,10 @@ use bip0039::Mnemonic;
 use zcash_client_backend::proto::service::TreeState;
 use zcash_encoding::{Optional, Vector};
 
-use zcash_primitives::consensus::{self, BlockHeight};
+use zcash_primitives::{
+    consensus::{self, BlockHeight},
+    transaction::TxId,
+};
 
 use crate::{config::ChainType, wallet::keys::unified::UnifiedKeyStore};
 
@@ -64,9 +69,10 @@ impl LightWallet {
         self.unified_key_store.write(&mut writer, self.network)?;
 
         // TODO: consider whether its worth tracking receiver selections. if so, we need to store them in encoded memos.
+        // FIXME: write ua ID also
         Vector::write(
             &mut writer,
-            &self.unified_addresses.iter().collect::<Vec<_>>(),
+            &self.unified_addresses.values().collect::<Vec<_>>(),
             |w, address| {
                 ReceiverSelection {
                     orchard: address.orchard().is_some(),
@@ -121,22 +127,20 @@ impl LightWallet {
     }
 
     /// Deserialize into `reader`
+    // TODO: update to return WalletError
     pub fn read<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
         let version = reader.read_u64::<LittleEndian>()?;
         info!("Reading wallet version {}", version);
         match version {
             ..32 => Self::read_v0(reader, network, version),
             32 => Self::read_v32(reader, network),
-            _ => {
-                return Err(io::Error::new(
-                    ErrorKind::InvalidData,
-                    format!(
-                        "Failed to read wallet version {}. Do you have the latest version?\n{}",
-                        version,
-                        "Note: wallet files from zecwallet or beta zingo are not compatible"
-                    ),
-                ));
-            }
+            _ => Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "Failed to read wallet version {}. Do you have the latest version?\n{}",
+                    version, "Note: wallet files from zecwallet or beta zingo are not compatible"
+                ),
+            )),
         }
     }
 
@@ -298,7 +302,7 @@ impl LightWallet {
             shard_trees: pepper_sync::wallet::ShardTrees::new(),
             sync_state: pepper_sync::wallet::SyncState::new(),
             transparent_addresses: BTreeMap::new(),
-            unified_addresses: AppendOnlyVec::new(),
+            unified_addresses: BTreeMap::new(),
             network,
         };
 
@@ -306,7 +310,109 @@ impl LightWallet {
     }
 
     fn read_v32<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
-        todo!()
+        let saved_network = utils::read_string(&mut reader)?;
+        if saved_network != network.to_string() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "Wallet chain name {} doesn't match expected {}",
+                    saved_network, network
+                ),
+            ));
+        }
+
+        let seed_bytes = Vector::read(&mut reader, |r| r.read_u8())?;
+        let mnemonic = if !seed_bytes.is_empty() {
+            let account_index = reader.read_u32::<LittleEndian>()?;
+            Some((
+                <Mnemonic>::from_entropy(seed_bytes)
+                    .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?,
+                account_index,
+            ))
+        } else {
+            None
+        };
+        let birthday = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
+        let unified_key_store = UnifiedKeyStore::read(&mut reader, network)?;
+
+        let receiver_selections = Vector::read(&mut reader, |r| ReceiverSelection::read(r, ()))?;
+
+        // FIXME: read ua ID also
+        let unified_addresses = BTreeMap::new();
+        // let unified_addresses = receiver_selections
+        //     .into_iter()
+        //     .enumerate()
+        //     .map(|(address_index, receivers)| {
+        //         unified_key_store.generate_unified_address(address_index as u32, receivers, false)
+        //     })
+        //     .collect::<Result<Vec<_>, KeyError>>()
+        //     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let mut transparent_addresses = BTreeMap::new();
+        for scope in [
+            TransparentScope::External,
+            TransparentScope::Internal,
+            TransparentScope::Refund,
+        ] {
+            let transparent_address_count = reader.read_u32::<LittleEndian>()? as usize;
+            for address_index in 0..transparent_address_count {
+                transparent_addresses.insert(
+                    TransparentAddressId::new(zip32::AccountId::ZERO, scope, address_index as u32),
+                    transparent::encode_address(
+                        &network,
+                        unified_key_store
+                            .generate_transparent_address(address_index as u32, scope, false)
+                            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                    ),
+                );
+            }
+        }
+
+        let wallet_blocks = Vector::read(&mut reader, |r| WalletBlock::read(r))?
+            .into_iter()
+            .map(|block| (block.block_height(), block))
+            .collect::<BTreeMap<_, _>>();
+        let wallet_transactions = Vector::read(&mut reader, |r| WalletTransaction::read(r))?
+            .into_iter()
+            .map(|transaction| (transaction.txid(), transaction))
+            .collect::<HashMap<_, _>>();
+        let nullifier_map = NullifierMap::read(&mut reader)?;
+        let outpoint_map = Vector::read(&mut reader, |mut r| {
+            let outpoint_txid = TxId::read(&mut r)?;
+            let output_index = r.read_u16::<LittleEndian>()?;
+            let locator_height = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
+            let locator_txid = TxId::read(&mut r)?;
+
+            Ok((
+                OutputId::new(outpoint_txid, output_index),
+                (locator_height, locator_txid),
+            ))
+        })?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+        let shard_trees = ShardTrees::read(&mut reader)?;
+        let sync_state = SyncState::read(&mut reader)?;
+
+        let wallet_options = WalletOptions::read(&mut reader)?;
+        let price = WalletZecPriceInfo::read(&mut reader)?;
+
+        Ok(Self {
+            network,
+            mnemonic,
+            birthday,
+            unified_key_store,
+            unified_addresses,
+            transparent_addresses,
+            wallet_blocks,
+            wallet_transactions,
+            nullifier_map,
+            outpoint_map,
+            shard_trees,
+            sync_state,
+            wallet_options: Arc::new(RwLock::new(wallet_options)),
+            price: Arc::new(RwLock::new(price)),
+            send_progress: Arc::new(RwLock::new(SendProgress::new(0))),
+        })
     }
 }
 

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -46,7 +46,7 @@ impl LightWallet {
     /// TODO: Add Doc Comment Here!
     // FIXME: sync integration, write rest of wallet data
     pub async fn write<W: Write>(
-        &self,
+        &mut self,
         mut writer: W,
         consensus_parameters: &impl consensus::Parameters,
     ) -> io::Result<()> {
@@ -111,8 +111,19 @@ impl LightWallet {
             &self.wallet_transactions.values().collect::<Vec<_>>(),
             |w, &transaction| transaction.write(w, consensus_parameters),
         )?;
-
-        Ok(())
+        self.nullifier_map.write(&mut writer)?;
+        Vector::write(
+            &mut writer,
+            &self.outpoint_map.iter().collect::<Vec<_>>(),
+            |w, (&output_id, &locator)| {
+                output_id.txid().write(&mut *w)?;
+                w.write_u16::<LittleEndian>(output_id.output_index())?;
+                w.write_u32::<LittleEndian>(locator.0.into())?;
+                locator.1.write(w)
+            },
+        )?;
+        self.shard_trees.write(&mut writer)?;
+        self.sync_state.write(&mut writer)
     }
 
     /// This is a Wallet constructor.  It is the internal function called by 2 LightWallet

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -3,6 +3,7 @@ use append_only_vec::AppendOnlyVec;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use log::{error, info};
+use pepper_sync::keys::transparent::TransparentScope;
 use zcash_keys::keys::UnifiedSpendingKey;
 use zip32::AccountId;
 
@@ -19,7 +20,7 @@ use bip0039::Mnemonic;
 use zcash_client_backend::proto::service::TreeState;
 use zcash_encoding::{Optional, Vector};
 
-use zcash_primitives::consensus::BlockHeight;
+use zcash_primitives::consensus::{self, BlockHeight};
 
 use crate::{config::ChainType, wallet::keys::unified::UnifiedKeyStore};
 
@@ -27,7 +28,7 @@ use crate::wallet::traits::ReadableWriteable;
 use crate::wallet::WalletOptions;
 use crate::wallet::{utils, SendProgress};
 
-use super::keys::unified::WalletCapability;
+use super::keys::unified::{ReceiverSelection, WalletCapability};
 
 use super::LightWallet;
 use super::{
@@ -36,39 +37,60 @@ use super::{
 };
 
 impl LightWallet {
-    /// Changes in version 31:
+    /// Changes in version 32:
     /// - Wallet restructure due to integration of new sync engine
     pub const fn serialized_version() -> u64 {
-        31 // FIXME: double check this is correctly incremented before sync integration is complete
+        32 // FIXME: double check this is correctly incremented before sync integration is complete
     }
 
     /// TODO: Add Doc Comment Here!
-    pub async fn write<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        // Write the version
+    // FIXME: sync integration, write rest of wallet data
+    pub async fn write<W: Write>(
+        &self,
+        mut writer: W,
+        consensus_parameters: &impl consensus::Parameters,
+    ) -> io::Result<()> {
+        // TODO: version can be u32 (or u16?)
         writer.write_u64::<LittleEndian>(Self::serialized_version())?;
+        self.unified_key_store.write(&mut writer, self.network)?;
 
-        // FIXME: sync integration, write keys and addresses
-        // Write all the keys
-        // self.transaction_context
-        //     .key
-        //     .write(&mut writer, self.transaction_context.config.chain)?;
+        for scope in [
+            TransparentScope::External,
+            TransparentScope::Internal,
+            TransparentScope::Refund,
+        ] {
+            let transparent_address_count = self
+                .transparent_addresses
+                .keys()
+                .filter(|address_id| address_id.scope() == scope)
+                .map(|address_id| address_id.address_index())
+                .max()
+                .map(|max_index| max_index + 1)
+                .unwrap_or(0);
+            writer.write_u32::<LittleEndian>(transparent_address_count)?;
+        }
 
-        // self.transaction_context
-        //     .transaction_metadata_set
-        //     .write()
-        //     .await
-        //     .write(&mut writer)
+        // TODO: consider whether its worth tracking receiver selections. if so, we need to store them in encoded memos.
+        Vector::write(
+            &mut writer,
+            &self.unified_addresses.iter().collect::<Vec<_>>(),
+            |w, address| {
+                ReceiverSelection {
+                    orchard: address.orchard().is_some(),
+                    sapling: address.sapling().is_some(),
+                    transparent: address.transparent().is_some(),
+                }
+                .write(w, ())
+            },
+        )?;
 
-        utils::write_string(&mut writer, &self.network.to_string())?; //     .await?;
-
+        utils::write_string(&mut writer, &self.network.to_string())?;
         self.wallet_options.read().await.write(&mut writer)?;
-
-        // TODO: make sure wallet always has a birthday
+        // TODO: birthday can be u32
         writer.write_u64::<LittleEndian>(self.birthday.into())?;
-
-        // Price info
         self.price.read().await.write(&mut writer)?;
 
+        // TODO: consider writing mnemonic before keys
         let seed_bytes = match &self.mnemonic {
             Some(m) => m.0.clone().into_entropy(),
             None => vec![],
@@ -78,6 +100,17 @@ impl LightWallet {
         if let Some(m) = &self.mnemonic {
             writer.write_u32::<LittleEndian>(m.1)?;
         }
+
+        Vector::write(
+            &mut writer,
+            &self.wallet_blocks.values().collect::<Vec<_>>(),
+            |w, &block| block.write(w),
+        )?;
+        Vector::write(
+            &mut writer,
+            &self.wallet_transactions.values().collect::<Vec<_>>(),
+            |w, &transaction| transaction.write(w, consensus_parameters),
+        )?;
 
         Ok(())
     }

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -44,7 +44,6 @@ impl LightWallet {
     }
 
     /// TODO: Add Doc Comment Here!
-    // FIXME: sync integration, write rest of wallet data
     pub async fn write<W: Write>(
         &mut self,
         mut writer: W,

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -300,6 +300,7 @@ impl LightWallet {
             transparent_addresses: BTreeMap::new(),
             unified_addresses: BTreeMap::new(),
             network,
+            save_required: false,
         };
 
         Ok(lw)
@@ -413,6 +414,7 @@ impl LightWallet {
             wallet_options: Arc::new(RwLock::new(wallet_options)),
             price: Arc::new(RwLock::new(price)),
             send_progress: Arc::new(RwLock::new(SendProgress::new(0))),
+            save_required: false,
         })
     }
 }

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -83,21 +83,15 @@ impl LightWallet {
                 .write(w, ())
             },
         )?;
-        for scope in [
-            TransparentScope::External,
-            TransparentScope::Internal,
-            TransparentScope::Refund,
-        ] {
-            let transparent_address_count = self
-                .transparent_addresses
-                .keys()
-                .filter(|address_id| address_id.scope() == scope)
-                .map(|address_id| address_id.address_index())
-                .max()
-                .map(|max_index| max_index + 1)
-                .unwrap_or(0);
-            writer.write_u32::<LittleEndian>(transparent_address_count)?;
-        }
+        Vector::write(
+            &mut writer,
+            &self.transparent_addresses.keys().collect::<Vec<_>>(),
+            |w, address_id| {
+                w.write_u32::<LittleEndian>(address_id.account_id().into())?;
+                w.write_u8(address_id.scope() as u8)?;
+                w.write_u32::<LittleEndian>(address_id.address_index())
+            },
+        )?;
 
         Vector::write(
             &mut writer,
@@ -354,26 +348,24 @@ impl LightWallet {
         })?
         .into_iter()
         .collect::<BTreeMap<_, _>>();
+        let transparent_addresses = Vector::read(&mut reader, |r| {
+            let account_id = zip32::AccountId::try_from(r.read_u32::<LittleEndian>()?)
+                .expect("only valid account ids are stored");
+            let scope = TransparentScope::try_from(r.read_u8()?)?;
+            let address_index = r.read_u32::<LittleEndian>()?;
 
-        let mut transparent_addresses = BTreeMap::new();
-        for scope in [
-            TransparentScope::External,
-            TransparentScope::Internal,
-            TransparentScope::Refund,
-        ] {
-            let transparent_address_count = reader.read_u32::<LittleEndian>()? as usize;
-            for address_index in 0..transparent_address_count {
-                transparent_addresses.insert(
-                    TransparentAddressId::new(zip32::AccountId::ZERO, scope, address_index as u32),
-                    transparent::encode_address(
-                        &network,
-                        unified_key_store
-                            .generate_transparent_address(address_index as u32, scope, false)
-                            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-                    ),
-                );
-            }
-        }
+            Ok((
+                TransparentAddressId::new(account_id, scope, address_index),
+                transparent::encode_address(
+                    &network,
+                    unified_key_store
+                        .generate_transparent_address(address_index as u32, scope, false)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                ),
+            ))
+        })?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
 
         let wallet_blocks = Vector::read(&mut reader, |r| WalletBlock::read(r))?
             .into_iter()

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -51,23 +51,17 @@ impl LightWallet {
         consensus_parameters: &impl consensus::Parameters,
     ) -> io::Result<()> {
         writer.write_u64::<LittleEndian>(Self::serialized_version())?;
-        self.unified_key_store.write(&mut writer, self.network)?;
-
-        for scope in [
-            TransparentScope::External,
-            TransparentScope::Internal,
-            TransparentScope::Refund,
-        ] {
-            let transparent_address_count = self
-                .transparent_addresses
-                .keys()
-                .filter(|address_id| address_id.scope() == scope)
-                .map(|address_id| address_id.address_index())
-                .max()
-                .map(|max_index| max_index + 1)
-                .unwrap_or(0);
-            writer.write_u32::<LittleEndian>(transparent_address_count)?;
+        utils::write_string(&mut writer, &self.network.to_string())?;
+        let seed_bytes = match &self.mnemonic {
+            Some(m) => m.0.clone().into_entropy(),
+            None => vec![],
+        };
+        Vector::write(&mut writer, &seed_bytes, |w, byte| w.write_u8(*byte))?;
+        if let Some(m) = &self.mnemonic {
+            writer.write_u32::<LittleEndian>(m.1)?;
         }
+        writer.write_u32::<LittleEndian>(self.birthday.into())?;
+        self.unified_key_store.write(&mut writer, self.network)?;
 
         // TODO: consider whether its worth tracking receiver selections. if so, we need to store them in encoded memos.
         Vector::write(
@@ -82,22 +76,20 @@ impl LightWallet {
                 .write(w, ())
             },
         )?;
-
-        utils::write_string(&mut writer, &self.network.to_string())?;
-        self.wallet_options.read().await.write(&mut writer)?;
-        // TODO: birthday can be u32
-        writer.write_u64::<LittleEndian>(self.birthday.into())?;
-        self.price.read().await.write(&mut writer)?;
-
-        // TODO: consider writing mnemonic before keys
-        let seed_bytes = match &self.mnemonic {
-            Some(m) => m.0.clone().into_entropy(),
-            None => vec![],
-        };
-        Vector::write(&mut writer, &seed_bytes, |w, byte| w.write_u8(*byte))?;
-
-        if let Some(m) = &self.mnemonic {
-            writer.write_u32::<LittleEndian>(m.1)?;
+        for scope in [
+            TransparentScope::External,
+            TransparentScope::Internal,
+            TransparentScope::Refund,
+        ] {
+            let transparent_address_count = self
+                .transparent_addresses
+                .keys()
+                .filter(|address_id| address_id.scope() == scope)
+                .map(|address_id| address_id.address_index())
+                .max()
+                .map(|max_index| max_index + 1)
+                .unwrap_or(0);
+            writer.write_u32::<LittleEndian>(transparent_address_count)?;
         }
 
         Vector::write(
@@ -122,7 +114,10 @@ impl LightWallet {
             },
         )?;
         self.shard_trees.write(&mut writer)?;
-        self.sync_state.write(&mut writer)
+        self.sync_state.write(&mut writer)?;
+
+        self.wallet_options.read().await.write(&mut writer)?;
+        self.price.read().await.write(&mut writer)
     }
 
     /// Deserialize into `reader`
@@ -147,9 +142,7 @@ impl LightWallet {
 
     fn read_v0<R: Read>(mut reader: R, network: ChainType, version: u64) -> io::Result<Self> {
         let mut wallet_capability = WalletCapability::read(&mut reader, network)?;
-
         let mut _blocks = Vector::read(&mut reader, |r| BlockData::read(r))?;
-
         let _transactions = if version <= 14 {
             TxMap::read_old(&mut reader, &wallet_capability)?
         } else {
@@ -157,7 +150,6 @@ impl LightWallet {
         };
 
         let chain_name = utils::read_string(&mut reader)?;
-
         if chain_name != network.to_string() {
             return Err(Error::new(
                 ErrorKind::InvalidData,
@@ -173,7 +165,6 @@ impl LightWallet {
         } else {
             WalletOptions::read(&mut reader)?
         };
-
         let birthday = BlockHeight::from_u32(
             reader
                 .read_u64::<LittleEndian>()?
@@ -188,7 +179,6 @@ impl LightWallet {
                 reader.read_u8()? == 1
             };
         }
-
         let _verified_tree = if version <= 21 {
             None
         } else {

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -50,7 +50,7 @@ impl LightWallet {
         mut writer: W,
         consensus_parameters: &impl consensus::Parameters,
     ) -> io::Result<()> {
-        // TODO: version can be u32 (or u16?)
+        // TODO: version can be u8
         writer.write_u64::<LittleEndian>(Self::serialized_version())?;
         self.unified_key_store.write(&mut writer, self.network)?;
 

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -359,7 +359,7 @@ impl LightWallet {
                 transparent::encode_address(
                     &network,
                     unified_key_store
-                        .generate_transparent_address(address_index as u32, scope, false)
+                        .generate_transparent_address(address_index, scope, false)
                         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
                 ),
             ))
@@ -371,10 +371,11 @@ impl LightWallet {
             .into_iter()
             .map(|block| (block.block_height(), block))
             .collect::<BTreeMap<_, _>>();
-        let wallet_transactions = Vector::read(&mut reader, |r| WalletTransaction::read(r))?
-            .into_iter()
-            .map(|transaction| (transaction.txid(), transaction))
-            .collect::<HashMap<_, _>>();
+        let wallet_transactions =
+            Vector::read(&mut reader, |r| WalletTransaction::read(r, &network))?
+                .into_iter()
+                .map(|transaction| (transaction.txid(), transaction))
+                .collect::<HashMap<_, _>>();
         let nullifier_map = NullifierMap::read(&mut reader)?;
         let outpoint_map = Vector::read(&mut reader, |mut r| {
             let outpoint_txid = TxId::read(&mut r)?;

--- a/zingolib/src/wallet/disk/testing.rs
+++ b/zingolib/src/wallet/disk/testing.rs
@@ -10,9 +10,8 @@ use super::LightWallet;
 
 impl LightWallet {
     /// connects a wallet to a local regtest node.
-    pub async fn unsafe_from_buffer(network: ChainType, data: &[u8]) -> Self {
-        Self::read_internal(data, network)
-            .await
+    pub fn unsafe_from_buffer(network: ChainType, data: &[u8]) -> Self {
+        Self::read(data, network)
             .map_err(|e| format!("Cannot deserialize LightWallet file!: {}", e))
             .unwrap()
     }

--- a/zingolib/src/wallet/disk/testing.rs
+++ b/zingolib/src/wallet/disk/testing.rs
@@ -69,7 +69,7 @@ pub async fn assert_wallet_capability_contains_n_triple_pool_receivers(
     expected_num_addresses: usize,
 ) {
     assert_eq!(wallet.unified_addresses.len(), expected_num_addresses);
-    for addr in wallet.unified_addresses.iter() {
+    for addr in wallet.unified_addresses.values() {
         assert!(addr.orchard().is_some());
         assert!(addr.sapling().is_some());
         assert!(addr.transparent().is_some());

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -121,159 +121,114 @@ pub enum AbsurdAmountVersion {
 impl NetworkSeedVersion {
     /// Loads wallet from test wallet files.
     // TODO: improve with macro
-    pub async fn load_example_wallet(&self, network: ChainType) -> LightWallet {
+    pub fn load_example_wallet(&self, network: ChainType) -> LightWallet {
         match self {
             NetworkSeedVersion::Regtest(seed) => match seed {
                 RegtestSeedVersion::HospitalMuseum(version) => match version {
-                    HospitalMuseumVersion::V27 => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/regtest/hmvasmuvwmssvichcarbpoct/v27/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
+                    HospitalMuseumVersion::V27 => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/regtest/hmvasmuvwmssvichcarbpoct/v27/zingo-wallet.dat"
+                        ),
+                    ),
                 },
                 RegtestSeedVersion::AbandonAbandon(version) => match version {
-                    AbandonAbandonVersion::V26 => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/regtest/aaaaaaaaaaaaaaaaaaaaaaaa/v26/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
+                    AbandonAbandonVersion::V26 => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/regtest/aaaaaaaaaaaaaaaaaaaaaaaa/v26/zingo-wallet.dat"
+                        ),
+                    ),
                 },
                 RegtestSeedVersion::AbsurdAmount(version) => match version {
-                    AbsurdAmountVersion::OrchAndSapl => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
+                    AbsurdAmountVersion::OrchAndSapl => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
                         "examples/regtest/aadaalacaadaalacaadaalac/orch_and_sapl/zingo-wallet.dat"
                     ),
-                        )
-                        .await
-                    }
-                    AbsurdAmountVersion::OrchOnly => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
+                    ),
+                    AbsurdAmountVersion::OrchOnly => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
                             "examples/regtest/aadaalacaadaalacaadaalac/orch_only/zingo-wallet.dat"
                         ),
-                        )
-                        .await
-                    }
+                    ),
                 },
             },
             NetworkSeedVersion::Testnet(seed) => match seed {
                 TestnetSeedVersion::ChimneyBetter(version) => match version {
-                    ChimneyBetterVersion::V26 => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/testnet/cbbhrwiilgbrababsshsmtpr/v26/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
-                    ChimneyBetterVersion::V27 => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/testnet/cbbhrwiilgbrababsshsmtpr/v27/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
-                    ChimneyBetterVersion::V28 => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/testnet/cbbhrwiilgbrababsshsmtpr/v28/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
-                    ChimneyBetterVersion::Latest => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/testnet/cbbhrwiilgbrababsshsmtpr/latest/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
+                    ChimneyBetterVersion::V26 => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/v26/zingo-wallet.dat"
+                        ),
+                    ),
+                    ChimneyBetterVersion::V27 => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/v27/zingo-wallet.dat"
+                        ),
+                    ),
+                    ChimneyBetterVersion::V28 => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/v28/zingo-wallet.dat"
+                        ),
+                    ),
+                    ChimneyBetterVersion::Latest => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/latest/zingo-wallet.dat"
+                        ),
+                    ),
                 },
                 TestnetSeedVersion::MobileShuffle(version) => match version {
-                    MobileShuffleVersion::Gab72a38b => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
+                    MobileShuffleVersion::Gab72a38b => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
                             "examples/testnet/mskmgdbhotbpetcjwcspgopp/Gab72a38b/zingo-wallet.dat"
                         ),
-                        )
-                        .await
-                    }
-                    MobileShuffleVersion::G93738061a => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
+                    ),
+                    MobileShuffleVersion::G93738061a => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
                             "examples/testnet/mskmgdbhotbpetcjwcspgopp/G93738061a/zingo-wallet.dat"
                         ),
-                        )
-                        .await
-                    }
-                    MobileShuffleVersion::Latest => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/testnet/mskmgdbhotbpetcjwcspgopp/latest/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
-                },
-                TestnetSeedVersion::GloryGoddess => {
-                    LightWallet::unsafe_from_buffer(
+                    ),
+                    MobileShuffleVersion::Latest => LightWallet::unsafe_from_buffer(
                         network,
-                        include_bytes!("examples/testnet/glory_goddess/latest/zingo-wallet.dat"),
-                    )
-                    .await
-                }
+                        include_bytes!(
+                            "examples/testnet/mskmgdbhotbpetcjwcspgopp/latest/zingo-wallet.dat"
+                        ),
+                    ),
+                },
+                TestnetSeedVersion::GloryGoddess => LightWallet::unsafe_from_buffer(
+                    network,
+                    include_bytes!("examples/testnet/glory_goddess/latest/zingo-wallet.dat"),
+                ),
             },
             NetworkSeedVersion::Mainnet(seed) => match seed {
                 MainnetSeedVersion::VillageTarget(version) => match version {
-                    VillageTargetVersion::V28 => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/mainnet/vtfcorfbcbpctcfupmegmwbp/v28/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
+                    VillageTargetVersion::V28 => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/mainnet/vtfcorfbcbpctcfupmegmwbp/v28/zingo-wallet.dat"
+                        ),
+                    ),
                 },
                 MainnetSeedVersion::HotelHumor(version) => match version {
-                    HotelHumorVersion::Gf0aaf9347 => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
+                    HotelHumorVersion::Gf0aaf9347 => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
                             "examples/mainnet/hhcclaltpcckcsslpcnetblr/gf0aaf9347/zingo-wallet.dat"
                         ),
-                        )
-                        .await
-                    }
-                    HotelHumorVersion::Latest => {
-                        LightWallet::unsafe_from_buffer(
-                            network,
-                            include_bytes!(
-                                "examples/mainnet/hhcclaltpcckcsslpcnetblr/latest/zingo-wallet.dat"
-                            ),
-                        )
-                        .await
-                    }
+                    ),
+                    HotelHumorVersion::Latest => LightWallet::unsafe_from_buffer(
+                        network,
+                        include_bytes!(
+                            "examples/mainnet/hhcclaltpcckcsslpcnetblr/latest/zingo-wallet.dat"
+                        ),
+                    ),
                 },
             },
         }
@@ -300,7 +255,7 @@ impl NetworkSeedVersion {
             NetworkSeedVersion::Mainnet(_) => crate::config::ZingoConfig::create_mainnet(),
         };
 
-        let wallet = self.load_example_wallet(config.chain).await;
+        let wallet = self.load_example_wallet(config.chain);
 
         LightClient::create_from_wallet_async(config, wallet)
             .await

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -188,7 +188,7 @@ async fn loaded_wallet_assert(
         assert_wallet_capability_matches_seed(&wallet, expected_seed_phrase).await;
 
         assert_eq!(wallet.unified_addresses.len(), expected_num_addresses);
-        for addr in wallet.unified_addresses.iter() {
+        for addr in wallet.unified_addresses.values() {
             assert!(addr.orchard().is_some());
             assert!(addr.sapling().is_some());
             assert!(addr.transparent().is_some());
@@ -273,7 +273,7 @@ async fn reload_wallet_from_buffer() {
     );
 
     assert_eq!(wallet.unified_addresses.len(), 3);
-    for addr in wallet.unified_addresses.iter() {
+    for addr in wallet.unified_addresses.values() {
         assert!(addr.orchard().is_some());
         assert!(addr.sapling().is_some());
         assert!(addr.transparent().is_some());

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -234,15 +234,12 @@ async fn reload_wallet_from_buffer() {
             .await;
     let mid_client_network = mid_client.wallet.lock().await.network;
 
-    let mid_buffer = {
-        let mut wallet = mid_client.wallet.lock().await;
-        wallet.save_required = true;
-        mid_client
-            .save(&mut *wallet)
-            .await
-            .unwrap()
-            .expect("forced save_required true")
-    };
+    mid_client.wallet.lock().await.save_required = true;
+    let mid_buffer = mid_client
+        .save()
+        .await
+        .unwrap()
+        .expect("forced save_required true");
 
     let client =
         LightClient::read_wallet_from_buffer_async(&ZingoConfig::create_testnet(), &mid_buffer[..])

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -234,12 +234,14 @@ async fn reload_wallet_from_buffer() {
             .await;
     let mid_client_network = mid_client.wallet.lock().await.network;
 
-    mid_client.wallet.lock().await.save_required = true;
-    let mid_buffer = mid_client
-        .save()
+    let mut mid_buffer: Vec<u8> = vec![];
+    mid_client
+        .wallet
+        .lock()
         .await
-        .unwrap()
-        .expect("forced save_required true");
+        .write(&mut mid_buffer, &mid_client.config.chain)
+        .await
+        .unwrap();
 
     let client =
         LightClient::read_wallet_from_buffer_async(&ZingoConfig::create_testnet(), &mid_buffer[..])

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -234,7 +234,15 @@ async fn reload_wallet_from_buffer() {
             .await;
     let mid_client_network = mid_client.wallet.lock().await.network;
 
-    let mid_buffer = mid_client.export_save_buffer_async().await.unwrap();
+    let mid_buffer = {
+        let mut wallet = mid_client.wallet.lock().await;
+        wallet.save_required = true;
+        mid_client
+            .save(&mut *wallet)
+            .await
+            .unwrap()
+            .expect("forced save_required true")
+    };
 
     let client =
         LightClient::read_wallet_from_buffer_async(&ZingoConfig::create_testnet(), &mid_buffer[..])

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -9,7 +9,7 @@ use sapling_crypto::{
     PaymentAddress,
 };
 use sha2::Sha256;
-use unified::ReceiverSelection;
+use unified::{ReceiverSelection, UnifiedAddressId};
 use zcash_keys::address::UnifiedAddress;
 use zcash_primitives::{
     consensus::NetworkConstants, legacy::TransparentAddress, zip32::ChildIndex,
@@ -28,8 +28,14 @@ impl LightWallet {
         &mut self,
         receivers: ReceiverSelection,
     ) -> Result<UnifiedAddress, KeyError> {
+        // filter as preparation for multi-account support
+        let unified_address_index = self
+            .unified_addresses
+            .keys()
+            .filter(|&address_id| address_id.account_id == zip32::AccountId::ZERO)
+            .count() as u32;
         let unified_address = self.unified_key_store.generate_unified_address(
-            self.unified_addresses.len() as u32,
+            unified_address_index,
             receivers,
             false,
         )?;
@@ -39,13 +45,19 @@ impl LightWallet {
                 TransparentAddressId::new(
                     zip32::AccountId::ZERO,
                     TransparentScope::External,
-                    self.unified_addresses.len() as u32,
+                    unified_address_index,
                 ),
                 transparent::encode_address(&self.network, *transparent_address),
             );
         }
 
-        self.unified_addresses.push(unified_address.clone());
+        self.unified_addresses.insert(
+            UnifiedAddressId {
+                account_id: zip32::AccountId::ZERO,
+                address_index: unified_address_index,
+            },
+            unified_address.clone(),
+        );
 
         Ok(unified_address)
     }
@@ -68,9 +80,11 @@ impl LightWallet {
                     TransparentScope::Refund,
                     address_index as u32,
                 );
-                let refund_address = self
-                    .unified_key_store
-                    .generate_refund_address(address_index as u32)?;
+                let refund_address = self.unified_key_store.generate_transparent_address(
+                    address_index as u32,
+                    TransparentScope::Refund,
+                    false,
+                )?;
 
                 self.transparent_addresses.insert(
                     transparent_address_id,

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -12,6 +12,8 @@ use bip0039::Mnemonic;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use orchard::note_encryption::OrchardDomain;
+use pepper_sync::keys::transparent::TransparentScope;
+use pepper_sync::keys::AddressIndex;
 use sapling_crypto::note_encryption::SaplingDomain;
 use zcash_address::unified::{Encoding as _, Ufvk};
 use zcash_client_backend::address::UnifiedAddress;
@@ -36,6 +38,13 @@ use super::legacy::{generate_transparent_address_from_legacy_key, legacy_sks_to_
 pub(crate) const KEY_TYPE_EMPTY: u8 = 0;
 pub(crate) const KEY_TYPE_VIEW: u8 = 1;
 pub(crate) const KEY_TYPE_SPEND: u8 = 2;
+
+/// Unique ID for unified addresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnifiedAddressId {
+    pub account_id: AccountId,
+    pub address_index: AddressIndex,
+}
 
 /// In-memory store for wallet spending or viewing keys
 #[derive(Debug)]
@@ -174,7 +183,11 @@ impl UnifiedKeyStore {
         };
 
         let transparent_receiver = if receivers.transparent {
-            Some(self.generate_transparent_address(unified_address_index, legacy_key)?)
+            Some(self.generate_transparent_address(
+                unified_address_index,
+                TransparentScope::External,
+                legacy_key,
+            )?)
         } else {
             None
         };
@@ -189,14 +202,17 @@ impl UnifiedKeyStore {
         Ok(unified_address)
     }
 
-    /// Generates a transparent address for the external scope at the given `address_index`.
+    /// Generates a transparent address for the given `address_index` and `scope`.
     ///
     /// Panics if `address_index` has the hardened bit set.
     pub fn generate_transparent_address(
         &self,
         address_index: u32,
-        // this should only be `true` when generating transparent addresses while loading from legacy keys (pre wallet version 29)
-        // legacy transparent keys are already derived to the external scope so setting `legacy_key` to `true` will skip this scope derivation
+        scope: TransparentScope,
+        // this should only be `true` when generating externally scoped transparent addresses while loading from legacy
+        // keys (pre wallet version 29).
+        // legacy transparent keys are already derived to the external scope so setting `legacy_key` to `true` will
+        // skip this scope derivation.
         legacy_key: bool,
     ) -> Result<TransparentAddress, KeyError> {
         let child_index = NonHardenedChildIndex::from_index(address_index)
@@ -206,34 +222,25 @@ impl UnifiedKeyStore {
             .ok_or(KeyError::NoViewCapability)?
             .clone();
 
-        let transparent_address = if legacy_key {
-            generate_transparent_address_from_legacy_key(&account_pubkey, child_index)?
-        } else {
-            account_pubkey
-                .derive_external_ivk()?
-                .derive_address(child_index)?
+        let transparent_address = match scope {
+            TransparentScope::External => {
+                if legacy_key {
+                    generate_transparent_address_from_legacy_key(&account_pubkey, child_index)?
+                } else {
+                    account_pubkey
+                        .derive_external_ivk()?
+                        .derive_address(child_index)?
+                }
+            }
+            TransparentScope::Internal => account_pubkey
+                .derive_internal_ivk()?
+                .derive_address(child_index)?,
+            TransparentScope::Refund => account_pubkey
+                .derive_ephemeral_ivk()?
+                .derive_ephemeral_address(child_index)?,
         };
 
         Ok(transparent_address)
-    }
-
-    /// Generates a transparent address for the refund scope at the given `address_index`.
-    ///
-    /// Panics if `address_index` has the hardened bit set.
-    pub fn generate_refund_address(
-        &self,
-        address_index: u32,
-    ) -> Result<TransparentAddress, KeyError> {
-        let child_index = NonHardenedChildIndex::from_index(address_index)
-            .expect("hardened bit should not be set for non-hardened child indexes");
-        let account_pubkey = UnifiedFullViewingKey::try_from(self)?
-            .transparent()
-            .ok_or(KeyError::NoViewCapability)?
-            .clone();
-
-        Ok(account_pubkey
-            .derive_ephemeral_ivk()?
-            .derive_ephemeral_address(child_index)?)
     }
 }
 

--- a/zingolib/src/wallet/sync.rs
+++ b/zingolib/src/wallet/sync.rs
@@ -52,6 +52,11 @@ impl SyncWallet for LightWallet {
     ) -> Result<&mut BTreeMap<TransparentAddressId, String>, Self::Error> {
         Ok(&mut self.transparent_addresses)
     }
+
+    fn set_save_flag(&mut self) -> Result<(), Self::Error> {
+        self.save_required = true;
+        Ok(())
+    }
 }
 
 impl SyncBlocks for LightWallet {

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -1150,7 +1150,7 @@ where
             let mut transaction_id_bytes = [0u8; 32];
             r.read_exact(&mut transaction_id_bytes)?;
             let status = match external_version {
-                5.. => ConfirmationStatus::read(r, ()),
+                5.. => ReadableWriteable::read(r, ()),
                 ..5 => {
                     let height = r.read_u32::<LittleEndian>()?;
                     Ok(ConfirmationStatus::Confirmed(BlockHeight::from_u32(height)))

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -1237,7 +1237,7 @@ where
             self.spending_tx_status().as_ref(),
             |w, &(transaction_id, status)| {
                 w.write_all(transaction_id.as_ref())?;
-                status.write(w, ())
+                ReadableWriteable::write(&status, w, ())
             },
         )?;
 


### PR DESCRIPTION
this PR solves the following issues with the current save method:
- cannot be triggered from the LightWallet i.e. during sync
- stores the entire wallet bytes in memory all the time so it takes up almost twice as much memory which has become a concern for zingo-mobile recently
- convoluted with conditional compilation for specific OSs instead of letting the consumer handle persistance
- there was no way to know if we are saving when the wallet state hasnt changed which is inefficient

The new save method works by setting a `save_required` flag in LightWallet anytime the wallet state changes. Then, calling LightWallet's `save` method which checks this flag and returns the wallet bytes if save is required. LightClient has a new `save_task` method which is the automated save task implementation used by zingo-cli and added to the commands.rs interface. Zingo-mobile will run a similar task natively.