### PR TITLE
fix shard tree missing checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ test_binaries/bins/lightwalletd
 test_binaries/bins/zcash-cli
 test_binaries/bins/zcashd
 libtonode-tests/tests/chain_generics.proptest-regressions
+libtonode-tests/store_all_checkpoints_test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,6 +3181,7 @@ dependencies = [
  "pepper-sync",
  "proptest",
  "rustls 0.23.35",
+ "shardtree",
  "test-log",
  "tokio",
  "tracing",

--- a/libtonode-tests/Cargo.toml
+++ b/libtonode-tests/Cargo.toml
@@ -27,6 +27,7 @@ zcash_address = { workspace = true, features = ["test-dependencies"] }
 zcash_client_backend = { workspace = true }
 zcash_primitives = { workspace = true }
 zcash_protocol = { workspace = true }
+shardtree.workspace = true
 bip0039.workspace = true
 zebra-chain = { workspace = true }
 

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -2,7 +2,13 @@ use std::{num::NonZeroU32, time::Duration};
 
 use bip0039::Mnemonic;
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
+use shardtree::store::ShardStore;
+use zcash_local_net::validator::Validator;
+use zcash_protocol::consensus::BlockHeight;
+use zingo_common_components::protocol::activation_heights::for_test::all_height_one_nus;
 use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
+use zingolib::testutils::lightclient::from_inputs::quick_send;
+use zingolib::testutils::paths::get_cargo_manifest_dir;
 use zingolib::testutils::tempfile::TempDir;
 use zingolib::{
     config::{DEFAULT_LIGHTWALLETD_SERVER, construct_lightwalletd_uri, load_clientconfig},
@@ -11,7 +17,7 @@ use zingolib::{
     testutils::lightclient::from_inputs::{self},
     wallet::{LightWallet, WalletBase, WalletSettings},
 };
-use zingolib_testutils::scenarios;
+use zingolib_testutils::scenarios::{self, increase_height_and_wait_for_client};
 
 #[ignore = "temporary mainnet test for sync development"]
 #[tokio::test]
@@ -176,4 +182,79 @@ async fn sync_test() {
     // );
     // let wallet = recipient.wallet.lock().await;
     // dbg!(wallet.wallet_blocks.len());
+}
+
+#[ignore = "only for building chain cache"]
+#[tokio::test]
+async fn store_all_checkpoints_in_verification_window_chain_cache() {
+    let (mut local_net, mut faucet, recipient) = scenarios::faucet_recipient_default().await;
+
+    let recipient_orchard_addr = get_base_address_macro!(recipient, "unified");
+    let recipient_sapling_addr = get_base_address_macro!(recipient, "sapling");
+
+    for _ in 0..27 {
+        quick_send(&mut faucet, vec![(&recipient_orchard_addr, 10_000, None)])
+            .await
+            .unwrap();
+        increase_height_and_wait_for_client(&local_net, &mut faucet, 1)
+            .await
+            .unwrap();
+
+        quick_send(&mut faucet, vec![(&recipient_sapling_addr, 10_000, None)])
+            .await
+            .unwrap();
+        increase_height_and_wait_for_client(&local_net, &mut faucet, 1)
+            .await
+            .unwrap();
+
+        quick_send(&mut faucet, vec![(&recipient_orchard_addr, 10_000, None)])
+            .await
+            .unwrap();
+        quick_send(&mut faucet, vec![(&recipient_sapling_addr, 10_000, None)])
+            .await
+            .unwrap();
+        increase_height_and_wait_for_client(&local_net, &mut faucet, 2)
+            .await
+            .unwrap();
+    }
+
+    local_net
+        .validator_mut()
+        .cache_chain(get_cargo_manifest_dir().join("store_all_checkpoints_test"));
+}
+
+#[tokio::test]
+async fn store_all_checkpoints_in_verification_window() {
+    let (_local_net, lightclient) = scenarios::unfunded_client(
+        all_height_one_nus(),
+        Some(get_cargo_manifest_dir().join("store_all_checkpoints_test")),
+    )
+    .await;
+
+    for height in 12..111 {
+        assert!(
+            lightclient
+                .wallet
+                .read()
+                .await
+                .shard_trees
+                .sapling
+                .store()
+                .get_checkpoint(&BlockHeight::from_u32(height))
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            lightclient
+                .wallet
+                .read()
+                .await
+                .shard_trees
+                .orchard
+                .store()
+                .get_checkpoint(&BlockHeight::from_u32(height))
+                .unwrap()
+                .is_some()
+        );
+    }
 }

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -231,7 +231,7 @@ async fn store_all_checkpoints_in_verification_window() {
     )
     .await;
 
-    for height in 12..111 {
+    for height in 12..112 {
         assert!(
             lightclient
                 .wallet
@@ -242,7 +242,8 @@ async fn store_all_checkpoints_in_verification_window() {
                 .store()
                 .get_checkpoint(&BlockHeight::from_u32(height))
                 .unwrap()
-                .is_some()
+                .is_some(),
+            "missing sapling checkpoint at height {height}"
         );
         assert!(
             lightclient
@@ -254,7 +255,8 @@ async fn store_all_checkpoints_in_verification_window() {
                 .store()
                 .get_checkpoint(&BlockHeight::from_u32(height))
                 .unwrap()
-                .is_some()
+                .is_some(),
+            "missing orchard checkpoint at height {height}"
         );
     }
 }

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -223,6 +223,7 @@ async fn store_all_checkpoints_in_verification_window_chain_cache() {
         .cache_chain(get_cargo_manifest_dir().join("store_all_checkpoints_test"));
 }
 
+#[ignore = "ignored until we add framework for chain caches as we don't want to check these into the zingolib repo"]
 #[tokio::test]
 async fn store_all_checkpoints_in_verification_window() {
     let (_local_net, lightclient) = scenarios::unfunded_client(

--- a/pepper-sync/src/error.rs
+++ b/pepper-sync/src/error.rs
@@ -176,7 +176,7 @@ pub enum ServerError {
     InvalidSubtreeRoot,
     /// Server returned blocks that could not be verified against wallet block data. Exceeded max verification window.
     #[error(
-        "server returned blocks that could not be verified against wallet block data. exceeded max verification window."
+        "server returned blocks that could not be verified against wallet block data. exceeded max verification window. wallet data has been cleared as shard tree data cannot be truncated further. wallet rescan required."
     )]
     ChainVerificationError,
     /// Fetcher task was dropped.

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -494,6 +494,7 @@ fn set_checkpoint_retentions<L>(
                     marking: Marking::None,
                 };
             }
+            // NOTE: if there are no outputs in the block, this last retention will be a checkpoint and nothing will need to be mutated.
             _ => (),
         }
     }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1003,22 +1003,22 @@ where
                 );
 
                 // extend verification range to VERIFY_BLOCK_RANGE_SIZE blocks below current verification range
-                let scan_range_to_verify = state::set_verify_scan_range(
+                let verification_start = state::set_verify_scan_range(
                     sync_state,
                     height - 1,
                     state::VerifyEnd::VerifyHighest,
-                );
+                )
+                .block_range()
+                .start;
                 state::merge_scan_ranges(sync_state, ScanPriority::Verify);
 
-                truncate_wallet_data(wallet, scan_range_to_verify.block_range().start - 1)?;
-
-                if initial_verification_height - scan_range_to_verify.block_range().start
-                    > MAX_VERIFICATION_WINDOW
-                {
+                if initial_verification_height - verification_start > MAX_VERIFICATION_WINDOW {
                     clear_wallet_data(wallet)?;
 
                     return Err(ServerError::ChainVerificationError.into());
                 }
+
+                truncate_wallet_data(wallet, verification_start - 1)?;
 
                 state::set_initial_state(
                     consensus_parameters,

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -364,7 +364,7 @@ where
         return Err(SyncError::ServerError(ServerError::GenesisBlockOnly));
     }
     if wallet_height > chain_height {
-        if wallet_height - chain_height > MAX_VERIFICATION_WINDOW {
+        if wallet_height - chain_height >= MAX_VERIFICATION_WINDOW {
             return Err(SyncError::ChainError(MAX_VERIFICATION_WINDOW));
         }
         truncate_wallet_data(&mut *wallet_guard, chain_height)?;
@@ -1015,6 +1015,8 @@ where
                 if initial_verification_height - scan_range_to_verify.block_range().start
                     > MAX_VERIFICATION_WINDOW
                 {
+                    clear_wallet_data(wallet)?;
+
                     return Err(ServerError::ChainVerificationError.into());
                 }
 
@@ -1091,13 +1093,13 @@ where
     Ok(())
 }
 
-/// Removes all wallet data above the given `truncate_height`.
+/// Removes wallet blocks, transactions, nullifiers, outpoints and shard tree data above the given `truncate_height`.
 fn truncate_wallet_data<W>(
     wallet: &mut W,
     truncate_height: BlockHeight,
 ) -> Result<(), SyncError<W::Error>>
 where
-    W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncShardTrees,
+    W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints + SyncShardTrees,
 {
     let birthday = wallet
         .get_sync_state()
@@ -1106,7 +1108,7 @@ where
         .expect("should be non-empty in this scope");
     let checked_truncate_height = match truncate_height.cmp(&birthday) {
         std::cmp::Ordering::Greater | std::cmp::Ordering::Equal => truncate_height,
-        std::cmp::Ordering::Less => birthday,
+        std::cmp::Ordering::Less => consensus::H0,
     };
 
     wallet
@@ -1118,9 +1120,40 @@ where
     wallet
         .truncate_nullifiers(checked_truncate_height)
         .map_err(SyncError::WalletError)?;
+    wallet
+        .truncate_outpoints(checked_truncate_height)
+        .map_err(SyncError::WalletError)?;
     wallet.truncate_shard_trees(checked_truncate_height)?;
 
     Ok(())
+}
+
+fn clear_wallet_data<W>(wallet: &mut W) -> Result<(), SyncError<W::Error>>
+where
+    W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints + SyncShardTrees,
+{
+    let scan_targets = wallet
+        .get_wallet_transactions()
+        .map_err(SyncError::WalletError)?
+        .values()
+        .filter_map(|transaction| {
+            transaction
+                .status()
+                .get_confirmed_height()
+                .map(|height| ScanTarget {
+                    block_height: height,
+                    txid: transaction.txid(),
+                    narrow_scan_area: true,
+                })
+        })
+        .collect::<Vec<_>>();
+    let sync_state = wallet
+        .get_sync_state_mut()
+        .map_err(SyncError::WalletError)?;
+    *sync_state = SyncState::new();
+    add_scan_targets(sync_state, &scan_targets);
+
+    truncate_wallet_data(wallet, consensus::H0)
 }
 
 /// Updates the wallet with data from `scan_results`

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -370,8 +370,8 @@ where
             })
             .expect("infallible");
 
-        if let Some(prev) = previous_checkpoint {
-            prev
+        let tree_state = if let Some(checkpoint) = previous_checkpoint {
+            checkpoint.tree_state()
         } else {
             let frontiers =
                 client::get_frontiers(fetch_request_sender.clone(), checkpoint_height - 1).await?;
@@ -379,14 +379,14 @@ where
                 ShieldedProtocol::Sapling => frontiers.final_sapling_tree().tree_size(),
                 ShieldedProtocol::Orchard => frontiers.final_orchard_tree().tree_size(),
             };
-            let tree_state = if tree_size == 0 {
+            if tree_size == 0 {
                 TreeState::Empty
             } else {
                 TreeState::AtPosition(incrementalmerkletree::Position::from(tree_size - 1))
-            };
+            }
+        };
 
-            Checkpoint::from_parts(tree_state, BTreeSet::new())
-        }
+        Checkpoint::from_parts(tree_state, BTreeSet::new())
     };
 
     shard_tree

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -370,8 +370,8 @@ where
             })
             .expect("infallible");
 
-        let tree_state = if let Some(checkpoint) = previous_checkpoint {
-            checkpoint.tree_state()
+        if let Some(prev) = previous_checkpoint {
+            prev
         } else {
             let frontiers =
                 client::get_frontiers(fetch_request_sender.clone(), checkpoint_height - 1).await?;
@@ -379,14 +379,14 @@ where
                 ShieldedProtocol::Sapling => frontiers.final_sapling_tree().tree_size(),
                 ShieldedProtocol::Orchard => frontiers.final_orchard_tree().tree_size(),
             };
-            if tree_size == 0 {
+            let tree_state = if tree_size == 0 {
                 TreeState::Empty
             } else {
                 TreeState::AtPosition(incrementalmerkletree::Position::from(tree_size - 1))
-            }
-        };
+            };
 
-        Checkpoint::from_parts(tree_state, BTreeSet::new())
+            Checkpoint::from_parts(tree_state, BTreeSet::new())
+        }
     };
 
     shard_tree

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -337,6 +337,7 @@ pub trait SyncShardTrees: SyncWallet {
     }
 }
 
+// TODO: move into `update_shard_trees` trait method
 async fn add_checkpoint<D, L, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     fetch_request_sender: mpsc::UnboundedSender<FetchRequest>,
     checkpoint_height: BlockHeight,

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -249,16 +249,14 @@ pub trait SyncShardTrees: SyncWallet {
             // limit the range that checkpoints are manually added to the top MAX_VERIFICATION_WINDOW blocks for efficiency.
             // As we sync the chain tip first and have spend-before-sync, we will always choose anchors very close to chain
             // height and we will also never need to truncate to checkpoints lower than this height.
+            let verification_window_start =
+                wallet_height.saturating_sub(MAX_VERIFICATION_WINDOW) + 1;
             let checkpoint_range = match (
-                scan_range.block_range().start
-                    > wallet_height.saturating_sub(MAX_VERIFICATION_WINDOW),
-                scan_range.block_range().end - 1
-                    > wallet_height.saturating_sub(MAX_VERIFICATION_WINDOW),
+                scan_range.block_range().start >= verification_window_start,
+                scan_range.block_range().end > verification_window_start,
             ) {
                 (true, _) => scan_range.block_range().clone(),
-                (false, true) => {
-                    (wallet_height - MAX_VERIFICATION_WINDOW)..scan_range.block_range().end
-                }
+                (false, true) => verification_window_start..scan_range.block_range().end,
                 (false, false) => BlockHeight::from_u32(0)..BlockHeight::from_u32(0),
             };
 
@@ -374,7 +372,7 @@ where
             checkpoint.tree_state()
         } else {
             let frontiers =
-                client::get_frontiers(fetch_request_sender.clone(), checkpoint_height - 1).await?;
+                client::get_frontiers(fetch_request_sender.clone(), checkpoint_height).await?;
             let tree_size = match D::SHIELDED_PROTOCOL {
                 ShieldedProtocol::Sapling => frontiers.final_sapling_tree().tree_size(),
                 ShieldedProtocol::Orchard => frontiers.final_orchard_tree().tree_size(),

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -452,11 +452,13 @@ pub async fn custom_clients(
         None,
         mine_to_pool,
         configured_activation_heights,
-        chain_cache,
+        chain_cache.clone(),
     )
     .await;
 
-    local_net.validator().generate_blocks(2).await.unwrap();
+    if chain_cache.is_none() {
+        local_net.validator().generate_blocks(2).await.unwrap();
+    }
 
     let client_builder = ClientBuilder::new(
         localhost_uri(local_net.indexer().listen_port()),


### PR DESCRIPTION
fixes:
- wallet data ends up in a unrecoverable state after reaching max re-org window. now clears the wallet data and error updated to tell user wallet requires a rescan
- bug where outpoints are not truncated
- vague doc comment on `truncate_wallet_data`
- bug where data in birthday block isnt truncated when truncation height is below birthday height

remaining bug:
- intended behaviour is sync should create a checkpoint for all top 100 blocks for each shielded protocol. however, some checkpoints are still missing if we can rule out that we are not witnessing a re-org of >100 blocks which is negligable. This PR makes the case where re-org is >100 blocks much more stable in any case.

related to but not fixing #2012 and #2015