### PR TITLE
invalid txs restore balance

### DIFF
--- a/pepper-sync/src/lib.rs
+++ b/pepper-sync/src/lib.rs
@@ -55,6 +55,7 @@ pub mod wallet;
 pub(crate) mod witness;
 
 pub use sync::add_scan_targets;
+pub use sync::reset_spends;
 pub use sync::scan_pending_transaction;
 pub use sync::sync;
 pub use sync::sync_status;

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -48,8 +48,7 @@ pub(crate) mod spend;
 pub(crate) mod state;
 pub(crate) mod transparent;
 
-const EXPIRY_HEIGHT: u32 = 40;
-const MEMPOOL_INVALID_SPEND_HEIGHT: u32 = 3;
+const MEMPOOL_SPEND_INVALIDATION_THRESHOLD: u32 = 3;
 pub(crate) const MAX_VERIFICATION_WINDOW: u32 = 100;
 const VERIFY_BLOCK_RANGE_SIZE: u32 = 10;
 
@@ -1037,23 +1036,24 @@ async fn process_mempool_transaction<W>(
 where
     W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints + SyncShardTrees,
 {
-    let block_height = if raw_transaction.height == 0 {
-        BlockHeight::from_u32(0)
-    } else {
-        BlockHeight::from_u32(
-            u32::try_from(raw_transaction.height + 1).expect("should be valid u32"),
-        )
-    };
+    // does not use raw transaction height due to lightwalletd off-by-one bug and potential to be zero
+    let mempool_height = wallet
+        .get_sync_state()
+        .map_err(SyncError::WalletError)?
+        .wallet_height()
+        .expect("wallet height must exist after sync is initialised")
+        + 1;
+
     let transaction = zcash_primitives::transaction::Transaction::read(
         &raw_transaction.data[..],
-        consensus::BranchId::for_height(consensus_parameters, block_height),
+        consensus::BranchId::for_height(consensus_parameters, mempool_height),
     )
     .map_err(ServerError::InvalidTransaction)?;
 
     tracing::debug!(
         "mempool received txid {} at height {}",
         transaction.txid(),
-        block_height
+        mempool_height
     );
 
     if let Some(tx) = wallet
@@ -1061,7 +1061,7 @@ where
         .map_err(SyncError::WalletError)?
         .get(&transaction.txid())
     {
-        if tx.status().is_confirmed() {
+        if tx.status().is_confirmed() || matches!(tx.status(), ConfirmationStatus::Mempool(_)) {
             return Ok(());
         }
     }
@@ -1071,7 +1071,7 @@ where
         ufvks,
         wallet,
         transaction,
-        ConfirmationStatus::Mempool(block_height),
+        ConfirmationStatus::Mempool(mempool_height),
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("infalliable for such long time periods")
@@ -1528,7 +1528,9 @@ where
         .values()
         .filter(|transaction| {
             matches!(transaction.status(), ConfirmationStatus::Mempool(_))
-                && transaction.status().get_height() <= wallet_height - MEMPOOL_INVALID_SPEND_HEIGHT
+                && transaction.status().get_height()
+                    // TODO: mempool can be zero?!
+                    <= wallet_height - MEMPOOL_SPEND_INVALIDATION_THRESHOLD
         })
         .map(|transaction| transaction.txid())
         .chain(
@@ -1537,7 +1539,7 @@ where
                 .filter(|transaction| {
                     (matches!(transaction.status(), ConfirmationStatus::Calculated(_))
                         || matches!(transaction.status(), ConfirmationStatus::Transmitted(_)))
-                        && transaction.status().get_height() <= wallet_height - EXPIRY_HEIGHT
+                        && wallet_height >= transaction.transaction().expiry_height()
                 })
                 .map(|transaction| transaction.txid()),
         )

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1529,7 +1529,6 @@ where
         .filter(|transaction| {
             matches!(transaction.status(), ConfirmationStatus::Mempool(_))
                 && transaction.status().get_height()
-                    // TODO: mempool can be zero?!
                     <= wallet_height - MEMPOOL_SPEND_INVALIDATION_THRESHOLD
         })
         .map(|transaction| transaction.txid())

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -48,8 +48,10 @@ pub(crate) mod spend;
 pub(crate) mod state;
 pub(crate) mod transparent;
 
-const VERIFY_BLOCK_RANGE_SIZE: u32 = 10;
+const EXPIRY_HEIGHT: u32 = 40;
+const MEMPOOL_INVALID_SPEND_HEIGHT: u32 = 3;
 pub(crate) const MAX_VERIFICATION_WINDOW: u32 = 100;
+const VERIFY_BLOCK_RANGE_SIZE: u32 = 10;
 
 /// A snapshot of the current state of sync. Useful for displaying the status of sync to a user / consumer.
 ///
@@ -416,6 +418,8 @@ where
         .expect("scan ranges must be non-empty")
         + 1;
 
+    reset_invalid_spends(&mut *wallet_guard)?;
+
     drop(wallet_guard);
 
     // create channel for receiving scan results and launch scanner
@@ -775,6 +779,50 @@ pub fn add_scan_targets(sync_state: &mut SyncState, scan_targets: &[ScanTarget])
     for scan_target in scan_targets {
         sync_state.scan_targets.insert(*scan_target);
     }
+}
+
+/// Resets the spending transaction field of all outputs that were previously spent but became unspent due to a
+/// spending transactions becoming invalid.
+///
+/// `invalid_txids` are the id's of the invalidated spending transactions. Any outputs in the `wallet_transactions`
+/// matching these spending transactions will be reset back to `None`.
+pub fn reset_spends(
+    wallet_transactions: &mut HashMap<TxId, WalletTransaction>,
+    invalid_txids: Vec<TxId>,
+) {
+    wallet_transactions
+        .values_mut()
+        .flat_map(|transaction| transaction.orchard_notes_mut())
+        .filter(|output| {
+            output
+                .spending_transaction
+                .is_some_and(|spending_txid| invalid_txids.contains(&spending_txid))
+        })
+        .for_each(|output| {
+            output.set_spending_transaction(None);
+        });
+    wallet_transactions
+        .values_mut()
+        .flat_map(|transaction| transaction.sapling_notes_mut())
+        .filter(|output| {
+            output
+                .spending_transaction
+                .is_some_and(|spending_txid| invalid_txids.contains(&spending_txid))
+        })
+        .for_each(|output| {
+            output.set_spending_transaction(None);
+        });
+    wallet_transactions
+        .values_mut()
+        .flat_map(|transaction| transaction.transparent_coins_mut())
+        .filter(|output| {
+            output
+                .spending_transaction
+                .is_some_and(|spending_txid| invalid_txids.contains(&spending_txid))
+        })
+        .for_each(|output| {
+            output.set_spending_transaction(None);
+        });
 }
 
 /// Returns true if the scanner and mempool are shutdown.
@@ -1459,6 +1507,42 @@ async fn mempool_monitor(
             }
         }
     }
+
+    Ok(())
+}
+
+fn reset_invalid_spends<W>(wallet: &mut W) -> Result<(), SyncError<W::Error>>
+where
+    W: SyncWallet + SyncTransactions,
+{
+    let wallet_height = wallet
+        .get_sync_state()
+        .map_err(SyncError::WalletError)?
+        .wallet_height()
+        .expect("wallet height must exist after scan ranges have been updated");
+    let wallet_transactions = wallet
+        .get_wallet_transactions_mut()
+        .map_err(SyncError::WalletError)?;
+
+    let invalid_txids = wallet_transactions
+        .values()
+        .filter(|transaction| {
+            matches!(transaction.status(), ConfirmationStatus::Mempool(_))
+                && transaction.status().get_height() <= wallet_height - MEMPOOL_INVALID_SPEND_HEIGHT
+        })
+        .map(|transaction| transaction.txid())
+        .chain(
+            wallet_transactions
+                .values()
+                .filter(|transaction| {
+                    (matches!(transaction.status(), ConfirmationStatus::Calculated(_))
+                        || matches!(transaction.status(), ConfirmationStatus::Transmitted(_)))
+                        && transaction.status().get_height() <= wallet_height - EXPIRY_HEIGHT
+                })
+                .map(|transaction| transaction.txid()),
+        )
+        .collect::<Vec<_>>();
+    reset_spends(wallet_transactions, invalid_txids);
 
     Ok(())
 }

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -19,7 +19,7 @@ use crate::wallet::{
     NullifierMap, OutputId, ShardTrees, SyncState, WalletBlock, WalletTransaction,
 };
 use crate::witness::LocatedTreeData;
-use crate::{Orchard, Sapling, SyncDomain, client};
+use crate::{Orchard, Sapling, SyncDomain, client, reset_spends};
 
 use super::{FetchRequest, ScanTarget, witness};
 
@@ -145,7 +145,6 @@ pub trait SyncTransactions: SyncWallet {
         &mut self,
         truncate_height: BlockHeight,
     ) -> Result<(), Self::Error> {
-        // TODO: Replace with `extract_if()` when it's in stable rust
         let invalid_txids: Vec<TxId> = self
             .get_wallet_transactions()?
             .values()
@@ -154,31 +153,7 @@ pub trait SyncTransactions: SyncWallet {
             .collect();
 
         let wallet_transactions = self.get_wallet_transactions_mut()?;
-        wallet_transactions
-            .values_mut()
-            .flat_map(|tx| tx.sapling_notes_mut())
-            .filter(|note| {
-                note.spending_transaction.map_or_else(
-                    || false,
-                    |spending_txid| invalid_txids.contains(&spending_txid),
-                )
-            })
-            .for_each(|note| {
-                note.spending_transaction = None;
-            });
-        wallet_transactions
-            .values_mut()
-            .flat_map(|tx| tx.orchard_notes_mut())
-            .filter(|note| {
-                note.spending_transaction.map_or_else(
-                    || false,
-                    |spending_txid| invalid_txids.contains(&spending_txid),
-                )
-            })
-            .for_each(|note| {
-                note.spending_transaction = None;
-            });
-
+        reset_spends(wallet_transactions, invalid_txids.clone());
         invalid_txids.iter().for_each(|invalid_txid| {
             wallet_transactions.remove(invalid_txid);
         });

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -96,8 +96,8 @@ impl LightWallet {
     }
 
     /// Removes transaction with the given `txid` from the wallet.
-    /// Also sets the `spending_transaction` fields of any outputs spent in this transaction to `None` allowing these
-    /// outputs to be re-selected for spending in future sends.
+    /// Also sets the `spending_transaction` fields of any outputs spent in this transaction to `None` restoring the
+    /// wallet balance and allowing these outputs to be re-selected for spending in future sends.
     ///
     /// # Error
     ///
@@ -111,31 +111,8 @@ impl LightWallet {
             return Err(RemovalError::TransactionNotFound);
         };
 
-        // TODO: could be added as an API to pepper-sync
-        self.wallet_transactions
-            .values_mut()
-            .flat_map(|transaction| transaction.transparent_coins_mut())
-            .filter(|output| (output.spending_transaction() == Some(txid)))
-            .for_each(|output| {
-                output.set_spending_transaction(None);
-            });
-        self.wallet_transactions
-            .values_mut()
-            .flat_map(|transaction| transaction.sapling_notes_mut())
-            .filter(|output| (output.spending_transaction() == Some(txid)))
-            .for_each(|output| {
-                output.set_spending_transaction(None);
-            });
-        self.wallet_transactions
-            .values_mut()
-            .flat_map(|transaction| transaction.orchard_notes_mut())
-            .filter(|output| (output.spending_transaction() == Some(txid)))
-            .for_each(|output| {
-                output.set_spending_transaction(None);
-            });
-        self.wallet_transactions
-            .remove(&txid)
-            .expect("transaction checked to exist");
+        pepper_sync::reset_spends(&mut self.wallet_transactions, vec![txid]);
+        self.wallet_transactions.remove(&txid);
         self.save_required = true;
 
         Ok(())


### PR DESCRIPTION
- txs in mempool for 3 blocks or calculated/transmitted txs that have expired (40 blocks) now automatically reset spent notes to restore balance and allow to be respent
- fixes re-org bug where transparent spends are not reset