### PR TITLE
fix large wallet file size due to excessive nullifier and outpoint maps in some cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "zingolib"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "append-only-vec",
  "bech32",

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -23,7 +23,7 @@ use zcash_protocol::consensus::{self, BlockHeight};
 use zingo_status::confirmation_status::ConfirmationStatus;
 
 use crate::client::{self, FetchRequest};
-use crate::config::SyncConfig;
+use crate::config::{PerformanceLevel, SyncConfig};
 use crate::error::{
     ContinuityError, MempoolError, ScanError, ServerError, SyncError, SyncModeError,
     SyncStatusError,
@@ -456,6 +456,7 @@ where
                     scan_range,
                     scan_results,
                     initial_verification_height,
+                    config.performance_level,
                 )
                 .await?;
                 wallet_guard.set_save_flag().map_err(SyncError::WalletError)?;
@@ -848,6 +849,7 @@ where
 }
 
 /// Scan post-processing
+#[allow(clippy::too_many_arguments)]
 async fn process_scan_results<W>(
     consensus_parameters: &impl consensus::Parameters,
     wallet: &mut W,
@@ -856,6 +858,7 @@ async fn process_scan_results<W>(
     scan_range: ScanRange,
     scan_results: Result<ScanResults, ScanError>,
     initial_verification_height: BlockHeight,
+    performance_level: PerformanceLevel,
 ) -> Result<(), SyncError<W::Error>>
 where
     W: SyncWallet
@@ -870,15 +873,17 @@ where
         Ok(results) => {
             let ScanResults {
                 mut nullifiers,
-                outpoints,
+                mut outpoints,
                 scanned_blocks,
                 wallet_transactions,
                 sapling_located_trees,
                 orchard_located_trees,
-                map_nullifiers,
+                mut map_nullifiers,
             } = results;
 
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
+                spend::update_transparent_spends(wallet, Some(&mut outpoints))
+                    .map_err(SyncError::WalletError)?;
                 spend::update_shielded_spends(
                     consensus_parameters,
                     wallet,
@@ -925,6 +930,20 @@ where
                     true,
                 );
             } else {
+                // nullifiers and outpoints are not mapped if nullifier map size limit will be exceeded
+                let nullifier_map = wallet.get_nullifiers().map_err(SyncError::WalletError)?;
+                if map_nullifiers
+                    && max_nullifier_map_size(performance_level).is_some_and(|max| {
+                        nullifier_map.orchard.len()
+                            + nullifier_map.sapling.len()
+                            + nullifiers.orchard.len()
+                            + nullifiers.sapling.len()
+                            > max
+                    })
+                {
+                    map_nullifiers = false;
+                }
+
                 update_wallet_data(
                     consensus_parameters,
                     wallet,
@@ -936,13 +955,25 @@ where
                     } else {
                         None
                     },
-                    outpoints,
+                    if map_nullifiers {
+                        Some(&mut outpoints)
+                    } else {
+                        None
+                    },
                     wallet_transactions,
                     sapling_located_trees,
                     orchard_located_trees,
                 )
                 .await?;
-                spend::update_transparent_spends(wallet).map_err(SyncError::WalletError)?;
+                spend::update_transparent_spends(
+                    wallet,
+                    if map_nullifiers {
+                        None
+                    } else {
+                        Some(&mut outpoints)
+                    },
+                )
+                .map_err(SyncError::WalletError)?;
                 spend::update_shielded_spends(
                     consensus_parameters,
                     wallet,
@@ -1173,7 +1204,7 @@ async fn update_wallet_data<W>(
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
     scan_range: &ScanRange,
     nullifiers: Option<&mut NullifierMap>,
-    mut outpoints: BTreeMap<OutputId, ScanTarget>,
+    outpoints: Option<&mut BTreeMap<OutputId, ScanTarget>>,
     transactions: HashMap<TxId, WalletTransaction>,
     sapling_located_trees: Vec<LocatedTreeData<sapling_crypto::Node>>,
     orchard_located_trees: Vec<LocatedTreeData<MerkleHashOrchard>>,
@@ -1213,9 +1244,11 @@ where
             .append_nullifiers(nullifiers)
             .map_err(SyncError::WalletError)?;
     }
-    wallet
-        .append_outpoints(&mut outpoints)
-        .map_err(SyncError::WalletError)?;
+    if let Some(outpoints) = outpoints {
+        wallet
+            .append_outpoints(outpoints)
+            .map_err(SyncError::WalletError)?;
+    }
     wallet
         .update_shard_trees(
             fetch_request_sender,
@@ -1597,4 +1630,13 @@ where
     reset_spends(wallet_transactions, invalid_txids);
 
     Ok(())
+}
+
+fn max_nullifier_map_size(performance_level: PerformanceLevel) -> Option<usize> {
+    match performance_level {
+        PerformanceLevel::Low => Some(0),
+        PerformanceLevel::Medium => Some(0),
+        PerformanceLevel::High => Some(2_000_000),
+        PerformanceLevel::Maximum => None,
+    }
 }

--- a/pepper-sync/src/sync/spend.rs
+++ b/pepper-sync/src/sync/spend.rs
@@ -299,14 +299,22 @@ where
 /// Locates any output ids of coins in the wallet's transactions which match an output id in the wallet's outpoint map.
 /// If a spend is detected, the output id is removed from the outpoint map and added to the map of spend scan targets.
 /// Finally, all coins that were detected as spent are updated with the located spending transaction.
-pub(super) fn update_transparent_spends<W>(wallet: &mut W) -> Result<(), W::Error>
+pub(super) fn update_transparent_spends<W>(
+    wallet: &mut W,
+    additional_outpoint_map: Option<&mut BTreeMap<OutputId, ScanTarget>>,
+) -> Result<(), W::Error>
 where
     W: SyncBlocks + SyncTransactions + SyncOutPoints,
 {
     let transparent_output_ids = collect_transparent_output_ids(wallet.get_wallet_transactions()?);
 
-    let transparent_spend_scan_targets =
-        detect_transparent_spends(wallet.get_outpoints_mut()?, transparent_output_ids);
+    let mut transparent_spend_scan_targets =
+        detect_transparent_spends(wallet.get_outpoints_mut()?, transparent_output_ids.clone());
+    if let Some(outpoint_map) = additional_outpoint_map {
+        let mut additional_transparent_spend_scan_targets =
+            detect_transparent_spends(outpoint_map, transparent_output_ids);
+        transparent_spend_scan_targets.append(&mut additional_transparent_spend_scan_targets);
+    }
 
     update_spent_coins(
         wallet.get_wallet_transactions_mut()?,

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -584,12 +584,13 @@ fn select_scan_range(
         } else {
             // scan ranges are sorted from lowest to highest priority.
             // scan ranges with the same priority are sorted in block height order.
-            // the highest priority scan range is the selected from the end of the list, the highest priority with highest
+            // the highest priority scan range is then selected from the end of the list, the highest priority with highest
             // starting block height.
             // if the highest priority is `Historic` the range with the lowest starting block height is selected instead.
             // if nullifiers are not being mapped to the wallet's main nullifier map due to performance constraints
             // (`map_nullifiers` is set `false`) then the range with the highest priority and lowest starting block
             // height is selected to allow notes to be spendable quickly on rescan, otherwise spends would not be detected.
+            // TODO: add this documentation of performance levels and order of scanning to pepper-sync doc comments
             let mut scan_ranges_priority_sorted: Vec<(usize, ScanRange)> =
                 sync_state.scan_ranges.iter().cloned().enumerate().collect();
             if !map_nullifiers {
@@ -603,6 +604,8 @@ fn select_scan_range(
                 .map(|(index, highest_priority_range)| {
                     if highest_priority_range.priority() == ScanPriority::Historic {
                         if map_nullifiers {
+                            // in this case, scan ranges are sorted from lowest to highest and we are selecting
+                            // the lowest range with historic priority
                             scan_ranges_priority_sorted
                                 .iter()
                                 .find(|(_, range)| range.priority() == ScanPriority::Historic)
@@ -610,7 +613,7 @@ fn select_scan_range(
                                 .clone()
                         } else {
                             // in this case, scan ranges are already sorted from highest to lowest and we are selecting
-                            // the last range (lowest)
+                            // the last range (lowest range with historic priority)
                             (*index, highest_priority_range.clone())
                         }
                     } else {
@@ -676,12 +679,7 @@ where
     W: SyncWallet + SyncBlocks + SyncNullifiers,
 {
     let nullifier_map = wallet.get_nullifiers()?;
-    let max_nullifier_map_size = match performance_level {
-        PerformanceLevel::Low => Some(0),
-        PerformanceLevel::Medium => Some(0),
-        PerformanceLevel::High => Some(2_000_000),
-        PerformanceLevel::Maximum => None,
-    };
+    let max_nullifier_map_size = super::max_nullifier_map_size(performance_level);
     let mut map_nullifiers = max_nullifier_map_size
         .is_none_or(|max| nullifier_map.orchard.len() + nullifier_map.sapling.len() < max);
 
@@ -717,27 +715,21 @@ where
                 .map(|(id, address)| (address.clone(), *id))
                 .collect();
 
-            // chain tip nullifiers are still mapped even in lowest performance setting to allow instant spendability
-            // of new notes.
-            if selected_range.priority() == ScanPriority::ChainTip {
-                map_nullifiers = true;
-            } else {
-                // map nullifiers if the scanning the lowest range to be scanned for final spend detection.
-                // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
-                // re-fetching of the nullifiers in this range.
-                // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
-                // scanning.
-                for scan_range in wallet.get_sync_state()?.scan_ranges() {
-                    if scan_range.priority() != ScanPriority::Scanned
-                        && scan_range.priority() != ScanPriority::ScannedWithoutMapping
-                        && scan_range.priority() != ScanPriority::Scanning
-                    {
-                        break;
-                    }
+            // map nullifiers if the scanning the lowest range to be scanned for final spend detection.
+            // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
+            // re-fetching of the nullifiers in this range.
+            // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
+            // scanning.
+            for scan_range in wallet.get_sync_state()?.scan_ranges() {
+                if scan_range.priority() != ScanPriority::Scanned
+                    && scan_range.priority() != ScanPriority::ScannedWithoutMapping
+                    && scan_range.priority() != ScanPriority::Scanning
+                {
+                    break;
+                }
 
-                    if scan_range.block_range() == selected_range.block_range() {
-                        map_nullifiers = true;
-                    }
+                if scan_range.block_range() == selected_range.block_range() {
+                    map_nullifiers = true;
                 }
             }
 


### PR DESCRIPTION
- sync no longer maps outpoints when nullifier map limit is reached
- sync no longer maps nullifiers and outpoints for chain tip on low memory settings
- each batch is now checked to ensure max nullifier map size limit is never exceeded