### PR TITLE
pepper-sync: pre-sapling_protection

### DIFF
--- a/pepper-sync/src/error.rs
+++ b/pepper-sync/src/error.rs
@@ -182,6 +182,9 @@ pub enum ServerError {
     /// Fetcher task was dropped.
     #[error("fetcher task was dropped.")]
     FetcherDropped,
+    /// Server reports only the genesis block exists.
+    #[error("server reports only the genesis block exists.")]
+    GenesisBlockOnly,
 }
 
 /// Sync mode error.

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -354,6 +354,9 @@ where
     let mut wallet_height = state::get_wallet_height(consensus_parameters, &*wallet_guard)
         .map_err(SyncError::WalletError)?;
     let chain_height = client::get_chain_height(fetch_request_sender.clone()).await?;
+    if chain_height == 0.into() {
+        return Err(SyncError::ServerError(ServerError::GenesisBlockOnly));
+    }
     if wallet_height > chain_height {
         if wallet_height - chain_height > MAX_VERIFICATION_WINDOW {
             return Err(SyncError::ChainError(MAX_VERIFICATION_WINDOW));

--- a/pepper-sync/src/sync/transparent.rs
+++ b/pepper-sync/src/sync/transparent.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::collections::{BTreeSet, HashMap};
 use std::ops::Range;
 
@@ -38,8 +39,16 @@ pub(crate) async fn update_addresses_and_scan_targets<W: SyncWallet>(
         .get_transparent_addresses_mut()
         .map_err(SyncError::WalletError)?;
     let mut scan_targets: BTreeSet<ScanTarget> = BTreeSet::new();
+    let sapling_activation_height = consensus_parameters
+        .activation_height(consensus::NetworkUpgrade::Sapling)
+        .expect("sapling activation height should always return Some");
+    let block_range_start = wallet_height.saturating_sub(MAX_VERIFICATION_WINDOW) + 1;
+    let checked_block_range_start = match block_range_start.cmp(&sapling_activation_height) {
+        cmp::Ordering::Greater | cmp::Ordering::Equal => block_range_start,
+        cmp::Ordering::Less => sapling_activation_height,
+    };
     let block_range = Range {
-        start: wallet_height.saturating_sub(MAX_VERIFICATION_WINDOW) + 1,
+        start: checked_block_range_start,
         end: chain_height + 1,
     };
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -56,6 +56,8 @@ pub mod serialization;
 /// For example, this is useful when targetting transparent outputs as scanning the whole shard will not affect the
 /// spendability of the scan target but will significantly reduce memory usage and/or storage as well as prioritise
 /// creating spendable notes.
+///
+/// Scan targets with block heights below sapling activation height are not supported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ScanTarget {
     /// Block height.

--- a/zingo-memo/src/lib.rs
+++ b/zingo-memo/src/lib.rs
@@ -229,16 +229,19 @@ mod tests {
             let (ua, _serialized_ua) = get_serialiazed_ua(test_vector);
             // version0
             #[allow(deprecated)]
-            let version0_bytes = create_wallet_internal_memo_version_0(&[ua.clone()]).unwrap();
+            let version0_bytes =
+                create_wallet_internal_memo_version_0(std::slice::from_ref(&ua)).unwrap();
             let success_parse = parse_zingo_memo(version0_bytes).expect("To succeed in parse.");
             if let ParsedMemo::Version0 { uas } = success_parse {
                 assert_eq!(uas[0], ua);
             };
             // version1
             let random_rejection_indexes = get_some_number_of_ephemeral_indexes();
-            let version1_bytes =
-                create_wallet_internal_memo_version_1(&[ua.clone()], &random_rejection_indexes)
-                    .expect("To create version 1 bytes");
+            let version1_bytes = create_wallet_internal_memo_version_1(
+                std::slice::from_ref(&ua),
+                &random_rejection_indexes,
+            )
+            .expect("To create version 1 bytes");
             let success_parse = parse_zingo_memo(version1_bytes).expect("To succeed in parse.");
             if let ParsedMemo::Version1 {
                 uas,


### PR DESCRIPTION
fix potential pre-sapling issues in the edge case that the wallet has transparent data just before the sapling epoch or when the test chain only contains the genesis block