### PR TITLE
stabilise spendable balance and spend before sync

### DIFF
--- a/zingolib/src/commands.rs
+++ b/zingolib/src/commands.rs
@@ -658,7 +658,10 @@ struct SpendableBalanceCommand {}
 impl Command for SpendableBalanceCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
-            Display the wallet's spendable balance for each shielded pool.
+            Display the wallet's spendable balance.
+
+            Potentially spendable balance includes notes that are not guaranteed to be unspent due to the wallet not
+            being fully synced to the blockchain.
 
             Usage:
             spendable_balance
@@ -667,25 +670,25 @@ impl Command for SpendableBalanceCommand {
     }
 
     fn short_help(&self) -> &'static str {
-        "Display the wallet's spendable balance for each shielded pool."
+        "Display the wallet's spendable balance."
     }
 
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
         RT.block_on(async move {
             let mut wallet = lightclient.wallet.write().await;
-            let orchard_spendable_balance =
-                match wallet.spendable_balance::<OrchardNote>(zip32::AccountId::ZERO) {
+            let spendable_balance =
+                match wallet.shielded_spendable_balance(zip32::AccountId::ZERO, false) {
                     Ok(bal) => bal,
                     Err(e) => return format!("Error: {e}"),
                 };
-            let sapling_spendable_balance =
-                match wallet.spendable_balance::<SaplingNote>(zip32::AccountId::ZERO) {
+            let potentially_spendable_balance =
+                match wallet.shielded_spendable_balance(zip32::AccountId::ZERO, true) {
                     Ok(bal) => bal,
                     Err(e) => return format!("Error: {e}"),
                 };
             object! {
-                "orchard_spendable_balance" => orchard_spendable_balance.into_u64(),
-                "sapling_spendable_balance" => sapling_spendable_balance.into_u64(),
+                "spendable_balance" => spendable_balance.into_u64(),
+                "potentially_spendable_balance" => potentially_spendable_balance.into_u64(),
             }
             .pretty(2)
         })

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -135,7 +135,7 @@ impl LightClient {
         account_id: zip32::AccountId,
     ) -> Result<Zatoshis, ProposeSendError> {
         let mut wallet = self.wallet.write().await;
-        let confirmed_balance = wallet.shielded_spendable_balance(account_id)?;
+        let confirmed_balance = wallet.shielded_spendable_balance(account_id, false)?;
         let mut spendable_balance = confirmed_balance;
 
         loop {

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -415,6 +415,9 @@ impl LightWallet {
     /// - satisfy the number of minimum confirmations set by the wallet
     /// - the nullifier derived from the note has not yet been found in a transaction input on chain
     ///
+    /// If `include_potentially_spent_notes` is `true`, notes will be included even if the wallet's current sync state
+    /// cannot guarantee the notes are unspent.
+    ///
     /// # Error
     ///
     /// Returns an error if:
@@ -424,10 +427,14 @@ impl LightWallet {
     pub fn spendable_balance<N>(
         &mut self,
         account_id: zip32::AccountId,
+        include_potentially_spent_notes: bool,
     ) -> Result<Zatoshis, BalanceError>
     where
         N: NoteInterface,
     {
+        let Some(spend_horizon) = self.spend_horizon() else {
+            return Ok(Zatoshis::ZERO);
+        };
         let Some(wallet_height) = self.sync_state.wallet_height() else {
             return Ok(Zatoshis::ZERO);
         };
@@ -490,6 +497,11 @@ impl LightWallet {
                                 }
                             }
                         })
+                    && if include_potentially_spent_notes {
+                        true
+                    } else {
+                        transaction.status().get_height() >= spend_horizon
+                    }
             },
             account_id,
         )?;
@@ -510,13 +522,18 @@ impl LightWallet {
     pub fn shielded_spendable_balance(
         &mut self,
         account_id: zip32::AccountId,
+        include_potentially_spent_notes: bool,
     ) -> Result<Zatoshis, BalanceError> {
-        let orchard_balance = match self.spendable_balance::<OrchardNote>(account_id) {
+        let orchard_balance = match self
+            .spendable_balance::<OrchardNote>(account_id, include_potentially_spent_notes)
+        {
             Ok(zats) => Ok(zats),
             Err(BalanceError::KeyError(KeyError::NoViewCapability)) => Ok(Zatoshis::ZERO),
             Err(e) => Err(e),
         }?;
-        let sapling_balance = match self.spendable_balance::<SaplingNote>(account_id) {
+        let sapling_balance = match self
+            .spendable_balance::<SaplingNote>(account_id, include_potentially_spent_notes)
+        {
             Ok(zats) => Ok(zats),
             Err(BalanceError::KeyError(KeyError::NoViewCapability)) => Ok(Zatoshis::ZERO),
             Err(e) => Err(e),

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -224,12 +224,19 @@ impl LightWallet {
     ///
     /// Any notes with output IDs in `exclude` will not be returned.
     /// Any notes without a nullifier or commitment tree position will not be returned.
+    /// Any notes that the wallet cannot construct a witness for with the current sync state will not be returned.
+    /// If `include_potentially_spent_notes` is `true`, notes will be included even if the wallet's current sync state
+    /// cannot guarantee the notes are unspent.
     pub(crate) fn spendable_notes<'a, N: NoteInterface>(
         &'a self,
         anchor_height: BlockHeight,
         exclude: &'a [OutputId],
         account: zip32::AccountId,
+        include_potentially_spent_notes: bool,
     ) -> Result<Vec<&'a N>, WalletError> {
+        let Some(spend_horizon) = self.spend_horizon() else {
+            return Err(WalletError::NoSyncData);
+        };
         if self
             .shard_trees
             .orchard
@@ -265,7 +272,14 @@ impl LightWallet {
                     .status()
                     .is_confirmed_before_or_at(&anchor_height)
                 {
-                    transaction_unspent_notes::<N>(transaction, exclude, account).collect()
+                    transaction_unspent_notes::<N>(
+                        transaction,
+                        exclude,
+                        account,
+                        spend_horizon,
+                        include_potentially_spent_notes,
+                    )
+                    .collect()
                 } else {
                     Vec::new()
                 }
@@ -336,18 +350,18 @@ impl LightWallet {
             .collect()
     }
 
-    /// Selects spendable notes for a given pool and `account` confirmed at or below `anchor_height` up to the total value of
-    /// `remaining_value_needed`.
+    /// Selects spendable notes for a given pool and `account` confirmed at or below `anchor_height` up to the total
+    /// value of `remaining_value_needed`.
     ///
-    /// Any notes with output IDs in `exclude` will not be selected.
-    /// Selects notes with smallest value that satisfies the target value. Otherwise, selects the note with the largest
-    /// value and repeats.
+    /// Selects notes with smallest value that satisfies the target value, without creating dust as change. Otherwise,
+    /// selects the note with the largest value and repeats.
     pub(crate) fn select_spendable_notes_by_pool<'a, N: NoteInterface>(
         &'a self,
         remaining_value_needed: &mut RemainingNeeded,
         anchor_height: BlockHeight,
         exclude: &'a [OutputId],
         account: zip32::AccountId,
+        include_potentially_spent_notes: bool,
     ) -> Result<Vec<&'a N>, WalletError> {
         let target_value = match remaining_value_needed {
             RemainingNeeded::Positive(value) => *value,
@@ -355,7 +369,12 @@ impl LightWallet {
         };
 
         let mut selected_notes: Vec<&'a N> = Vec::new();
-        let mut unselected_notes = self.spendable_notes::<N>(anchor_height, exclude, account)?;
+        let mut unselected_notes = self.spendable_notes::<N>(
+            anchor_height,
+            exclude,
+            account,
+            include_potentially_spent_notes,
+        )?;
         unselected_notes.sort_by_key(|&output| output.value());
         let dust_index =
             unselected_notes.partition_point(|output| output.value() <= MARGINAL_FEE.into_u64());
@@ -387,8 +406,9 @@ impl LightWallet {
 
             match unselected_notes.get(unselected_note_index) {
                 Some(&smallest_unselected) => {
-                    // selected a note to test if it has enough value to complete the transaction on its own
-                    if smallest_unselected.value() >= updated_target_value {
+                    // select a note to test if it has enough value to complete the transaction without creating dust as change
+                    if smallest_unselected.value() > updated_target_value + MARGINAL_FEE.into_u64()
+                    {
                         selected_notes.push(smallest_unselected);
                         unselected_notes.remove(unselected_note_index);
                     } else {

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -3,13 +3,13 @@
 use std::num::NonZeroU32;
 
 use zcash_client_backend::{
-    data_api::wallet::input_selection::GreedyInputSelector,
+    data_api::{scanning::ScanPriority, wallet::input_selection::GreedyInputSelector},
     fees::{DustAction, DustOutputPolicy},
     zip321::TransactionRequest,
 };
 use zcash_protocol::{
     ShieldedProtocol,
-    consensus::Parameters,
+    consensus::{BlockHeight, Parameters},
     memo::{Memo, MemoBytes},
     value::Zatoshis,
 };
@@ -176,6 +176,28 @@ impl LightWallet {
             }
         };
         MemoBytes::from(Memo::Arbitrary(Box::new(uas_bytes)))
+    }
+
+    /// Returns the block height at which all blocks equal to and above this height are scanned.
+    /// Returns `None` if `self.scan_ranges` is empty.
+    ///
+    /// Useful for determining which height all the nullifiers have been mapped from for guaranteeing if a note is
+    /// unspent.
+    pub(crate) fn spend_horizon(&self) -> Option<BlockHeight> {
+        if let Some(scan_range) = self
+            .sync_state
+            .scan_ranges()
+            .iter()
+            .rev()
+            .find(|scan_range| scan_range.priority() != ScanPriority::Scanned)
+        {
+            Some(scan_range.block_range().end)
+        } else {
+            self.sync_state
+                .scan_ranges()
+                .first()
+                .map(|range| range.block_range().start)
+        }
     }
 }
 

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -1,4 +1,5 @@
 use zcash_primitives::transaction::TxId;
+use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::ZatBalance;
 
 use pepper_sync::wallet::{
@@ -206,17 +207,30 @@ impl LightWallet {
 /// Returns all unspent notes of the specified pool and `account` in the given `transaction`.
 ///
 /// Any output IDs in `exclude` will not be returned.
+/// `spend_horizon` is the block height from which all nullifiers have been mapped, guaranteeing a note from a block
+/// equal to or above this height is unspent.
+/// If `include_potentially_spent_notes` is `true`, notes will be included even if the wallet's current sync state
+/// cannot guarantee the notes are unspent. In this case, the `spend_horizon` is not used.
 pub(crate) fn transaction_unspent_notes<'a, N: NoteInterface + 'a>(
     transaction: &'a WalletTransaction,
     exclude: &'a [OutputId],
     account: zip32::AccountId,
+    spend_horizon: BlockHeight,
+    include_potentially_unspent_notes: bool,
 ) -> impl Iterator<Item = &'a N> + 'a {
+    let guaranteed_unspent = if include_potentially_unspent_notes {
+        true
+    } else {
+        transaction.status().get_height() >= spend_horizon
+    };
+
     N::transaction_outputs(transaction)
         .iter()
         .filter(move |&note| {
             note.spending_transaction().is_none()
                 && !exclude.contains(&note.output_id())
                 && note.key_id().account_id() == account
+                && guaranteed_unspent
         })
 }
 

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -582,6 +582,7 @@ impl InputSource for LightWallet {
         let mut selected_sapling_notes = Vec::new();
         let mut selected_orchard_notes = Vec::new();
         for include_potentially_spent_notes in [false, true] {
+            // prioritise note selection for the given `sources`
             if sources.contains(&ShieldedProtocol::Sapling) {
                 let notes = self
                     .select_spendable_notes_by_pool::<SaplingNote>(
@@ -612,6 +613,34 @@ impl InputSource for LightWallet {
                 exclude_orchard.extend(notes.iter().map(|note| note.output_id()));
                 selected_orchard_notes.extend(notes);
             }
+
+            let notes = self
+                .select_spendable_notes_by_pool::<SaplingNote>(
+                    &mut remaining_value_needed,
+                    anchor_height,
+                    &exclude_sapling,
+                    account,
+                    include_potentially_spent_notes,
+                )?
+                .into_iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            exclude_sapling.extend(notes.iter().map(|note| note.output_id()));
+            selected_sapling_notes.extend(notes);
+
+            let notes = self
+                .select_spendable_notes_by_pool::<OrchardNote>(
+                    &mut remaining_value_needed,
+                    anchor_height,
+                    &exclude_orchard,
+                    account,
+                    include_potentially_spent_notes,
+                )?
+                .into_iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            exclude_orchard.extend(notes.iter().map(|note| note.output_id()));
+            selected_orchard_notes.extend(notes);
         }
 
         /* TODO: Priority

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -578,26 +578,29 @@ impl InputSource for LightWallet {
             .collect::<Vec<_>>();
         let mut remaining_value_needed = RemainingNeeded::Positive(target_value);
 
-        let selected_sapling_notes = if sources.contains(&ShieldedProtocol::Sapling) {
-            self.select_spendable_notes_by_pool::<SaplingNote>(
-                &mut remaining_value_needed,
-                anchor_height,
-                &exclude_sapling,
-                account,
-            )?
-        } else {
-            Vec::new()
-        };
-        let selected_orchard_notes = if sources.contains(&ShieldedProtocol::Orchard) {
-            self.select_spendable_notes_by_pool::<OrchardNote>(
-                &mut remaining_value_needed,
-                anchor_height,
-                &exclude_orchard,
-                account,
-            )?
-        } else {
-            Vec::new()
-        };
+        // prioritises selecting spendable notes that are guaranteed to be unspent first
+        let mut selected_sapling_notes = Vec::new();
+        let mut selected_orchard_notes = Vec::new();
+        for include_potentially_spent_notes in [false, true] {
+            if sources.contains(&ShieldedProtocol::Sapling) {
+                selected_sapling_notes.extend(self.select_spendable_notes_by_pool::<SaplingNote>(
+                    &mut remaining_value_needed,
+                    anchor_height,
+                    &exclude_sapling,
+                    account,
+                    include_potentially_spent_notes,
+                )?);
+            }
+            if sources.contains(&ShieldedProtocol::Orchard) {
+                selected_orchard_notes.extend(self.select_spendable_notes_by_pool::<OrchardNote>(
+                    &mut remaining_value_needed,
+                    anchor_height,
+                    &exclude_orchard,
+                    account,
+                    false,
+                )?);
+            }
+        }
 
         /* TODO: Priority
         if selected

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -566,12 +566,12 @@ impl InputSource for LightWallet {
         anchor_height: BlockHeight,
         exclude: &[Self::NoteRef],
     ) -> Result<SpendableNotes<Self::NoteRef>, Self::Error> {
-        let exclude_sapling = exclude
+        let mut exclude_sapling = exclude
             .iter()
             .filter(|&note_id| note_id.pool_type() == PoolType::SAPLING)
             .map(|note_id| OutputId::new(note_id.txid(), note_id.output_index()))
             .collect::<Vec<_>>();
-        let exclude_orchard = exclude
+        let mut exclude_orchard = exclude
             .iter()
             .filter(|&note_id| note_id.pool_type() == PoolType::ORCHARD)
             .map(|note_id| OutputId::new(note_id.txid(), note_id.output_index()))
@@ -583,22 +583,34 @@ impl InputSource for LightWallet {
         let mut selected_orchard_notes = Vec::new();
         for include_potentially_spent_notes in [false, true] {
             if sources.contains(&ShieldedProtocol::Sapling) {
-                selected_sapling_notes.extend(self.select_spendable_notes_by_pool::<SaplingNote>(
-                    &mut remaining_value_needed,
-                    anchor_height,
-                    &exclude_sapling,
-                    account,
-                    include_potentially_spent_notes,
-                )?);
+                let notes = self
+                    .select_spendable_notes_by_pool::<SaplingNote>(
+                        &mut remaining_value_needed,
+                        anchor_height,
+                        &exclude_sapling,
+                        account,
+                        include_potentially_spent_notes,
+                    )?
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                exclude_sapling.extend(notes.iter().map(|note| note.output_id()));
+                selected_sapling_notes.extend(notes);
             }
             if sources.contains(&ShieldedProtocol::Orchard) {
-                selected_orchard_notes.extend(self.select_spendable_notes_by_pool::<OrchardNote>(
-                    &mut remaining_value_needed,
-                    anchor_height,
-                    &exclude_orchard,
-                    account,
-                    false,
-                )?);
+                let notes = self
+                    .select_spendable_notes_by_pool::<OrchardNote>(
+                        &mut remaining_value_needed,
+                        anchor_height,
+                        &exclude_orchard,
+                        account,
+                        include_potentially_spent_notes,
+                    )?
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                exclude_orchard.extend(notes.iter().map(|note| note.output_id()));
+                selected_orchard_notes.extend(notes);
             }
         }
 


### PR DESCRIPTION
- changes note selection to prioritise notes that are guaranteed spent based on the current state of the nullifier map
- add bool parameter to `spendable_balance` wallet method to return either spendable balance or potentially spendable balance (useful for sending funds out of old wallets which would have to sync for along time before the spendable funds show, making them recoverable much earlier to the user)
- update spendable balance command to return both balances