### PR TITLE
experiment with traits for combining augmentation behavior with foreign types

### DIFF
--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -309,7 +309,9 @@ pub mod scenarios {
 
     use zcash_primitives::consensus::{BlockHeight, BranchId};
     use zcash_protocol::{PoolType, ShieldedProtocol};
-    use zingolib::testutils::zingo_infra_services::indexer::Lightwalletd;
+    use zingolib::testutils::{
+        LocalNetwork, LocalNetworkExt as _, zingo_infra_services::indexer::Lightwalletd,
+    };
 
     use super::{
         DarksideConnector, init_darksidewalletd, update_tree_states_for_transaction,
@@ -344,7 +346,7 @@ pub mod scenarios {
                 darkside_connector.0.clone(),
                 zingolib::testutils::tempfile::tempdir().unwrap(),
             );
-            let activation_heights = zingolib::testutils::default_regtest_heights();
+            let activation_heights = LocalNetwork::default_regtest_heights();
             DarksideEnvironment {
                 lightwalletd,
                 darkside_connector,

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -24,7 +24,8 @@ use zingolib::wallet::summary::data::ValueTransferKind;
 use zingolib::{testutils::scenarios::LIGHTWALLETD_BIN, wallet::summary::data::SentValueTransfer};
 use zingolib::{
     testutils::{
-        lightclient::from_inputs, paths::get_cargo_manifest_dir, scenarios::ClientBuilder,
+        LocalNetwork, LocalNetworkExt, lightclient::from_inputs, paths::get_cargo_manifest_dir,
+        scenarios::ClientBuilder,
     },
     wallet::balance::AccountBalance,
 };
@@ -51,7 +52,7 @@ async fn reorg_changes_incoming_tx_height() {
         ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
         202,
         true,
-        zingolib::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
     );
 
     light_client.sync_and_await().await.unwrap();
@@ -215,7 +216,7 @@ async fn reorg_changes_incoming_tx_index() {
         ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
         202,
         true,
-        zingolib::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
     );
 
     light_client.sync_and_await().await.unwrap();
@@ -379,7 +380,7 @@ async fn reorg_expires_incoming_tx() {
         ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
         202,
         true,
-        zingolib::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
     );
 
     light_client.sync_and_await().await.unwrap();
@@ -565,7 +566,7 @@ async fn reorg_changes_outgoing_tx_height() {
         ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
         202,
         true,
-        zingolib::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
     );
 
     light_client.sync_and_await().await.unwrap();
@@ -826,7 +827,7 @@ async fn reorg_expires_outgoing_tx_height() {
         ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
         202,
         true,
-        zingolib::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
     );
 
     let expected_initial_balance = AccountBalance {
@@ -1032,7 +1033,7 @@ async fn reorg_changes_outgoing_tx_index() {
         ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
         202,
         true,
-        zingolib::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
     );
 
     light_client.sync_and_await().await.unwrap();

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -22,6 +22,7 @@ use zingolib::testutils::scenarios::LIGHTWALLETD_BIN;
 use zingolib::testutils::tempfile;
 use zingolib::testutils::testvectors;
 use zingolib::testutils::zingo_infra_services;
+use zingolib::testutils::{LocalNetwork, LocalNetworkExt};
 use zingolib::wallet::balance::AccountBalance;
 
 #[ignore = "darkside bug, invalid block hash length in tree states"]
@@ -39,7 +40,7 @@ async fn simple_sync() {
     prepare_darksidewalletd(server_id.clone(), true)
         .await
         .unwrap();
-    let activation_heights = zingolib::testutils::default_regtest_heights();
+    let activation_heights = LocalNetwork::default_regtest_heights();
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id, wallet_dir).build_client(
         DARKSIDE_SEED.to_string(),
@@ -89,7 +90,7 @@ async fn reorg_receipt_sync_generic() {
         .await
         .unwrap();
 
-    let activation_heights = zingolib::testutils::default_regtest_heights();
+    let activation_heights = LocalNetwork::default_regtest_heights();
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
         DARKSIDE_SEED.to_string(),
@@ -157,7 +158,7 @@ async fn sent_transaction_reorged_into_mempool() {
 
     let wallet_dir = TempDir::new().unwrap();
     let mut client_manager = ClientBuilder::new(server_id.clone(), wallet_dir);
-    let activation_heights = zingolib::testutils::default_regtest_heights();
+    let activation_heights = LocalNetwork::default_regtest_heights();
     let mut light_client =
         client_manager.build_client(DARKSIDE_SEED.to_string(), 0, true, activation_heights);
     let mut recipient = client_manager.build_client(

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -8,7 +8,9 @@ use zcash_primitives::transaction::fees::zip317::MINIMUM_FEE;
 use zcash_protocol::value::Zatoshis;
 use zingolib::testutils::lightclient::from_inputs;
 use zingolib::testutils::testvectors::{BASE_HEIGHT, block_rewards, seeds::HOSPITAL_MUSEUM_SEED};
-use zingolib::testutils::{increase_height_and_wait_for_client, scenarios};
+use zingolib::testutils::{
+    LocalNetwork, LocalNetworkExt, increase_height_and_wait_for_client, scenarios,
+};
 use zingolib::utils::conversion::address_from_str;
 use zingolib::wallet::balance::AccountBalance;
 use zingolib::wallet::keys::unified::UnifiedKeyStore;
@@ -631,7 +633,7 @@ mod fast {
             Some(100_000),
             None,
             PoolType::Shielded(ShieldedProtocol::Orchard),
-            zingolib::testutils::default_regtest_heights(),
+            LocalNetwork::default_regtest_heights(),
             None,
         )
         .await;
@@ -1277,7 +1279,7 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
     async fn mine_to_orchard() {
         let (local_net, mut faucet) = scenarios::faucet(
             PoolType::ORCHARD,
-            zingolib::testutils::default_regtest_heights(),
+            LocalNetwork::default_regtest_heights(),
             None,
         )
         .await;
@@ -1293,7 +1295,7 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
     async fn mine_to_sapling() {
         let (local_net, mut faucet) = scenarios::faucet(
             PoolType::SAPLING,
-            zingolib::testutils::default_regtest_heights(),
+            LocalNetwork::default_regtest_heights(),
             None,
         )
         .await;
@@ -1308,7 +1310,7 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
     async fn mine_to_transparent() {
         let (local_net, mut faucet, _recipient) = scenarios::faucet_recipient(
             PoolType::Transparent,
-            zingolib::testutils::default_regtest_heights(),
+            LocalNetwork::default_regtest_heights(),
             None,
         )
         .await;
@@ -1363,7 +1365,7 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
 
     #[tokio::test]
     async fn mine_to_transparent_and_shield() {
-        let activation_heights = zingolib::testutils::default_regtest_heights();
+        let activation_heights = LocalNetwork::default_regtest_heights();
         let (local_net, mut faucet, _recipient) =
             scenarios::faucet_recipient(PoolType::Transparent, activation_heights, None).await;
         increase_height_and_wait_for_client(&local_net, &mut faucet, 100)
@@ -1388,7 +1390,7 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
 
     #[tokio::test]
     async fn mine_to_transparent_and_propose_shielding() {
-        let activation_heights = zingolib::testutils::default_regtest_heights();
+        let activation_heights = LocalNetwork::default_regtest_heights();
         let (local_net, mut faucet, _recipient) =
             scenarios::faucet_recipient(PoolType::Transparent, activation_heights, None).await;
         increase_height_and_wait_for_client(&local_net, &mut faucet, 100)
@@ -2527,7 +2529,7 @@ TransactionSummary {
         // NOTE that the balance doesn't give insight into the distribution across notes.
         let (local_net, mut faucet) = scenarios::faucet(
             PoolType::SAPLING,
-            zingolib::testutils::default_regtest_heights(),
+            LocalNetwork::default_regtest_heights(),
             None,
         )
         .await;
@@ -2605,7 +2607,7 @@ TransactionSummary {
                 Some(100_000),
                 Some(100_000),
                 PoolType::Shielded(ShieldedProtocol::Orchard),
-                zingolib::testutils::default_regtest_heights(),
+                LocalNetwork::default_regtest_heights(),
                 None,
             )
             .await;
@@ -2693,7 +2695,7 @@ TransactionSummary {
                 Some(funding_value),
                 None,
                 PoolType::Shielded(ShieldedProtocol::Orchard),
-                zingolib::testutils::default_regtest_heights(),
+                LocalNetwork::default_regtest_heights(),
                 None,
             )
             .await;

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -15,7 +15,8 @@ use pepper_sync::config::PerformanceLevel;
 use pepper_sync::keys::transparent;
 use std::sync::LazyLock;
 use tokio::runtime::Runtime;
-use zingolib::testutils;
+#[cfg(feature = "regtest")]
+use zingolib::testutils::{LocalNetwork, LocalNetworkExt as _};
 
 use zcash_address::unified::{Container, Encoding, Ufvk};
 use zcash_keys::address::Address;
@@ -219,7 +220,8 @@ impl Command for ParseAddressCommand {
             [
                 zingolib::config::ChainType::Mainnet,
                 zingolib::config::ChainType::Testnet,
-                zingolib::config::ChainType::Regtest(testutils::default_regtest_heights()),
+                #[cfg(feature = "regtest")]
+                zingolib::config::ChainType::Regtest(LocalNetwork::default_regtest_heights()),
             ]
             .iter()
             .find_map(|chain| Address::decode(chain, address).zip(Some(*chain)))

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -23,6 +23,8 @@ use commands::ShortCircuitedCommand;
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use zingolib::config::ChainType;
 use zingolib::lightclient::LightClient;
+#[cfg(feature = "regtest")]
+use zingolib::testutils::{LocalNetwork, LocalNetworkExt as _};
 use zingolib::wallet::{LightWallet, WalletBase, WalletSettings};
 
 use crate::commands::RT;
@@ -651,7 +653,7 @@ pub fn run_regtest_cli() {
         sync: false, // Don't auto-sync in regtest
         waitsync: false,
         command: None,
-        chaintype: ChainType::Regtest(zingolib::testutils::default_regtest_heights()),
+        chaintype: ChainType::Regtest(LocalNetwork::default_regtest_heights()),
         tor_enabled: false,
     };
 

--- a/zingo-cli/src/regtest.rs
+++ b/zingo-cli/src/regtest.rs
@@ -7,6 +7,7 @@ use zingolib::testutils::testvectors::REG_O_ADDR_FROM_ABANDONART;
 use zingolib::testutils::zingo_infra_services::LocalNet;
 use zingolib::testutils::zingo_infra_services::indexer::{Lightwalletd, LightwalletdConfig};
 use zingolib::testutils::zingo_infra_services::validator::{Zcashd, ZcashdConfig};
+use zingolib::testutils::{LocalNetwork, LocalNetworkExt as _};
 
 /// Launch a local regtest network
 pub(crate) async fn launch_local_net() -> LocalNet<Lightwalletd, Zcashd> {
@@ -21,7 +22,7 @@ pub(crate) async fn launch_local_net() -> LocalNet<Lightwalletd, Zcashd> {
             zcashd_bin: ZCASHD_BIN.clone(),
             zcash_cli_bin: ZCASH_CLI_BIN.clone(),
             rpc_listen_port: None,
-            activation_heights: zingolib::testutils::default_regtest_heights(),
+            activation_heights: LocalNetwork::default_regtest_heights(),
             miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
             chain_cache: None,
         },

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -116,12 +116,12 @@ impl Parameters for ChainType {
 /// * `Err(String)` - An error message if the chain name is invalid
 #[cfg(any(test, feature = "testutils"))]
 pub fn chain_from_str(chain_name: &str) -> Result<ChainType, String> {
-    use crate::testutils;
+    use crate::testutils::{LocalNetwork, LocalNetworkExt};
 
     match chain_name {
         "testnet" => Ok(ChainType::Testnet),
         "mainnet" => Ok(ChainType::Mainnet),
-        "regtest" => Ok(ChainType::Regtest(testutils::default_regtest_heights())),
+        "regtest" => Ok(ChainType::Regtest(LocalNetwork::default_regtest_heights())),
         _ => Err(format!(
             "Invalid chain '{}'. Expected one of: testnet, mainnet, regtest",
             chain_name

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -323,13 +323,15 @@ mod tests {
     use testvectors::seeds::CHIMNEY_BETTER_SEED;
 
     use crate::{lightclient::LightClient, wallet::WalletBase};
+    use testutils::{LocalNetwork, LocalNetworkExt};
 
     #[tokio::test]
     async fn new_wallet_from_phrase() {
         let temp_dir = TempDir::new().unwrap();
-        let config = ZingoConfig::build(ChainType::Regtest(testutils::default_regtest_heights()))
-            .set_wallet_dir(temp_dir.path().to_path_buf())
-            .create();
+        let config =
+            ZingoConfig::build(ChainType::Regtest(LocalNetwork::default_regtest_heights()))
+                .set_wallet_dir(temp_dir.path().to_path_buf())
+                .create();
         let mut lc = LightClient::create_from_wallet(
             LightWallet::new(
                 config.chain,

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -13,7 +13,7 @@ use zcash_keys::address::UnifiedAddress;
 use zcash_keys::encoding::AddressCodec;
 use zcash_primitives::consensus::NetworkConstants;
 use zcash_protocol::consensus::BlockHeight;
-use zcash_protocol::local_consensus::LocalNetwork;
+pub use zcash_protocol::local_consensus::LocalNetwork;
 use zcash_protocol::{PoolType, ShieldedProtocol, consensus};
 use zingo_infra_services::LocalNet;
 use zingo_infra_services::indexer::Indexer;
@@ -44,20 +44,25 @@ pub use tempfile;
 pub use testvectors;
 pub use zingo_infra_services;
 
-/// This function provides a DRY and succint instance of the most common regtest height
-/// config.
-pub fn default_regtest_heights() -> LocalNetwork {
-    LocalNetwork {
-        overwinter: Some(1.into()),
-        sapling: Some(1.into()),
-        blossom: Some(1.into()),
-        heartwood: Some(1.into()),
-        canopy: Some(1.into()),
-        nu5: Some(1.into()),
-        nu6: Some(1.into()),
-        nu6_1: Some(1.into()),
+/// Extension trait for LocalNetwork providing common test configurations
+pub trait LocalNetworkExt {
+    /// Provides a DRY and succinct instance of the most common regtest height config
+    fn default_regtest_heights() -> LocalNetwork {
+        LocalNetwork {
+            overwinter: Some(1.into()),
+            sapling: Some(1.into()),
+            blossom: Some(1.into()),
+            heartwood: Some(1.into()),
+            canopy: Some(1.into()),
+            nu5: Some(1.into()),
+            nu6: Some(1.into()),
+            nu6_1: Some(1.into()),
+        }
     }
 }
+
+impl LocalNetworkExt for LocalNetwork {}
+
 /// TODO: Add Doc Comment Here!
 pub fn build_fvks_from_unified_keystore(unified_keystore: &UnifiedKeyStore) -> [Fvk; 3] {
     let orchard_vk: orchard::keys::FullViewingKey = unified_keystore.try_into().unwrap();

--- a/zingolib/src/testutils/scenarios.rs
+++ b/zingolib/src/testutils/scenarios.rs
@@ -13,10 +13,10 @@
 //! build the scenario with the most common settings. This simplifies test writing in
 //! most cases by removing the need for configuration.
 
+use super::{LocalNetwork, LocalNetworkExt as _};
 use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::sync::LazyLock;
-use zcash_protocol::local_consensus::LocalNetwork;
 
 use bip0039::Mnemonic;
 
@@ -418,7 +418,7 @@ pub async fn unfunded_client(
 /// TODO: Add Doc Comment Here!
 pub async fn unfunded_client_default() -> (LocalNet<DefaultIndexer, DefaultValidator>, LightClient)
 {
-    unfunded_client(crate::testutils::default_regtest_heights(), None).await
+    unfunded_client(LocalNetwork::default_regtest_heights(), None).await
 }
 
 /// Many scenarios need to start with spendable funds.  This setup provides
@@ -454,7 +454,7 @@ pub async fn faucet(
 pub async fn faucet_default() -> (LocalNet<DefaultIndexer, DefaultValidator>, LightClient) {
     faucet(
         PoolType::ORCHARD,
-        crate::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
         None,
     )
     .await
@@ -499,7 +499,7 @@ pub async fn faucet_recipient_default() -> (
 ) {
     faucet_recipient(
         PoolType::ORCHARD,
-        crate::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
         None,
     )
     .await
@@ -603,7 +603,7 @@ pub async fn faucet_funded_recipient_default(
             None,
             None,
             PoolType::ORCHARD,
-            crate::testutils::default_regtest_heights(),
+            LocalNetwork::default_regtest_heights(),
             None,
         )
         .await;
@@ -638,7 +638,7 @@ pub async fn custom_clients_default() -> (LocalNet<DefaultIndexer, DefaultValida
 {
     let (local_net, client_builder) = custom_clients(
         PoolType::ORCHARD,
-        crate::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
         None,
     )
     .await;
@@ -654,7 +654,7 @@ pub async fn unfunded_mobileclient() -> LocalNet<DefaultIndexer, DefaultValidato
     >>::launch(
         Some(20_000),
         PoolType::SAPLING,
-        crate::testutils::default_regtest_heights(),
+        LocalNetwork::default_regtest_heights(),
         None,
     )
     .await

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -9,6 +9,7 @@ use zingo_infra_services::network::localhost_uri;
 use super::super::LightWallet;
 use crate::config::ChainType;
 use crate::lightclient::LightClient;
+use crate::testutils::{LocalNetwork, LocalNetworkExt as _};
 use crate::wallet::WalletSettings;
 
 /// ExampleWalletNetworkCase sorts first by Network, then seed, then last saved version.
@@ -279,7 +280,7 @@ impl NetworkSeedVersion {
                 crate::config::load_clientconfig(
                     lightwalletd_uri,
                     None,
-                    crate::config::ChainType::Regtest(crate::testutils::default_regtest_heights()),
+                    crate::config::ChainType::Regtest(LocalNetwork::default_regtest_heights()),
                     WalletSettings {
                         sync_config: SyncConfig {
                             transparent_address_discovery: TransparentAddressDiscovery::minimal(),


### PR DESCRIPTION
Some commentary by @dorianvp and @Oscar-Pepper led me to think about the potential for extension traits as cross-repo interfaces.

The basic pattern is to add the functionality as a trait that wraps the foreign type, and then import both in the scope of use.

@dorianvp reminded me about the constraints of the orphan rule, and this little experiment helped me to appreciate why and how it's necessary to import implementing traits into the scope of use.