### PR TITLE
Safe taddr generation

### DIFF
--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -1275,7 +1275,7 @@ uregtest1n22mmna853578fakgx6z6adn24ey5r7wfye8ulhscqc9hvm0rf5czxjuz9te0zzc8j93y35
         );
 
         let (taddress_id, new_taddress) = recipient
-            .generate_transparent_address(zip32::AccountId::ZERO)
+            .generate_transparent_address(zip32::AccountId::ZERO, false)
             .await
             .unwrap();
         assert_eq!(

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -750,25 +750,11 @@ mod fast {
         // Addresses: alice, bob, charlie
         let alice = get_base_address(&recipient, PoolType::ORCHARD).await;
         let (_, bob) = faucet
-            .generate_unified_address(
-                ReceiverSelection {
-                    orchard: true,
-                    sapling: true,
-                    transparent: true,
-                },
-                zip32::AccountId::ZERO,
-            )
+            .generate_unified_address(ReceiverSelection::all_shielded(), zip32::AccountId::ZERO)
             .await
             .unwrap();
         let (_, charlie) = faucet
-            .generate_unified_address(
-                ReceiverSelection {
-                    orchard: true,
-                    sapling: true,
-                    transparent: true,
-                },
-                zip32::AccountId::ZERO,
-            )
+            .generate_unified_address(ReceiverSelection::all_shielded(), zip32::AccountId::ZERO)
             .await
             .unwrap();
 

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -791,7 +791,7 @@ impl Command for NewTransparentAddressCommand {
         RT.block_on(async move {
             let mut wallet = lightclient.wallet.lock().await;
             let network = wallet.network;
-            match wallet.generate_transparent_address(zip32::AccountId::ZERO) {
+            match wallet.generate_transparent_address(zip32::AccountId::ZERO, true) {
                 Ok((id, transparent_address)) => {
                     json::object! {
                         "account" => u32::from(id.account_id()),

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -717,6 +717,9 @@ impl Command for NewUnifiedAddressCommand {
         indoc! {r#"
             Create a new unified address.
 
+            Transparent receivers not supported.
+            See `new_taddress` for creating transparent addresses.
+
             Usage:
             new_address [ o | z ]
 
@@ -750,7 +753,6 @@ impl Command for NewUnifiedAddressCommand {
             let receivers = ReceiverSelection {
                 orchard: args[0].contains('o'),
                 sapling: args[0].contains('z'),
-                transparent: false,
             };
             match wallet.generate_unified_address(receivers, zip32::AccountId::ZERO) {
                 Ok((id, unified_address)) => {

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -158,11 +158,12 @@ impl LightClient {
     pub async fn generate_transparent_address(
         &mut self,
         account_id: zip32::AccountId,
+        enforce_no_gap: bool,
     ) -> Result<(TransparentAddressId, TransparentAddress), KeyError> {
         self.wallet
             .lock()
             .await
-            .generate_transparent_address(account_id)
+            .generate_transparent_address(account_id, enforce_no_gap)
     }
 
     /// Wrapper for [crate::wallet::LightWallet::unified_addresses_json].

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -215,11 +215,8 @@ impl LightWallet {
                 account_id: zip32::AccountId::ZERO,
                 address_index: 0,
             };
-            let first_unified_address = unified_key.generate_unified_address(
-                unified_address_id.address_index,
-                receivers,
-                false,
-            )?;
+            let first_unified_address = unified_key
+                .generate_unified_address(unified_address_id.address_index, receivers)?;
             unified_addresses.insert(unified_address_id, first_unified_address.clone());
         }
 
@@ -232,7 +229,6 @@ impl LightWallet {
         match unified_key.generate_transparent_address(
             transparent_address_id.address_index(),
             transparent_address_id.scope(),
-            false,
         ) {
             Ok(first_transparent_address) => {
                 transparent_addresses.insert(

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -67,7 +67,7 @@ impl LightWallet {
                 unified_key.write(w, self.network)
             },
         )?;
-        // TODO: consider whether its worth tracking receiver selections. if so, we need to store them in encoded memos.
+        // TODO: also store receiver selections in encoded memos.
         Vector::write(
             &mut writer,
             &self.unified_addresses.iter().collect::<Vec<_>>(),
@@ -77,7 +77,6 @@ impl LightWallet {
                 ReceiverSelection {
                     orchard: address.orchard().is_some(),
                     sapling: address.sapling().is_some(),
-                    transparent: false,
                 }
                 .write(w, ())
             },
@@ -266,7 +265,7 @@ impl LightWallet {
                 address_index: 0,
             };
             let first_unified_address = unified_key
-                .generate_unified_address(unified_address_id.address_index, receivers, false)
+                .generate_unified_address(unified_address_id.address_index, receivers)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             unified_addresses.insert(unified_address_id, first_unified_address.clone());
         }
@@ -280,7 +279,6 @@ impl LightWallet {
         match unified_key.generate_transparent_address(
             transparent_address_id.address_index(),
             transparent_address_id.scope(),
-            false,
         ) {
             Ok(first_transparent_address) => {
                 transparent_addresses.insert(
@@ -389,8 +387,7 @@ impl LightWallet {
             let account_id = zip32::AccountId::try_from(r.read_u32::<LittleEndian>()?)
                 .expect("only valid account ids are stored");
             let address_index = r.read_u32::<LittleEndian>()?;
-            let mut receivers = ReceiverSelection::read(r, ())?;
-            receivers.transparent = false;
+            let receivers = ReceiverSelection::read(r, ())?;
 
             Ok((
                 UnifiedAddressId {
@@ -406,7 +403,7 @@ impl LightWallet {
                             u32::from(account_id)
                         ),
                     ))?
-                    .generate_unified_address(address_index, receivers, false)
+                    .generate_unified_address(address_index, receivers)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             ))
         })?
@@ -432,7 +429,7 @@ impl LightWallet {
                                 u32::from(account_id)
                             ),
                         ))?
-                        .generate_transparent_address(address_index, scope, false)
+                        .generate_transparent_address(address_index, scope)
                         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
                 ),
             ))

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -184,6 +184,11 @@ pub enum KeyError {
     /// Unified address missing shielded receiver
     #[error("Unified address must contain a shielded receiver")]
     UnifiedAddressError,
+    /// Transparent address generation failed. Latest transparent address has not received funds.
+    #[error(
+        "Transparent address generation failed. Latest transparent address has not received funds."
+    )]
+    GapError,
 }
 
 impl From<bip32::Error> for KeyError {

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -5,7 +5,7 @@ use pepper_sync::{
         decode_address,
         transparent::{self, TransparentAddressId, TransparentScope},
     },
-    wallet::KeyIdInterface,
+    wallet::{KeyIdInterface, TransparentCoin},
 };
 use unified::{ReceiverSelection, UnifiedAddressId};
 use zcash_keys::address::UnifiedAddress;
@@ -76,21 +76,37 @@ impl LightWallet {
 
     /// Generates a new transparent address of `external` scope for the given `account_id`.
     /// The new address is added to the wallet and returned.
+    ///
+    /// If `enforced_no_gap` is `true`, an error is returned if the latest transparent address has not received funds.
     pub fn generate_transparent_address(
         &mut self,
         account_id: zip32::AccountId,
+        enforce_no_gap: bool,
     ) -> Result<(TransparentAddressId, TransparentAddress), KeyError> {
-        let address_index = self
+        let latest_address = self
             .transparent_addresses
-            .keys()
-            .filter(|&address_id| {
+            .iter()
+            .filter(|(address_id, _)| {
                 address_id.scope() == TransparentScope::External
                     && address_id.account_id() == account_id
             })
-            .map(|&address_id| address_id.address_index())
-            .max()
-            .map_or(Ok(NonHardenedChildIndex::ZERO), |address_index| {
+            .max_by_key(|(address_id, _)| address_id.address_index());
+        if enforce_no_gap {
+            if let Some((_, address)) = latest_address {
+                if !self
+                    .wallet_outputs::<TransparentCoin>()
+                    .iter()
+                    .any(|&output| output.address() == address.as_str())
+                {
+                    return Err(KeyError::GapError);
+                }
+            }
+        }
+
+        let address_index =
+            latest_address.map_or(Ok(NonHardenedChildIndex::ZERO), |(address_index, _)| {
                 address_index
+                    .address_index()
                     .next()
                     .ok_or(KeyError::InvalidNonHardenedChildIndex)
             })?;
@@ -101,7 +117,6 @@ impl LightWallet {
             .get(&account_id)
             .ok_or(KeyError::NoAccountKeys)?
             .generate_transparent_address(address_id.address_index(), address_id.scope())?;
-
         self.transparent_addresses.insert(
             address_id,
             transparent::encode_address(&self.network, external_address),

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -45,11 +45,8 @@ pub enum WalletAddressRef {
 }
 
 impl LightWallet {
-    /// Returns a new unified address for the given `receivers` and `account_id`.
-    /// Also adds this new unified address to the wallet.
-    ///
-    /// Although supported, it is not recommended to include transparent receivers in unified addresses.
-    /// If the unified address contains a transparent receiver, this is also added to the wallet's transparent addresses.
+    /// Returns a new unified address for the given `receivers` and `account_id`, adding this new unified address to
+    /// the wallet.
     pub fn generate_unified_address(
         &mut self,
         receivers: ReceiverSelection,
@@ -69,19 +66,7 @@ impl LightWallet {
             .unified_key_store
             .get(&account_id)
             .ok_or(KeyError::NoAccountKeys)?
-            .generate_unified_address(address_id.address_index, receivers, false)?;
-
-        if let Some(transparent_address) = unified_address.transparent() {
-            self.transparent_addresses.insert(
-                TransparentAddressId::new(
-                    account_id,
-                    TransparentScope::External,
-                    NonHardenedChildIndex::from_index(address_id.address_index)
-                        .ok_or(KeyError::InvalidNonHardenedChildIndex)?,
-                ),
-                transparent::encode_address(&self.network, *transparent_address),
-            );
-        }
+            .generate_unified_address(address_id.address_index, receivers)?;
         self.unified_addresses
             .insert(address_id, unified_address.clone());
         self.save_required = true;
@@ -115,7 +100,7 @@ impl LightWallet {
             .unified_key_store
             .get(&account_id)
             .ok_or(KeyError::NoAccountKeys)?
-            .generate_transparent_address(address_id.address_index(), address_id.scope(), false)?;
+            .generate_transparent_address(address_id.address_index(), address_id.scope())?;
 
         self.transparent_addresses.insert(
             address_id,
@@ -161,11 +146,7 @@ impl LightWallet {
                     .unified_key_store
                     .get(&account_id)
                     .ok_or(KeyError::NoAccountKeys)?
-                    .generate_transparent_address(
-                        address_id.address_index(),
-                        address_id.scope(),
-                        false,
-                    )?;
+                    .generate_transparent_address(address_id.address_index(), address_id.scope())?;
 
                 self.transparent_addresses.insert(
                     address_id,

--- a/zingolib/src/wallet/keys/legacy.rs
+++ b/zingolib/src/wallet/keys/legacy.rs
@@ -2,15 +2,10 @@
 
 use std::{
     io::{self, Read, Write},
-    sync::{
-        Arc,
-        atomic::{self, AtomicBool},
-    },
+    sync::{Arc, atomic::AtomicBool},
 };
 
 use append_only_vec::AppendOnlyVec;
-use bip32::ExtendedPublicKey;
-use bip0039::Mnemonic;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use zcash_address::unified::Typecode;
@@ -20,17 +15,13 @@ use zcash_keys::{
     address::UnifiedAddress,
     keys::{Era, UnifiedFullViewingKey, UnifiedSpendingKey},
 };
-use zcash_primitives::legacy::{
-    TransparentAddress,
-    keys::{AccountPubKey, IncomingViewingKey as _, NonHardenedChildIndex},
-};
-use zip32::{AccountId, DiversifierIndex};
+use zcash_primitives::legacy::TransparentAddress;
 
 use super::unified::{
     KEY_TYPE_EMPTY, KEY_TYPE_SPEND, KEY_TYPE_VIEW, ReceiverSelection, UnifiedKeyStore,
 };
 use crate::{
-    config::{ChainType, ZingoConfig},
+    config::ChainType,
     wallet::{error::KeyError, legacy::WitnessTrees, traits::ReadableWriteable},
 };
 
@@ -42,6 +33,7 @@ pub mod extended_transparent;
 /// loaded from a [`zcash_keys::keys::UnifiedSpendingKey`] <br>
 /// or a [`zcash_keys::keys::UnifiedFullViewingKey`]. <br><br>
 /// In addition to fundamental spending and viewing keys, the type caches generated addresses.
+#[allow(dead_code)]
 pub struct WalletCapability {
     /// Unified key store
     pub unified_key_store: UnifiedKeyStore,
@@ -71,188 +63,6 @@ impl Default for WalletCapability {
 
 impl WalletCapability {
     /// TODO: Add Doc Comment Here!
-    pub fn addresses(&self) -> &AppendOnlyVec<UnifiedAddress> {
-        &self.unified_addresses
-    }
-
-    /// TODO: Add Doc Comment Here!
-    pub fn transparent_child_addresses(&self) -> &Arc<AppendOnlyVec<(usize, TransparentAddress)>> {
-        &self.transparent_child_addresses
-    }
-
-    /// Generates a unified address from the given desired receivers
-    ///
-    /// See [`self::WalletCapability::generate_transparent_receiver`] for information on using `legacy_key`
-    pub fn new_address(
-        &self,
-        desired_receivers: ReceiverSelection,
-        legacy_key: bool,
-    ) -> Result<UnifiedAddress, String> {
-        if self
-            .addresses_write_lock
-            .swap(true, atomic::Ordering::Acquire)
-        {
-            return Err("addresses_write_lock collision!".to_string());
-        }
-
-        let previous_num_addresses = self.unified_addresses.len();
-        let orchard_receiver = if desired_receivers.orchard {
-            let fvk: orchard::keys::FullViewingKey = match (&self.unified_key_store).try_into() {
-                Ok(viewkey) => viewkey,
-                Err(e) => {
-                    self.addresses_write_lock
-                        .swap(false, atomic::Ordering::Release);
-                    return Err(e.to_string());
-                }
-            };
-            Some(fvk.address_at(self.unified_addresses.len(), orchard::keys::Scope::External))
-        } else {
-            None
-        };
-
-        // produce a Sapling address to increment Sapling diversifier index
-        let sapling_receiver = if desired_receivers.sapling {
-            let mut sapling_diversifier_index = DiversifierIndex::new();
-            let mut address;
-            let mut count = 0;
-            let fvk: sapling_crypto::zip32::DiversifiableFullViewingKey =
-                match (&self.unified_key_store).try_into() {
-                    Ok(viewkey) => viewkey,
-                    Err(e) => {
-                        self.addresses_write_lock
-                            .swap(false, atomic::Ordering::Release);
-                        return Err(e.to_string());
-                    }
-                };
-            loop {
-                (sapling_diversifier_index, address) = fvk
-                    .find_address(sapling_diversifier_index)
-                    .expect("Diversifier index overflow");
-                sapling_diversifier_index
-                    .increment()
-                    .expect("Diversifier index overflow");
-                // Not all sapling_diversifier_indexes produce valid
-                // sapling addresses.
-                // Because of this self.unified_addresses.len()
-                // will be <= sapling_diversifier_index
-                if count == self.unified_addresses.len() {
-                    break;
-                }
-                count += 1;
-            }
-            Some(address)
-        } else {
-            None
-        };
-
-        let transparent_receiver = if desired_receivers.transparent {
-            self.generate_transparent_receiver(legacy_key)
-                .map_err(|e| e.to_string())?
-        } else {
-            None
-        };
-
-        let ua = UnifiedAddress::from_receivers(
-            orchard_receiver,
-            sapling_receiver,
-            transparent_receiver,
-        );
-        let ua = match ua {
-            Some(address) => address,
-            None => {
-                self.addresses_write_lock
-                    .swap(false, atomic::Ordering::Release);
-                return Err(
-                    "Invalid receivers requested! At least one of sapling or orchard required"
-                        .to_string(),
-                );
-            }
-        };
-        self.unified_addresses.push(ua.clone());
-        assert_eq!(self.unified_addresses.len(), previous_num_addresses + 1);
-        self.addresses_write_lock
-            .swap(false, atomic::Ordering::Release);
-        Ok(ua)
-    }
-
-    /// Generates a transparent receiver for the specified scope.
-    pub fn generate_transparent_receiver(
-        &self,
-        // this should only be `true` when generating transparent addresses while loading from legacy keys (pre wallet version 29)
-        // legacy transparent keys are already derived to the external scope so setting `legacy_key` to `true` will skip this scope derivation
-        legacy_key: bool,
-    ) -> Result<Option<TransparentAddress>, bip32::Error> {
-        let derive_address = |transparent_fvk: &AccountPubKey,
-                              child_index: NonHardenedChildIndex|
-         -> Result<TransparentAddress, bip32::Error> {
-            let t_addr = if legacy_key {
-                generate_transparent_address_from_legacy_key(transparent_fvk, child_index)?
-            } else {
-                transparent_fvk
-                    .derive_external_ivk()?
-                    .derive_address(child_index)?
-            };
-
-            self.transparent_child_addresses
-                .push((self.addresses().len(), t_addr));
-            Ok(t_addr)
-        };
-        let child_index = NonHardenedChildIndex::from_index(self.addresses().len() as u32)
-            .expect("hardened bit should not be set for non-hardened child indexes");
-        let transparent_receiver = match &self.unified_key_store {
-            UnifiedKeyStore::Spend(usk) => {
-                derive_address(&usk.transparent().to_account_pubkey(), child_index)
-                    .map(Option::Some)
-            }
-            UnifiedKeyStore::View(ufvk) => ufvk
-                .transparent()
-                .map(|pub_key| derive_address(pub_key, child_index))
-                .transpose(),
-            UnifiedKeyStore::Empty => Ok(None),
-        }?;
-
-        Ok(transparent_receiver)
-    }
-
-    /// TODO: Add Doc Comment Here!
-    pub fn new_from_seed(
-        config: &ZingoConfig,
-        seed: &[u8; 64],
-        position: u32,
-    ) -> Result<Self, KeyError> {
-        let usk = UnifiedSpendingKey::from_seed(
-            &config.chain,
-            seed,
-            AccountId::try_from(position).map_err(KeyError::InvalidAccountId)?,
-        )
-        .map_err(KeyError::KeyDerivationError)?;
-
-        Ok(Self {
-            unified_key_store: UnifiedKeyStore::Spend(Box::new(usk)),
-            ..Default::default()
-        })
-    }
-
-    /// TODO: Add Doc Comment Here!
-    pub fn new_from_phrase(
-        config: &ZingoConfig,
-        seed_phrase: &Mnemonic,
-        position: u32,
-    ) -> Result<Self, KeyError> {
-        // The seed bytes is the raw entropy. To pass it to HD wallet generation,
-        // we need to get the 64 byte bip39 entropy
-        let bip39_seed = seed_phrase.to_seed("");
-        Self::new_from_seed(config, &bip39_seed, position)
-    }
-
-    /// TODO: Add Doc Comment Here!
-    pub fn first_sapling_address(&self) -> sapling_crypto::PaymentAddress {
-        // This index is dangerous, but all ways to instantiate a UnifiedSpendAuthority
-        // create it with a suitable first address
-        *self.addresses()[0].sapling().unwrap()
-    }
-
-    /// TODO: Add Doc Comment Here!
     //TODO: NAME?????!!
     pub fn get_trees_witness_trees(&self) -> Option<WitnessTrees> {
         if self.unified_key_store.is_spending_key() {
@@ -261,13 +71,6 @@ impl WalletCapability {
             None
         }
     }
-
-    /// TODO: Add Doc Comment Here!
-    pub fn get_rejection_addresses(
-        &self,
-    ) -> &Arc<AppendOnlyVec<(TransparentAddress, TransparentAddressMetadata)>> {
-        &self.rejection_addresses
-    }
 }
 
 impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
@@ -275,12 +78,9 @@ impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
 
     fn read<R: Read>(mut reader: R, input: ChainType) -> io::Result<Self> {
         let version = Self::get_version(&mut reader)?;
-        let legacy_key: bool;
         let wc = match version {
             // in version 1, only spending keys are stored
             1 => {
-                legacy_key = true;
-
                 // Create a temporary USK for address generation to load old wallets
                 // due to missing BIP0032 transparent extended private key data
                 //
@@ -297,8 +97,6 @@ impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
                 }
             }
             2 => {
-                legacy_key = true;
-
                 let orchard_capability = Capability::<
                     orchard::keys::FullViewingKey,
                     orchard::keys::SpendingKey,
@@ -386,16 +184,11 @@ impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
                     ..Default::default()
                 }
             }
-            3 => {
-                legacy_key = false;
-
-                Self {
-                    unified_key_store: UnifiedKeyStore::read(&mut reader, input)?,
-                    ..Default::default()
-                }
-            }
+            3 => Self {
+                unified_key_store: UnifiedKeyStore::read(&mut reader, input)?,
+                ..Default::default()
+            },
             4 => {
-                legacy_key = false;
                 let _length_of_rejection_addresses = reader.read_u32::<LittleEndian>()?;
 
                 Self {
@@ -410,11 +203,7 @@ impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
                 ));
             }
         };
-        let receiver_selections = Vector::read(&mut reader, |r| ReceiverSelection::read(r, ()))?;
-        for rs in receiver_selections {
-            wc.new_address(rs, legacy_key)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        }
+        let _receiver_selections = Vector::read(&mut reader, |r| ReceiverSelection::read(r, ()))?;
 
         Ok(wc)
     }
@@ -572,40 +361,6 @@ pub(crate) fn legacy_sks_to_usk(
     usk_bytes.write_all(&account_tkey_bytes)?;
 
     UnifiedSpendingKey::from_bytes(Era::Orchard, &usk_bytes).map_err(|_| KeyError::KeyDecodingError)
-}
-
-/// Generates a transparent address from legacy key
-///
-/// Legacy key is a key used ONLY during wallet load for wallet versions <29
-/// This legacy key is already derived to the external scope so should only derive a child at the `address_index`
-/// and use this child to derive the transparent address
-#[allow(deprecated)]
-pub(crate) fn generate_transparent_address_from_legacy_key(
-    external_pubkey: &AccountPubKey,
-    address_index: NonHardenedChildIndex,
-) -> Result<TransparentAddress, bip32::Error> {
-    let external_pubkey_bytes = external_pubkey.serialize();
-
-    let mut chain_code = [0u8; 32];
-    chain_code.copy_from_slice(&external_pubkey_bytes[..32]);
-    let public_key = secp256k1::PublicKey::from_slice(&external_pubkey_bytes[32..])?;
-
-    let extended_pubkey = ExtendedPublicKey::new(
-        public_key,
-        bip32::ExtendedKeyAttrs {
-            depth: 4,
-            parent_fingerprint: [0xff, 0xff, 0xff, 0xff],
-            child_number: bip32::ChildNumber::new(0, true)
-                .expect("hard-coded index of 0 is not larger than the hardened bit"),
-            chain_code,
-        },
-    );
-
-    // address generation copied from IncomingViewingKey::derive_address in LRZ
-    let child_key = extended_pubkey.derive_child(address_index.into())?;
-    Ok(zcash_primitives::legacy::keys::pubkey_to_address(
-        child_key.public_key(),
-    ))
 }
 
 impl ReadableWriteable for sapling_crypto::zip32::ExtendedSpendingKey {

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -22,8 +22,6 @@ use crate::config::ChainType;
 use crate::wallet::error::KeyError;
 use crate::wallet::traits::ReadableWriteable;
 
-use super::legacy::generate_transparent_address_from_legacy_key;
-
 pub(crate) const KEY_TYPE_EMPTY: u8 = 0;
 pub(crate) const KEY_TYPE_VIEW: u8 = 1;
 pub(crate) const KEY_TYPE_SPEND: u8 = 2;
@@ -123,13 +121,10 @@ impl UnifiedKeyStore {
     }
 
     /// Generates a unified address for the given `unified_address_index` and `receivers`.
-    ///
-    /// See [`self::UnifiedKeyStore::generate_transparent_address`] for information on using `legacy_key`.
     pub fn generate_unified_address(
         &self,
         unified_address_index: u32,
         receivers: ReceiverSelection,
-        legacy_key: bool,
     ) -> Result<UnifiedAddress, KeyError> {
         let orchard_receiver = if receivers.orchard {
             let fvk = orchard::keys::FullViewingKey::try_from(self)?;
@@ -144,25 +139,9 @@ impl UnifiedKeyStore {
             None
         };
 
-        let transparent_receiver = if receivers.transparent {
-            Some(
-                self.generate_transparent_address(
-                    NonHardenedChildIndex::from_index(unified_address_index)
-                        .ok_or(KeyError::InvalidNonHardenedChildIndex)?,
-                    TransparentScope::External,
-                    legacy_key,
-                )?,
-            )
-        } else {
-            None
-        };
-
-        let unified_address = UnifiedAddress::from_receivers(
-            orchard_receiver,
-            sapling_receiver,
-            transparent_receiver,
-        )
-        .ok_or(KeyError::UnifiedAddressError)?;
+        let unified_address =
+            UnifiedAddress::from_receivers(orchard_receiver, sapling_receiver, None)
+                .ok_or(KeyError::UnifiedAddressError)?;
 
         Ok(unified_address)
     }
@@ -172,11 +151,6 @@ impl UnifiedKeyStore {
         &self,
         address_index: NonHardenedChildIndex,
         scope: TransparentScope,
-        // this should only be `true` when generating externally scoped transparent addresses while loading from legacy
-        // keys (pre wallet version 29).
-        // legacy transparent keys are already derived to the external scope so setting `legacy_key` to `true` will
-        // skip this scope derivation.
-        legacy_key: bool,
     ) -> Result<TransparentAddress, KeyError> {
         let account_pubkey = UnifiedFullViewingKey::try_from(self)?
             .transparent()
@@ -184,15 +158,9 @@ impl UnifiedKeyStore {
             .clone();
 
         let transparent_address = match scope {
-            TransparentScope::External => {
-                if legacy_key {
-                    generate_transparent_address_from_legacy_key(&account_pubkey, address_index)?
-                } else {
-                    account_pubkey
-                        .derive_external_ivk()?
-                        .derive_address(address_index)?
-                }
-            }
+            TransparentScope::External => account_pubkey
+                .derive_external_ivk()?
+                .derive_address(address_index)?,
             TransparentScope::Internal => account_pubkey
                 .derive_internal_ivk()?
                 .derive_address(address_index)?,
@@ -418,8 +386,6 @@ pub struct ReceiverSelection {
     pub orchard: bool,
     /// Sapling
     pub sapling: bool,
-    /// Transparent
-    pub transparent: bool,
 }
 
 impl ReceiverSelection {
@@ -428,7 +394,6 @@ impl ReceiverSelection {
         Self {
             orchard: true,
             sapling: true,
-            transparent: false,
         }
     }
 
@@ -437,7 +402,6 @@ impl ReceiverSelection {
         Self {
             orchard: true,
             sapling: false,
-            transparent: false,
         }
     }
 
@@ -446,13 +410,12 @@ impl ReceiverSelection {
         Self {
             orchard: false,
             sapling: true,
-            transparent: false,
         }
     }
 }
 
 impl ReadableWriteable for ReceiverSelection {
-    const VERSION: u8 = 1;
+    const VERSION: u8 = 2;
 
     fn read<R: Read>(mut reader: R, _input: ()) -> io::Result<Self> {
         let _version = Self::get_version(&mut reader)?;
@@ -460,7 +423,6 @@ impl ReadableWriteable for ReceiverSelection {
         Ok(Self {
             orchard: receivers & 0b1 != 0,
             sapling: receivers & 0b10 != 0,
-            transparent: receivers & 0b100 != 0,
         })
     }
 
@@ -472,9 +434,6 @@ impl ReadableWriteable for ReceiverSelection {
         };
         if self.sapling {
             receivers |= 0b10;
-        };
-        if self.transparent {
-            receivers |= 0b100;
         };
         writer.write_u8(receivers)?;
         Ok(())

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -442,8 +442,8 @@ impl ReadableWriteable for ReceiverSelection {
 
 #[test]
 fn read_write_receiver_selections() {
-    for (i, receivers_selected) in (0..8)
-        .map(|n| ReceiverSelection::read([1, n].as_slice(), ()).unwrap())
+    for (i, receivers_selected) in (0..4)
+        .map(|n| ReceiverSelection::read([2, n].as_slice(), ()).unwrap())
         .enumerate()
     {
         let mut receivers_selected_bytes = [0; 2];


### PR DESCRIPTION
- add no gap enforcement option to keep sync initialisation very efficient
- remove transparent receiver support for UAs due to an issue with potentially missing transparent funds and also general support from community due to privacy concerns
- remove a bunch of kruft no longer needed in legacy read/write