### PR TITLE
update zingolib version for 2.1.2 release

### DIFF
--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zingolib"
 description = "Zingo backend library."
-version = "2.1.0"
+version = "2.1.2"
 authors = ["<zingo@zingolabs.org>"]
 edition = "2024"
 repository = "https://github.com/zingolabs/zingolib"


### PR DESCRIPTION
cutting a new release with zingolib cargo toml matching the new version and with the prefix "zingolib" in the release tag