### PR TITLE
Polished a test

### DIFF
--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -18,17 +18,17 @@ proptest! {
     #![proptest_config(proptest::test_runner::Config::with_cases(4))]
     #[ignore = "darkside bug, invalid block hash length in tree states"]
     #[test]
-        fn single_sufficient_send_darkside(send_value in 0..50_000u64, change_value in 0..10_000u64, sender_protocol in 1..2, receiver_pool in 1..2) {
+        fn any_source_sends_to_any_receiver_darkside(send_value in 0..50_000u64, change_value in 0..10_000u64, sender_protocol in 1..2, receiver_pool in 1..2) {
         // note: this darkside test does not check the mempool
         Runtime::new().unwrap().block_on(async {
-            fixtures::single_sufficient_send::<DarksideEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, change_value, false).await;
+            fixtures::any_source_sends_to_any_receiver::<DarksideEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, change_value, false).await;
         });
      }
     #[ignore = "darkside bug, invalid block hash length in tree states"]
     #[test]
-    fn single_sufficient_send_0_change_darkside(send_value in 0..50_000u64, sender_protocol in 1..2, receiver_pool in 1..2) {
+    fn any_source_sends_to_any_receiver_0_change_darkside(send_value in 0..50_000u64, sender_protocol in 1..2, receiver_pool in 1..2) {
         Runtime::new().unwrap().block_on(async {
-            fixtures::single_sufficient_send::<DarksideEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, 0, false).await;
+            fixtures::any_source_sends_to_any_receiver::<DarksideEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, 0, false).await;
         });
      }
 }

--- a/libtonode-tests/tests/chain_generics.rs
+++ b/libtonode-tests/tests/chain_generics.rs
@@ -5,19 +5,17 @@ use zingolib::testutils::{
 };
 
 proptest::proptest! {
-    #![proptest_config(proptest::test_runner::Config::with_cases(4))]
-    #[ignore = "hangs"]
+    #![proptest_config(proptest::test_runner::Config::with_cases(1))]
     #[test]
-    fn single_sufficient_send_libtonode(send_value in 0..50_000u64, change_value in 0..10_000u64, sender_protocol in 1..2, receiver_pool in 0..2) {
+    fn any_source_sends_to_any_receiver_libtonode(send_value in 0..50_000u64, change_value in 0..10_000u64, sender_protocol in 1..2, receiver_pool in 0..2) {
         Runtime::new().unwrap().block_on(async {
-            fixtures::single_sufficient_send::<LibtonodeEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, change_value, true).await;
+            fixtures::any_source_sends_to_any_receiver::<LibtonodeEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, change_value, true).await;
         });
      }
-    #[ignore = "hangs"]
     #[test]
-    fn single_sufficient_send_0_change_libtonode(send_value in 0..50_000u64, sender_protocol in 1..2, receiver_pool in 0..2) {
+    fn any_source_sends_te_any_receiver_0_change_libtonode(send_value in 0..50_000u64, sender_protocol in 1..2, receiver_pool in 0..2) {
         Runtime::new().unwrap().block_on(async {
-            fixtures::single_sufficient_send::<LibtonodeEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, 0, true).await;
+            fixtures::any_source_sends_to_any_receiver::<LibtonodeEnvironment>(int_to_shieldedprotocol(sender_protocol), int_to_pooltype(receiver_pool), send_value, 0, true).await;
         });
      }
 }

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -668,3 +668,9 @@ pub fn int_to_pooltype(int: i32) -> PoolType {
         n => PoolType::Shielded(int_to_shieldedprotocol(n)),
     }
 }
+
+/// helperized test print.
+/// if someone figures out how to improve this code it can be done in one place right here.
+pub(crate) fn timestamped_test_log(text: &str) {
+    println!("{}: {}", crate::wallet::now(), text);
+}

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -11,6 +11,7 @@ use crate::testutils::chain_generics::with_assertions;
 use crate::testutils::fee_tables;
 use crate::testutils::lightclient::from_inputs;
 use crate::testutils::lightclient::get_base_address;
+use crate::testutils::timestamped_test_log;
 use crate::wallet::data::summaries::SelfSendValueTransfer;
 use crate::wallet::data::summaries::SentValueTransfer;
 use crate::wallet::data::summaries::ValueTransferKind;
@@ -470,7 +471,7 @@ where
 }
 
 /// the simplest test that sends from a specific shielded pool to another specific pool. also known as simpool.
-pub async fn single_sufficient_send<CC>(
+pub async fn any_source_sends_to_any_receiver<CC>(
     shpool: ShieldedProtocol,
     pool: PoolType,
     receiver_value: u64,
@@ -479,9 +480,11 @@ pub async fn single_sufficient_send<CC>(
 ) where
     CC: ConductChain,
 {
+    timestamped_test_log(format!("starting a {:?} to {} test", shpool, pool).as_str());
+
     let mut environment = CC::setup().await;
 
-    let mut primary = environment.fund_client_orchard(1_000_000).await;
+    let mut primary = environment.create_faucet().await;
     let mut secondary = environment.create_client();
     let mut tertiary = environment.create_client();
 

--- a/zingolib/src/testutils/chain_generics/libtonode.rs
+++ b/zingolib/src/testutils/chain_generics/libtonode.rs
@@ -8,6 +8,7 @@ use crate::config::RegtestNetwork;
 use crate::lightclient::LightClient;
 use crate::testutils::chain_generics::conduct_chain::ConductChain;
 use crate::testutils::scenarios::setup::ScenarioBuilder;
+use crate::testutils::timestamped_test_log;
 
 /// includes utilities for connecting to zcashd regtest
 pub struct LibtonodeEnvironment {
@@ -21,6 +22,7 @@ pub struct LibtonodeEnvironment {
 /// these tests cannot portray the full range of network weather.
 impl ConductChain for LibtonodeEnvironment {
     async fn setup() -> Self {
+        timestamped_test_log("starting mock libtonode network");
         let regtest_network = RegtestNetwork::all_upgrades_active();
         let scenario_builder = ScenarioBuilder::build_configure_launch(
             Some(PoolType::Shielded(Sapling)),
@@ -30,6 +32,7 @@ impl ConductChain for LibtonodeEnvironment {
             true,
         )
         .await;
+        timestamped_test_log("started mock libtonode network");
         LibtonodeEnvironment {
             regtest_network,
             scenario_builder,

--- a/zingolib/src/testutils/chain_generics/with_assertions.rs
+++ b/zingolib/src/testutils/chain_generics/with_assertions.rs
@@ -6,6 +6,7 @@ use crate::testutils::assertions::for_each_proposed_transaction;
 use crate::testutils::chain_generics::conduct_chain::ConductChain;
 use crate::testutils::lightclient::from_inputs;
 use crate::testutils::lightclient::get_base_address;
+use crate::testutils::timestamped_test_log;
 use nonempty::NonEmpty;
 use zcash_client_backend::proposal::Proposal;
 use zcash_client_backend::PoolType;
@@ -51,9 +52,13 @@ pub async fn propose_send_bump_sync_all_recipients<CC>(
 where
     CC: ConductChain,
 {
+    timestamped_test_log("started integration-test send.");
     sender.sync_and_await(true).await.unwrap();
+    timestamped_test_log("syncked.");
     let proposal = from_inputs::propose(sender, payments).await.unwrap();
+    timestamped_test_log("proposed.");
     let txids = sender.send_stored_proposal().await.unwrap();
+    timestamped_test_log("sent.");
 
     follow_proposal(
         environment,
@@ -100,7 +105,7 @@ pub async fn follow_proposal<CC, NoteRef>(
 where
     CC: ConductChain,
 {
-    println!("following proposal, preparing to unwind if an assertion fails.");
+    timestamped_test_log("following proposal, preparing to unwind if an assertion fails.");
 
     let server_height_at_send = BlockHeight::from(
         crate::grpc_connector::get_latest_block(environment.lightserver_uri().unwrap())
@@ -136,8 +141,10 @@ where
     }
 
     let option_recipient_mempool_outputs = if test_mempool {
+        timestamped_test_log("syncking transaction from mempool.");
         // mempool scan shows the same
         sender.sync_and_await(true).await.unwrap();
+        timestamped_test_log("cross-checking mempool records.");
 
         // let the mempool monitor get a chance
         // to listen
@@ -204,9 +211,13 @@ where
         None
     };
 
+    timestamped_test_log("cross-checked mempool records.");
+
     environment.bump_chain().await;
+    timestamped_test_log("syncking transaction confirmation.");
     // chain scan shows the same
     sender.sync_and_await(true).await.unwrap();
+    timestamped_test_log("cross-checking confirmed records.");
 
     // check that each record has the expected fee and status, returning the fee and outputs
     let (sender_confirmed_fees, (sender_confirmed_outputs, sender_confirmed_statuses)): (
@@ -264,6 +275,7 @@ where
         }
         recipients_confirmed_outputs.push(recipient_confirmed_outputs);
     }
+    timestamped_test_log("cross-checked confirmed records.");
 
     option_recipient_mempool_outputs.inspect(|recipient_mempool_outputs| {
         assert_eq!(recipients_confirmed_outputs, *recipient_mempool_outputs);


### PR DESCRIPTION
Simplified, shortening runtime,
documented,
and renamed any_source_sends_to_any_receiver test
un-ignored any_source_sends_to_any_receiver_libtonode