### PR TITLE
improve anchor height for send

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -125,6 +125,7 @@ mod fast {
         lightclient::describe::UAReceivers,
         testutils::{
             chain_generics::{conduct_chain::ConductChain, libtonode::LibtonodeEnvironment},
+            increase_server_height,
             lightclient::{from_inputs, get_base_address},
         },
         wallet::{
@@ -431,6 +432,33 @@ mod fast {
     //             .unwrap()
     //     )
     // }
+
+    #[tokio::test]
+    async fn send_not_fully_synced() {
+        let (regtest_manager, _cph, _faucet, mut recipient, _, _, _) =
+            scenarios::faucet_funded_recipient(
+                Some(200_000),
+                Some(100_000),
+                None,
+                PoolType::Shielded(ShieldedProtocol::Orchard),
+                RegtestNetwork::all_upgrades_active(),
+                true,
+            )
+            .await;
+
+        increase_server_height(&regtest_manager, 5).await;
+
+        recipient
+            .propose_send_all(
+                address_from_str(&get_base_address_macro!(&recipient, "sapling")).unwrap(),
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        recipient.send_stored_proposal().await.unwrap();
+    }
 
     #[tokio::test]
     async fn create_send_to_self_with_zfz_active() {

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -11,6 +11,7 @@ use log::{error, info};
 
 use clap::{self, Arg};
 use pepper_sync::sync::{SyncConfig, TransparentAddressDiscovery};
+use zingolib::commands::RT;
 use zingolib::config::ChainType;
 use zingolib::testutils::regtest;
 use zingolib::wallet::{LightWallet, WalletBase, WalletSettings};
@@ -532,6 +533,12 @@ pub fn startup(
 
     let update = commands::do_user_command("save", &["run"], &mut lightclient);
     println!("{}", update);
+
+    // TODO: remove debugging after shard tree send bug is fixed
+    // let wallet = lightclient.wallet.clone();
+    // RT.block_on(async move {
+    //     dbg!(&wallet.lock().await.shard_trees.sapling);
+    // });
 
     // Start the command loop
     let (command_transmitter, resp_receiver) = command_loop(lightclient);

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -11,7 +11,6 @@ use log::{error, info};
 
 use clap::{self, Arg};
 use pepper_sync::sync::{SyncConfig, TransparentAddressDiscovery};
-use zingolib::commands::RT;
 use zingolib::config::ChainType;
 use zingolib::testutils::regtest;
 use zingolib::wallet::{LightWallet, WalletBase, WalletSettings};

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -97,10 +97,8 @@ pub async fn increase_server_height(manager: &RegtestManager, n: u32) {
     manager
         .generate_n_blocks(n)
         .expect("Called for side effect, failed!");
-    let mut count = 0;
     while poll_server_height(manager).as_fixed_point_u64(2).unwrap() < target {
         tokio::time::sleep(Duration::from_millis(50)).await;
-        count = dbg!(count + 1);
     }
 }
 

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, convert::Infallible, num::NonZeroU32, ops::Range};
 
 use secrecy::SecretVec;
-use shardtree::{ShardTree, error::ShardTreeError};
+use shardtree::{ShardTree, error::ShardTreeError, store::ShardStore};
 use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
@@ -181,9 +181,22 @@ impl WalletRead for LightWallet {
             return Ok(None);
         };
 
+        let max_checkpoint_height = self
+            .shard_trees
+            .sapling
+            .store()
+            .max_checkpoint_id()
+            .expect("infallible")
+            .expect("should be at least 1 checkpoint");
+
+        let anchor_height = std::cmp::min(
+            max_checkpoint_height,
+            target_height - min_confirmations.get(),
+        );
+
         Ok(Some((
             target_height,
-            std::cmp::max(1.into(), target_height - min_confirmations.get()),
+            std::cmp::max(1.into(), anchor_height),
         )))
     }
 


### PR DESCRIPTION
this does not fix the current shard tree bug but it fixes a potential bug with choosing anchor heights higher than the current highest shardstore checkpoint height