### PR TITLE
Doubled nextest timeout.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,9 +1,9 @@
 [profile.default]
 fail-fast = false
-slow-timeout = { period = "60s", terminate-after = 5, grace-period = "30s" }
+slow-timeout = { period = "60s", terminate-after = 10, grace-period = "30s" }
 
 [profile.ci]
 failure-output = "immediate-final"
 fail-fast = false
-slow-timeout = { period = "60s", terminate-after = 5, grace-period = "30s" }
+slow-timeout = { period = "60s", terminate-after = 10, grace-period = "30s" }
 


### PR DESCRIPTION
Problem:
Sometimes the tests go over the timeout but barely.

Solution:
Increase timeout by a small factor.