### PR TITLE
Fix incomplete tree bug

### DIFF
--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -4,7 +4,11 @@ use zingolib::{
     config::{construct_lightwalletd_uri, load_clientconfig, DEFAULT_LIGHTWALLETD_SERVER},
     get_base_address_macro,
     lightclient::LightClient,
-    testutils::{increase_server_height, lightclient::from_inputs, scenarios},
+    testutils::{
+        increase_height_and_wait_for_client, increase_server_height,
+        lightclient::from_inputs::{self, quick_send},
+        scenarios,
+    },
     wallet::{LightWallet, WalletBase},
 };
 
@@ -118,4 +122,24 @@ async fn sync_test() {
     // dbg!(&wallet.nullifier_map);
     // dbg!(&wallet.outpoint_map);
     // dbg!(&wallet.sync_state);
+}
+
+#[ignore = "sync and zingo 2.0 dev temp test"]
+#[tokio::test]
+async fn initial_frontier_test() {
+    let (regtest_manager, _cph, faucet, mut recipient, _txid) =
+        scenarios::faucet_funded_recipient_default(100_000).await;
+
+    increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 3)
+        .await
+        .unwrap();
+    // println!("{}", recipient.do_balance().await);
+    // println!("{}", recipient.transaction_summaries().await);
+    println!("{:#?}", recipient.wallet.lock().await.shard_trees.orchard);
+    quick_send(
+        &recipient,
+        vec![(&get_base_address_macro!(&faucet, "unified"), 50_000, None)],
+    )
+    .await
+    .unwrap();
 }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1,11 +1,13 @@
 //! Entrypoint for sync engine
 
+use std::cmp;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{self, AtomicBool, AtomicU8};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use error::MempoolError;
+use incrementalmerkletree::{Marking, Retention};
 use tokio::sync::{mpsc, Mutex};
 
 use shardtree::store::ShardStore;
@@ -132,6 +134,13 @@ where
     .await;
 
     update_subtree_roots(
+        consensus_parameters,
+        fetch_request_sender.clone(),
+        &mut *wallet_guard,
+    )
+    .await;
+
+    add_initial_frontier(
         consensus_parameters,
         fetch_request_sender.clone(),
         &mut *wallet_guard,
@@ -729,6 +738,74 @@ async fn update_subtree_roots<W>(
     let shard_trees = wallet.get_shard_trees_mut().unwrap();
     witness::add_subtree_roots(sapling_subtree_roots, &mut shard_trees.sapling);
     witness::add_subtree_roots(orchard_subtree_roots, &mut shard_trees.orchard);
+}
+
+async fn add_initial_frontier<W>(
+    consensus_parameters: &impl consensus::Parameters,
+    fetch_request_sender: mpsc::UnboundedSender<FetchRequest>,
+    wallet: &mut W,
+) where
+    W: SyncWallet + SyncShardTrees,
+{
+    let birthday = checked_birthday(consensus_parameters, wallet);
+    if birthday
+        == consensus_parameters
+            .activation_height(consensus::NetworkUpgrade::Sapling)
+            .expect("sapling activation height should always return Some")
+    {
+        return;
+    }
+
+    // if the shard store only contains the first checkpoint added on initialisation, add frontiers to complete the
+    // shard trees.
+    let shard_trees = wallet.get_shard_trees_mut().unwrap();
+    if shard_trees
+        .sapling
+        .store()
+        .checkpoint_count()
+        .expect("infalliable")
+        == 1
+    {
+        let frontiers = client::get_frontiers(fetch_request_sender, birthday)
+            .await
+            .unwrap();
+        shard_trees
+            .sapling
+            .insert_frontier(
+                frontiers.final_sapling_tree().clone(),
+                Retention::Checkpoint {
+                    id: birthday,
+                    marking: Marking::None,
+                },
+            )
+            .unwrap();
+        shard_trees
+            .orchard
+            .insert_frontier(
+                frontiers.final_orchard_tree().clone(),
+                Retention::Checkpoint {
+                    id: birthday,
+                    marking: Marking::None,
+                },
+            )
+            .unwrap();
+    }
+}
+
+/// Compares the wallet birthday to sapling activation height and returns the highest block height.
+fn checked_birthday<W: SyncWallet>(
+    consensus_parameters: &impl consensus::Parameters,
+    wallet: &W,
+) -> BlockHeight {
+    let wallet_birthday = wallet.get_birthday().unwrap();
+    let sapling_activation_height = consensus_parameters
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .expect("sapling activation height should always return Some");
+
+    match wallet_birthday.cmp(&sapling_activation_height) {
+        cmp::Ordering::Greater | cmp::Ordering::Equal => wallet_birthday,
+        cmp::Ordering::Less => sapling_activation_height,
+    }
 }
 
 /// Sets up mempool stream.

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -26,7 +26,7 @@ use crate::{
     wallet::{Locator, SyncState, TreeBounds, WalletTransaction},
 };
 
-use super::VERIFY_BLOCK_RANGE_SIZE;
+use super::{checked_birthday, VERIFY_BLOCK_RANGE_SIZE};
 
 /// Used to determine which end of the scan range is verified.
 pub(super) enum VerifyEnd {
@@ -37,27 +37,18 @@ pub(super) enum VerifyEnd {
 /// Returns the last known chain height stored in the wallet.
 ///
 /// If no chain height is yet known, returns the highest value of the wallet birthday or sapling activation height.
-pub(super) fn get_wallet_height<P, W>(
-    consensus_parameters: &P,
+pub(super) fn get_wallet_height<W>(
+    consensus_parameters: &impl consensus::Parameters,
     wallet: &W,
 ) -> Result<BlockHeight, ()>
 where
-    P: consensus::Parameters,
     W: SyncWallet,
 {
     let wallet_height = if let Some(height) = wallet.get_sync_state().unwrap().wallet_height() {
         height
     } else {
-        let wallet_birthday = wallet.get_birthday().unwrap();
-        let sapling_activation_height = consensus_parameters
-            .activation_height(consensus::NetworkUpgrade::Sapling)
-            .expect("sapling activation height should always return Some");
-
-        let highest = match wallet_birthday.cmp(&sapling_activation_height) {
-            cmp::Ordering::Greater | cmp::Ordering::Equal => wallet_birthday,
-            cmp::Ordering::Less => sapling_activation_height,
-        };
-        highest - 1
+        let birthday = checked_birthday(consensus_parameters, wallet);
+        birthday - 1
     };
 
     Ok(wallet_height)

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -65,6 +65,7 @@ pub struct PoolBalances {
     pub transparent_balance: Option<u64>,
 }
 
+// TODO: underscore every 3 digits instead of 4
 fn format_option_zatoshis(ioz: &Option<u64>) -> String {
     ioz.map(|ioz_num| {
         if ioz_num == 0 {


### PR DESCRIPTION
adds frontiers to new wallets to complete the tree for witness construction

can be tested by running the ignored "initial_frontier_test". it will fail if the new "add_initial_frontiers" fn is commented out and pass when uncommented