### PR TITLE
Fix bad anchor bug

### DIFF
--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -5,7 +5,7 @@ use zingolib::{
     get_base_address_macro,
     lightclient::LightClient,
     testutils::{
-        increase_height_and_wait_for_client, increase_server_height,
+        increase_server_height,
         lightclient::from_inputs::{self, quick_send},
         scenarios,
     },
@@ -127,7 +127,7 @@ async fn sync_test() {
 #[ignore = "sync and zingo 2.0 dev temp test"]
 #[tokio::test]
 async fn initial_frontier_test() {
-    let (regtest_manager, _cph, mut faucet, mut recipient, _txid) =
+    let (_regtest_manager, _cph, faucet, recipient, _txid) =
         scenarios::faucet_funded_recipient_default(100_000).await;
 
     // increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 3)

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -127,19 +127,33 @@ async fn sync_test() {
 #[ignore = "sync and zingo 2.0 dev temp test"]
 #[tokio::test]
 async fn initial_frontier_test() {
-    let (regtest_manager, _cph, faucet, mut recipient, _txid) =
+    let (regtest_manager, _cph, mut faucet, mut recipient, _txid) =
         scenarios::faucet_funded_recipient_default(100_000).await;
 
-    increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 3)
-        .await
-        .unwrap();
+    // increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 3)
+    //     .await
+    //     .unwrap();
     // println!("{}", recipient.do_balance().await);
     // println!("{}", recipient.transaction_summaries().await);
-    println!("{:#?}", recipient.wallet.lock().await.shard_trees.orchard);
+    // println!("{:#?}", recipient.wallet.lock().await.shard_trees.sapling);
+    // println!("{:#?}", recipient.wallet.lock().await.shard_trees.orchard);
     quick_send(
         &recipient,
-        vec![(&get_base_address_macro!(&faucet, "unified"), 50_000, None)],
+        vec![(&get_base_address_macro!(&faucet, "sapling"), 50_000, None)],
     )
     .await
     .unwrap();
+    // increase_height_and_wait_for_client(&regtest_manager, &mut faucet, 3)
+    //     .await
+    //     .unwrap();
+    // quick_send(
+    //     &faucet,
+    //     vec![(
+    //         &get_base_address_macro!(&recipient, "sapling"),
+    //         100_000,
+    //         None,
+    //     )],
+    // )
+    // .await
+    // .unwrap();
 }

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -319,9 +319,9 @@ fn calculate_sapling_leaves_and_retentions<D: Domain>(
                     last_outputs_in_block && output_index == last_output_index;
                 let decrypted: bool = incoming_output_indexes.contains(&(output_index as u16));
                 let retention = match (decrypted, last_output_in_block) {
-                    (is_marked, true) => Retention::Checkpoint {
+                    (decrypted, true) => Retention::Checkpoint {
                         id: block_height,
-                        marking: if is_marked {
+                        marking: if decrypted {
                             Marking::Marked
                         } else {
                             Marking::None

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -455,7 +455,7 @@ where
 {
     match scan_results {
         Ok(results) => {
-            update_wallet_data(consensus_parameters, wallet, results).unwrap();
+            update_wallet_data(consensus_parameters, wallet, &scan_range, results).unwrap();
             spend::update_transparent_spends(wallet).unwrap();
             spend::update_shielded_spends(
                 consensus_parameters,
@@ -578,6 +578,7 @@ where
 fn update_wallet_data<W>(
     consensus_parameters: &impl consensus::Parameters,
     wallet: &mut W,
+    scan_range: &ScanRange,
     scan_results: ScanResults,
 ) -> Result<(), ()>
 where
@@ -593,6 +594,9 @@ where
     } = scan_results;
 
     let sync_state = wallet.get_sync_state_mut().unwrap();
+    let wallet_height = sync_state
+        .wallet_height()
+        .expect("scan ranges should not be empty in this scope");
     for transaction in wallet_transactions.values() {
         state::update_found_note_shard_priority(
             consensus_parameters,
@@ -615,7 +619,12 @@ where
     wallet.append_nullifiers(nullifiers).unwrap();
     wallet.append_outpoints(&mut outpoints).unwrap();
     wallet
-        .update_shard_trees(sapling_located_trees, orchard_located_trees)
+        .update_shard_trees(
+            scan_range,
+            wallet_height,
+            sapling_located_trees,
+            orchard_located_trees,
+        )
         .unwrap();
 
     Ok(())

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -259,14 +259,13 @@ pub trait SyncShardTrees: SyncWallet {
 
     /// Removes all shard tree data above the given `block_height`.
     fn truncate_shard_trees(&mut self, truncate_height: BlockHeight) -> Result<(), Self::Error> {
-        // TODO: investigate resetting the shard completely when truncate height is 0
         if !self
             .get_shard_trees_mut()?
             .sapling
             .truncate_to_checkpoint(&truncate_height)
             .unwrap()
         {
-            panic!("max checkpoints should always be higher than verification window!");
+            panic!("max checkpoints should always be higher or equal to max verification window!");
         }
         if !self
             .get_shard_trees_mut()?
@@ -274,7 +273,7 @@ pub trait SyncShardTrees: SyncWallet {
             .truncate_to_checkpoint(&truncate_height)
             .unwrap()
         {
-            panic!("max checkpoints should always be higher than verification window!");
+            panic!("max checkpoints should always be higher or equal to max verification window!");
         }
 
         Ok(())

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -1,15 +1,18 @@
 //! Traits for interfacing a wallet with the sync engine
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Debug;
 
 use orchard::tree::MerkleHashOrchard;
+use shardtree::store::{Checkpoint, ShardStore};
+use zcash_client_backend::data_api::scanning::ScanRange;
 use zcash_client_backend::keys::UnifiedFullViewingKey;
 use zcash_primitives::consensus::BlockHeight;
 use zcash_primitives::transaction::TxId;
 use zcash_primitives::zip32::AccountId;
 
 use crate::keys::transparent::TransparentAddressId;
+use crate::sync::MAX_VERIFICATION_WINDOW;
 use crate::wallet::{
     Locator, NullifierMap, OutputId, ShardTrees, SyncState, WalletBlock, WalletTransaction,
 };
@@ -236,10 +239,101 @@ pub trait SyncShardTrees: SyncWallet {
     /// Update wallet shard trees with new shard tree data
     fn update_shard_trees(
         &mut self,
+        scan_range: &ScanRange,
+        wallet_height: BlockHeight,
         sapling_located_trees: Vec<LocatedTreeData<sapling_crypto::Node>>,
         orchard_located_trees: Vec<LocatedTreeData<MerkleHashOrchard>>,
     ) -> Result<(), Self::Error> {
         let shard_trees = self.get_shard_trees_mut()?;
+
+        // limit the range that checkpoints are manually added to the top MAX_VERIFICATION_WINDOW blocks for efficiency.
+        // As we sync the chain tip first and have spend-before-sync, we will always choose anchors very close to chain
+        // height and we will also never need to truncate to checkpoints lower than this height.
+        let checkpoint_range = match (
+            scan_range.block_range().start > wallet_height - MAX_VERIFICATION_WINDOW,
+            scan_range.block_range().end - 1 > wallet_height - MAX_VERIFICATION_WINDOW,
+        ) {
+            (true, _) => scan_range.block_range().clone(),
+            (false, true) => {
+                (wallet_height - MAX_VERIFICATION_WINDOW)..scan_range.block_range().end
+            }
+            (false, false) => BlockHeight::from_u32(0)..BlockHeight::from_u32(0),
+        };
+
+        // in the case that sapling and/or orchard note commitments are not in an entire block there will be no retention
+        // at that height. Therefore, to prevent anchor and truncate errors, checkpoints are manually added first and
+        // copy the tree state from the previous checkpoint where the commitment tree has not changed as of that block.
+        for checkpoint_height in u32::from(checkpoint_range.start)..u32::from(checkpoint_range.end)
+        {
+            let checkpoint_height = BlockHeight::from_u32(checkpoint_height);
+            let checkpoint = sapling_located_trees
+                .iter()
+                .flat_map(|tree| tree.checkpoints.iter())
+                .find(|(height, _)| **height == checkpoint_height)
+                .map_or_else(
+                    || {
+                        let mut next_checkpoint_below = None;
+                        shard_trees
+                            .sapling
+                            .store()
+                            .for_each_checkpoint(100, |height, checkpoint| {
+                                if *height < checkpoint_height {
+                                    next_checkpoint_below = Some(checkpoint.clone());
+                                }
+                                Ok(())
+                            })
+                            .expect("infallible");
+
+                        Checkpoint::from_parts(
+                            next_checkpoint_below
+                                .expect("should always have a checkpoint below")
+                                .tree_state(),
+                            BTreeSet::new(),
+                        )
+                    },
+                    |(_, position)| Checkpoint::at_position(*position),
+                );
+
+            shard_trees
+                .sapling
+                .store_mut()
+                .add_checkpoint(checkpoint_height, checkpoint)
+                .expect("infallible");
+
+            let checkpoint = orchard_located_trees
+                .iter()
+                .flat_map(|tree| tree.checkpoints.iter())
+                .find(|(height, _)| **height == checkpoint_height)
+                .map_or_else(
+                    || {
+                        let mut next_checkpoint_below = None;
+                        shard_trees
+                            .orchard
+                            .store()
+                            .for_each_checkpoint(100, |height, checkpoint| {
+                                if *height < checkpoint_height {
+                                    next_checkpoint_below = Some(checkpoint.clone());
+                                }
+                                Ok(())
+                            })
+                            .expect("infallible");
+
+                        Checkpoint::from_parts(
+                            next_checkpoint_below
+                                .expect("should always have a checkpoint below")
+                                .tree_state(),
+                            BTreeSet::new(),
+                        )
+                    },
+                    |(_, position)| Checkpoint::at_position(*position),
+                );
+
+            shard_trees
+                .orchard
+                .store_mut()
+                .add_checkpoint(checkpoint_height, checkpoint)
+                .expect("infallible");
+        }
 
         for tree in sapling_located_trees.into_iter() {
             shard_trees

--- a/pepper-sync/src/witness.rs
+++ b/pepper-sync/src/witness.rs
@@ -14,6 +14,7 @@ pub(crate) const SHARD_HEIGHT: u8 = 16;
 const LOCATED_TREE_SIZE: usize = MAX_BATCH_OUTPUTS / 16;
 
 /// Required data for updating [`shardtree::ShardTree`]
+#[derive(Debug)]
 pub(crate) struct WitnessData {
     pub(crate) sapling_initial_position: Position,
     pub(crate) orchard_initial_position: Position,
@@ -37,6 +38,7 @@ impl WitnessData {
 }
 
 /// Located prunable tree data built from nodes and retentions during scanning for insertion into the shard store.
+#[derive(Debug)]
 pub struct LocatedTreeData<H> {
     /// Located prunable tree
     pub(crate) subtree: LocatedPrunableTree<H>,

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -377,7 +377,6 @@ impl LightWallet {
     ///
     /// Intended to be called from a save task which calls `save` in a loop, awaiting the wallet lock and checking
     /// `self.save_required` status, writing the returned wallet bytes to persistance.
-    // FIXME: zingo-cli needs a save task
     pub async fn save(&mut self) -> std::io::Result<Option<Vec<u8>>> {
         if self.save_required {
             let network = self.network;


### PR DESCRIPTION
the shardtree `insert trees` method does not guarantee every block has a checkpoint for each shielded protocol. this may result in send errors where LRZ send requires an anchor for both orchard and sapling at the same height and one may not exist. This PR fixes this by manually enforcing the top 100 blocks to all have checkpoints for all shielded protocols