### PR TITLE
Manual note selection for quicksend command by transaction id

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ zingodisclosure@proton.me
 * Price information is retrieved from Gemini exchange.
 
 ### Note Management
-Zingo-CLI does automatic note and utxo management, which means it doesn't allow you to manually select which address to send outgoing transactions from. It follows these principles:
+Zingo-CLI does automatic note and utxo management by default. It follows these principles:
 * Defaults to sending shielded transactions, even if you're sending to a transparent address
 * Can select funds from multiple shielded addresses in the same transaction
 * Will automatically shield your sapling funds at the first opportunity
     * When sending an outgoing transaction to a shielded address, Zingo-CLI can decide to use the transaction to additionally shield your sapling funds (i.e., send your sapling funds to your own orchard address in the same transaction)
 * Transparent funds are only spent via explicit shield operations
+
+Manual note selection is possible by providing txid, currently only as an argument for `quicksend` command.
+When used, the automatically-selected notes are filtered by the given transaction id. This way it is possible
+to spend funds only from a certain note. If transaction id is not found, it will result in Insufficient balance error.
 
 ## Compiling from source
 

--- a/zingocli/src/commands.rs
+++ b/zingocli/src/commands.rs
@@ -1148,12 +1148,15 @@ impl Command for QuickSendCommand {
             Warning:
                 Transaction(s) will be sent without the user being aware of the fee amount.
             Usage:
-                quicksend <address> <amount in zatoshis> "<optional memo>"
+                quicksend <address> <amount in zatoshis> "<optional memo>" "<optional txid to select notes from>"
                 OR
-                quicksend '[{"address":"<address>", "amount":<amount in zatoshis>, "memo":"<optional memo>"}, ...]'
+                quicksend '[{"address":"<address>", "amount":<amount in zatoshis>, "memo":"<optional memo>"}, ...]' "<optional txid to select notes from>"
             Example:
                 quicksend ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d 200000 "Hello from the command line"
 
+            Notes:
+                • The optional txid restricts note selection to notes created by that transaction id.
+                • Passing txid as the 4th argument without a memo is not supported.
         "#}
     }
 
@@ -1162,7 +1165,37 @@ impl Command for QuickSendCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
-        let receivers = match utils::parse_send_args(args) {
+        // Extract optional txid filter argument (positional or JSON form)
+        // Positional: <addr> <amount> "<memo>" "<txid>"
+        // JSON: '[{...}]' "<txid>"
+        let mut txid_filter_opt = None;
+        let mut send_args: Vec<&str> = args.iter().copied().collect();
+
+        // JSON form with an extra txid as the last argument
+        if send_args.len() >= 2 {
+            let first = send_args[0].trim();
+            if first.starts_with('[') || first.starts_with('{') {
+                if let Some(candidate) = send_args.last().copied() {
+                    if candidate.len() >= 64 {
+                        if let Ok(txid) = zingolib::utils::conversion::txid_from_hex_encoded_str(candidate) {
+                            txid_filter_opt = Some(txid);
+                            send_args.pop();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Positional form with a 4th argument as txid
+        if send_args.len() >= 4 {
+            let candidate = send_args[3];
+            if let Ok(txid) = zingolib::utils::conversion::txid_from_hex_encoded_str(candidate) {
+                txid_filter_opt = Some(txid);
+                send_args.truncate(3);
+            }
+        }
+
+        let receivers = match utils::parse_send_args(&send_args) {
             Ok(receivers) => receivers,
             Err(e) => {
                 return format!(
@@ -1182,15 +1215,22 @@ impl Command for QuickSendCommand {
             }
         };
         RT.block_on(async move {
-            match lightclient.quick_send(request, zip32::AccountId::ZERO).await {
-                Ok(txids) => {
-                    object! { "txids" => txids.iter().map(|txid| txid.to_string()).collect::<Vec<_>>() }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
+            // Apply optional txid filter for this quicksend only
+            if let Some(txid) = txid_filter_opt {
+                lightclient.wallet.write().await.txid_spend_filter = Some(txid);
             }
-            .pretty(2)
+
+            let result = match lightclient.quick_send(request, zip32::AccountId::ZERO).await {
+                Ok(txids) => object! { "txids" => txids.iter().map(|txid| txid.to_string()).collect::<Vec<_>>() }.pretty(2),
+                Err(e) => object! { "error" => e.to_string() }.pretty(2),
+            };
+
+            // Always clear the filter afterwards
+            if txid_filter_opt.is_some() {
+                lightclient.wallet.write().await.txid_spend_filter = None;
+            }
+
+            result
         })
     }
 }

--- a/zingocli/src/lib.rs
+++ b/zingocli/src/lib.rs
@@ -109,10 +109,10 @@ fn parse_seed(s: &str) -> Result<String, String> {
     match s.parse::<String>() {
         Ok(s) => {
             let count = s.split_whitespace().count();
-            if count == 24 {
+            if [12, 15, 18, 21, 24].contains(&count) {
                 Ok(s)
             } else {
-                Err(format!("Expected 24 words, but received: {}.", count))
+                Err(format!("Expected 12/15/18/21/24 words, but received: {}.", count))
             }
         }
         Err(_) => Err("Unexpected failure to parse String!!".to_string()),
@@ -290,7 +290,8 @@ pub fn command_loop(
 pub struct ConfigTemplate {
     params: Vec<String>,
     server: http::Uri,
-    from: Option<String>,
+    seed: Option<String>,
+    ufvk: Option<String>,
     birthday: u64,
     data_dir: PathBuf,
     sync: bool,
@@ -317,21 +318,16 @@ impl ConfigTemplate {
         } else {
             None
         };
-        let seed = matches.get_one::<String>("seed");
-        let viewkey = matches.get_one::<String>("viewkey");
-        let from = if seed.is_some() && viewkey.is_some() {
+        let seed = matches.get_one::<String>("seed").cloned();
+        let ufvk = matches.get_one::<String>("viewkey").cloned();
+        if seed.is_some() && ufvk.is_some() {
             return Err("Cannot load a wallet from both seed phrase and viewkey!".to_string());
-        } else if seed.is_some() {
-            seed
-        } else if viewkey.is_some() {
-            viewkey
-        } else {
-            None
-        };
+        }
         let maybe_birthday = matches
             .get_one::<u32>("birthday")
             .map(|bday| bday.to_string());
-        if from.is_some() && maybe_birthday.is_none() {
+        let from_provided = seed.is_some() || ufvk.is_some();
+        if from_provided && maybe_birthday.is_none() {
             eprintln!("ERROR!");
             eprintln!(
                 "Please specify the wallet birthday (eg. '--birthday 600000') to restore a wallet. (If you want to load the entire blockchain instead, you can use birthday 0. /this would require extensive time and computational resources)"
@@ -342,7 +338,6 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
                     .to_string(),
             );
         }
-        let from = from.map(|seed| seed.to_string());
         if matches.contains_id("chain") && is_regtest {
             return Err("regtest mode incompatible with custom chain selection".to_string());
         }
@@ -403,7 +398,8 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
         Ok(Self {
             params,
             server,
-            from,
+            seed,
+            ufvk,
             birthday,
             data_dir,
             sync,
@@ -442,12 +438,12 @@ pub fn startup(
     )
     .unwrap();
 
-    let mut lightclient = match filled_template.from.clone() {
-        Some(phrase) => LightClient::create_from_wallet(
+    let mut lightclient = if let Some(seed_phrase) = filled_template.seed.clone() {
+        LightClient::create_from_wallet(
             LightWallet::new(
                 config.chain,
                 WalletBase::Mnemonic {
-                    mnemonic: Mnemonic::from_phrase(phrase).map_err(|e| {
+                    mnemonic: Mnemonic::from_phrase(seed_phrase).map_err(|e| {
                         std::io::Error::new(
                             std::io::ErrorKind::InvalidInput,
                             format!("Invalid seed phrase. {}", e),
@@ -472,41 +468,62 @@ pub fn startup(
                 std::io::ErrorKind::Other,
                 format!("Failed to create lightclient. {}", e),
             )
-        })?,
-
-        None => {
-            if config.wallet_path_exists() {
-                LightClient::create_from_wallet_path(config.clone()).map_err(|e| {
+        })?
+    } else if let Some(ufvk) = filled_template.ufvk.clone() {
+        LightClient::create_from_wallet(
+            LightWallet::new(
+                config.chain,
+                WalletBase::Ufvk(ufvk),
+                (filled_template.birthday as u32).into(),
+                config.wallet_settings.clone(),
+            )
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to create wallet. {}", e),
+                )
+            })?,
+            config.clone(),
+            false,
+        )
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to create lightclient. {}", e),
+            )
+        })?
+    } else {
+        if config.wallet_path_exists() {
+            LightClient::create_from_wallet_path(config.clone()).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to create lightclient. {}", e),
+                )
+            })?
+        } else {
+            println!("Creating a new wallet");
+            // Call the lightwalletd server to get the current block-height
+            // Do a getinfo first, before opening the wallet
+            let server_uri = config.get_lightwalletd_uri();
+            let chain_height = RT
+                .block_on(async move {
+                    zingolib::grpc_connector::get_latest_block(server_uri)
+                        .await
+                        .map(|block_id| BlockHeight::from_u32(block_id.height as u32))
+                })
+                .map_err(|e| {
                     std::io::Error::new(
                         std::io::ErrorKind::Other,
                         format!("Failed to create lightclient. {}", e),
                     )
-                })?
-            } else {
-                println!("Creating a new wallet");
-                // Call the lightwalletd server to get the current block-height
-                // Do a getinfo first, before opening the wallet
-                let server_uri = config.get_lightwalletd_uri();
-                let chain_height = RT
-                    .block_on(async move {
-                        zingolib::grpc_connector::get_latest_block(server_uri)
-                            .await
-                            .map(|block_id| BlockHeight::from_u32(block_id.height as u32))
-                    })
-                    .map_err(|e| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("Failed to create lightclient. {}", e),
-                        )
-                    })?;
-                // Create a wallet with height - 100, to protect against reorgs
-                LightClient::new(config.clone(), chain_height - 100, false).map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        format!("Failed to create lightclient. {}", e),
-                    )
-                })?
-            }
+                })?;
+            // Create a wallet with height - 100, to protect against reorgs
+            LightClient::new(config.clone(), chain_height - 100, false).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to create lightclient. {}", e),
+                )
+            })?
         }
     };
 

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -139,6 +139,9 @@ pub struct LightWallet {
     pub price_list: PriceList,
     /// Progress of an outgoing transaction
     pub send_progress: SendProgress,
+    /// Optional txid filter to restrict which shielded notes are eligible for selection during the next send.
+    /// When set, only notes created by this transaction id will be considered during input selection.
+    pub txid_spend_filter: Option<zcash_primitives::transaction::TxId>,
     /// Boolean for tracking whether the wallet state has changed since last save.
     pub save_required: bool,
 }
@@ -253,6 +256,7 @@ impl LightWallet {
             price_list: PriceList::new(),
             save_required: true,
             send_progress: SendProgress::new(0),
+            txid_spend_filter: None,
         })
     }
 

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -324,6 +324,7 @@ impl LightWallet {
             birthday,
             unified_key_store,
             send_progress: SendProgress::new(0),
+            txid_spend_filter: None,
             price_list: PriceList::new(),
             wallet_blocks: BTreeMap::new(),
             wallet_transactions: HashMap::new(),
@@ -566,6 +567,7 @@ impl LightWallet {
             wallet_settings,
             price_list,
             send_progress: SendProgress::new(0),
+            txid_spend_filter: None,
             save_required: false,
         })
     }

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -358,6 +358,12 @@ impl LightWallet {
             account,
             include_potentially_spent_notes,
         )?;
+
+        // If a txid spend filter is set, restrict eligible notes to those created by that transaction.
+        if let Some(filter_txid) = self.txid_spend_filter {
+            unselected_notes.retain(|note| note.output_id().txid() == filter_txid);
+        }
+
         unselected_notes.sort_by_key(|&output| output.value());
         let dust_index =
             unselected_notes.partition_point(|output| output.value() <= MARGINAL_FEE.into_u64());


### PR DESCRIPTION
Zingo-cli manages note selection automatically.
In order to allow the user to spend note from specific transaction id (txid) only, this patch adds quick support for that.
It accepts optional txid argument and filters the automatically-selected notes by this txid.

Currently for quicksend only. This could be perhaps useful for "send" command too, but I don't use it so I skipped it due to additional complexity. I am not sure if you even like to include such filter in zingolib. I will be happy for feedback if you have any.
