### PR TITLE
Fix value transfers

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -475,7 +475,7 @@ mod fast {
         let mut recipient = environment.create_client();
 
         environment.bump_chain().await;
-        faucet.sync_and_await(true).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
 
         check_client_balances!(faucet, o: 0 s: 2_500_000_000u64 t: 0u64);
 
@@ -498,7 +498,7 @@ mod fast {
         .unwrap();
 
         environment.bump_chain().await;
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
 
         let no_messages = &recipient.messages_containing(None).await;
 
@@ -523,7 +523,7 @@ mod fast {
         .unwrap();
 
         environment.bump_chain().await;
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
 
         let single_message = &recipient.messages_containing(None).await;
 
@@ -702,7 +702,7 @@ mod fast {
         let mut recipient = environment.create_client();
 
         environment.bump_chain().await;
-        faucet.sync_and_await(true).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
 
         check_client_balances!(faucet, o: 0 s: 2_500_000_000u64 t: 0u64);
 
@@ -735,7 +735,7 @@ mod fast {
         .unwrap();
 
         environment.bump_chain().await;
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
 
         let value_transfers = &recipient.sorted_value_transfers(true).await;
         let value_transfers1 = &recipient.sorted_value_transfers(true).await;
@@ -830,7 +830,7 @@ mod fast {
         .await
         .unwrap();
 
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
 
         let transactions = &recipient.transaction_summaries().await.0;
         transactions.iter().for_each(|tx| {
@@ -1708,7 +1708,7 @@ mod slow {
         )
         .await
         .unwrap();
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
 
         // 3. Test the list
         let transaction = recipient
@@ -2236,7 +2236,7 @@ mod slow {
         let faucet_to_recipient_amount = 20_000u64;
         let recipient_to_faucet_amount = 5_000u64;
         // check start state
-        faucet.sync_and_await(true).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
         let wallet_fully_scanned_height = faucet
             .wallet
             .lock()
@@ -2270,7 +2270,7 @@ mod slow {
         )
         .await
         .unwrap();
-        faucet.sync_and_await(true).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
         let faucet_orch = three_blocks_reward + orch_change + u64::from(MINIMUM_FEE);
 
         println!(
@@ -2299,7 +2299,7 @@ mod slow {
         zingolib::testutils::increase_height_and_wait_for_client(&regtest_manager, &mut faucet, 1)
             .await
             .unwrap();
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
 
         let faucet_final_orch = faucet_orch
             + recipient_to_faucet_amount
@@ -2479,7 +2479,7 @@ mod slow {
         )
         .await
         .unwrap();
-        faucet.sync_and_await(true).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
         from_inputs::quick_send(
             &faucet,
             vec![
@@ -3723,7 +3723,7 @@ mod slow {
         )
         .await
         .unwrap();
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
         {
             let recipient_wallet = recipient.wallet.lock().await;
             let sapling_notes = recipient_wallet.wallet_outputs::<OrchardNote>();
@@ -3812,8 +3812,8 @@ mod basic_transactions {
             .await
             .unwrap();
 
-        recipient.sync_and_await(true).await.unwrap();
-        faucet.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
 
         for _ in 0..2 {
             from_inputs::quick_send(&faucet, vec![(recipient_addr_ua.as_str(), 40_000, None)])
@@ -3825,8 +3825,8 @@ mod basic_transactions {
             .await
             .unwrap();
 
-        recipient.sync_and_await(true).await.unwrap();
-        faucet.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
 
         from_inputs::quick_send(&recipient, vec![(faucet_addr_ua.as_str(), 50_000, None)])
             .await
@@ -3836,8 +3836,8 @@ mod basic_transactions {
             .await
             .unwrap();
 
-        recipient.sync_and_await(true).await.unwrap();
-        faucet.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
     }
 
     // FIXME: zingo2 rewrite action / inputs / outputs counting using new interface
@@ -4292,7 +4292,7 @@ mod send_all {
         increase_height_and_wait_for_client(&regtest_manager, &mut faucet, 1)
             .await
             .unwrap();
-        recipient.sync_and_await(true).await.unwrap();
+        recipient.sync_and_await(false).await.unwrap();
 
         recipient
             .propose_send_all(
@@ -4309,7 +4309,7 @@ mod send_all {
         increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 1)
             .await
             .unwrap();
-        faucet.sync_and_await(true).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
 
         assert_eq!(
             recipient

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -41,7 +41,7 @@ async fn sync_mainnet_test() {
     )
     .unwrap();
 
-    lightclient.sync_and_await(true).await.unwrap();
+    lightclient.sync_and_await(false).await.unwrap();
 
     let wallet = lightclient.wallet.lock().await;
     // dbg!(&wallet.wallet_blocks);
@@ -78,7 +78,7 @@ async fn sync_status() {
     )
     .unwrap();
 
-    lightclient.sync_and_await(true).await.unwrap();
+    lightclient.sync_and_await(false).await.unwrap();
 }
 
 // temporary test for sync development
@@ -93,7 +93,7 @@ async fn sync_test() {
     from_inputs::quick_send(
         &recipient,
         vec![(
-            &get_base_address_macro!(&faucet, "unified"),
+            &get_base_address_macro!(&recipient, "unified"),
             100_000,
             None,
             // Some("send to self test"),

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -85,35 +85,28 @@ async fn sync_test() {
 
     let (regtest_manager, _cph, faucet, mut recipient, _txid) =
         scenarios::faucet_funded_recipient_default(5_000_000).await;
+
+    {
+        let wallet = recipient.wallet.lock().await;
+        dbg!(&wallet.shard_trees);
+    }
+
     from_inputs::quick_send(
-        &faucet,
+        &recipient,
         vec![(
-            &get_base_address_macro!(&recipient, "transparent"),
+            &get_base_address_macro!(&recipient, "unified"),
             100_000,
-            None,
+            Some("send to self test"),
         )],
     )
     .await
     .unwrap();
-    // from_inputs::quick_send(
-    //     &recipient,
-    //     vec![(
-    //         &get_base_address_macro!(&faucet, "unified"),
-    //         100_000,
-    //         Some("Outgoing decrypt test"),
-    //     )],
-    // )
-    // .await
-    // .unwrap();
 
     increase_server_height(&regtest_manager, 1).await;
-    recipient.sync_and_await(true).await.unwrap();
-    recipient.quick_shield().await.unwrap();
-    increase_server_height(&regtest_manager, 1).await;
-    recipient.sync_and_await(true).await.unwrap();
+    recipient.sync_and_await(false).await.unwrap();
 
-    // let wallet = recipient.wallet.lock().await;
-    // dbg!(&wallet.wallet_transactions);
+    let wallet = recipient.wallet.lock().await;
+    dbg!(&wallet.wallet_transactions);
     // dbg!(&wallet.wallet_blocks);
     // dbg!(&wallet.nullifier_map);
     // dbg!(&wallet.outpoint_map);

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -5,8 +5,8 @@ use zingolib::{
     get_base_address_macro,
     lightclient::LightClient,
     testutils::{
-        increase_height_and_wait_for_client, increase_server_height,
-        lightclient::from_inputs::{self, quick_send},
+        increase_height_and_wait_for_client,
+        lightclient::from_inputs::{self},
         scenarios,
     },
     wallet::{LightWallet, WalletBase},
@@ -90,63 +90,28 @@ async fn sync_test() {
     let (regtest_manager, _cph, faucet, mut recipient, _txid) =
         scenarios::faucet_funded_recipient_default(5_000_000).await;
 
-    {
-        let wallet = recipient.wallet.lock().await;
-        dbg!(&wallet.shard_trees);
-    }
-
     from_inputs::quick_send(
         &recipient,
         vec![(
-            &get_base_address_macro!(&recipient, "unified"),
+            &get_base_address_macro!(&faucet, "unified"),
             100_000,
-            Some("send to self test"),
+            None,
+            // Some("send to self test"),
         )],
     )
     .await
     .unwrap();
 
-    increase_server_height(&regtest_manager, 1).await;
-    recipient.sync_and_await(false).await.unwrap();
+    increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 1)
+        .await
+        .unwrap();
 
-    let wallet = recipient.wallet.lock().await;
-    dbg!(&wallet.wallet_transactions);
+    println!("{}", recipient.transaction_summaries().await);
+    println!("{}", recipient.value_transfers().await);
+    // let wallet = recipient.wallet.lock().await;
+    // dbg!(&wallet.wallet_transactions);
     // dbg!(&wallet.wallet_blocks);
     // dbg!(&wallet.nullifier_map);
     // dbg!(&wallet.outpoint_map);
     // dbg!(&wallet.sync_state);
-}
-
-#[ignore = "sync and zingo 2.0 dev temp test"]
-#[tokio::test]
-async fn initial_frontier_test() {
-    let (regtest_manager, _cph, mut faucet, mut recipient, _txid) =
-        scenarios::faucet_funded_recipient_default(100_000).await;
-
-    // increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 3)
-    //     .await
-    //     .unwrap();
-    // println!("{}", recipient.do_balance().await);
-    // println!("{}", recipient.transaction_summaries().await);
-    // println!("{:#?}", recipient.wallet.lock().await.shard_trees.sapling);
-    // println!("{:#?}", recipient.wallet.lock().await.shard_trees.orchard);
-    quick_send(
-        &recipient,
-        vec![(&get_base_address_macro!(&faucet, "sapling"), 50_000, None)],
-    )
-    .await
-    .unwrap();
-    // increase_height_and_wait_for_client(&regtest_manager, &mut faucet, 3)
-    //     .await
-    //     .unwrap();
-    // quick_send(
-    //     &faucet,
-    //     vec![(
-    //         &get_base_address_macro!(&recipient, "sapling"),
-    //         100_000,
-    //         None,
-    //     )],
-    // )
-    // .await
-    // .unwrap();
 }

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -87,7 +87,7 @@ async fn sync_status() {
 async fn sync_test() {
     tracing_subscriber::fmt().init();
 
-    let (regtest_manager, _cph, faucet, mut recipient, _txid) =
+    let (regtest_manager, _cph, _faucet, mut recipient, _txid) =
         scenarios::faucet_funded_recipient_default(5_000_000).await;
 
     from_inputs::quick_send(

--- a/pepper-sync/src/keys.rs
+++ b/pepper-sync/src/keys.rs
@@ -10,10 +10,13 @@ use orchard::{
 use sapling_crypto::{
     self as sapling, note_encryption::SaplingDomain, NullifierDerivingKey, SaplingIvk,
 };
-use zcash_keys::keys::UnifiedFullViewingKey;
+use zcash_address::ZcashAddress;
+use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
 use zcash_note_encryption::Domain;
 use zcash_primitives::consensus;
 use zip32::Scope;
+
+pub mod transparent;
 
 /// Child index for the `address_index` path level in the BIP44 hierarchy.
 pub type AddressIndex = u32;
@@ -26,8 +29,6 @@ pub struct KeyId {
     /// Scope
     pub scope: Scope,
 }
-
-pub mod transparent;
 
 impl KeyId {
     pub(crate) fn from_parts(account_id: zcash_primitives::zip32::AccountId, scope: Scope) -> Self {
@@ -200,4 +201,46 @@ pub(crate) fn encode_orchard_receiver(
         .unwrap(),
         &parameters.network_type(),
     ))
+}
+
+/// Decode string to unified address.
+// TODO: surely there is a more straightforward way to decode unified address from string
+// TODO: return custom error type
+pub fn decode_unified_address(
+    consensus_parameters: &impl consensus::Parameters,
+    encoded_address: &str,
+) -> std::io::Result<UnifiedAddress> {
+    struct UnifiedAddressConverter(zcash_address::unified::Address);
+
+    impl zcash_address::TryFromRawAddress for UnifiedAddressConverter {
+        type Error = std::convert::Infallible;
+
+        fn try_from_raw_unified(
+            ua: zcash_address::unified::Address,
+        ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
+            Ok(UnifiedAddressConverter(ua))
+        }
+    }
+
+    let unified_address = ZcashAddress::try_from_encoded(encoded_address)
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to decode unified address. {e}"),
+            )
+        })?
+        .convert_if_network::<UnifiedAddressConverter>(consensus_parameters.network_type())
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to decode unified address. {e}"),
+            )
+        })?
+        .0;
+    zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("failed to decode unified address. {e}"),
+        )
+    })
 }

--- a/pepper-sync/src/keys.rs
+++ b/pepper-sync/src/keys.rs
@@ -204,43 +204,40 @@ pub(crate) fn encode_orchard_receiver(
 }
 
 /// Decode string to unified address.
-// TODO: surely there is a more straightforward way to decode unified address from string
 // TODO: return custom error type
 pub fn decode_unified_address(
     consensus_parameters: &impl consensus::Parameters,
     encoded_address: &str,
 ) -> std::io::Result<UnifiedAddress> {
-    struct UnifiedAddressConverter(zcash_address::unified::Address);
-
-    impl zcash_address::TryFromRawAddress for UnifiedAddressConverter {
-        type Error = std::convert::Infallible;
-
-        fn try_from_raw_unified(
-            ua: zcash_address::unified::Address,
-        ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
-            Ok(UnifiedAddressConverter(ua))
-        }
-    }
-
-    let unified_address = ZcashAddress::try_from_encoded(encoded_address)
-        .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to decode unified address. {e}"),
-            )
-        })?
-        .convert_if_network::<UnifiedAddressConverter>(consensus_parameters.network_type())
-        .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to decode unified address. {e}"),
-            )
-        })?
-        .0;
-    zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
-        std::io::Error::new(
+    if let zcash_keys::address::Address::Unified(unified_address) =
+        decode_address(consensus_parameters, encoded_address)?
+    {
+        Ok(unified_address)
+    } else {
+        Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("failed to decode unified address. {e}"),
-        )
-    })
+            format!("failed to decode unified address. incorrect address type."),
+        ))
+    }
+}
+
+/// Decode string to [`zcash_keys::address::Address`] enum.
+pub fn decode_address(
+    consensus_parameters: &impl consensus::Parameters,
+    encoded_address: &str,
+) -> std::io::Result<zcash_keys::address::Address> {
+    ZcashAddress::try_from_encoded(encoded_address)
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to decode unified address. {e}"),
+            )
+        })?
+        .convert_if_network::<zcash_keys::address::Address>(consensus_parameters.network_type())
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to decode unified address. {e}"),
+            )
+        })
 }

--- a/pepper-sync/src/keys.rs
+++ b/pepper-sync/src/keys.rs
@@ -216,7 +216,7 @@ pub fn decode_unified_address(
     } else {
         Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("failed to decode unified address. incorrect address type."),
+            "failed to decode unified address. incorrect address type.".to_string(),
         ))
     }
 }

--- a/pepper-sync/src/scan/transactions.rs
+++ b/pepper-sync/src/scan/transactions.rs
@@ -426,7 +426,7 @@ where
                 key_id: key_ids[key_index],
                 note,
                 memo: Memo::from_bytes(memo_bytes.as_ref()).unwrap(),
-                recipient_unified_address: None,
+                recipient_full_unified_address: None,
             });
         }
     }
@@ -496,7 +496,7 @@ fn add_recipient_unified_address<P, Nz>(
             .iter_mut()
             .filter(|note| ua_receivers.contains(&note.encoded_recipient(parameters)))
             .for_each(|note| {
-                note.recipient_unified_address = Some(ua.clone());
+                note.recipient_full_unified_address = Some(ua.clone());
             });
     }
 }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -6,11 +6,10 @@ use std::sync::atomic::{self, AtomicBool, AtomicU8};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use error::MempoolError;
-use incrementalmerkletree::{Marking, Retention};
-use shardtree::store::ShardStore as _;
 use tokio::sync::{mpsc, Mutex};
 
+use incrementalmerkletree::{Marking, Retention};
+use shardtree::store::ShardStore;
 use zcash_client_backend::proto::service::RawTransaction;
 use zcash_client_backend::ShieldedProtocol;
 use zcash_client_backend::{
@@ -35,9 +34,10 @@ use crate::wallet::traits::{
     SyncBlocks, SyncNullifiers, SyncOutPoints, SyncShardTrees, SyncTransactions, SyncWallet,
 };
 use crate::wallet::{Locator, NullifierMap, SyncMode, SyncResult, SyncState, SyncStatus};
+use error::MempoolError;
 
 #[cfg(not(feature = "darkside_test"))]
-use {crate::witness, shardtree::store::ShardStore};
+use crate::witness;
 
 pub mod error;
 pub(crate) mod spend;

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -600,8 +600,7 @@ impl WalletTransaction {
 
 #[cfg(feature = "wallet_essentials")]
 impl WalletTransaction {
-    /// Returns the total value sent to receivers, including value explicitly sent to the wallet own addresses but
-    /// excluding change.
+    /// Returns the total value sent to receivers, excluding value sent to the wallet's own addresses.
     pub fn total_value_sent(&self) -> u64 {
         let transparent_value_sent = self.transaction.transparent_bundle().map_or(0, |bundle| {
             bundle
@@ -611,9 +610,12 @@ impl WalletTransaction {
                 .sum()
         }) - self.total_output_value::<TransparentCoin>();
 
-        transparent_value_sent
-            + self.total_outgoing_note_value::<OutgoingSaplingNote>()
-            + self.total_outgoing_note_value::<OutgoingOrchardNote>()
+        let sapling_value_sent = self.total_outgoing_note_value::<OutgoingSaplingNote>()
+            - self.total_output_value::<SaplingNote>();
+        let orchard_value_sent = self.total_outgoing_note_value::<OutgoingOrchardNote>()
+            - self.total_output_value::<OrchardNote>();
+
+        transparent_value_sent + sapling_value_sent + orchard_value_sent
     }
 
     /// Returns total sum of all output values.
@@ -948,13 +950,16 @@ pub trait OutgoingNoteInterface: Sized {
     /// Memo.
     fn memo(&self) -> &Memo;
 
+    /// Recipient unified address as given by recipient and recorded in an encoded memo (all original receivers).
+    fn recipient_full_unified_address(&self) -> Option<&UnifiedAddress>;
+
     /// Encoded recipient address recorded in note on chain (single receiver).
     fn encoded_recipient<P>(&self, parameters: &P) -> String
     where
         P: consensus::Parameters + consensus::NetworkConstants;
 
     /// Encoded recipient unified address as given by recipient and recorded in an encoded memo (all original receivers).
-    fn encoded_recipient_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
+    fn encoded_recipient_full_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
     where
         P: consensus::Parameters + consensus::NetworkConstants;
 
@@ -974,7 +979,7 @@ pub struct OutgoingNote<N> {
     /// Memo.
     pub(crate) memo: Memo,
     /// Recipient's full unified address from encoded memo.
-    pub(crate) recipient_unified_address: Option<UnifiedAddress>,
+    pub(crate) recipient_full_unified_address: Option<UnifiedAddress>,
 }
 
 /// Outgoing sapling note.
@@ -1005,6 +1010,10 @@ impl OutgoingNoteInterface for OutgoingSaplingNote {
         &self.memo
     }
 
+    fn recipient_full_unified_address(&self) -> Option<&UnifiedAddress> {
+        self.recipient_full_unified_address.as_ref()
+    }
+
     fn encoded_recipient<P>(&self, consensus_parameters: &P) -> String
     where
         P: consensus::Parameters + consensus::NetworkConstants,
@@ -1015,11 +1024,11 @@ impl OutgoingNoteInterface for OutgoingSaplingNote {
         )
     }
 
-    fn encoded_recipient_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
+    fn encoded_recipient_full_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
     where
         P: consensus::Parameters + consensus::NetworkConstants,
     {
-        self.recipient_unified_address
+        self.recipient_full_unified_address
             .as_ref()
             .map(|unified_address| unified_address.encode(consensus_parameters))
     }
@@ -1057,6 +1066,10 @@ impl OutgoingNoteInterface for OutgoingOrchardNote {
         &self.memo
     }
 
+    fn recipient_full_unified_address(&self) -> Option<&UnifiedAddress> {
+        self.recipient_full_unified_address.as_ref()
+    }
+
     fn encoded_recipient<P>(&self, parameters: &P) -> String
     where
         P: consensus::Parameters + consensus::NetworkConstants,
@@ -1064,11 +1077,11 @@ impl OutgoingNoteInterface for OutgoingOrchardNote {
         keys::encode_orchard_receiver(parameters, &self.note().recipient()).unwrap()
     }
 
-    fn encoded_recipient_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
+    fn encoded_recipient_full_unified_address<P>(&self, consensus_parameters: &P) -> Option<String>
     where
         P: consensus::Parameters + consensus::NetworkConstants,
     {
-        self.recipient_unified_address
+        self.recipient_full_unified_address
             .as_ref()
             .map(|unified_address| unified_address.encode(consensus_parameters))
     }

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -12,7 +12,6 @@ use shardtree::{
     store::{memory::MemoryShardStore, Checkpoint, ShardStore, TreeState},
     LocatedPrunableTree, ShardTree,
 };
-use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::scanning::{ScanPriority, ScanRange},
     serialization::shardtree::{read_shard, write_shard},
@@ -31,6 +30,7 @@ use zingo_status::confirmation_status::ConfirmationStatus;
 
 use crate::{
     keys::{
+        decode_unified_address,
         transparent::{TransparentAddressId, TransparentScope},
         KeyId,
     },
@@ -55,18 +55,6 @@ fn read_string<R: Read>(mut reader: R) -> std::io::Result<String> {
 fn write_string<W: Write>(mut writer: W, str: &str) -> std::io::Result<()> {
     writer.write_u64::<LittleEndian>(str.len() as u64)?;
     writer.write_all(str.as_bytes())
-}
-
-struct UnifiedAddressConverter(zcash_address::unified::Address);
-
-impl zcash_address::TryFromRawAddress for UnifiedAddressConverter {
-    type Error = std::convert::Infallible;
-
-    fn try_from_raw_unified(
-        ua: zcash_address::unified::Address,
-    ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
-        Ok(UnifiedAddressConverter(ua))
-    }
 }
 
 impl SyncState {
@@ -714,24 +702,7 @@ impl OutgoingSaplingNote {
         let recipient_unified_address = Optional::read(&mut reader, |r| {
             let encoded_address = read_string(r)?;
 
-            // TODO: surely there is a more straightforward way to decode unified address from string
-            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
-                .unwrap()
-                .convert_if_network::<UnifiedAddressConverter>(consensus_parameters.network_type())
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("failed to convert recipient unified address. {e}"),
-                    )
-                })?
-                .0;
-
-            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to convert recipient unified address. {e}"),
-                )
-            })
+            decode_unified_address(consensus_parameters, &encoded_address)
         })?;
 
         Ok(Self {
@@ -739,7 +710,7 @@ impl OutgoingSaplingNote {
             key_id: KeyId::from_parts(account_id, scope),
             note: sapling_crypto::Note::from_parts(recipient, value, rseed),
             memo,
-            recipient_unified_address,
+            recipient_full_unified_address: recipient_unified_address,
         })
     }
 
@@ -773,7 +744,7 @@ impl OutgoingSaplingNote {
         writer.write_all(self.memo.encode().as_array())?;
         Optional::write(
             &mut writer,
-            self.recipient_unified_address.as_ref(),
+            self.recipient_full_unified_address.as_ref(),
             |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
         )?;
 
@@ -833,24 +804,7 @@ impl OutgoingOrchardNote {
         let recipient_unified_address = Optional::read(&mut reader, |r| {
             let encoded_address = read_string(r)?;
 
-            // TODO: surely there is a more straightforward way to decode unified address from string
-            let unified_address = ZcashAddress::try_from_encoded(&encoded_address)
-                .unwrap()
-                .convert_if_network::<UnifiedAddressConverter>(consensus_parameters.network_type())
-                .map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("failed to convert recipient unified address. {e}"),
-                    )
-                })?
-                .0;
-
-            zcash_keys::address::UnifiedAddress::try_from(unified_address).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("failed to convert recipient unified address. {e}"),
-                )
-            })
+            decode_unified_address(consensus_parameters, &encoded_address)
         })?;
 
         Ok(Self {
@@ -859,7 +813,7 @@ impl OutgoingOrchardNote {
             note: orchard::note::Note::from_parts(recipient, value, rho, rseed)
                 .expect("should be a valid orchard note"),
             memo,
-            recipient_unified_address,
+            recipient_full_unified_address: recipient_unified_address,
         })
     }
 
@@ -885,7 +839,7 @@ impl OutgoingOrchardNote {
         writer.write_all(self.memo.encode().as_array())?;
         Optional::write(
             &mut writer,
-            self.recipient_unified_address.as_ref(),
+            self.recipient_full_unified_address.as_ref(),
             |w, unified_address| write_string(w, &unified_address.encode(consensus_parameters)),
         )?;
 

--- a/zingolib/src/grpc_connector.rs
+++ b/zingolib/src/grpc_connector.rs
@@ -4,9 +4,10 @@ use std::sync::Arc;
 
 use tonic::Request;
 
-use zcash_client_backend::proto::service::{
-    BlockId, ChainSpec, Empty, LightdInfo, RawTransaction, TreeState,
-};
+use zcash_client_backend::proto::service::{BlockId, ChainSpec, Empty, LightdInfo, RawTransaction};
+
+#[cfg(feature = "test-elevation")]
+use zcash_client_backend::proto::service::TreeState;
 
 pub(crate) use zingo_netutils::GrpcConnector;
 

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -133,7 +133,7 @@ pub mod test {
 
         let mut lc = wallet_case.load_example_wallet_with_client().await;
 
-        let sync_result = lc.sync_and_await(true).await.unwrap();
+        let sync_result = lc.sync_and_await(false).await.unwrap();
         println!("{}", sync_result);
         println!("{:?}", lc.do_balance().await);
         lc

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -237,7 +237,7 @@ pub async fn send_value_between_clients_and_sync(
     .await
     .unwrap();
     increase_height_and_wait_for_client(manager, sender, 1).await?;
-    recipient.sync_and_await(true).await?;
+    recipient.sync_and_await(false).await?;
     Ok(txid.first().to_string())
 }
 
@@ -279,7 +279,7 @@ pub async fn sync_to_target_height(
     target_block_height: u32,
 ) -> Result<(), LightClientError> {
     // sync first so ranges exist for the `fully_scanned_height` call
-    client.sync_and_await(true).await?;
+    client.sync_and_await(false).await?;
     while u32::from(
         client
             .wallet
@@ -291,7 +291,7 @@ pub async fn sync_to_target_height(
     ) < target_block_height
     {
         tokio::time::sleep(Duration::from_millis(500)).await;
-        client.sync_and_await(true).await?;
+        client.sync_and_await(false).await?;
     }
     Ok(())
 }

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -427,7 +427,7 @@ where
     let mut secondary = environment.create_client();
     let tertiary = environment.create_client();
 
-    secondary.sync_and_await(true).await.unwrap();
+    secondary.sync_and_await(false).await.unwrap();
 
     let expected_fee = fee_tables::one_to_one(None, pool, true);
 

--- a/zingolib/src/testutils/chain_generics/with_assertions.rs
+++ b/zingolib/src/testutils/chain_generics/with_assertions.rs
@@ -295,7 +295,7 @@ where
 
     Ok((
         sender_confirmed_fees.iter().sum(),
-        recipients_confirmed_outputs.into_iter().flatten().sum(), // this construction is problematic, because receivers are often duplicates
+        recipients_confirmed_outputs.into_iter().flatten().sum(),
         sender_confirmed_outputs.iter().sum(), // this construction will be problematic when 2-step transactions mean some value is received and respent.
     ))
 }

--- a/zingolib/src/testutils/scenarios.rs
+++ b/zingolib/src/testutils/scenarios.rs
@@ -401,7 +401,7 @@ pub async fn faucet(
     )
     .await;
     let mut faucet = sb.client_builder.build_faucet(false, regtest_network);
-    faucet.sync_and_await(true).await.unwrap();
+    faucet.sync_and_await(false).await.unwrap();
     (
         sb.regtest_manager,
         sb.child_process_handler.unwrap(),
@@ -440,7 +440,7 @@ pub async fn faucet_recipient(
     )
     .await;
     let mut faucet = sb.client_builder.build_faucet(false, regtest_network);
-    faucet.sync_and_await(true).await.unwrap();
+    faucet.sync_and_await(false).await.unwrap();
 
     let recipient = sb.client_builder.build_client(
         HOSPITAL_MUSEUM_SEED.to_string(),
@@ -544,7 +544,7 @@ pub async fn faucet_funded_recipient(
     increase_height_and_wait_for_client(&regtest_manager, &mut recipient, 1)
         .await
         .unwrap();
-    faucet.sync_and_await(true).await.unwrap();
+    faucet.sync_and_await(false).await.unwrap();
     (
         regtest_manager,
         child_process_handler,
@@ -661,7 +661,7 @@ pub async fn funded_orchard_mobileclient(value: u64) -> (RegtestManager, ChildPr
         false,
         regtest_network,
     );
-    faucet.sync_and_await(true).await.unwrap();
+    faucet.sync_and_await(false).await.unwrap();
     super::lightclient::from_inputs::quick_send(
         &faucet,
         vec![(&get_base_address_macro!(recipient, "unified"), value, None)],
@@ -961,7 +961,7 @@ pub mod chainload {
         let mut sb =
             setup::ScenarioBuilder::new_load_1153_saplingcb_regtest_chain(&regtest_network).await;
         let mut faucet = sb.client_builder.build_faucet(false, regtest_network);
-        faucet.sync_and_await(true).await.unwrap();
+        faucet.sync_and_await(false).await.unwrap();
         let recipient = sb.client_builder.build_client(
             HOSPITAL_MUSEUM_SEED.to_string(),
             0,

--- a/zingolib/src/utils.rs
+++ b/zingolib/src/utils.rs
@@ -1,5 +1,12 @@
 //! General library utilities such as parsing and conversions.
 
+use std::path::Path;
+
+use tokio::io::AsyncWriteExt as _;
+
+#[cfg(feature = "test-elevation")]
+use zcash_primitives::consensus::NetworkConstants;
+
 pub mod conversion;
 pub mod error;
 
@@ -32,16 +39,12 @@ macro_rules! build_push_list {
     };
 }
 
-use std::path::Path;
-
 pub(crate) use build_method;
 #[cfg(any(test, feature = "test-elevation"))]
 pub(crate) use build_method_push;
 #[allow(unused_imports)]
 #[cfg(any(test, feature = "test-elevation"))]
 pub(crate) use build_push_list;
-use tokio::io::AsyncWriteExt as _;
-use zcash_primitives::consensus::NetworkConstants;
 
 /// Take a P2PKH taddr and interpret it as a tex addr
 #[cfg(feature = "test-elevation")]

--- a/zingolib/src/wallet/data.rs
+++ b/zingolib/src/wallet/data.rs
@@ -57,8 +57,6 @@ pub mod finsight {
 /// Not to be used for internal logic in the system.
 // TODO: move to summary module and remove unecessary builders and bloat etc.
 pub mod summaries {
-    use std::collections::HashMap;
-
     use chrono::DateTime;
     use json::JsonValue;
     use pepper_sync::keys::KeyId;
@@ -272,72 +270,6 @@ pub mod summaries {
         pub fn new(value_transfers: Vec<ValueTransfer>) -> Self {
             ValueTransfers(value_transfers)
         }
-
-        /// Creates value transfers for all notes in a transaction that are sent to another
-        /// recipient.  A value transfer is a group of all notes to a specific receiver in a transaction.
-        /// The value transfer list is sorted by the output index of the notes.
-        pub fn create_send_value_transfers(
-            transaction_summary: &TransactionSummary,
-        ) -> Vec<ValueTransfer> {
-            let mut value_transfers: Vec<ValueTransfer> = Vec::new();
-            let outgoing_notes = transaction_summary
-                .outgoing_orchard_notes
-                .iter()
-                .chain(transaction_summary.outgoing_sapling_notes.iter())
-                .collect::<Vec<_>>();
-            let mut addresses = HashMap::with_capacity(outgoing_notes.len());
-            outgoing_notes.iter().for_each(|note| {
-                let address = if let Some(ua) = note.recipient_unified_address.clone() {
-                    ua
-                } else {
-                    note.recipient.clone()
-                };
-                // hash map is used to create unique list of addresses as duplicates are not inserted twice
-                addresses.insert(address, note.output_index);
-            });
-            let mut addresses_vec = addresses.into_iter().collect::<Vec<_>>();
-            addresses_vec.sort_by_key(|(_address, output_index)| *output_index);
-            addresses_vec.iter().for_each(|(address, _output_index)| {
-                let outgoing_notes_to_address: Vec<&OutgoingNoteSummary> = outgoing_notes
-                    .iter()
-                    .filter(|&&note| {
-                        let query_address = if let Some(ua) = note.recipient_unified_address.clone()
-                        {
-                            ua
-                        } else {
-                            note.recipient.clone()
-                        };
-                        query_address == *address
-                    })
-                    .cloned()
-                    .collect();
-                let value: u64 = outgoing_notes_to_address
-                    .iter()
-                    .map(|&note| note.value)
-                    .sum();
-                let memos: Vec<String> = outgoing_notes_to_address
-                    .iter()
-                    .filter_map(|&note| note.memo.clone())
-                    .collect();
-                value_transfers.push(
-                    ValueTransferBuilder::new()
-                        .txid(transaction_summary.txid())
-                        .datetime(transaction_summary.datetime())
-                        .status(transaction_summary.status())
-                        .blockheight(transaction_summary.blockheight())
-                        .transaction_fee(transaction_summary.fee())
-                        .zec_price(transaction_summary.zec_price())
-                        .kind(ValueTransferKind::Sent(SentValueTransfer::Send))
-                        .value(value)
-                        .recipient_address(Some(address.clone()))
-                        .pool_received(None)
-                        .memos(memos)
-                        .build()
-                        .expect("all fields should be populated"),
-                );
-            });
-            value_transfers
-        }
     }
 
     impl std::fmt::Display for ValueTransfers {
@@ -473,7 +405,6 @@ pub mod summaries {
         SendToSelf(SelfSendValueTransfer),
     }
     /// There are 4 kinds of self sends (so far)
-    #[non_exhaustive]
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     pub enum SelfSendValueTransfer {
         /// Explicit memo-less value sent to self
@@ -493,7 +424,7 @@ pub mod summaries {
                 ValueTransferKind::Sent(sent) => match sent {
                     SentValueTransfer::Send => write!(f, "sent"),
                     SentValueTransfer::SendToSelf(selfsend) => match selfsend {
-                        SelfSendValueTransfer::Basic => write!(f, "basic"),
+                        SelfSendValueTransfer::Basic => write!(f, "send-to-self"),
                         SelfSendValueTransfer::Shield => write!(f, "shield"),
                         SelfSendValueTransfer::MemoToSelf => write!(f, "memo-to-self"),
                         SelfSendValueTransfer::Rejection => write!(f, "rejection"),
@@ -974,6 +905,7 @@ pub mod summaries {
     /// A struct designed for conveniently displaying information to the user or converting to JSON to pass through an FFI.
     /// A "snapshot" of the state of the output in the wallet at the time the summary was constructed.
     /// Not to be used for internal logic in the system.
+    // TODO: add scope to distinguish "refund" scope value transfers
     #[derive(Clone, PartialEq, Debug)]
     pub struct BasicCoinSummary {
         value: u64,

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -252,42 +252,62 @@ impl LightWallet {
             && transaction.outgoing_sapling_notes().is_empty()
             && transaction.outgoing_orchard_notes().is_empty()
         {
-            // no spends and no outgoing notes
             TransactionKind::Received
         } else if !transparent_spends.is_empty()
             && sapling_spends.is_empty()
             && orchard_spends.is_empty()
             && transaction.outgoing_sapling_notes().is_empty()
             && transaction.outgoing_orchard_notes().is_empty()
-            && (!transaction.orchard_notes().is_empty() | !transaction.sapling_notes().is_empty())
+            && (!transaction.orchard_notes().is_empty() || !transaction.sapling_notes().is_empty())
         {
-            // only transparent spends, no outgoing notes and notes received
-            // TODO: this could be improved by checking outputs recipient addr against the wallet addrs
             TransactionKind::Sent(SendType::Shield)
-        } else if transaction.outgoing_sapling_notes().is_empty()
-            && transaction.outgoing_orchard_notes().is_empty()
-            || (transaction.outgoing_sapling_notes().len() == 1
-                && transaction
-                    .outgoing_sapling_notes()
-                    .iter()
-                    .any(|outgoing_note| {
-                        outgoing_note.encoded_recipient(&self.network) == *zfz_address
-                            || outgoing_note.encoded_recipient_unified_address(&self.network)
-                                == Some(zfz_address.to_string())
-                    }))
-            || (transaction.outgoing_orchard_notes().len() == 1
-                && transaction
-                    .outgoing_orchard_notes()
-                    .iter()
-                    .any(|outgoing_note| {
-                        outgoing_note.encoded_recipient(&self.network) == *zfz_address
-                            || outgoing_note.encoded_recipient_unified_address(&self.network)
-                                == Some(zfz_address.to_string())
-                    }))
+        } else if transaction
+            .transaction()
+            .transparent_bundle()
+            .map_or(true, |bundle| {
+                bundle.vout.len() == transaction.transparent_coins().len()
+            })
+            && transaction
+                .outgoing_sapling_notes()
+                .iter()
+                .all(|outgoing_note| {
+                    if let Some(full_address) = outgoing_note.recipient_full_unified_address() {
+                        self.unified_addresses
+                            .values()
+                            .any(|address| full_address.sapling() == address.sapling())
+                            || outgoing_note
+                                .encoded_recipient_full_unified_address(&self.network)
+                                .expect("should exist in this scope")
+                                == zfz_address.to_string()
+                    } else {
+                        self.unified_addresses.values().any(|address| {
+                            address.sapling().map_or(true, |address| {
+                                outgoing_note.note().recipient() == *address
+                            })
+                        })
+                    }
+                })
+            && transaction
+                .outgoing_orchard_notes()
+                .iter()
+                .all(|outgoing_note| {
+                    if let Some(full_address) = outgoing_note.recipient_full_unified_address() {
+                        self.unified_addresses
+                            .values()
+                            .any(|address| full_address.orchard() == address.orchard())
+                            || outgoing_note
+                                .encoded_recipient_full_unified_address(&self.network)
+                                .expect("should exist in this scope")
+                                == zfz_address.to_string()
+                    } else {
+                        self.unified_addresses.values().any(|address| {
+                            address.orchard().map_or(true, |address| {
+                                outgoing_note.note().recipient() == *address
+                            })
+                        })
+                    }
+                })
         {
-            // not Received, this capability created this transaction
-            // not Shield, notes were spent
-            // no outgoing notes, with the exception of ONLY a Zennies For Zingo! donation
             TransactionKind::Sent(SendType::SendToSelf)
         } else {
             TransactionKind::Sent(SendType::Send)
@@ -378,10 +398,12 @@ impl LightWallet {
     ) {
         let kind = self.transaction_kind(transaction);
         let value = match kind {
-            TransactionKind::Received
-            | TransactionKind::Sent(SendType::Shield)
-            | TransactionKind::Sent(SendType::SendToSelf) => transaction.total_value_received(),
-            TransactionKind::Sent(SendType::Send) => transaction.total_value_sent(),
+            TransactionKind::Received | TransactionKind::Sent(SendType::Shield) => {
+                transaction.total_value_received()
+            }
+            TransactionKind::Sent(SendType::Send) | TransactionKind::Sent(SendType::SendToSelf) => {
+                transaction.total_value_sent()
+            }
         };
         let fee = self.calculate_transaction_fee(transaction).ok();
         let orchard_notes = transaction
@@ -455,7 +477,7 @@ impl LightWallet {
                     value: note.value(),
                     recipient: note.encoded_recipient(&self.network),
                     recipient_unified_address: note
-                        .encoded_recipient_unified_address(&self.network),
+                        .encoded_recipient_full_unified_address(&self.network),
                 }
             })
             .collect::<Vec<_>>();
@@ -476,7 +498,7 @@ impl LightWallet {
                     value: note.value(),
                     recipient: note.encoded_recipient(&self.network),
                     recipient_unified_address: note
-                        .encoded_recipient_unified_address(&self.network),
+                        .encoded_recipient_full_unified_address(&self.network),
                 }
             })
             .collect::<Vec<_>>();

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -308,8 +308,8 @@ impl LightWallet {
                     orchard_notes,
                     sapling_notes,
                     transparent_coins,
-                    outgoing_sapling_notes,
                     outgoing_orchard_notes,
+                    outgoing_sapling_notes,
                 ) = self.basic_transaction_summary_parts(transaction);
 
                 TransactionSummaryBuilder::new()

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -1,5 +1,8 @@
 //! Wallet-State reporters as LightWallet methods.
 use json::JsonValue;
+use pepper_sync::keys::decode_unified_address;
+use pepper_sync::keys::transparent;
+use pepper_sync::keys::transparent::TransparentScope;
 use zcash_address::ZcashAddress;
 use zcash_client_backend::PoolType;
 use zcash_client_backend::ShieldedProtocol;
@@ -20,6 +23,7 @@ use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
 use std::cmp::Ordering;
+use std::collections::HashMap;
 
 use bip0039::Mnemonic;
 
@@ -272,19 +276,15 @@ impl LightWallet {
                 .iter()
                 .all(|outgoing_note| {
                     if let Some(full_address) = outgoing_note.recipient_full_unified_address() {
-                        self.unified_addresses
-                            .values()
-                            .any(|address| full_address.sapling() == address.sapling())
+                        full_address
+                            .sapling()
+                            .map_or(true, |address| self.is_sapling_send_to_self(address))
                             || outgoing_note
                                 .encoded_recipient_full_unified_address(&self.network)
                                 .expect("should exist in this scope")
                                 == zfz_address.to_string()
                     } else {
-                        self.unified_addresses.values().any(|address| {
-                            address.sapling().map_or(true, |address| {
-                                outgoing_note.note().recipient() == *address
-                            })
-                        })
+                        self.is_sapling_send_to_self(&outgoing_note.note().recipient())
                     }
                 })
             && transaction
@@ -292,19 +292,15 @@ impl LightWallet {
                 .iter()
                 .all(|outgoing_note| {
                     if let Some(full_address) = outgoing_note.recipient_full_unified_address() {
-                        self.unified_addresses
-                            .values()
-                            .any(|address| full_address.orchard() == address.orchard())
+                        full_address
+                            .orchard()
+                            .map_or(true, |address| self.is_orchard_send_to_self(address))
                             || outgoing_note
                                 .encoded_recipient_full_unified_address(&self.network)
                                 .expect("should exist in this scope")
                                 == zfz_address.to_string()
                     } else {
-                        self.unified_addresses.values().any(|address| {
-                            address.orchard().map_or(true, |address| {
-                                outgoing_note.note().recipient() == *address
-                            })
-                        })
+                        self.is_orchard_send_to_self(&outgoing_note.note().recipient())
                     }
                 })
         {
@@ -316,6 +312,7 @@ impl LightWallet {
 
     /// Provides a list of transaction summaries related to this wallet in order of blockheight
     // TODO: move to summary
+    // TODO: should have outgoing coins
     pub async fn transaction_summaries(&self) -> TransactionSummaries {
         let mut transaction_summaries = self
             .wallet_transactions
@@ -519,39 +516,44 @@ impl LightWallet {
     // TODO: move to summary
     pub async fn value_transfers(&self) -> ValueTransfers {
         let mut value_transfers: Vec<ValueTransfer> = Vec::new();
-        let summaries = self.transaction_summaries().await;
+        let transaction_summaries = self.transaction_summaries().await.0;
 
-        let transaction_summaries = summaries.iter();
-
-        for tx in transaction_summaries {
-            match tx.kind() {
+        for transaction in transaction_summaries.iter() {
+            match transaction.kind() {
                 TransactionKind::Sent(SendType::Send) => {
                     // create 1 sent value transfer for each non-self recipient address
                     // if recipient_ua is available it overrides recipient_address
-                    value_transfers.append(&mut ValueTransfers::create_send_value_transfers(tx));
+                    value_transfers.append(&mut self.create_send_value_transfers(transaction));
 
                     // create 1 memo-to-self if a sending transaction receives any number of memos
-                    if tx.orchard_notes().iter().any(|note| note.memo().is_some())
-                        || tx.sapling_notes().iter().any(|note| note.memo().is_some())
+                    if transaction
+                        .orchard_notes()
+                        .iter()
+                        .any(|note| note.memo().is_some())
+                        || transaction
+                            .sapling_notes()
+                            .iter()
+                            .any(|note| note.memo().is_some())
                     {
-                        let memos: Vec<String> = tx
+                        let memos: Vec<String> = transaction
                             .orchard_notes()
                             .iter()
                             .filter_map(|note| note.memo().map(|memo| memo.to_string()))
                             .chain(
-                                tx.sapling_notes()
+                                transaction
+                                    .sapling_notes()
                                     .iter()
                                     .filter_map(|note| note.memo().map(|memo| memo.to_string())),
                             )
                             .collect();
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
                                     SelfSendValueTransfer::MemoToSelf,
                                 )))
@@ -566,22 +568,25 @@ impl LightWallet {
                 }
                 TransactionKind::Sent(SendType::Shield) => {
                     // create 1 shielding value transfer for each pool shielded to
-                    if !tx.orchard_notes().is_empty() {
-                        let value: u64 =
-                            tx.orchard_notes().iter().map(|output| output.value()).sum();
-                        let memos: Vec<String> = tx
+                    if !transaction.orchard_notes().is_empty() {
+                        let value: u64 = transaction
+                            .orchard_notes()
+                            .iter()
+                            .map(|output| output.value())
+                            .sum();
+                        let memos: Vec<String> = transaction
                             .orchard_notes()
                             .iter()
                             .filter_map(|note| note.memo().map(|memo| memo.to_string()))
                             .collect();
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
                                     SelfSendValueTransfer::Shield,
                                 )))
@@ -595,22 +600,25 @@ impl LightWallet {
                                 .expect("all fields should be populated"),
                         );
                     }
-                    if !tx.sapling_notes().is_empty() {
-                        let value: u64 =
-                            tx.sapling_notes().iter().map(|output| output.value()).sum();
-                        let memos: Vec<String> = tx
+                    if !transaction.sapling_notes().is_empty() {
+                        let value: u64 = transaction
+                            .sapling_notes()
+                            .iter()
+                            .map(|output| output.value())
+                            .sum();
+                        let memos: Vec<String> = transaction
                             .sapling_notes()
                             .iter()
                             .filter_map(|note| note.memo().map(|memo| memo.to_string()))
                             .collect();
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
                                     SelfSendValueTransfer::Shield,
                                 )))
@@ -629,27 +637,34 @@ impl LightWallet {
                     // create 1 memo-to-self if a sending transaction receives any number of memos
                     // otherwise, create 1 send-to-self value transfer so every transaction creates at least 1 value transfer
                     // eventually we may replace send-to-self with a range of kinds such as deshield and migrate etc.
-                    if tx.orchard_notes().iter().any(|note| note.memo().is_some())
-                        || tx.sapling_notes().iter().any(|note| note.memo().is_some())
+                    if transaction
+                        .orchard_notes()
+                        .iter()
+                        .any(|note| note.memo().is_some())
+                        || transaction
+                            .sapling_notes()
+                            .iter()
+                            .any(|note| note.memo().is_some())
                     {
-                        let memos: Vec<String> = tx
+                        let memos: Vec<String> = transaction
                             .orchard_notes()
                             .iter()
                             .filter_map(|note| note.memo().map(|memo| memo.to_string()))
                             .chain(
-                                tx.sapling_notes()
+                                transaction
+                                    .sapling_notes()
                                     .iter()
                                     .filter_map(|note| note.memo().map(|memo| memo.to_string())),
                             )
                             .collect();
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
                                     SelfSendValueTransfer::MemoToSelf,
                                 )))
@@ -663,12 +678,12 @@ impl LightWallet {
                     } else {
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
                                     SelfSendValueTransfer::Basic,
                                 )))
@@ -682,26 +697,29 @@ impl LightWallet {
                     }
 
                     // in the case Zennies For Zingo! is active
-                    value_transfers.append(&mut ValueTransfers::create_send_value_transfers(tx));
+                    value_transfers.append(&mut self.create_send_value_transfers(transaction));
                 }
                 TransactionKind::Received => {
                     // create 1 received value transfer for each pool received to
-                    if !tx.orchard_notes().is_empty() {
-                        let value: u64 =
-                            tx.orchard_notes().iter().map(|output| output.value()).sum();
-                        let memos: Vec<String> = tx
+                    if !transaction.orchard_notes().is_empty() {
+                        let value: u64 = transaction
+                            .orchard_notes()
+                            .iter()
+                            .map(|output| output.value())
+                            .sum();
+                        let memos: Vec<String> = transaction
                             .orchard_notes()
                             .iter()
                             .filter_map(|note| note.memo().map(|memo| memo.to_string()))
                             .collect();
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Received)
                                 .value(value)
                                 .recipient_address(None)
@@ -713,22 +731,25 @@ impl LightWallet {
                                 .expect("all fields should be populated"),
                         );
                     }
-                    if !tx.sapling_notes().is_empty() {
-                        let value: u64 =
-                            tx.sapling_notes().iter().map(|output| output.value()).sum();
-                        let memos: Vec<String> = tx
+                    if !transaction.sapling_notes().is_empty() {
+                        let value: u64 = transaction
+                            .sapling_notes()
+                            .iter()
+                            .map(|output| output.value())
+                            .sum();
+                        let memos: Vec<String> = transaction
                             .sapling_notes()
                             .iter()
                             .filter_map(|note| note.memo().map(|memo| memo.to_string()))
                             .collect();
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Received)
                                 .value(value)
                                 .recipient_address(None)
@@ -740,20 +761,20 @@ impl LightWallet {
                                 .expect("all fields should be populated"),
                         );
                     }
-                    if !tx.transparent_coins().is_empty() {
-                        let value: u64 = tx
+                    if !transaction.transparent_coins().is_empty() {
+                        let value: u64 = transaction
                             .transparent_coins()
                             .iter()
                             .map(|output| output.value())
                             .sum();
                         value_transfers.push(
                             ValueTransferBuilder::new()
-                                .txid(tx.txid())
-                                .datetime(tx.datetime())
-                                .status(tx.status())
-                                .blockheight(tx.blockheight())
-                                .transaction_fee(tx.fee())
-                                .zec_price(tx.zec_price())
+                                .txid(transaction.txid())
+                                .datetime(transaction.datetime())
+                                .status(transaction.status())
+                                .blockheight(transaction.blockheight())
+                                .transaction_fee(transaction.fee())
+                                .zec_price(transaction.zec_price())
                                 .kind(ValueTransferKind::Received)
                                 .value(value)
                                 .recipient_address(None)
@@ -784,6 +805,115 @@ impl LightWallet {
     // TODO: remove
     pub async fn value_transfers_json_string(&self) -> String {
         json::JsonValue::from(self.sorted_value_transfers(true).await).pretty(2)
+    }
+
+    /// Creates value transfers for all notes in a transaction that are sent to another
+    /// recipient.  A value transfer is a group of all notes to a specific receiver in a transaction.
+    /// The value transfer list is sorted by the output index of the notes.
+    // FIXME: error handling
+    fn create_send_value_transfers(
+        &self,
+        transaction_summary: &TransactionSummary,
+    ) -> Vec<ValueTransfer> {
+        let mut value_transfers: Vec<ValueTransfer> = Vec::new();
+        let outgoing_notes = transaction_summary
+            .outgoing_orchard_notes()
+            .iter()
+            .chain(transaction_summary.outgoing_sapling_notes().iter())
+            .collect::<Vec<_>>();
+        let mut addresses = HashMap::with_capacity(outgoing_notes.len());
+
+        outgoing_notes.iter().for_each(|&note| {
+            let encoded_address = if let Some(ua) = note.recipient_unified_address.clone() {
+                ua
+            } else {
+                note.recipient.clone()
+            };
+
+            let address = decode_unified_address(&self.network, &encoded_address).unwrap();
+
+            if address.transparent().map_or(true, |addr| {
+                self.is_transparent_send_to_self(addr).is_none()
+            }) && address
+                .sapling()
+                .map_or(true, |addr| !self.is_sapling_send_to_self(addr))
+                && address
+                    .orchard()
+                    .map_or(true, |addr| !self.is_orchard_send_to_self(addr))
+            {
+                // hash map is used to create unique list of addresses as duplicates are not inserted twice
+                addresses.insert(encoded_address, note.output_index);
+            }
+        });
+        let mut addresses_vec = addresses.into_iter().collect::<Vec<_>>();
+        addresses_vec.sort_by_key(|(_address, output_index)| *output_index);
+        addresses_vec.iter().for_each(|(address, _output_index)| {
+            let outgoing_notes_to_address: Vec<&OutgoingNoteSummary> = outgoing_notes
+                .iter()
+                .filter(|&&note| {
+                    let query_address = if let Some(ua) = note.recipient_unified_address.clone() {
+                        ua
+                    } else {
+                        note.recipient.clone()
+                    };
+                    query_address == *address
+                })
+                .cloned()
+                .collect();
+            let value: u64 = outgoing_notes_to_address
+                .iter()
+                .map(|&note| note.value)
+                .sum();
+            let memos: Vec<String> = outgoing_notes_to_address
+                .iter()
+                .filter_map(|&note| note.memo.clone())
+                .collect();
+            value_transfers.push(
+                ValueTransferBuilder::new()
+                    .txid(transaction_summary.txid())
+                    .datetime(transaction_summary.datetime())
+                    .status(transaction_summary.status())
+                    .blockheight(transaction_summary.blockheight())
+                    .transaction_fee(transaction_summary.fee())
+                    .zec_price(transaction_summary.zec_price())
+                    .kind(ValueTransferKind::Sent(SentValueTransfer::Send))
+                    .value(value)
+                    .recipient_address(Some(address.clone()))
+                    .pool_received(None)
+                    .memos(memos)
+                    .build()
+                    .expect("all fields should be populated"),
+            );
+        });
+        value_transfers
+    }
+
+    fn is_transparent_send_to_self(
+        &self,
+        address: &TransparentAddress,
+    ) -> Option<TransparentScope> {
+        let encoded_address = transparent::encode_address(&self.network, *address);
+
+        self.transparent_addresses
+            .iter()
+            .find(|(_, wallet_address)| **wallet_address == encoded_address)
+            .map(|(address_id, _)| address_id.scope())
+    }
+
+    // FIXME: error handling
+    fn is_sapling_send_to_self(&self, address: &sapling_crypto::PaymentAddress) -> bool {
+        sapling_crypto::zip32::DiversifiableFullViewingKey::try_from(&self.unified_key_store)
+            .unwrap()
+            .decrypt_diversifier(address)
+            .is_some()
+    }
+
+    // FIXME: error handling
+    fn is_orchard_send_to_self(&self, address: &orchard::Address) -> bool {
+        orchard::keys::FullViewingKey::try_from(&self.unified_key_store)
+            .unwrap()
+            .scope_for_address(address)
+            .is_some()
     }
 }
 

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -1,6 +1,6 @@
 //! Wallet-State reporters as LightWallet methods.
 use json::JsonValue;
-use pepper_sync::keys::decode_unified_address;
+use pepper_sync::keys::decode_address;
 use pepper_sync::keys::transparent;
 use pepper_sync::keys::transparent::TransparentScope;
 use zcash_address::ZcashAddress;
@@ -830,17 +830,28 @@ impl LightWallet {
                 note.recipient.clone()
             };
 
-            let address = decode_unified_address(&self.network, &encoded_address).unwrap();
+            let send_to_external_recipient =
+                match decode_address(&self.network, &encoded_address).unwrap() {
+                    zcash_keys::address::Address::Sapling(address) => {
+                        !self.is_sapling_send_to_self(&address)
+                    }
+                    zcash_keys::address::Address::Transparent(address) => {
+                        self.is_transparent_send_to_self(&address).is_none()
+                    }
+                    zcash_keys::address::Address::Unified(address) => {
+                        address.transparent().map_or(true, |addr| {
+                            self.is_transparent_send_to_self(addr).is_none()
+                        }) && address
+                            .sapling()
+                            .map_or(true, |addr| !self.is_sapling_send_to_self(addr))
+                            && address
+                                .orchard()
+                                .map_or(true, |addr| !self.is_orchard_send_to_self(addr))
+                    }
+                    zcash_keys::address::Address::Tex(_) => true,
+                };
 
-            if address.transparent().map_or(true, |addr| {
-                self.is_transparent_send_to_self(addr).is_none()
-            }) && address
-                .sapling()
-                .map_or(true, |addr| !self.is_sapling_send_to_self(addr))
-                && address
-                    .orchard()
-                    .map_or(true, |addr| !self.is_orchard_send_to_self(addr))
-            {
+            if send_to_external_recipient {
                 // hash map is used to create unique list of addresses as duplicates are not inserted twice
                 addresses.insert(encoded_address, note.output_index);
             }

--- a/zingolib/src/wallet/describe.rs
+++ b/zingolib/src/wallet/describe.rs
@@ -282,7 +282,7 @@ impl LightWallet {
                             || outgoing_note
                                 .encoded_recipient_full_unified_address(&self.network)
                                 .expect("should exist in this scope")
-                                == zfz_address.to_string()
+                                == *zfz_address
                     } else {
                         self.is_sapling_send_to_self(&outgoing_note.note().recipient())
                     }
@@ -298,7 +298,7 @@ impl LightWallet {
                             || outgoing_note
                                 .encoded_recipient_full_unified_address(&self.network)
                                 .expect("should exist in this scope")
-                                == zfz_address.to_string()
+                                == *zfz_address
                     } else {
                         self.is_orchard_send_to_self(&outgoing_note.note().recipient())
                     }

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -208,7 +208,7 @@ async fn loaded_wallet_assert(
         )
         .await
         .unwrap();
-        lightclient.sync_and_await(true).await.unwrap();
+        lightclient.sync_and_await(false).await.unwrap();
         crate::testutils::lightclient::from_inputs::quick_send(
             &lightclient,
             vec![(


### PR DESCRIPTION
fixes couple bugs in value transfers such as send to self transaction kinds only working with zennies for zingo (ZFZ) active and send to self value transfers showing up as "basic" on user interface. also upgrades value transfers and transaction summary logic to handle the use of internally scoped keys which is now causing tests to fail. this PR does not entirely fix any tests, it is an important step towards it, a reference test is "generate_a_range_of_value_transfers" which now fails for other reasons