### PR TITLE
Add command new_taddress_allow_gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This will launch the interactive prompt. Type `help` to get a list of commands.
 
 ## Running in non-interactive mode:
 You can also run `zingo-cli` in non-interactive mode by passing the command you want to run as an argument. For example, `zingo-cli addresses` will list all wallet addresses and exit.
+If you need to sync the wallet first before running the command, use --waitsync argument. This is useful for example for `zingo-cli balance`.
 Run `zingo-cli help` to see a list of all commands.
 
 ## Options
@@ -62,6 +63,8 @@ Here are some CLI arguments you can pass to `zingo-cli`. Please run `zingo-cli -
 
 * `--data-dir`: uses the specified path as data directory. This is required when not using the `--regtest` option.
     * Example: `./zingo-cli --data-dir /path/to/data_directory/` will use the provided directory to store `zingo-wallet.dat` and logs. If the provided directory does not exist, it will create it.
+* `--waitsync`: Wait for sync before running a command in non-interactive mode
+    * Example: `./zingo-cli --data-dir /path/to/data_directory/ --waitsync balance`
 * `--server`: Connect to a custom zcash lightwalletd server.
     * Example: `./zingo-cli --data-dir /path/to/data_directory/ --server 127.0.0.1:9067`
 * `--seed`: Restore a wallet from a seed phrase. Note that this will fail if there is an existing wallet. Delete (or move) any existing wallet to restore from the 24-word seed phrase

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -838,6 +838,58 @@ impl Command for NewTransparentAddressCommand {
     }
 }
 
+struct NewTransparentAddressAllowGapCommand {}
+impl Command for NewTransparentAddressAllowGapCommand {
+    fn help(&self) -> &'static str {
+        indoc! {r#"
+            Create a new transparent address even if the current one has not received funds.
+
+            Usage:
+            new_taddress_allow_gap
+
+            Notes:
+            This command bypasses the built-in "no-gap" rule that normally prevents creating a new
+            transparent address until the last one has received funds. The rule exists to avoid
+            large gaps in address indices, which can cause problems when restoring a wallet from
+            seed, since all unused addresses beyond the gap may not be discovered automatically.
+
+            By using this command you take responsibility for:
+              - Tracking unused addresses yourself.
+              - Ensuring you do not create excessive gaps that make wallet recovery slow or incomplete.
+              - Understanding that funds sent to skipped addresses may not appear after recovery
+                unless you explicitly rescan or adjust the gap limit.
+
+           Use only if you know why you need consecutive empty transparent addresses and are
+           prepared to manage the risks of wallet recovery and scanning.
+        "#}
+    }
+
+    fn short_help(&self) -> &'static str {
+        "Create a new transparent address (even if the last one did not receive any funds)."
+    }
+
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+        RT.block_on(async move {
+            // Generate without enforcing the no-gap constraint
+            let mut wallet = lightclient.wallet.write().await;
+            let network = wallet.network;
+
+            match wallet.generate_transparent_address(zip32::AccountId::ZERO, false) {
+                Ok((id, transparent_address)) => {
+                    json::object! {
+                        "account" => u32::from(id.account_id()),
+                        "address_index" => id.address_index().index(),
+                        "scope" => id.scope().to_string(),
+                        "encoded_address" => transparent::encode_address(&network, transparent_address),
+                    }
+                }
+                Err(e) => object! { "error" => e.to_string() },
+            }
+            .pretty(2)
+        })
+    }
+}
+
 struct UnifiedAddressesCommand {}
 impl Command for UnifiedAddressesCommand {
     fn help(&self) -> &'static str {
@@ -2012,6 +2064,10 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
         ("coins", Box::new(CoinsCommand {})),
         ("new_address", Box::new(NewUnifiedAddressCommand {})),
         ("new_taddress", Box::new(NewTransparentAddressCommand {})),
+        (
+            "new_taddress_allow_gap",
+            Box::new(NewTransparentAddressAllowGapCommand {}),
+        ),
         ("recovery_info", Box::new(RecoveryInfoCommand {})),
         ("birthday", Box::new(BirthdayCommand {})),
         ("wallet_kind", Box::new(WalletKindCommand {})),


### PR DESCRIPTION
This change adds new command new_taddress_allow_gap, to create a new transparent address even if the current one has not received funds.

There are legitimate situations where the user may need to generate multiple addresses in advance for organizational or privacy reasons without immediately using each one.

This new command bypasses the built-in "no-gap" rule for new_taddress, and provides detailed explanation in help, so the user can take full responsibility to choose what (s)he needs.