### PR TITLE
Add initial `tracing` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7532,6 +7532,7 @@ dependencies = [
  "rustls 0.23.27",
  "rustyline",
  "shellwords",
+ "tracing-subscriber",
  "zcash_protocol",
  "zingolib",
 ]
@@ -7642,6 +7643,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tonic",
+ "tracing",
  "tracing-subscriber",
  "zcash_address",
  "zcash_client_backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ serde = "1"
 serde_json = "1"
 shellwords = "1"
 subtle = "2"
-tempdir = "0.3"
 tempfile = "3"
 thiserror = "2"
 tokio = "1"
@@ -103,7 +102,6 @@ tonic-build = "0.12"
 tower = { version = "0.5" }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-webpki-roots = "1"
 
 # Parallel processing
 crossbeam-channel = "0.5"

--- a/zingocli/Cargo.toml
+++ b/zingocli/Cargo.toml
@@ -17,3 +17,4 @@ log = { workspace = true }
 rustls = { workspace = true }
 rustyline = { workspace = true }
 shellwords = { workspace = true }
+tracing-subscriber.workspace = true

--- a/zingocli/src/main.rs
+++ b/zingocli/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 pub fn main() {
+    tracing_subscriber::fmt().init();
     // install default crypto provider (ring)
     if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
         eprintln!("Error installing crypto provider: {:?}", e)

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -81,6 +81,7 @@ tonic = { workspace = true }
 tracing-subscriber = { workspace = true }
 bech32 = { workspace = true }
 rust-embed = { workspace = true, features = ["debug-embed"] }
+tracing.workspace = true
 
 [dev-dependencies]
 portpicker = { workspace = true }

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -10,7 +10,6 @@ use log::info;
 
 use bip0039::Mnemonic;
 
-use tracing::{Level, event, instrument};
 use zcash_client_backend::proto::service::TreeState;
 use zcash_encoding::{Optional, Vector};
 use zcash_keys::keys::UnifiedSpendingKey;
@@ -121,25 +120,19 @@ impl LightWallet {
 
     /// Deserialize into `reader`
     // TODO: update to return WalletError
-    #[instrument(level = "info", skip(reader))]
     pub fn read<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
-        event!(Level::INFO, "Started parsing wallet");
         let version = reader.read_u64::<LittleEndian>()?;
         info!("Reading wallet version {}", version);
         match version {
             ..32 => Self::read_v0(reader, network, version),
             32..=36 => Self::read_v32(reader, network, version),
-            _ => {
-                event!(Level::ERROR, "Failed to read wallet version {}", version);
-                Err(io::Error::new(
-                    ErrorKind::InvalidData,
-                    format!(
-                        "Failed to read wallet version {}. Do you have the latest version?\n{}",
-                        version,
-                        "Note: wallet files from zecwallet or beta zingo are not compatible"
-                    ),
-                ))
-            }
+            _ => Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "Failed to read wallet version {}. Do you have the latest version?\n{}",
+                    version, "Note: wallet files from zecwallet or beta zingo are not compatible"
+                ),
+            )),
         }
     }
 

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -10,6 +10,7 @@ use log::info;
 
 use bip0039::Mnemonic;
 
+use tracing::{Level, event, instrument};
 use zcash_client_backend::proto::service::TreeState;
 use zcash_encoding::{Optional, Vector};
 use zcash_keys::keys::UnifiedSpendingKey;
@@ -120,19 +121,25 @@ impl LightWallet {
 
     /// Deserialize into `reader`
     // TODO: update to return WalletError
+    #[instrument(level = "info", skip(reader))]
     pub fn read<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
+        event!(Level::INFO, "Started parsing wallet");
         let version = reader.read_u64::<LittleEndian>()?;
         info!("Reading wallet version {}", version);
         match version {
             ..32 => Self::read_v0(reader, network, version),
             32..=36 => Self::read_v32(reader, network, version),
-            _ => Err(io::Error::new(
-                ErrorKind::InvalidData,
-                format!(
-                    "Failed to read wallet version {}. Do you have the latest version?\n{}",
-                    version, "Note: wallet files from zecwallet or beta zingo are not compatible"
-                ),
-            )),
+            _ => {
+                event!(Level::ERROR, "Failed to read wallet version {}", version);
+                Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "Failed to read wallet version {}. Do you have the latest version?\n{}",
+                        version,
+                        "Note: wallet files from zecwallet or beta zingo are not compatible"
+                    ),
+                ))
+            }
         }
     }
 

--- a/zingolib/src/wallet/keys/legacy.rs
+++ b/zingolib/src/wallet/keys/legacy.rs
@@ -8,7 +8,6 @@ use std::{
 use append_only_vec::AppendOnlyVec;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
-use tracing::{Level, event, instrument};
 use zcash_address::unified::Typecode;
 use zcash_client_backend::wallet::TransparentAddressMetadata;
 use zcash_encoding::{CompactSize, Vector};
@@ -77,9 +76,7 @@ impl WalletCapability {
 impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
     const VERSION: u8 = 4;
 
-    #[instrument(level = "info", skip(reader))]
     fn read<R: Read>(mut reader: R, input: ChainType) -> io::Result<Self> {
-        event!(Level::INFO, "Started parsing WalletCapability");
         let version = Self::get_version(&mut reader)?;
         let wc = match version {
             // in version 1, only spending keys are stored
@@ -219,17 +216,11 @@ impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
 impl ReadableWriteable for orchard::keys::SpendingKey {
     const VERSION: u8 = 0; //Not applicable
 
-    #[instrument(level = "info", skip(reader, _input))]
     fn read<R: Read>(mut reader: R, _input: ()) -> io::Result<Self> {
-        event!(Level::INFO, "Started parsing SpendingKey");
         let mut data = [0u8; 32];
         reader.read_exact(&mut data)?;
 
         Option::from(Self::from_bytes(data)).ok_or_else(|| {
-            event!(
-                Level::ERROR,
-                "Unable to deserialize a valid Orchard SpendingKey from bytes"
-            );
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Unable to deserialize a valid Orchard SpendingKey from bytes".to_owned(),
@@ -261,10 +252,7 @@ where
 {
     const VERSION: u8 = 1;
 
-    #[instrument(level = "info", skip(reader, _input))]
     fn read<R: Read>(mut reader: R, _input: ()) -> io::Result<Self> {
-        event!(Level::INFO, "Started parsing Capability");
-
         let _version = Self::get_version(&mut reader)?;
         let capability_type = reader.read_u8()?;
         Ok(match capability_type {
@@ -272,7 +260,6 @@ where
             KEY_TYPE_VIEW => Capability::View(V::read(&mut reader, ())?),
             KEY_TYPE_SPEND => Capability::Spend(S::read(&mut reader, ())?),
             x => {
-                event!(Level::ERROR, "Unknown wallet Capability type: {}", x);
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Unknown wallet Capability type: {}", x),

--- a/zingolib/src/wallet/keys/legacy.rs
+++ b/zingolib/src/wallet/keys/legacy.rs
@@ -8,6 +8,7 @@ use std::{
 use append_only_vec::AppendOnlyVec;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
+use tracing::{Level, event, instrument};
 use zcash_address::unified::Typecode;
 use zcash_client_backend::wallet::TransparentAddressMetadata;
 use zcash_encoding::{CompactSize, Vector};
@@ -76,7 +77,9 @@ impl WalletCapability {
 impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
     const VERSION: u8 = 4;
 
+    #[instrument(level = "info", skip(reader))]
     fn read<R: Read>(mut reader: R, input: ChainType) -> io::Result<Self> {
+        event!(Level::INFO, "Started parsing WalletCapability");
         let version = Self::get_version(&mut reader)?;
         let wc = match version {
             // in version 1, only spending keys are stored
@@ -216,11 +219,17 @@ impl ReadableWriteable<ChainType, ChainType> for WalletCapability {
 impl ReadableWriteable for orchard::keys::SpendingKey {
     const VERSION: u8 = 0; //Not applicable
 
+    #[instrument(level = "info", skip(reader, _input))]
     fn read<R: Read>(mut reader: R, _input: ()) -> io::Result<Self> {
+        event!(Level::INFO, "Started parsing SpendingKey");
         let mut data = [0u8; 32];
         reader.read_exact(&mut data)?;
 
         Option::from(Self::from_bytes(data)).ok_or_else(|| {
+            event!(
+                Level::ERROR,
+                "Unable to deserialize a valid Orchard SpendingKey from bytes"
+            );
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Unable to deserialize a valid Orchard SpendingKey from bytes".to_owned(),
@@ -251,7 +260,11 @@ where
     S: ReadableWriteable<(), ()>,
 {
     const VERSION: u8 = 1;
+
+    #[instrument(level = "info", skip(reader, _input))]
     fn read<R: Read>(mut reader: R, _input: ()) -> io::Result<Self> {
+        event!(Level::INFO, "Started parsing Capability");
+
         let _version = Self::get_version(&mut reader)?;
         let capability_type = reader.read_u8()?;
         Ok(match capability_type {
@@ -259,6 +272,7 @@ where
             KEY_TYPE_VIEW => Capability::View(V::read(&mut reader, ())?),
             KEY_TYPE_SPEND => Capability::Spend(S::read(&mut reader, ())?),
             x => {
+                event!(Level::ERROR, "Unknown wallet Capability type: {}", x);
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Unknown wallet Capability type: {}", x),

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -6,7 +6,6 @@ use bip0039::Mnemonic;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
 use pepper_sync::keys::transparent::TransparentScope;
-use tracing::{Level, event, instrument};
 use zcash_address::unified::{Encoding as _, Ufvk};
 use zcash_client_backend::address::UnifiedAddress;
 use zcash_client_backend::keys::{Era, UnifiedSpendingKey};
@@ -236,10 +235,7 @@ impl UnifiedKeyStore {
 impl ReadableWriteable<ChainType, ChainType> for UnifiedKeyStore {
     const VERSION: u8 = 0;
 
-    #[instrument(level = "info", skip(reader, input))]
     fn read<R: Read>(mut reader: R, input: ChainType) -> io::Result<Self> {
-        event!(Level::INFO, "Started parsing UnifiedKeyStore");
-
         let _version = Self::get_version(&mut reader)?;
         let key_type = reader.read_u8()?;
         Ok(match key_type {
@@ -251,7 +247,6 @@ impl ReadableWriteable<ChainType, ChainType> for UnifiedKeyStore {
             }
             KEY_TYPE_EMPTY => UnifiedKeyStore::Empty,
             x => {
-                event!(Level::ERROR, "Unknown key type: {}", x);
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Unknown key type: {}", x),
@@ -297,29 +292,19 @@ impl ReadableWriteable for UnifiedSpendingKey {
 impl ReadableWriteable<ChainType, ChainType> for UnifiedFullViewingKey {
     const VERSION: u8 = 0;
 
-    #[instrument(level = "info", skip(reader, input))]
     fn read<R: Read>(mut reader: R, input: ChainType) -> io::Result<Self> {
-        event!(Level::INFO, "Started parsing Unified Full Viewing Key");
-
         let len = CompactSize::read(&mut reader)?;
         let mut ufvk = vec![0u8; len as usize];
         reader.read_exact(&mut ufvk)?;
         let ufvk_encoded = std::str::from_utf8(&ufvk)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
-        match UnifiedFullViewingKey::decode(&input, ufvk_encoded) {
-            Ok(key) => {
-                event!(Level::INFO, "Successfully parsed UFVK");
-                Ok(key)
-            }
-            Err(e) => {
-                event!(Level::ERROR, error = %e, "UFVK decoding error");
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("UFVK decoding error: {}", e),
-                ))
-            }
-        }
+        UnifiedFullViewingKey::decode(&input, ufvk_encoded).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("UFVK decoding error: {}", e),
+            )
+        })
     }
 
     fn write<W: Write>(&self, mut writer: W, input: ChainType) -> io::Result<()> {

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -6,6 +6,7 @@ use bip0039::Mnemonic;
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
 use pepper_sync::keys::transparent::TransparentScope;
+use tracing::{Level, event, instrument};
 use zcash_address::unified::{Encoding as _, Ufvk};
 use zcash_client_backend::address::UnifiedAddress;
 use zcash_client_backend::keys::{Era, UnifiedSpendingKey};
@@ -234,7 +235,11 @@ impl UnifiedKeyStore {
 
 impl ReadableWriteable<ChainType, ChainType> for UnifiedKeyStore {
     const VERSION: u8 = 0;
+
+    #[instrument(level = "info", skip(reader, input))]
     fn read<R: Read>(mut reader: R, input: ChainType) -> io::Result<Self> {
+        event!(Level::INFO, "Started parsing UnifiedKeyStore");
+
         let _version = Self::get_version(&mut reader)?;
         let key_type = reader.read_u8()?;
         Ok(match key_type {
@@ -246,6 +251,7 @@ impl ReadableWriteable<ChainType, ChainType> for UnifiedKeyStore {
             }
             KEY_TYPE_EMPTY => UnifiedKeyStore::Empty,
             x => {
+                event!(Level::ERROR, "Unknown key type: {}", x);
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Unknown key type: {}", x),
@@ -291,19 +297,29 @@ impl ReadableWriteable for UnifiedSpendingKey {
 impl ReadableWriteable<ChainType, ChainType> for UnifiedFullViewingKey {
     const VERSION: u8 = 0;
 
+    #[instrument(level = "info", skip(reader, input))]
     fn read<R: Read>(mut reader: R, input: ChainType) -> io::Result<Self> {
+        event!(Level::INFO, "Started parsing Unified Full Viewing Key");
+
         let len = CompactSize::read(&mut reader)?;
         let mut ufvk = vec![0u8; len as usize];
         reader.read_exact(&mut ufvk)?;
         let ufvk_encoded = std::str::from_utf8(&ufvk)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
-        UnifiedFullViewingKey::decode(&input, ufvk_encoded).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("UFVK decoding error: {}", e),
-            )
-        })
+        match UnifiedFullViewingKey::decode(&input, ufvk_encoded) {
+            Ok(key) => {
+                event!(Level::INFO, "Successfully parsed UFVK");
+                Ok(key)
+            }
+            Err(e) => {
+                event!(Level::ERROR, error = %e, "UFVK decoding error");
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("UFVK decoding error: {}", e),
+                ))
+            }
+        }
     }
 
     fn write<W: Write>(&self, mut writer: W, input: ChainType) -> io::Result<()> {

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -2,6 +2,7 @@
 use std::io::{self, Read, Write};
 
 use byteorder::ReadBytesExt;
+use tracing::{Level, event, instrument};
 
 /// TODO: Add Doc Comment Here!
 pub trait ReadableWriteable<ReadInput = (), WriteInput = ()>: Sized {
@@ -15,13 +16,22 @@ pub trait ReadableWriteable<ReadInput = (), WriteInput = ()>: Sized {
     fn write<W: Write>(&self, writer: W, input: WriteInput) -> io::Result<()>;
 
     /// TODO: Add Doc Comment Here!
+    #[instrument(level = "info", skip(reader))]
     fn get_version<R: Read>(mut reader: R) -> io::Result<u8> {
         let external_version = reader.read_u8()?;
         if external_version > Self::VERSION {
+            event!(
+                Level::ERROR,
+                where = std::any::type_name::<Self>(),
+                got_version = external_version,
+                expected_version = Self::VERSION,
+                kind = ?io::ErrorKind::InvalidData,
+                msg = "Struct version is from a future version of zingo"
+            );
             Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "Wallet file version \"{}\" is from future version of zingo",
+                    "Struct version \"{}\" is from future version of zingo",
                     external_version,
                 ),
             ))

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -16,7 +16,7 @@ pub trait ReadableWriteable<ReadInput = (), WriteInput = ()>: Sized {
     fn write<W: Write>(&self, writer: W, input: WriteInput) -> io::Result<()>;
 
     /// Reads a serialized version of the struct from `reader`, and returns the
-    /// deserialized struct. Else, returns an `io::Error` with `io::ErrorKind::InvalidData`.
+    /// struct version. Else, returns an `io::Error` with `io::ErrorKind::InvalidData`.
     #[instrument(level = "info", skip(reader))]
     fn get_version<R: Read>(mut reader: R) -> io::Result<u8> {
         let external_version = reader.read_u8()?;

--- a/zingolib/src/wallet/traits.rs
+++ b/zingolib/src/wallet/traits.rs
@@ -15,7 +15,8 @@ pub trait ReadableWriteable<ReadInput = (), WriteInput = ()>: Sized {
     /// TODO: Add Doc Comment Here!
     fn write<W: Write>(&self, writer: W, input: WriteInput) -> io::Result<()>;
 
-    /// TODO: Add Doc Comment Here!
+    /// Reads a serialized version of the struct from `reader`, and returns the
+    /// deserialized struct. Else, returns an `io::Error` with `io::ErrorKind::InvalidData`.
     #[instrument(level = "info", skip(reader))]
     fn get_version<R: Read>(mut reader: R) -> io::Result<u8> {
         let external_version = reader.read_u8()?;


### PR DESCRIPTION
This PR adds tracing. In order to see the events, prefix the run command with `RUST_LOG=info`.