### PR TITLE
`zingolib`: Reintroduce `zcash-params` for mobile devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,6 +4299,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.101",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7681,6 +7715,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "ring 0.17.14",
+ "rust-embed",
  "rustls 0.23.27",
  "sapling-crypto",
  "secp256k1",

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -80,6 +80,7 @@ tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }
 tracing-subscriber = { workspace = true }
 bech32 = { workspace = true }
+rust-embed = { workspace = true, features = ["debug-embed"] }
 
 [dev-dependencies]
 portpicker = { workspace = true }

--- a/zingolib/build.rs
+++ b/zingolib/build.rs
@@ -36,17 +36,37 @@ fn git_description() {
 }
 
 /// Checks if zcash params are available and downloads them if not.
+/// Also copies them to an internal location for use by mobile platforms.
 fn get_zcash_params() {
     println!("Checking if params are available...");
 
-    match zcash_proofs::download_sapling_parameters(Some(100)) {
+    let params_path = match zcash_proofs::download_sapling_parameters(Some(100)) {
         Ok(p) => {
             println!("Params downloaded!");
             println!("Spend path: {}", p.spend.to_str().unwrap());
             println!("Output path: {}", p.output.to_str().unwrap());
+            p
         }
-        Err(e) => println!("Error downloading params: {}", e),
-    }
+        Err(e) => {
+            println!("Error downloading params: {}", e);
+            panic!();
+        }
+    };
+
+    // Copy the params to the internal location.
+    let internal_params_path = Path::new("zcash-params");
+    std::fs::create_dir_all(internal_params_path).unwrap();
+    std::fs::copy(
+        params_path.spend,
+        internal_params_path.join("sapling-spend.params"),
+    )
+    .unwrap();
+
+    std::fs::copy(
+        params_path.output,
+        internal_params_path.join("sapling-output.params"),
+    )
+    .unwrap();
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -20,6 +20,13 @@ pub mod testutils;
 // This line includes the generated `git_description()` function directly into this scope.
 include!(concat!(env!("OUT_DIR"), "/git_description.rs"));
 
+#[macro_use]
+extern crate rust_embed;
+/// Embedded zcash-params for mobile devices.
+#[derive(RustEmbed)]
+#[folder = "zcash-params/"]
+pub struct SaplingParams;
+
 /// TODO: Add Doc Comment Here!
 // TODO:  use `get_latest_block` gRPC, also should be removed from zingolib, runtimes should be handled by consumers
 pub fn get_latest_block_height(lightwalletd_uri: http::Uri) -> std::io::Result<u64> {

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -80,13 +80,12 @@ impl LightWallet {
         // Reset the progress to start. Any errors will get recorded here
         self.reset_send_progress().await;
 
-        let (sapling_output, sapling_spend) = crate::wallet::utils::read_sapling_params()
-            .map_err(CalculateTransactionError::SaplingParams)?;
+        let (sapling_output, sapling_spend): (Vec<u8>, Vec<u8>) =
+            crate::wallet::utils::read_sapling_params()
+                .map_err(CalculateTransactionError::SaplingParams)?;
 
-        let sapling_prover = zcash_proofs::prover::LocalTxProver::new(
-            sapling_spend.as_path(),
-            sapling_output.as_path(),
-        );
+        let sapling_prover =
+            zcash_proofs::prover::LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
 
         let calculated_txids = match proposal.steps().len() {
             1 => {

--- a/zingolib/src/wallet/utils.rs
+++ b/zingolib/src/wallet/utils.rs
@@ -1,9 +1,6 @@
 //! TODO: Add Mod Description Here!
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::{
-    io::{self, Read, Write},
-    path::PathBuf,
-};
+use std::io::{self, Read, Write};
 use zcash_primitives::{memo::MemoBytes, transaction::TxId};
 
 /// TODO: Add Doc Comment Here!
@@ -50,12 +47,23 @@ pub fn txid_from_slice(txid: &[u8]) -> TxId {
     TxId::from_bytes(txid_bytes)
 }
 
-/// Returns the path to the downloaded Sapling parameters
-pub(crate) fn read_sapling_params() -> Result<(PathBuf, PathBuf), String> {
-    let zcash_params_path = zcash_proofs::download_sapling_parameters(Some(5)).unwrap();
+/// Returns the downloaded Sapling parameters as bytes.
+pub(crate) fn read_sapling_params() -> Result<(Vec<u8>, Vec<u8>), String> {
+    use crate::SaplingParams;
+    let mut sapling_output = vec![];
+    sapling_output.extend_from_slice(
+        SaplingParams::get("sapling-output.params")
+            .unwrap()
+            .data
+            .as_ref(),
+    );
 
-    let sapling_output_path = zcash_params_path.output;
-    let sapling_spend_path = zcash_params_path.spend;
-
-    Ok((sapling_output_path, sapling_spend_path))
+    let mut sapling_spend = vec![];
+    sapling_spend.extend_from_slice(
+        SaplingParams::get("sapling-spend.params")
+            .unwrap()
+            .data
+            .as_ref(),
+    );
+    Ok((sapling_output, sapling_spend))
 }

--- a/zingolib/zcash-params/.gitignore
+++ b/zingolib/zcash-params/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This PR fixes an issue where the sapling params where not being included for mobile bundles. 
Now they are copied from the default params location to the previous location.