### PR TITLE
Replace tempdir with tempfile.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
  "prost",
  "sapling-crypto",
  "serde_json",
- "tempdir",
+ "tempfile",
  "testvectors",
  "tokio",
  "tonic",
@@ -1051,12 +1051,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -2543,19 +2537,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -2595,21 +2576,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2656,15 +2622,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2746,15 +2703,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -3356,16 +3304,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"
@@ -4845,7 +4783,6 @@ dependencies = [
  "sha2",
  "shardtree",
  "subtle",
- "tempdir",
  "tempfile",
  "test-case",
  "testvectors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,21 @@ shardtree = "0.5"
 # annotated tag starting with LRZ base tag and ending with `git describe --dirty`
 # TAG FROM `main_zingolib` BRANCH OF LIBRUSTZCASH FORK!
 zcash_address = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2" }
-zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2" , features = ["lightwalletd-tonic", "orchard", "transparent-inputs"] }
-zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2"  }
-zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2" , features = ["transparent-inputs", "sapling", "orchard" ] }
+zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2", features = [
+    "lightwalletd-tonic",
+    "orchard",
+    "transparent-inputs",
+] }
+zcash_encoding = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2" }
+zcash_keys = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2", features = [
+    "transparent-inputs",
+    "sapling",
+    "orchard",
+] }
 zcash_note_encryption = "0.4"
-zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2"  }
-zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2"  }
-zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2"  }
+zcash_primitives = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2" }
+zcash_proofs = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2" }
+zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", tag = "zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2" }
 zip32 = "0.1"
 
 append-only-vec = { git = "https://github.com/zancas/append-only-vec.git", branch = "add_debug_impl" }
@@ -71,7 +79,10 @@ portpicker = "0.1"
 proptest = "1"
 prost = "0.13"
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["cookies", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "cookies",
+    "rustls-tls",
+] }
 ring = "0.17"
 rust-embed = "6"
 rustls = { version = "0.23", features = ["ring"] }
@@ -84,13 +95,16 @@ serde_json = "1"
 sha2 = "0.10"
 shellwords = "1"
 subtle = "2"
-tempdir = "0.3"
 tempfile = "3"
 test-case = "3"
 thiserror = "1"
 tokio = "1"
 tokio-rustls = "0.26"
-tonic = {version = "0.12", features = ["tls", "tls-roots", "tls-webpki-roots"]}
+tonic = { version = "0.12", features = [
+    "tls",
+    "tls-roots",
+    "tls-webpki-roots",
+] }
 tonic-build = "0.12"
 tower = { version = "0.5" }
 tracing = "0.1"

--- a/darkside-tests/Cargo.toml
+++ b/darkside-tests/Cargo.toml
@@ -27,7 +27,7 @@ http-body = { workspace = true }
 hex = { workspace = true }
 
 zcash_primitives = { workspace = true }
-tempdir = { workspace = true }
+tempfile = { workspace = true }
 portpicker = { workspace = true }
 futures-util = { workspace = true }
 orchard = { workspace = true }

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -9,7 +9,7 @@ use std::{
     process::{Child, Command},
     time::Duration,
 };
-use tempdir;
+use tempfile;
 use tokio::time::sleep;
 use zcash_primitives::consensus::BranchId;
 use zcash_primitives::{merkle_tree::read_commitment_tree, transaction::Transaction};
@@ -103,7 +103,7 @@ pub async fn prepare_darksidewalletd(
 }
 pub fn generate_darksidewalletd(set_port: Option<portpicker::Port>) -> (String, PathBuf) {
     let darkside_grpc_port = TestEnvironmentGenerator::pick_unused_port_to_string(set_port);
-    let darkside_dir = tempdir::TempDir::new("zingo_darkside_test")
+    let darkside_dir = tempfile::TempDir::with_prefix("zingo_darkside_test")
         .unwrap()
         .into_path();
     (darkside_grpc_port, darkside_dir)

--- a/zingo-testutils/Cargo.toml
+++ b/zingo-testutils/Cargo.toml
@@ -10,8 +10,8 @@ default = ["grpc-proxy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zingoconfig = { path = "../zingoconfig" , features = ["test-elevation"] }
-zingolib = { path = "../zingolib" , features = ["test-elevation"] }
+zingoconfig = { path = "../zingoconfig", features = ["test-elevation"] }
+zingolib = { path = "../zingolib", features = ["test-elevation"] }
 zingo-netutils = { path = "../zingo-netutils", features = ["test-features"] }
 zingo-testvectors = { path = "../zingo-testvectors" }
 zingo-status = { path = "../zingo-status" }
@@ -20,8 +20,8 @@ zcash_client_backend = { workspace = true }
 zcash_primitives = { workspace = true }
 zcash_address = { workspace = true }
 orchard = { workspace = true }
-portpicker = { workspace = true}
-tempdir = { workspace = true }
+portpicker = { workspace = true }
+tempfile = { workspace = true }
 incrementalmerkletree = { workspace = true }
 
 json = { workspace = true }
@@ -32,6 +32,5 @@ tonic = { workspace = true, optional = true }
 nonempty.workspace = true
 
 [dev-dependencies]
-zingoconfig = { path = "../zingoconfig" , features = ["test-elevation"] }
-zingolib = { path = "../zingolib" , features = ["test-elevation"] }
-
+zingoconfig = { path = "../zingoconfig", features = ["test-elevation"] }
+zingolib = { path = "../zingolib", features = ["test-elevation"] }

--- a/zingoconfig/Cargo.toml
+++ b/zingoconfig/Cargo.toml
@@ -15,4 +15,4 @@ http.workspace = true
 dirs = { workspace = true }
 log = { workspace = true }
 log4rs = { workspace = true }
-tempdir.workspace = true
+tempfile.workspace = true

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -12,7 +12,7 @@ darkside_tests = []
 default = ["sync"]
 deprecations = ["lightclient-deprecated"]
 lightclient-deprecated = []
-test-elevation = ["portpicker", "testvectors", "tempfile", "tempdir"]
+test-elevation = ["portpicker", "testvectors", "tempfile"]
 sync = ['zingo-sync']
 zaino-test = ['test-elevation']
 
@@ -25,9 +25,17 @@ testvectors = { path = "../testvectors", optional = true }
 
 orchard = { workspace = true }
 shardtree = { workspace = true, features = ["legacy-api"] }
-incrementalmerkletree = { workspace = true, features = ["test-dependencies", "legacy-api"] }
+incrementalmerkletree = { workspace = true, features = [
+    "test-dependencies",
+    "legacy-api",
+] }
 zcash_address = { workspace = true }
-zcash_client_backend = { workspace = true, features = ["unstable", "transparent-inputs", "unstable-serialization", "unstable-spanning-tree"] }
+zcash_client_backend = { workspace = true, features = [
+    "unstable",
+    "transparent-inputs",
+    "unstable-serialization",
+    "unstable-spanning-tree",
+] }
 zcash_encoding = { workspace = true }
 zcash_keys = { workspace = true }
 zcash_note_encryption = { workspace = true }
@@ -75,11 +83,10 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 subtle = { workspace = true }
-tempdir = {workspace = true, optional = true }
-tempfile = {workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
 test-case = { workspace = true }
 thiserror = { workspace = true }
-tokio =  { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }
 tracing-subscriber = { workspace = true }
 bech32 = { workspace = true }

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -204,8 +204,8 @@ impl ZingoConfigBuilder {
     /// # Examples
     /// ```
     /// use zingolib::config::ZingoConfigBuilder;
-    /// use tempdir::TempDir;
-    /// let dir = TempDir::new("zingo_doc_test").unwrap().into_path();
+    /// use tempfile::TempDir;
+    /// let dir = tempfile::TempDir::with_prefix("zingo_doc_test").unwrap().into_path();
     /// let config = ZingoConfigBuilder::default().set_wallet_dir(dir.clone()).create();
     /// assert_eq!(config.wallet_dir.clone().unwrap(), dir);
     /// ```


### PR DESCRIPTION
This removes `remove_dir_all` as a dependency which had a low-severity vulnerability, as reported here: https://github.com/zingolabs/zingolib/security/dependabot/13.