### PR TITLE
Added dev-dependencies item so that `cargo nextest run -p zingolib` works out of the box

### DIFF
--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -92,6 +92,8 @@ tracing.workspace = true
 [dev-dependencies]
 portpicker = { workspace = true }
 concat-idents = { workspace = true }
+testvectors = { workspace = true }
+tempfile = { workspace = true }
 
 [build-dependencies]
 zcash_proofs = { workspace = true, features = ["download-params"] }


### PR DESCRIPTION
`cargo nextest run -p zingolib` now works out of the box!