### PR TITLE
rework spendable balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,9 +2514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
- "proptest",
- "rand 0.8.5",
- "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -47,9 +47,6 @@ async fn reorg_changes_incoming_tx_height() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -88,9 +85,6 @@ async fn reorg_changes_incoming_tx_height() {
     // Assert that balance holds
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -214,9 +208,6 @@ async fn reorg_changes_incoming_tx_index() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -255,9 +246,6 @@ async fn reorg_changes_incoming_tx_index() {
     // Assert that balance holds
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -381,9 +369,6 @@ async fn reorg_expires_incoming_tx() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -422,9 +407,6 @@ async fn reorg_expires_incoming_tx() {
     // Assert that balance holds
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -570,9 +552,6 @@ async fn reorg_changes_outgoing_tx_height() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -638,9 +617,6 @@ async fn reorg_changes_outgoing_tx_height() {
 
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -715,9 +691,6 @@ async fn reorg_changes_outgoing_tx_height() {
     // Assert that balance holds
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -849,9 +822,6 @@ async fn reorg_expires_outgoing_tx_height() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -900,9 +870,6 @@ async fn reorg_expires_outgoing_tx_height() {
 
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -959,9 +926,6 @@ async fn reorg_expires_outgoing_tx_height() {
     // sent transaction was never mined and has expired.
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -1049,9 +1013,6 @@ async fn reorg_changes_outgoing_tx_index() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -1117,9 +1078,6 @@ async fn reorg_changes_outgoing_tx_index() {
 
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -1201,9 +1159,6 @@ async fn reorg_changes_outgoing_tx_index() {
     // Assert that balance holds
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -39,9 +39,6 @@ async fn simple_sync() {
     assert_eq!(result.blocks_scanned, 3);
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -82,9 +79,6 @@ async fn reorg_receipt_sync_generic() {
 
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -106,9 +100,6 @@ async fn reorg_receipt_sync_generic() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -154,9 +145,6 @@ async fn sent_transaction_reorged_into_mempool() {
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
         light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -200,9 +188,6 @@ async fn sent_transaction_reorged_into_mempool() {
     println!(
         "Recipient pre-reorg: {}",
         &recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap()
@@ -210,9 +195,6 @@ async fn sent_transaction_reorged_into_mempool() {
     println!(
         "Sender pre-reorg (unsynced): {}",
         &light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap()
@@ -231,9 +213,6 @@ async fn sent_transaction_reorged_into_mempool() {
     println!(
         "Recipient post-reorg: {}",
         &recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap()
@@ -241,9 +220,6 @@ async fn sent_transaction_reorged_into_mempool() {
     println!(
         "Sender post-reorg: {}",
         &light_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap()
@@ -255,9 +231,6 @@ async fn sent_transaction_reorged_into_mempool() {
     loaded_client.sync_and_await().await.unwrap();
     assert_eq!(
         loaded_client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap()

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -1199,9 +1199,6 @@ mod fast {
         .await
         .unwrap();
         let balance_b = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -1425,6 +1422,8 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
     }
 }
 mod slow {
+    use std::num::NonZeroU32;
+
     use pepper_sync::sync::{SyncConfig, TransparentAddressDiscovery};
     use pepper_sync::wallet::{
         NoteInterface, OrchardNote, OutgoingNoteInterface, OutputInterface, SaplingNote,
@@ -1498,9 +1497,6 @@ mod slow {
         println!(
             "{}",
             &recipient
-                .wallet
-                .read()
-                .await
                 .account_balance(zip32::AccountId::ZERO)
                 .await
                 .unwrap()
@@ -1785,6 +1781,7 @@ mod slow {
                 sync_config: SyncConfig {
                     transparent_address_discovery: TransparentAddressDiscovery::minimal(),
                 },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             },
             1.try_into().unwrap(),
         )
@@ -1816,9 +1813,6 @@ mod slow {
         .await
         .unwrap();
         let original_recipient_balance = original_recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -1867,18 +1861,12 @@ mod slow {
             let mut watch_client = build_fvk_client(fvks, zingo_config.clone());
             // assert empty wallet before rescan
             let balance = watch_client
-                .wallet
-                .read()
-                .await
                 .account_balance(zip32::AccountId::ZERO)
                 .await
                 .unwrap();
             check_expected_balance_with_fvks(fvks, balance, 0, 0, 0);
             watch_client.rescan_and_await().await.unwrap();
             let balance = watch_client
-                .wallet
-                .read()
-                .await
                 .account_balance(zip32::AccountId::ZERO)
                 .await
                 .unwrap();
@@ -2017,9 +2005,6 @@ mod slow {
         println!(
             "{}",
             &recipient
-                .wallet
-                .read()
-                .await
                 .account_balance(zip32::AccountId::ZERO)
                 .await
                 .unwrap()
@@ -2033,9 +2018,6 @@ mod slow {
         println!(
             "{}",
             &recipient
-                .wallet
-                .read()
-                .await
                 .account_balance(zip32::AccountId::ZERO)
                 .await
                 .unwrap()
@@ -2252,7 +2234,6 @@ mod slow {
             assert_eq!(
                 recipient_wallet
                     .unconfirmed_balance::<OrchardNote>(zip32::AccountId::ZERO)
-                    .await
                     .unwrap(),
                 expected_funds.try_into().unwrap()
             );
@@ -2260,7 +2241,6 @@ mod slow {
             assert_eq!(
                 recipient_wallet
                     .confirmed_balance::<OrchardNote>(zip32::AccountId::ZERO)
-                    .await
                     .unwrap(),
                 0.try_into().unwrap()
             );
@@ -2488,7 +2468,6 @@ TransactionSummary {
                 .read()
                 .await
                 .confirmed_balance::<OrchardNote>(zip32::AccountId::ZERO)
-                .await
                 .unwrap(),
             second_wave_expected_funds.try_into().unwrap(),
         );
@@ -2546,9 +2525,6 @@ TransactionSummary {
         println!(
             "{}",
             &faucet
-                .wallet
-                .read()
-                .await
                 .account_balance(zip32::AccountId::ZERO)
                 .await
                 .unwrap()
@@ -2611,9 +2587,6 @@ TransactionSummary {
             .await
             .unwrap();
         let balance = faucet
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -2876,9 +2849,6 @@ TransactionSummary {
 
         // 3. Check the balance is correct, and we received the incoming transaction from ?outside?
         let balance = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -3437,9 +3407,6 @@ TransactionSummary {
             scenarios::faucet_funded_recipient_default(value).await;
 
         let bal = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -3457,9 +3424,6 @@ TransactionSummary {
         .await
         .unwrap();
         let bal = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -3483,9 +3447,6 @@ TransactionSummary {
         .unwrap();
 
         let bal = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -3506,9 +3467,6 @@ TransactionSummary {
         .unwrap();
 
         let bal = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -4023,9 +3981,6 @@ TransactionSummary {
             );
         }
         let balance = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -4070,9 +4025,6 @@ TransactionSummary {
             );
         }
         let balance = recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();
@@ -4532,7 +4484,7 @@ mod send_all {
             Zatoshis::from_u64(initial_funds - zennies_magnitude - expected_fee).unwrap();
         assert_eq!(
             recipient
-                .get_spendable_shielded_balance(external_uaddress, true, zip32::AccountId::ZERO)
+                .max_send_value(external_uaddress, true, zip32::AccountId::ZERO)
                 .await
                 .unwrap(),
             expected_balance
@@ -4607,7 +4559,6 @@ mod send_all {
                 .read()
                 .await
                 .confirmed_balance_excluding_dust::<SaplingNote>(zip32::AccountId::ZERO)
-                .await
                 .unwrap()
                 .into_u64(),
             0
@@ -4618,7 +4569,6 @@ mod send_all {
                 .read()
                 .await
                 .confirmed_balance_excluding_dust::<OrchardNote>(zip32::AccountId::ZERO)
-                .await
                 .unwrap()
                 .into_u64(),
             0

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -1186,7 +1186,7 @@ mod fast {
         let addresses = recipient.unified_addresses_json().await;
         let address_5000_nonememo_tuples = addresses
             .members()
-            .map(|ua| (ua["encoded_address"].as_str().unwrap(), 5_000, None))
+            .map(|ua| (ua["encoded_address"].as_str().unwrap(), 10_000, None))
             .collect::<Vec<(&str, u64, Option<&str>)>>();
         from_inputs::quick_send(&mut faucet, address_5000_nonememo_tuples)
             .await
@@ -1205,11 +1205,11 @@ mod fast {
         assert_eq!(
             balance_b,
             AccountBalance {
-                total_sapling_balance: Some(5000.try_into().unwrap()),
-                confirmed_sapling_balance: Some(5000.try_into().unwrap()),
+                total_sapling_balance: Some(10_000.try_into().unwrap()),
+                confirmed_sapling_balance: Some(10_000.try_into().unwrap()),
                 unconfirmed_sapling_balance: Some(0.try_into().unwrap()),
-                total_orchard_balance: Some(15000.try_into().unwrap()),
-                confirmed_orchard_balance: Some(15000.try_into().unwrap()),
+                total_orchard_balance: Some(30_000.try_into().unwrap()),
+                confirmed_orchard_balance: Some(30_000.try_into().unwrap()),
                 unconfirmed_orchard_balance: Some(0.try_into().unwrap()),
                 total_transparent_balance: Some(0.try_into().unwrap()),
                 confirmed_transparent_balance: Some(0.try_into().unwrap()),
@@ -2479,7 +2479,7 @@ TransactionSummary {
         let (regtest_manager, _cph, mut faucet, mut recipient) =
             scenarios::faucet_recipient_default().await;
         let faucet_to_recipient_amount = 20_000u64;
-        let recipient_to_faucet_amount = 5_000u64;
+        let recipient_to_faucet_amount = 10_000u64;
         // check start state
         faucet.sync_and_await().await.unwrap();
         let wallet_fully_scanned_height = faucet
@@ -2575,7 +2575,7 @@ TransactionSummary {
         )
         .await;
 
-        let amount_to_send = 5_000;
+        let amount_to_send = 10_000;
         let faucet_ua = get_base_address_macro!(faucet, "unified");
         from_inputs::quick_send(
             &mut faucet,
@@ -3088,7 +3088,7 @@ TransactionSummary {
         )
         .await
         .unwrap();
-        check_client_balances!(recipient, o: for_orchard s: for_sapling t: 0 );
+        check_client_balances!(recipient, o: for_orchard s: 0 t: 0 );
 
         from_inputs::quick_send(
             &mut recipient,
@@ -3108,7 +3108,7 @@ TransactionSummary {
         .await
         .unwrap();
         let remaining_orchard = for_orchard - (6 * fee);
-        check_client_balances!(recipient, o: remaining_orchard s: for_sapling t: 0);
+        check_client_balances!(recipient, o: remaining_orchard s: 0 t: 0);
     }
     // FIXME: zingo2 yet to implement transaction filter in sync engine. its also not clear how this test exceeds the tx filter.
     // #[tokio::test]

--- a/libtonode-tests/tests/shield_transparent.rs
+++ b/libtonode-tests/tests/shield_transparent.rs
@@ -12,16 +12,10 @@ async fn shield_transparent() {
             faucet: {}
             recipient: {}",
         &faucet
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
         &recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -42,16 +36,10 @@ async fn shield_transparent() {
             faucet: {}
             recipient: {}",
         &faucet
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
         &recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -65,16 +53,10 @@ async fn shield_transparent() {
             faucet: {}
             recipient: {}",
         &faucet
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
         &recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
@@ -98,16 +80,10 @@ async fn shield_transparent() {
             faucet: {}
             recipient: {}",
         &faucet
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),
         &recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap(),

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -34,6 +34,7 @@ async fn sync_mainnet_test() {
             sync_config: SyncConfig {
                 transparent_address_discovery: TransparentAddressDiscovery::minimal(),
             },
+            min_confirmations: NonZeroU32::try_from(1).unwrap(),
         },
         1.try_into().unwrap(),
     )
@@ -81,6 +82,7 @@ async fn sync_status() {
             sync_config: SyncConfig {
                 transparent_address_discovery: TransparentAddressDiscovery::minimal(),
             },
+            min_confirmations: NonZeroU32::try_from(1).unwrap(),
         },
         1.try_into().unwrap(),
     )
@@ -131,9 +133,6 @@ async fn sync_test() {
     println!(
         "{}",
         recipient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap()

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -1056,7 +1056,8 @@ impl OutgoingNoteInterface for OutgoingOrchardNote {
     }
 }
 
-// TODO: allow consumer to define shard store
+// TODO: allow consumer to define shard store. memory shard store has infallible error type but other may not so error
+// handling will need to replace expects
 /// Type alias for sapling memory shard store
 pub type SaplingShardStore = MemoryShardStore<sapling_crypto::Node, BlockHeight>;
 

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -465,6 +465,7 @@ pub fn startup(
             sync_config: SyncConfig {
                 transparent_address_discovery: TransparentAddressDiscovery::minimal(),
             },
+            min_confirmations: NonZeroU32::try_from(1).unwrap(),
         },
         1.try_into().unwrap(),
     )

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -27,10 +27,6 @@ testvectors = { workspace = true, optional = true }
 orchard = { workspace = true }
 shardtree = { workspace = true, features = ["legacy-api"] }
 incrementalmerkletree = { workspace = true }
-# incrementalmerkletree = { workspace = true, features = [
-#     "test-dependencies",
-#     "legacy-api",
-# ] }
 zcash_address = { workspace = true }
 zcash_client_backend = { workspace = true, features = [
     "unstable",

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -26,10 +26,11 @@ testvectors = { workspace = true, optional = true }
 
 orchard = { workspace = true }
 shardtree = { workspace = true, features = ["legacy-api"] }
-incrementalmerkletree = { workspace = true, features = [
-    "test-dependencies",
-    "legacy-api",
-] }
+incrementalmerkletree = { workspace = true }
+# incrementalmerkletree = { workspace = true, features = [
+#     "test-dependencies",
+#     "legacy-api",
+# ] }
 zcash_address = { workspace = true }
 zcash_client_backend = { workspace = true, features = [
     "unstable",

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -697,7 +697,7 @@ impl Command for MaxSendValueCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
             Display the maximum value the wallet can currently send to the given address.
-            
+
             This value is calculated from the shielded spendable balance minus any fees required to send those funds to
             the given `address`. If the wallet is still syncing, the spendable balance may be less than the confirmed
             balance - minus the fee - due to notes being above the minimum confirmation threshold or not being able to

--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -73,11 +73,12 @@ impl Command for ChangeServerCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
             Change the lightwalletd server to receive blockchain data from
+
             Usage:
-            changeserver [server_uri]
+            change_server [server_uri]
 
             Example:
-            changeserver https://mainnet.lightwalletd.com:9067
+            change_server https://mainnet.lightwalletd.com:9067
         "#}
     }
 
@@ -433,8 +434,9 @@ impl Command for SendProgressCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
             Get the progress of any send transactions that are currently computing
+
             Usage:
-            sendprogress
+            send_progress
         "#}
     }
 
@@ -644,13 +646,7 @@ impl Command for BalanceCommand {
 
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
         RT.block_on(async move {
-            match lightclient
-                .wallet
-                .read()
-                .await
-                .account_balance(zip32::AccountId::ZERO)
-                .await
-            {
+            match lightclient.account_balance(zip32::AccountId::ZERO).await {
                 Ok(bal) => bal.to_string(),
                 Err(e) => format!("Error: {e}"),
             }
@@ -662,44 +658,83 @@ struct SpendableBalanceCommand {}
 impl Command for SpendableBalanceCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
-            Display the wallet's spendable balance.
-            Calculated as the confirmed shielded balance minus the fee required to send all funds to
-            the given address.
-            An address must be specified as fees, and therefore spendable balance, depends on the receiver
-            type.
-            zennies_for_zingo must also be specified as "true"|"false".  If set to "true" 1_000_000 ZAT will
-            earmarked to the zingolabs developer fund with each transaction.
+            Display the wallet's spendable balance for each shielded pool.
 
             Usage:
-            spendablebalance <address>
-            OR
-            spendablebalance { "address": "<address>", "zennies_for_zingo": <true|false> }
+            spendable_balance
 
         "#}
     }
 
     fn short_help(&self) -> &'static str {
-        "Display the wallet's spendable balance."
+        "Display the wallet's spendable balance for each shielded pool."
+    }
+
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+        RT.block_on(async move {
+            let mut wallet = lightclient.wallet.write().await;
+            let orchard_spendable_balance =
+                match wallet.spendable_balance::<OrchardNote>(zip32::AccountId::ZERO) {
+                    Ok(bal) => bal,
+                    Err(e) => return format!("Error: {e}"),
+                };
+            let sapling_spendable_balance =
+                match wallet.spendable_balance::<SaplingNote>(zip32::AccountId::ZERO) {
+                    Ok(bal) => bal,
+                    Err(e) => return format!("Error: {e}"),
+                };
+            object! {
+                "orchard_spendable_balance" => orchard_spendable_balance.into_u64(),
+                "sapling_spendable_balance" => sapling_spendable_balance.into_u64(),
+            }
+            .pretty(2)
+        })
+    }
+}
+
+struct MaxSendValueCommand {}
+impl Command for MaxSendValueCommand {
+    fn help(&self) -> &'static str {
+        indoc! {r#"
+            Display the maximum value the wallet can currently send to the given address.
+            
+            This value is calculated from the shielded spendable balance minus any fees required to send those funds to
+            the given `address`. If the wallet is still syncing, the spendable balance may be less than the confirmed
+            balance - minus the fee - due to notes being above the minimum confirmation threshold or not being able to
+            construct a witness from the current state of the wallet's note commitment tree.
+            If `zennies_for_zingo` is set true, an additional payment of 1_000_000 ZAT to the ZingoLabs developer address
+            will be taken into account.
+
+            Usage:
+            max_send_value <address>
+            OR
+            max_send_value { "address": "<address>", "zennies_for_zingo": <true|false> }
+
+        "#}
+    }
+
+    fn short_help(&self) -> &'static str {
+        "Display the maximum value the wallet can currently send to a given address."
     }
 
     fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
-        let (address, zennies_for_zingo) = match utils::parse_spendable_balance_args(args) {
+        let (address, zennies_for_zingo) = match utils::parse_max_send_value_args(args) {
             Ok(address_and_zennies) => address_and_zennies,
             Err(e) => {
                 return format!(
-                    "Error: {}\nTry 'help spendablebalance' for correct usage and examples.",
+                    "Error: {}\nTry 'help max_send_value' for correct usage and examples.",
                     e
                 );
             }
         };
         RT.block_on(async move {
             match lightclient
-                .get_spendable_shielded_balance(address, zennies_for_zingo, zip32::AccountId::ZERO)
+                .max_send_value(address, zennies_for_zingo, zip32::AccountId::ZERO)
                 .await
             {
                 Ok(bal) => {
                     object! {
-                        "balance" => bal.into_u64(),
+                        "max_send_value" => bal.into_u64(),
                     }
                 }
                 Err(e) => {
@@ -946,7 +981,7 @@ impl Command for ExportUfvkCommand {
             Note: If you want to backup spend capability, use the 'recovery_info' command instead.
 
             Usage:
-            exportufvk
+            export_ufvk
         "#}
     }
 
@@ -1051,11 +1086,11 @@ impl Command for SendAllCommand {
             Warning:
                 Does not send transparent funds. These funds must be shielded first. Type `help shield` for more information.
             Usage:
-                sendall <address> "<optional memo>"
+                send_all <address> "<optional memo>"
                 OR
-                sendall '{ "address": "<address>", "memo": "<optional memo>", "zennies_for_zingo": <true|false> }'
+                send_all '{ "address": "<address>", "memo": "<optional memo>", "zennies_for_zingo": <true|false> }'
             Example:
-                sendall ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d "Sending all funds"
+                send_all ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d "Sending all funds"
                 confirm
 
         "#}
@@ -1417,7 +1452,7 @@ impl Command for ValueTransfersCommand {
             A value transfer is a group of all notes to a specific receiver in a transaction.
 
             Usage:
-            valuetransfers
+            value_transfers
         "#}
     }
 
@@ -1994,22 +2029,28 @@ impl Command for QuitCommand {
 
 /// TODO: Add Doc Comment Here!
 pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
-    let mut entries: Vec<(&'static str, Box<dyn Command>)> = vec![
+    let entries: Vec<(&'static str, Box<dyn Command>)> = vec![
         ("version", Box::new(GetVersionCommand {})),
         ("sync", Box::new(SyncCommand {})),
         ("parse_address", Box::new(ParseAddressCommand {})),
         ("parse_viewkey", Box::new(ParseViewKeyCommand {})),
-        ("changeserver", Box::new(ChangeServerCommand {})),
+        ("change_server", Box::new(ChangeServerCommand {})),
         ("rescan", Box::new(RescanCommand {})),
         ("clear", Box::new(ClearCommand {})),
         ("help", Box::new(HelpCommand {})),
         ("balance", Box::new(BalanceCommand {})),
+        ("spendable_balance", Box::new(SpendableBalanceCommand {})),
+        ("max_send_value", Box::new(MaxSendValueCommand {})),
+        ("send_all", Box::new(SendAllCommand {})),
+        ("quicksend", Box::new(QuickSendCommand {})),
+        ("quickshield", Box::new(QuickShieldCommand {})),
+        ("confirm", Box::new(ConfirmCommand {})),
         ("addresses", Box::new(UnifiedAddressesCommand {})),
         ("t_addresses", Box::new(TransparentAddressesCommand {})),
         ("check_address", Box::new(CheckAddressCommand {})),
         ("height", Box::new(HeightCommand {})),
-        ("sendprogress", Box::new(SendProgressCommand {})),
-        ("valuetransfers", Box::new(ValueTransfersCommand {})),
+        ("send_progress", Box::new(SendProgressCommand {})),
+        ("value_transfers", Box::new(ValueTransfersCommand {})),
         ("transactions", Box::new(TransactionsCommand {})),
         ("value_to_address", Box::new(ValueToAddressCommand {})),
         ("sends_to_address", Box::new(SendsToAddressCommand {})),
@@ -2018,7 +2059,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
             "memobytes_to_address",
             Box::new(MemoBytesToAddressCommand {}),
         ),
-        ("exportufvk", Box::new(ExportUfvkCommand {})),
+        ("export_ufvk", Box::new(ExportUfvkCommand {})),
         ("info", Box::new(InfoCommand {})),
         ("current_price", Box::new(CurrentPriceCommand {})),
         ("send", Box::new(SendCommand {})),
@@ -2036,13 +2077,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         ("delete", Box::new(DeleteCommand {})),
         ("remove_transaction", Box::new(RemoveTransactionCommand {})),
     ];
-    {
-        entries.push(("spendablebalance", Box::new(SpendableBalanceCommand {})));
-        entries.push(("sendall", Box::new(SendAllCommand {})));
-        entries.push(("quicksend", Box::new(QuickSendCommand {})));
-        entries.push(("quickshield", Box::new(QuickShieldCommand {})));
-        entries.push(("confirm", Box::new(ConfirmCommand {})));
-    }
+
     entries.into_iter().collect()
 }
 

--- a/zingolib/src/commands/utils.rs
+++ b/zingolib/src/commands/utils.rs
@@ -122,7 +122,7 @@ pub(super) fn parse_send_all_args(
 // - 1 argument for a single address. &["<address>"]
 // NOTE: zennies_for_zingo can only be set in a JSON
 // string.
-pub(super) fn parse_spendable_balance_args(
+pub(super) fn parse_max_send_value_args(
     args: &[&str],
 ) -> Result<(ZcashAddress, bool), CommandError> {
     if args.len() > 2 {

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -250,6 +250,7 @@ impl Default for ZingoConfigBuilder {
                     transparent_address_discovery:
                         pepper_sync::sync::TransparentAddressDiscovery::minimal(),
                 },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             },
             no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
         }
@@ -668,6 +669,8 @@ impl ActivationHeights {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use crate::wallet::WalletSettings;
 
     /// Validate that the load_clientconfig function creates a valid config from an empty uri
@@ -693,6 +696,7 @@ mod tests {
                     transparent_address_discovery:
                         pepper_sync::sync::TransparentAddressDiscovery::minimal(),
                 },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             },
             1.try_into().unwrap(),
         );
@@ -725,6 +729,7 @@ mod tests {
                     transparent_address_discovery:
                         pepper_sync::sync::TransparentAddressDiscovery::minimal(),
                 },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             },
             1.try_into().unwrap(),
         )

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -26,7 +26,8 @@ use crate::{
     data::proposal::ZingoProposal,
     wallet::{
         LightWallet, WalletBase,
-        error::{KeyError, SummaryError, WalletError},
+        balance::AccountBalance,
+        error::{BalanceError, KeyError, SummaryError, WalletError},
         keys::unified::{ReceiverSelection, UnifiedAddressId},
         summary::data::{
             TransactionSummaries, ValueTransfers,
@@ -224,6 +225,14 @@ impl LightClient {
     /// Wrapper for [crate::wallet::LightWallet::transparent_addresses_json].
     pub async fn transparent_addresses_json(&self) -> JsonValue {
         self.wallet.read().await.transparent_addresses_json()
+    }
+
+    /// Wrapper for [crate::wallet::LightWallet::account_balance].
+    pub async fn account_balance(
+        &self,
+        account_id: zip32::AccountId,
+    ) -> Result<AccountBalance, BalanceError> {
+        self.wallet.read().await.account_balance(account_id)
     }
 
     /// Wrapper for [crate::wallet::LightWallet::transaction_summaries].

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -19,7 +19,7 @@ use crate::wallet::error::ProposeSendError;
 use crate::wallet::error::ProposeShieldError;
 
 impl LightClient {
-    fn append_zingo_zenny_receiver(&self, receivers: &mut Vec<Receiver>) {
+    pub(super) fn append_zingo_zenny_receiver(&self, receivers: &mut Vec<Receiver>) {
         let zfz_address = match self.config().chain {
             ChainType::Mainnet => ZENNIES_FOR_ZINGO_DONATION_ADDRESS,
             ChainType::Testnet => ZENNIES_FOR_ZINGO_TESTNET_ADDRESS,
@@ -68,13 +68,13 @@ impl LightClient {
         memo: Option<zcash_primitives::memo::MemoBytes>,
         account_id: zip32::AccountId,
     ) -> Result<ProportionalFeeProposal, ProposeSendError> {
-        let spendable_balance = self
-            .get_spendable_shielded_balance(address.clone(), zennies_for_zingo, account_id)
+        let max_send_value = self
+            .max_send_value(address.clone(), zennies_for_zingo, account_id)
             .await?;
-        if spendable_balance == Zatoshis::ZERO {
+        if max_send_value == Zatoshis::ZERO {
             return Err(ProposeSendError::ZeroValueSendAll);
         }
-        let mut receivers = vec![Receiver::new(address, spendable_balance, memo)];
+        let mut receivers = vec![Receiver::new(address, max_send_value, memo)];
         if zennies_for_zingo {
             self.append_zingo_zenny_receiver(&mut receivers);
         }
@@ -95,26 +95,47 @@ impl LightClient {
         Ok(proposal)
     }
 
-    /// Returns the total confirmed shielded balance minus any fees required to send those funds to
-    /// a given address
-    /// Take zennies_for_zingo flag that if set true, will create a receiver of 1_000_000 ZAT at the
-    /// ZingoLabs developer address.
+    /// Creates and stores a proposal for shielding all transparent funds..
+    pub async fn propose_shield(
+        &mut self,
+        account_id: zip32::AccountId,
+    ) -> Result<ProportionalFeeShieldProposal, ProposeShieldError> {
+        let proposal = self
+            .wallet
+            .write()
+            .await
+            .create_shield_proposal(account_id)
+            .await?;
+        self.store_proposal(ZingoProposal::Shield {
+            proposal: proposal.clone(),
+            shielding_account: account_id,
+        })
+        .await;
+
+        Ok(proposal)
+    }
+
+    /// Returns the maximum value that can be sent from the given `account_id`.
+    ///
+    /// This value is calculated from the shielded spendable balance minus any fees required to send those funds to
+    /// the given `address`. If the wallet is still syncing, the spendable balance may be less than the confirmed
+    /// balance - minus the fee - due to notes being above the minimum confirmation threshold or not being able to
+    /// construct a witness from the current state of the wallet's note commitment tree.
+    /// If `zennies_for_zingo` is set true, an additional payment of 1_000_000 ZAT to the ZingoLabs developer address
+    /// will be taken into account.
     ///
     /// # Error
     ///
     /// Will return an error if this method fails to calculate the total wallet balance or create the
     /// proposal needed to calculate the fee
-    // TODO: move spendable balance and create proposal to wallet layer
-    pub async fn get_spendable_shielded_balance(
+    pub async fn max_send_value(
         &self,
         address: ZcashAddress,
         zennies_for_zingo: bool,
         account_id: zip32::AccountId,
     ) -> Result<Zatoshis, ProposeSendError> {
         let mut wallet = self.wallet.write().await;
-        let confirmed_balance = wallet
-            .confirmed_shielded_balance_excluding_dust(account_id)
-            .await?;
+        let confirmed_balance = wallet.shielded_spendable_balance(account_id)?;
         let mut spendable_balance = confirmed_balance;
 
         loop {
@@ -169,30 +190,12 @@ impl LightClient {
 
         Ok(spendable_balance)
     }
-
-    /// Creates and stores a proposal for shielding all transparent funds..
-    pub async fn propose_shield(
-        &mut self,
-        account_id: zip32::AccountId,
-    ) -> Result<ProportionalFeeShieldProposal, ProposeShieldError> {
-        let proposal = self
-            .wallet
-            .write()
-            .await
-            .create_shield_proposal(account_id)
-            .await?;
-        self.store_proposal(ZingoProposal::Shield {
-            proposal: proposal.clone(),
-            shielding_account: account_id,
-        })
-        .await;
-
-        Ok(proposal)
-    }
 }
 
 #[cfg(test)]
 mod shielding {
+    use std::num::NonZeroU32;
+
     use bip0039::Mnemonic;
     use pepper_sync::sync::SyncConfig;
     use zcash_protocol::consensus::Parameters;
@@ -221,6 +224,7 @@ mod shielding {
                         transparent_address_discovery:
                             pepper_sync::sync::TransparentAddressDiscovery::minimal(),
                     },
+                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
                 },
             )
             .unwrap(),

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -129,6 +129,8 @@ pub mod send_with_proposal {
     mod test {
         //! all tests below (and in this mod) use example wallets, which describe real-world chains.
 
+        use std::num::NonZeroU32;
+
         use bip0039::Mnemonic;
         use pepper_sync::sync::SyncConfig;
 
@@ -162,6 +164,7 @@ pub mod send_with_proposal {
                             transparent_address_discovery:
                                 pepper_sync::sync::TransparentAddressDiscovery::minimal(),
                         },
+                        min_confirmations: NonZeroU32::try_from(1).unwrap(),
                     },
                 )
                 .unwrap(),

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -171,14 +171,7 @@ pub mod test {
 
         let sync_result = lc.sync_and_await().await.unwrap();
         println!("{}", sync_result);
-        println!(
-            "{:?}",
-            lc.wallet
-                .read()
-                .await
-                .account_balance(zip32::AccountId::ZERO)
-                .await
-        );
+        println!("{:?}", lc.account_balance(zip32::AccountId::ZERO).await);
         lc
     }
 

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -5,6 +5,7 @@
 
 pub mod scenarios;
 
+use std::num::NonZeroU32;
 use std::{io::Read, string::String, time::Duration};
 
 use json::JsonValue;
@@ -76,6 +77,7 @@ pub fn build_fvk_client(fvks: &[&Fvk], config: ZingoConfig) -> LightClient {
                 sync_config: SyncConfig {
                     transparent_address_discovery: TransparentAddressDiscovery::minimal(),
                 },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             },
         )
         .unwrap(),

--- a/zingolib/src/testutils/macros.rs
+++ b/zingolib/src/testutils/macros.rs
@@ -51,9 +51,6 @@ macro_rules! get_base_address_macro {
 macro_rules! check_client_balances {
     ($client:ident, o: $orchard:tt s: $sapling:tt t: $transparent:tt) => {
         let balance = $client
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();

--- a/zingolib/src/testutils/macros.rs
+++ b/zingolib/src/testutils/macros.rs
@@ -75,22 +75,5 @@ macro_rules! check_client_balances {
             balance.confirmed_transparent_balance.unwrap().into_u64(),
             $transparent
         );
-        let summaries = $client.transaction_summaries(false).await.unwrap();
-        let summaries_balance = summaries
-            .iter()
-            .map(|summary| {
-                summary
-                    .balance_delta()
-                    .unwrap_or_else(|| panic!("field not correctly populated"))
-            })
-            .sum::<i64>();
-        assert_eq!(
-            (balance.total_orchard_balance.unwrap().into_u64()
-                + balance.total_sapling_balance.unwrap().into_u64()
-                + balance.confirmed_transparent_balance.unwrap().into_u64()) as i64,
-            summaries_balance,
-            "transaction_summaries: {}",
-            summaries
-        );
     };
 }

--- a/zingolib/src/testutils/scenarios.rs
+++ b/zingolib/src/testutils/scenarios.rs
@@ -26,6 +26,7 @@ mod config_templaters;
 
 /// TODO: Add Doc Comment Here!
 pub mod setup {
+    use std::num::NonZeroU32;
     use std::path::PathBuf;
 
     use bip0039::Mnemonic;
@@ -223,6 +224,7 @@ pub mod setup {
                     sync_config: SyncConfig {
                         transparent_address_discovery: TransparentAddressDiscovery::minimal(),
                     },
+                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
                 },
                 1.try_into().unwrap(),
             )

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -45,6 +45,9 @@ mod zcb_traits;
 pub struct WalletSettings {
     /// Sync configuration.
     pub sync_config: pepper_sync::sync::SyncConfig,
+    /// Minimum confirmations.
+    // TODO: read/write
+    pub min_confirmations: NonZeroU32,
 }
 
 /// Provides necessary information to recover the wallet without the wallet file.

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -413,6 +413,7 @@ impl LightWallet {
     /// - not dust (note value larger than 5_000 zats)
     /// - the wallet can build a witness for the note's commitment
     /// - satisfy the number of minimum confirmations set by the wallet
+    /// - the nullifier derived from the note has not yet been found in a transaction input on chain
     ///
     /// # Error
     ///

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -439,18 +439,26 @@ impl LightWallet {
             .orchard
             .store()
             .get_checkpoint(&anchor_height)
-            .is_err()
+            .expect("infallible")
+            .is_none()
         {
-            return Err(BalanceError::CheckpointNotFound(anchor_height));
+            return Err(BalanceError::CheckpointNotFound {
+                shielded_protocol: ShieldedProtocol::Orchard,
+                height: anchor_height,
+            });
         }
         if self
             .shard_trees
             .sapling
             .store()
             .get_checkpoint(&anchor_height)
-            .is_err()
+            .expect("infallible")
+            .is_none()
         {
-            return Err(BalanceError::CheckpointNotFound(anchor_height));
+            return Err(BalanceError::CheckpointNotFound {
+                shielded_protocol: ShieldedProtocol::Sapling,
+                height: anchor_height,
+            });
         }
 
         let mut shard_trees = std::mem::take(&mut self.shard_trees);

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -491,7 +491,7 @@ impl LightWallet {
 
     /// Returns total spendable balance of all shielded pools of a given `account_id`.
     ///
-    /// See [`self::spendable_balance`] for more information.
+    /// See [`Self::spendable_balance`] for more information.
     ///
     /// # Error
     ///

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -1,8 +1,10 @@
 //! Balance methods and types for `crate::wallet::LightWallet`.
 
 use pepper_sync::wallet::{
-    KeyIdInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin, WalletTransaction,
+    KeyIdInterface, NoteInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin,
+    WalletTransaction,
 };
+use shardtree::store::ShardStore;
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_protocol::{PoolType, value::Zatoshis};
 
@@ -129,18 +131,18 @@ fn format_zatoshis(zatoshis: Zatoshis) -> String {
 
 impl LightWallet {
     /// Returns account balance.
-    pub async fn account_balance(
+    pub fn account_balance(
         &self,
         account_id: zip32::AccountId,
     ) -> Result<AccountBalance, BalanceError> {
         let confirmed_orchard_balance =
-            match self.confirmed_balance::<OrchardNote>(account_id).await {
+            match self.confirmed_balance_excluding_dust::<OrchardNote>(account_id) {
                 Ok(zats) => Some(zats),
                 Err(BalanceError::KeyError(KeyError::NoViewCapability)) => None,
                 Err(e) => return Err(e),
             };
         let unconfirmed_orchard_balance =
-            match self.unconfirmed_balance::<OrchardNote>(account_id).await {
+            match self.unconfirmed_balance_excluding_dust::<OrchardNote>(account_id) {
                 Ok(zats) => Some(zats),
                 Err(BalanceError::KeyError(KeyError::NoViewCapability)) => None,
                 Err(e) => return Err(e),
@@ -149,13 +151,13 @@ impl LightWallet {
             confirmed_orchard_balance.and_then(|confirmed| unconfirmed_orchard_balance + confirmed);
 
         let confirmed_sapling_balance =
-            match self.confirmed_balance::<SaplingNote>(account_id).await {
+            match self.confirmed_balance_excluding_dust::<SaplingNote>(account_id) {
                 Ok(zats) => Some(zats),
                 Err(BalanceError::KeyError(KeyError::NoViewCapability)) => None,
                 Err(e) => return Err(e),
             };
         let unconfirmed_sapling_balance =
-            match self.unconfirmed_balance::<SaplingNote>(account_id).await {
+            match self.unconfirmed_balance_excluding_dust::<SaplingNote>(account_id) {
                 Ok(zats) => Some(zats),
                 Err(BalanceError::KeyError(KeyError::NoViewCapability)) => None,
                 Err(e) => return Err(e),
@@ -164,19 +166,17 @@ impl LightWallet {
             confirmed_sapling_balance.and_then(|confirmed| unconfirmed_sapling_balance + confirmed);
 
         let confirmed_transparent_balance =
-            match self.confirmed_balance::<TransparentCoin>(account_id).await {
+            match self.confirmed_balance_excluding_dust::<TransparentCoin>(account_id) {
                 Ok(zats) => Some(zats),
                 Err(BalanceError::KeyError(KeyError::NoViewCapability)) => None,
                 Err(e) => return Err(e),
             };
-        let unconfirmed_transparent_balance = match self
-            .unconfirmed_balance::<TransparentCoin>(account_id)
-            .await
-        {
-            Ok(zats) => Some(zats),
-            Err(BalanceError::KeyError(KeyError::NoViewCapability)) => None,
-            Err(e) => return Err(e),
-        };
+        let unconfirmed_transparent_balance =
+            match self.unconfirmed_balance_excluding_dust::<TransparentCoin>(account_id) {
+                Ok(zats) => Some(zats),
+                Err(BalanceError::KeyError(KeyError::NoViewCapability)) => None,
+                Err(e) => return Err(e),
+            };
         let total_transparent_balance = confirmed_transparent_balance
             .and_then(|confirmed| unconfirmed_transparent_balance + confirmed);
 
@@ -193,8 +193,8 @@ impl LightWallet {
         })
     }
 
-    /// Returns the total balance of the all outputs of a given pool type and `account_id` matching the output and transaction
-    /// criteria specified by the `filter_function`.
+    /// Returns the total balance of the all unspent outputs of a given pool type and `account_id` matching the output
+    /// and transaction criteria specified by the `filter_function`.
     ///
     /// # Error
     ///
@@ -202,7 +202,7 @@ impl LightWallet {
     /// - no keys are found for the given `account_id`
     /// - the UFVK does not have viewing capability for the given pool type
     /// - the balance summation exceeds the valid range of zatoshis
-    pub async fn get_filtered_balance<Op, F>(
+    pub fn get_filtered_balance<Op, F>(
         &self,
         filter_function: F,
         account_id: zip32::AccountId,
@@ -254,7 +254,8 @@ impl LightWallet {
         )?)
     }
 
-    /// Returns total wallet balance of unspent notes in confirmed blocks for a given shielded pool and `account_id`.
+    /// Returns the total balance of the all unspent outputs of a given pool type and `account_id` matching the output
+    /// and transaction criteria specified by the mutable `filter_function`.
     ///
     /// # Error
     ///
@@ -262,7 +263,67 @@ impl LightWallet {
     /// - no keys are found for the given `account_id`
     /// - the UFVK does not have viewing capability for the given pool type
     /// - the balance summation exceeds the valid range of zatoshis
-    pub async fn confirmed_balance<Op>(
+    pub fn get_filtered_balance_mut<Op, F>(
+        &self,
+        mut filter_function: F,
+        account_id: zip32::AccountId,
+    ) -> Result<Zatoshis, BalanceError>
+    where
+        Op: OutputInterface,
+        F: FnMut(&Op, &WalletTransaction) -> bool,
+    {
+        match &self
+            .unified_key_store
+            .get(&account_id)
+            .ok_or(KeyError::NoAccountKeys)?
+        {
+            UnifiedKeyStore::Spend(_) => (),
+            UnifiedKeyStore::View(ufvk) => match Op::POOL_TYPE {
+                PoolType::Transparent => {
+                    if ufvk.transparent().is_none() {
+                        return Err(KeyError::NoViewCapability.into());
+                    };
+                }
+                PoolType::SAPLING => {
+                    if ufvk.sapling().is_none() {
+                        return Err(KeyError::NoViewCapability.into());
+                    };
+                }
+                PoolType::ORCHARD => {
+                    if ufvk.orchard().is_none() {
+                        return Err(KeyError::NoViewCapability.into());
+                    };
+                }
+            },
+            UnifiedKeyStore::Empty => return Err(KeyError::NoViewCapability.into()),
+        }
+
+        Ok(utils::conversion::zatoshis_from_u64(
+            self.wallet_transactions
+                .values()
+                .fold(0, |acc, transaction| {
+                    acc + Op::transaction_outputs(transaction)
+                        .iter()
+                        .filter(|&output| {
+                            filter_function(output, transaction)
+                                && output.spending_transaction().is_none()
+                                && output.key_id().account_id() == account_id
+                        })
+                        .map(|output| output.value())
+                        .sum::<u64>()
+                }),
+        )?)
+    }
+
+    /// Returns total balance of unspent notes in confirmed blocks for a given shielded pool and `account_id`.
+    ///
+    /// # Error
+    ///
+    /// Returns an error if:
+    /// - no keys are found for the given `account_id`
+    /// - the UFVK does not have viewing capability for the given pool type
+    /// - the balance summation exceeds the valid range of zatoshis
+    pub fn confirmed_balance<Op>(
         &self,
         account_id: zip32::AccountId,
     ) -> Result<Zatoshis, BalanceError>
@@ -273,11 +334,10 @@ impl LightWallet {
             |_, transaction: &WalletTransaction| transaction.status().is_confirmed(),
             account_id,
         )
-        .await
     }
 
-    /// Returns total wallet balance of unspent notes not yet confirmed on the block chain for a given shielded pool
-    /// and `account_id`.
+    /// Returns total balance of unspent notes in confirmed blocks for a given shielded pool and `account_id`,
+    /// excluding any notes with value less than marginal fee (5_000).
     ///
     /// # Error
     ///
@@ -285,30 +345,7 @@ impl LightWallet {
     /// - no keys are found for the given `account_id`
     /// - the UFVK does not have viewing capability for the given pool type
     /// - the balance summation exceeds the valid range of zatoshis
-    pub async fn unconfirmed_balance<Op>(
-        &self,
-        account_id: zip32::AccountId,
-    ) -> Result<Zatoshis, BalanceError>
-    where
-        Op: OutputInterface,
-    {
-        self.get_filtered_balance::<Op, _>(
-            |_, transaction: &WalletTransaction| !transaction.status().is_confirmed(),
-            account_id,
-        )
-        .await
-    }
-
-    /// Returns total wallet balance of unspent notes in confirmed blocks for a given shielded pool excluding any notes
-    /// with value less than marginal fee (5_000).
-    ///
-    /// # Error
-    ///
-    /// Returns an error if:
-    /// - no keys are found for the given `account_id`
-    /// - the UFVK does not have viewing capability for the given pool type
-    /// - the balance summation exceeds the valid range of zatoshis
-    pub async fn confirmed_balance_excluding_dust<Op>(
+    pub fn confirmed_balance_excluding_dust<Op>(
         &self,
         account_id: zip32::AccountId,
     ) -> Result<Zatoshis, BalanceError>
@@ -321,34 +358,143 @@ impl LightWallet {
             },
             account_id,
         )
-        .await
     }
 
-    /// Returns total balance of all shielded pools excluding any notes with value less than marginal fee
-    /// that are confirmed on the block chain (the block has at least 1 confirmation).
-    /// Does not include transparent funds.
+    /// Returns total balance of unspent notes not yet confirmed on the block chain for a given shielded pool and
+    /// `account_id`.
+    ///
+    /// # Error
+    ///
+    /// Returns an error if:
+    /// - no keys are found for the given `account_id`
+    /// - the UFVK does not have viewing capability for the given pool type
+    /// - the balance summation exceeds the valid range of zatoshis
+    pub fn unconfirmed_balance<Op>(
+        &self,
+        account_id: zip32::AccountId,
+    ) -> Result<Zatoshis, BalanceError>
+    where
+        Op: OutputInterface,
+    {
+        self.get_filtered_balance::<Op, _>(
+            |_, transaction: &WalletTransaction| !transaction.status().is_confirmed(),
+            account_id,
+        )
+    }
+
+    /// Returns total balance of unspent notes not yet confirmed on the block chain for a given shielded pool and
+    /// `account_id`, excluding any notes with value less than marginal fee (5_000).
+    ///
+    /// # Error
+    ///
+    /// Returns an error if:
+    /// - no keys are found for the given `account_id`
+    /// - the UFVK does not have viewing capability for the given pool type
+    /// - the balance summation exceeds the valid range of zatoshis
+    pub fn unconfirmed_balance_excluding_dust<Op>(
+        &self,
+        account_id: zip32::AccountId,
+    ) -> Result<Zatoshis, BalanceError>
+    where
+        Op: OutputInterface,
+    {
+        self.get_filtered_balance::<Op, _>(
+            |note, transaction: &WalletTransaction| {
+                Op::value(note) > MARGINAL_FEE.into_u64() && !transaction.status().is_confirmed()
+            },
+            account_id,
+        )
+    }
+
+    /// Returns total balance of spendable notes for a given shielded pool and `account_id`.
+    ///
+    /// Spendable notes are:
+    /// - confirmed
+    /// - not dust (note value larger than 5_000 zats)
+    /// - the wallet can build a witness for the note's commitment
+    /// - satisfy the number of minimum confirmations set by the wallet
+    ///
+    /// # Error
+    ///
+    /// Returns an error if:
+    /// - no keys are found for the given `account_id`
+    /// - the UFVK does not have viewing capability for the given pool type
+    /// - the balance summation exceeds the valid range of zatoshis
+    pub fn spendable_balance<N>(
+        &mut self,
+        account_id: zip32::AccountId,
+    ) -> Result<Zatoshis, BalanceError>
+    where
+        N: NoteInterface,
+    {
+        let Some(wallet_height) = self.sync_state.wallet_height() else {
+            return Ok(Zatoshis::ZERO);
+        };
+        let anchor_height = wallet_height + 1 - u32::from(self.wallet_settings.min_confirmations);
+        if anchor_height == 0.into() {
+            return Ok(Zatoshis::ZERO);
+        }
+        if self
+            .shard_trees
+            .orchard
+            .store()
+            .get_checkpoint(&anchor_height)
+            .is_err()
+        {
+            return Err(BalanceError::CheckpointNotFound(anchor_height));
+        }
+        if self
+            .shard_trees
+            .sapling
+            .store()
+            .get_checkpoint(&anchor_height)
+            .is_err()
+        {
+            return Err(BalanceError::CheckpointNotFound(anchor_height));
+        }
+
+        let mut shard_trees = std::mem::take(&mut self.shard_trees);
+        let spendable_balance = self.get_filtered_balance_mut::<N, _>(
+            |note, transaction: &WalletTransaction| {
+                N::value(note) > MARGINAL_FEE.into_u64()
+                    && transaction.status().is_confirmed()
+                    && transaction.status().get_height() <= anchor_height
+                    && note.position().is_some_and(|position| {
+                        match shard_trees
+                            .orchard
+                            .witness_at_checkpoint_id_caching(position, &anchor_height)
+                        {
+                            Ok(witness) => witness.is_some(),
+                            Err(_) => false,
+                        }
+                    })
+            },
+            account_id,
+        )?;
+        self.shard_trees = shard_trees;
+
+        Ok(spendable_balance)
+    }
+
+    /// Returns total spendable balance of all shielded pools of a given `account_id`.
+    ///
+    /// See [`self::spendable_balance`] for more information.
     ///
     /// # Error
     ///
     /// Returns an error if:
     /// - no keys are found for the given `account_id`
     /// - the balance summation exceeds the valid range of zatoshis
-    pub async fn confirmed_shielded_balance_excluding_dust(
-        &self,
+    pub fn shielded_spendable_balance(
+        &mut self,
         account_id: zip32::AccountId,
     ) -> Result<Zatoshis, BalanceError> {
-        let orchard_balance = match self
-            .confirmed_balance_excluding_dust::<OrchardNote>(account_id)
-            .await
-        {
+        let orchard_balance = match self.spendable_balance::<OrchardNote>(account_id) {
             Ok(zats) => Ok(zats),
             Err(BalanceError::KeyError(KeyError::NoViewCapability)) => Ok(Zatoshis::ZERO),
             Err(e) => Err(e),
         }?;
-        let sapling_balance = match self
-            .confirmed_balance_excluding_dust::<SaplingNote>(account_id)
-            .await
-        {
+        let sapling_balance = match self.spendable_balance::<SaplingNote>(account_id) {
             Ok(zats) => Ok(zats),
             Err(BalanceError::KeyError(KeyError::NoViewCapability)) => Ok(Zatoshis::ZERO),
             Err(e) => Err(e),

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -6,7 +6,7 @@ use pepper_sync::wallet::{
 };
 use shardtree::store::ShardStore;
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
-use zcash_protocol::{PoolType, value::Zatoshis};
+use zcash_protocol::{PoolType, ShieldedProtocol, value::Zatoshis};
 
 use crate::utils;
 
@@ -459,15 +459,28 @@ impl LightWallet {
                 N::value(note) > MARGINAL_FEE.into_u64()
                     && transaction.status().is_confirmed()
                     && transaction.status().get_height() <= anchor_height
-                    && note.position().is_some_and(|position| {
-                        match shard_trees
-                            .orchard
-                            .witness_at_checkpoint_id_caching(position, &anchor_height)
-                        {
-                            Ok(witness) => witness.is_some(),
-                            Err(_) => false,
-                        }
-                    })
+                    && note
+                        .position()
+                        .is_some_and(|position| match N::SHIELDED_PROTOCOL {
+                            ShieldedProtocol::Orchard => {
+                                match shard_trees
+                                    .orchard
+                                    .witness_at_checkpoint_id_caching(position, &anchor_height)
+                                {
+                                    Ok(witness) => witness.is_some(),
+                                    Err(_) => false,
+                                }
+                            }
+                            ShieldedProtocol::Sapling => {
+                                match shard_trees
+                                    .sapling
+                                    .witness_at_checkpoint_id_caching(position, &anchor_height)
+                                {
+                                    Ok(witness) => witness.is_some(),
+                                    Err(_) => false,
+                                }
+                            }
+                        })
             },
             account_id,
         )?;

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     io::{self, Error, ErrorKind, Read, Write},
+    num::NonZeroU32,
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -333,6 +334,7 @@ impl LightWallet {
                 sync_config: SyncConfig {
                     transparent_address_discovery: TransparentAddressDiscovery::minimal(),
                 },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             },
         };
 
@@ -510,12 +512,14 @@ impl LightWallet {
         let wallet_settings = if version >= 33 {
             WalletSettings {
                 sync_config: SyncConfig::read(&mut reader)?,
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             }
         } else {
             WalletSettings {
                 sync_config: SyncConfig {
                     transparent_address_discovery: TransparentAddressDiscovery::minimal(),
                 },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
             }
         };
 

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use bytes::Buf;
 
 use pepper_sync::sync::{SyncConfig, TransparentAddressDiscovery};
@@ -284,6 +286,7 @@ impl NetworkSeedVersion {
                         sync_config: SyncConfig {
                             transparent_address_discovery: TransparentAddressDiscovery::minimal(),
                         },
+                        min_confirmations: NonZeroU32::try_from(1).unwrap(),
                     },
                     1.try_into().unwrap(),
                 )

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -190,9 +190,6 @@ async fn loaded_wallet_assert(
         }
 
         let balance = lightclient
-            .wallet
-            .read()
-            .await
             .account_balance(zip32::AccountId::ZERO)
             .await
             .unwrap();

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -141,8 +141,11 @@ pub enum BalanceError {
     #[error("conversion failed. {0}")]
     ConversionFailed(#[from] crate::utils::error::ConversionError),
     /// Summation overflow
-    #[error("overflow occured during summation")]
+    #[error("overflow occured during summation.")]
     Overflow,
+    /// Shard store checkpoint not found.
+    #[error("shard store checkpoint not found at anchor height {0}.")]
+    CheckpointNotFound(BlockHeight),
 }
 
 /// Errors associated with key and address derivation

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -3,23 +3,25 @@
 use std::convert::Infallible;
 
 use pepper_sync::{error::ScanError, wallet::OutputId};
+use shardtree::error::ShardTreeError;
 use zcash_keys::keys::DerivationError;
 use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-use zcash_protocol::PoolType;
+use zcash_protocol::{PoolType, ShieldedProtocol};
 
 use super::output::OutputRef;
 
 /// Top level wallet errors
+// TODO: unify errors and error variants
 #[derive(Debug, thiserror::Error)]
 pub enum WalletError {
     /// Key error
-    #[error("{0}")]
+    #[error("Key error. {0}")]
     KeyError(#[from] KeyError),
     /// Mnemonic not found.
     #[error("Mnemonic not found.")]
     MnemonicNotFound,
     /// Mnemonic error
-    #[error("{0}")]
+    #[error("Mnemonic error. {0}")]
     MnemonicError(#[from] bip0039::Error),
     /// Value outside the valid range of zatoshis
     #[error("Value outside valid range of zatoshis. {0:?}")]
@@ -45,6 +47,15 @@ pub enum WalletError {
     /// Maximum number of accounts already in use.
     #[error("Maximum number of accounts already in use.")]
     AccountCreationFailed,
+    /// Shard store checkpoint not found.
+    #[error("{shielded_protocol:?} shard store checkpoint not found at anchor height {height}.")]
+    CheckpointNotFound {
+        shielded_protocol: ShieldedProtocol,
+        height: BlockHeight,
+    },
+    /// Shard tree error.
+    #[error("shard tree error. {0}")]
+    ShardTreeError(#[from] ShardTreeError<Infallible>),
 }
 
 /// Price error
@@ -72,12 +83,12 @@ pub enum RemovalError {
 /// Summary error
 #[derive(Debug, thiserror::Error)]
 pub enum SummaryError {
-    /// Address parse error
-    #[error("address parse error. {0}")]
-    ParseError(#[from] zcash_address::ParseError),
     /// Key error.
     #[error("key error. {0}")]
     KeyError(#[from] KeyError),
+    /// Address parse error
+    #[error("address parse error. {0}")]
+    ParseError(#[from] zcash_address::ParseError),
     /// Spend error
     #[error("spend error. {0}")]
     SpendError(#[from] SpendError),
@@ -144,8 +155,11 @@ pub enum BalanceError {
     #[error("overflow occured during summation.")]
     Overflow,
     /// Shard store checkpoint not found.
-    #[error("shard store checkpoint not found at anchor height {0}.")]
-    CheckpointNotFound(BlockHeight),
+    #[error("{shielded_protocol:?} shard store checkpoint not found at anchor height {height}.")]
+    CheckpointNotFound {
+        shielded_protocol: ShieldedProtocol,
+        height: BlockHeight,
+    },
 }
 
 /// Errors associated with key and address derivation

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -2,10 +2,12 @@
 
 use std::num::NonZeroU32;
 
+use shardtree::store::ShardStore;
 use zcash_primitives::consensus::BlockHeight;
 use zcash_primitives::transaction::TxId;
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_protocol::PoolType;
+use zcash_protocol::ShieldedProtocol;
 use zcash_protocol::value::Zatoshis;
 
 use super::LightWallet;
@@ -222,14 +224,41 @@ impl LightWallet {
     ///
     /// Any notes with output IDs in `exclude` will not be returned.
     /// Any notes without a nullifier or commitment tree position will not be returned.
-    // TODO: implement checking the witness can be constructed also
     pub(crate) fn spendable_notes<'a, N: NoteInterface>(
         &'a self,
         anchor_height: BlockHeight,
         exclude: &'a [OutputId],
         account: zip32::AccountId,
-    ) -> Vec<&'a N> {
-        self.wallet_transactions
+    ) -> Result<Vec<&'a N>, WalletError> {
+        if self
+            .shard_trees
+            .orchard
+            .store()
+            .get_checkpoint(&anchor_height)
+            .expect("infallible")
+            .is_none()
+        {
+            return Err(WalletError::CheckpointNotFound {
+                shielded_protocol: ShieldedProtocol::Orchard,
+                height: anchor_height,
+            });
+        }
+        if self
+            .shard_trees
+            .sapling
+            .store()
+            .get_checkpoint(&anchor_height)
+            .expect("infallible")
+            .is_none()
+        {
+            return Err(WalletError::CheckpointNotFound {
+                shielded_protocol: ShieldedProtocol::Sapling,
+                height: anchor_height,
+            });
+        }
+
+        Ok(self
+            .wallet_transactions
             .values()
             .flat_map(|transaction| {
                 if transaction
@@ -241,8 +270,30 @@ impl LightWallet {
                     Vec::new()
                 }
             })
-            .filter(|&note| note.nullifier().is_some() && note.position().is_some())
-            .collect()
+            .filter(|&note| {
+                note.nullifier().is_some()
+                    && note
+                        .position()
+                        .is_some_and(|position| match N::SHIELDED_PROTOCOL {
+                            ShieldedProtocol::Orchard => match self
+                                .shard_trees
+                                .orchard
+                                .witness_at_checkpoint_id(position, &anchor_height)
+                            {
+                                Ok(witness) => witness.is_some(),
+                                Err(_) => false,
+                            },
+                            ShieldedProtocol::Sapling => match self
+                                .shard_trees
+                                .sapling
+                                .witness_at_checkpoint_id(position, &anchor_height)
+                            {
+                                Ok(witness) => witness.is_some(),
+                                Err(_) => false,
+                            },
+                        })
+            })
+            .collect())
     }
 
     /// Returns all spendable transparent coins for a given `account` confirmed at or below `target_height`.
@@ -304,7 +355,7 @@ impl LightWallet {
         };
 
         let mut selected_notes: Vec<&'a N> = Vec::new();
-        let mut unselected_notes = self.spendable_notes::<N>(anchor_height, exclude, account);
+        let mut unselected_notes = self.spendable_notes::<N>(anchor_height, exclude, account)?;
         unselected_notes.sort_by_key(|&output| output.value());
         let dust_index =
             unselected_notes.partition_point(|output| output.value() <= MARGINAL_FEE.into_u64());

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -59,9 +59,8 @@ impl LightWallet {
             &input_selector,
             &change_strategy,
             request,
-            NonZeroU32::MIN,
             // TODO: update anchor height selection
-            // NonZeroU32::try_from(3).expect("hard coded non-zero integer"),
+            NonZeroU32::MIN,
         )
         .map_err(ProposeSendError::Proposal)
     }


### PR DESCRIPTION
- updates spendable balance to check witness can be constructed
- changes `spendablebalance` command to return orchard and sapling spendable balances
- adds `max_send_value` method and command to show maximum value that can be sent to a given address (previously `spendablebalance`)
- adds `account_balance` wrapper to lightclient
- removes async from balance fns
- adds minimum confirmations to wallet settings to be used in spendable notes logic
- removes dust from confirmed and unconfirmed balances in `account_balance` wallet method