### PR TITLE
fix large wallet file size due to excessive nullifier and outpoint maps in some cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "zingolib"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "append-only-vec",
  "bech32",

--- a/pepper-sync/src/scan.rs
+++ b/pepper-sync/src/scan.rs
@@ -89,7 +89,6 @@ pub(crate) struct ScanResults {
     pub(crate) wallet_transactions: HashMap<TxId, WalletTransaction>,
     pub(crate) sapling_located_trees: Vec<LocatedTreeData<sapling_crypto::Node>>,
     pub(crate) orchard_located_trees: Vec<LocatedTreeData<MerkleHashOrchard>>,
-    pub(crate) map_nullifiers: bool,
 }
 
 pub(crate) struct DecryptedNoteData {
@@ -129,7 +128,6 @@ where
         end_seam_block,
         mut scan_targets,
         transparent_addresses,
-        map_nullifiers,
     } = scan_task;
 
     if compact_blocks
@@ -161,7 +159,6 @@ where
             wallet_transactions: HashMap::new(),
             sapling_located_trees: Vec::new(),
             orchard_located_trees: Vec::new(),
-            map_nullifiers,
         });
     }
 
@@ -244,7 +241,6 @@ where
         wallet_transactions,
         sapling_located_trees,
         orchard_located_trees,
-        map_nullifiers,
     })
 }
 

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -200,7 +200,7 @@ where
         &mut self,
         wallet: &mut W,
         shutdown_mempool: Arc<AtomicBool>,
-        performance_level: PerformanceLevel,
+        nullifier_map_limit_exceeded: bool,
     ) -> Result<(), SyncError<W::Error>>
     where
         W: SyncWallet + SyncBlocks + SyncNullifiers,
@@ -235,7 +235,7 @@ where
                 }
 
                 // scan ranges with `Verify` priority
-                self.update_batcher(wallet, performance_level)
+                self.update_batcher(wallet, nullifier_map_limit_exceeded)
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Scan => {
@@ -244,7 +244,7 @@ where
                     .expect("batcher should be running")
                     .update_batch_store();
                 self.update_workers();
-                self.update_batcher(wallet, performance_level)
+                self.update_batcher(wallet, nullifier_map_limit_exceeded)
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Shutdown => {
@@ -279,7 +279,7 @@ where
     fn update_batcher<W>(
         &mut self,
         wallet: &mut W,
-        performance_level: PerformanceLevel,
+        nullifier_map_limit_exceeded: bool,
     ) -> Result<(), W::Error>
     where
         W: SyncWallet + SyncBlocks + SyncNullifiers,
@@ -289,7 +289,7 @@ where
             if let Some(scan_task) = sync::state::create_scan_task(
                 &self.consensus_parameters,
                 wallet,
-                performance_level,
+                nullifier_map_limit_exceeded,
             )? {
                 batcher.add_scan_task(scan_task);
             } else if wallet.get_sync_state()?.scan_complete() {
@@ -738,7 +738,6 @@ pub(crate) struct ScanTask {
     pub(crate) end_seam_block: Option<WalletBlock>,
     pub(crate) scan_targets: BTreeSet<ScanTarget>,
     pub(crate) transparent_addresses: HashMap<String, TransparentAddressId>,
-    pub(crate) map_nullifiers: bool,
 }
 
 impl ScanTask {
@@ -748,7 +747,6 @@ impl ScanTask {
         end_seam_block: Option<WalletBlock>,
         scan_targets: BTreeSet<ScanTarget>,
         transparent_addresses: HashMap<String, TransparentAddressId>,
-        map_nullifiers: bool,
     ) -> Self {
         Self {
             compact_blocks: Vec::new(),
@@ -757,7 +755,6 @@ impl ScanTask {
             end_seam_block,
             scan_targets,
             transparent_addresses,
-            map_nullifiers,
         }
     }
 
@@ -829,7 +826,6 @@ impl ScanTask {
                 end_seam_block: upper_task_first_block,
                 scan_targets: lower_task_scan_targets,
                 transparent_addresses: self.transparent_addresses.clone(),
-                map_nullifiers: self.map_nullifiers,
             },
             ScanTask {
                 compact_blocks: upper_compact_blocks,
@@ -841,7 +837,6 @@ impl ScanTask {
                 end_seam_block: self.end_seam_block,
                 scan_targets: upper_task_scan_targets,
                 transparent_addresses: self.transparent_addresses,
-                map_nullifiers: self.map_nullifiers,
             },
         ))
     }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -23,7 +23,7 @@ use zcash_protocol::consensus::{self, BlockHeight};
 use zingo_status::confirmation_status::ConfirmationStatus;
 
 use crate::client::{self, FetchRequest};
-use crate::config::SyncConfig;
+use crate::config::{PerformanceLevel, SyncConfig};
 use crate::error::{
     ContinuityError, MempoolError, ScanError, ServerError, SyncError, SyncModeError,
     SyncStatusError,
@@ -456,6 +456,7 @@ where
                     scan_range,
                     scan_results,
                     initial_verification_height,
+                    config.performance_level,
                 )
                 .await?;
                 wallet_guard.set_save_flag().map_err(SyncError::WalletError)?;
@@ -848,6 +849,7 @@ where
 }
 
 /// Scan post-processing
+#[allow(clippy::too_many_arguments)]
 async fn process_scan_results<W>(
     consensus_parameters: &impl consensus::Parameters,
     wallet: &mut W,
@@ -856,6 +858,7 @@ async fn process_scan_results<W>(
     scan_range: ScanRange,
     scan_results: Result<ScanResults, ScanError>,
     initial_verification_height: BlockHeight,
+    performance_level: PerformanceLevel,
 ) -> Result<(), SyncError<W::Error>>
 where
     W: SyncWallet
@@ -870,15 +873,17 @@ where
         Ok(results) => {
             let ScanResults {
                 mut nullifiers,
-                outpoints,
+                mut outpoints,
                 scanned_blocks,
                 wallet_transactions,
                 sapling_located_trees,
                 orchard_located_trees,
-                map_nullifiers,
+                mut map_nullifiers,
             } = results;
 
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
+                spend::update_transparent_spends(wallet, Some(&mut outpoints))
+                    .map_err(SyncError::WalletError)?;
                 spend::update_shielded_spends(
                     consensus_parameters,
                     wallet,
@@ -925,6 +930,20 @@ where
                     true,
                 );
             } else {
+                // nullifiers and outpoints are not mapped if nullifier map size limit will be exceeded
+                let nullifier_map = wallet.get_nullifiers().map_err(SyncError::WalletError)?;
+                if map_nullifiers
+                    && max_nullifier_map_size(performance_level).is_some_and(|max| {
+                        nullifier_map.orchard.len()
+                            + nullifier_map.sapling.len()
+                            + nullifiers.orchard.len()
+                            + nullifiers.sapling.len()
+                            > max
+                    })
+                {
+                    map_nullifiers = false;
+                }
+
                 update_wallet_data(
                     consensus_parameters,
                     wallet,
@@ -936,13 +955,25 @@ where
                     } else {
                         None
                     },
-                    outpoints,
+                    if map_nullifiers {
+                        Some(&mut outpoints)
+                    } else {
+                        None
+                    },
                     wallet_transactions,
                     sapling_located_trees,
                     orchard_located_trees,
                 )
                 .await?;
-                spend::update_transparent_spends(wallet).map_err(SyncError::WalletError)?;
+                spend::update_transparent_spends(
+                    wallet,
+                    if map_nullifiers {
+                        None
+                    } else {
+                        Some(&mut outpoints)
+                    },
+                )
+                .map_err(SyncError::WalletError)?;
                 spend::update_shielded_spends(
                     consensus_parameters,
                     wallet,
@@ -1173,7 +1204,7 @@ async fn update_wallet_data<W>(
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
     scan_range: &ScanRange,
     nullifiers: Option<&mut NullifierMap>,
-    mut outpoints: BTreeMap<OutputId, ScanTarget>,
+    outpoints: Option<&mut BTreeMap<OutputId, ScanTarget>>,
     transactions: HashMap<TxId, WalletTransaction>,
     sapling_located_trees: Vec<LocatedTreeData<sapling_crypto::Node>>,
     orchard_located_trees: Vec<LocatedTreeData<MerkleHashOrchard>>,
@@ -1213,9 +1244,11 @@ where
             .append_nullifiers(nullifiers)
             .map_err(SyncError::WalletError)?;
     }
-    wallet
-        .append_outpoints(&mut outpoints)
-        .map_err(SyncError::WalletError)?;
+    if let Some(outpoints) = outpoints {
+        wallet
+            .append_outpoints(outpoints)
+            .map_err(SyncError::WalletError)?;
+    }
     wallet
         .update_shard_trees(
             fetch_request_sender,
@@ -1597,4 +1630,13 @@ where
     reset_spends(wallet_transactions, invalid_txids);
 
     Ok(())
+}
+
+fn max_nullifier_map_size(performance_level: PerformanceLevel) -> Option<usize> {
+    match performance_level {
+        PerformanceLevel::Low => Some(0),
+        PerformanceLevel::Medium => Some(0),
+        PerformanceLevel::High => Some(2_000_000),
+        PerformanceLevel::Maximum => None,
+    }
 }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -442,6 +442,7 @@ where
 
     // TODO: implement an option for continuous scanning where it doesnt exit when complete
 
+    let mut nullifier_map_limit_exceeded = false;
     let mut interval = tokio::time::interval(Duration::from_millis(50));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
@@ -457,6 +458,7 @@ where
                     scan_results,
                     initial_verification_height,
                     config.performance_level,
+                    &mut nullifier_map_limit_exceeded,
                 )
                 .await?;
                 wallet_guard.set_save_flag().map_err(SyncError::WalletError)?;
@@ -525,7 +527,7 @@ where
                     },
                 }
 
-                scanner.update(&mut *wallet.write().await, shutdown_mempool.clone(), config.performance_level).await?;
+                scanner.update(&mut *wallet.write().await, shutdown_mempool.clone(), nullifier_map_limit_exceeded).await?;
 
                 if matches!(scanner.state, ScannerState::Shutdown) {
                     // wait for mempool monitor to receive mempool transactions
@@ -859,6 +861,7 @@ async fn process_scan_results<W>(
     scan_results: Result<ScanResults, ScanError>,
     initial_verification_height: BlockHeight,
     performance_level: PerformanceLevel,
+    nullifier_map_limit_exceeded: &mut bool,
 ) -> Result<(), SyncError<W::Error>>
 where
     W: SyncWallet
@@ -878,10 +881,11 @@ where
                 wallet_transactions,
                 sapling_located_trees,
                 orchard_located_trees,
-                mut map_nullifiers,
             } = results;
 
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
+                // FIXME: assert this is the first non-scanned / non-scanning range
+
                 spend::update_transparent_spends(wallet, Some(&mut outpoints))
                     .map_err(SyncError::WalletError)?;
                 spend::update_shielded_spends(
@@ -927,21 +931,49 @@ where
                         .get_sync_state_mut()
                         .map_err(SyncError::WalletError)?,
                     scan_range.block_range().clone(),
-                    true,
+                    true, // NOTE: although nullifiers are not actually added to the wallet's nullifier map for efficiency, there is effectively no difference as they are still checked for spends using the `additional_nullifier_map` parameter and would be removed on the following cleanup (`remove_irrelevant_data`) due to `ScannedWithoutMapping` ranges always being the first non-scanned non-scanning range and therefore always raise the wallet's fully scanned height after processing.
                 );
+                // FIXME: there may be a bug where ScannedWithoutMapping ranges could be processed before a lower range (with `Scanning` priority) is processed, missing spend detection of outputs in the lower scan range. investigate.
             } else {
                 // nullifiers and outpoints are not mapped if nullifier map size limit will be exceeded
-                let nullifier_map = wallet.get_nullifiers().map_err(SyncError::WalletError)?;
-                if map_nullifiers
-                    && max_nullifier_map_size(performance_level).is_some_and(|max| {
+                if !*nullifier_map_limit_exceeded {
+                    let nullifier_map = wallet.get_nullifiers().map_err(SyncError::WalletError)?;
+                    if max_nullifier_map_size(performance_level).is_some_and(|max| {
                         nullifier_map.orchard.len()
                             + nullifier_map.sapling.len()
                             + nullifiers.orchard.len()
                             + nullifiers.sapling.len()
                             > max
-                    })
+                    }) {
+                        *nullifier_map_limit_exceeded = true;
+                    }
+                }
+                let mut map_nullifiers = !*nullifier_map_limit_exceeded;
+
+                // map nullifiers if the scanning the lowest range to be scanned for final spend detection.
+                // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
+                // re-fetching of the nullifiers in this range.
+                // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
+                // scanning.
+                for query_scan_range in wallet
+                    .get_sync_state()
+                    .map_err(SyncError::WalletError)?
+                    .scan_ranges()
                 {
-                    map_nullifiers = false;
+                    if query_scan_range.priority() != ScanPriority::Scanned
+                        && query_scan_range.priority() != ScanPriority::Scanning
+                        && query_scan_range.priority() != ScanPriority::ScannedWithoutMapping
+                    {
+                        break;
+                    }
+
+                    if query_scan_range.priority() == ScanPriority::ScannedWithoutMapping
+                        && query_scan_range.block_range().start == scan_range.block_range().start
+                    {
+                        map_nullifiers = true;
+                    } else {
+                        break;
+                    }
                 }
 
                 update_wallet_data(

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -884,20 +884,6 @@ where
             } = results;
 
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
-                // TODO: error if this in not the first non-scanned / non-scanning range
-
-                spend::update_transparent_spends(wallet, Some(&mut outpoints))
-                    .map_err(SyncError::WalletError)?;
-                spend::update_shielded_spends(
-                    consensus_parameters,
-                    wallet,
-                    fetch_request_sender.clone(),
-                    ufvks,
-                    &scanned_blocks,
-                    Some(&mut nullifiers),
-                )
-                .await?;
-
                 // add missing block bounds in the case that nullifier batch limit was reached and scan range was split
                 let mut missing_block_bounds = BTreeMap::new();
                 for block_bound in [
@@ -926,6 +912,48 @@ where
                         .map_err(SyncError::WalletError)?;
                 }
 
+                let first_unscanned_range = wallet
+                    .get_sync_state()
+                    .map_err(SyncError::WalletError)?
+                    .scan_ranges
+                    .iter()
+                    .find(|scan_range| scan_range.priority() != ScanPriority::Scanned)
+                    .expect("the scan range being processed is not yet set to scanned so at least one unscanned range must exist");
+                if !(first_unscanned_range
+                    .block_range()
+                    .contains(&scan_range.block_range().start)
+                    && first_unscanned_range
+                        .block_range()
+                        .contains(&(scan_range.block_range().end - 1)))
+                {
+                    // in this rare edge case, a scanned `ScannedWithoutMapping` range was the highest priority yet it was not the first unscanned range so it must be discarded to avoid missing spends
+
+                    // reset scan range from `Scanning` to `ScannedWithoutMapping`
+                    state::punch_scan_priority(
+                        wallet
+                            .get_sync_state_mut()
+                            .map_err(SyncError::WalletError)?,
+                        scan_range.block_range().clone(),
+                        ScanPriority::ScannedWithoutMapping,
+                        true,
+                    );
+                    tracing::debug!("Scan results discarded.");
+
+                    return Ok(());
+                }
+
+                spend::update_transparent_spends(wallet, Some(&mut outpoints))
+                    .map_err(SyncError::WalletError)?;
+                spend::update_shielded_spends(
+                    consensus_parameters,
+                    wallet,
+                    fetch_request_sender.clone(),
+                    ufvks,
+                    &scanned_blocks,
+                    Some(&mut nullifiers),
+                )
+                .await?;
+
                 state::set_scanned_scan_range(
                     wallet
                         .get_sync_state_mut()
@@ -933,7 +961,6 @@ where
                     scan_range.block_range().clone(),
                     true, // NOTE: although nullifiers are not actually added to the wallet's nullifier map for efficiency, there is effectively no difference as they are still checked for spends using the `additional_nullifier_map` parameter and would be removed on the following cleanup (`remove_irrelevant_data`) due to `ScannedWithoutMapping` ranges always being the first non-scanned non-scanning range and therefore always raise the wallet's fully scanned height after processing.
                 );
-                // FIXME: there may be a bug where ScannedWithoutMapping ranges could be processed before a lower range (with `Scanning` priority) is processed, missing spend detection of outputs in the lower scan range. investigate.
             } else {
                 // nullifiers and outpoints are not mapped if nullifier map size limit will be exceeded
                 if !*nullifier_map_limit_exceeded {

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1701,7 +1701,7 @@ where
 fn max_nullifier_map_size(performance_level: PerformanceLevel) -> Option<usize> {
     match performance_level {
         PerformanceLevel::Low => Some(0),
-        PerformanceLevel::Medium => Some(250_000),
+        PerformanceLevel::Medium => Some(125_000),
         PerformanceLevel::High => Some(2_000_000),
         PerformanceLevel::Maximum => None,
     }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -172,8 +172,8 @@ pub enum ScanPriority {
     Scanned,
     /// Block ranges that have already been scanned. The nullifiers from this range were not mapped after scanning and
     /// spend detection to reduce memory consumption and/or storage for non-linear scanning. These nullifiers will need
-    /// to be re-fetched for final spend detection when merging this range is the lowest unscanned range in the
-    /// wallet's list of scan ranges.
+    /// to be re-fetched for final spend detection when this range is the lowest unscanned range in the wallet's list
+    /// of scan ranges.
     ScannedWithoutMapping,
     /// Block ranges to be scanned to advance the fully-scanned height.
     Historic,
@@ -944,8 +944,6 @@ where
                     return Ok(());
                 }
 
-                spend::update_transparent_spends(wallet, Some(&mut outpoints))
-                    .map_err(SyncError::WalletError)?;
                 spend::update_shielded_spends(
                     consensus_parameters,
                     wallet,
@@ -964,7 +962,7 @@ where
                     true, // NOTE: although nullifiers are not actually added to the wallet's nullifier map for efficiency, there is effectively no difference as spends are still updated using the `additional_nullifier_map` and would be removed on the following cleanup (`remove_irrelevant_data`) due to `ScannedWithoutMapping` ranges always being the first non-scanned range and therefore always raise the wallet's fully scanned height after processing.
                 );
             } else {
-                // nullifiers and outpoints are not mapped if nullifier map size limit will be exceeded
+                // nullifiers are not mapped if nullifier map size limit will be exceeded
                 if !*nullifier_map_limit_exceeded {
                     let nullifier_map = wallet.get_nullifiers().map_err(SyncError::WalletError)?;
                     if max_nullifier_map_size(performance_level).is_some_and(|max| {
@@ -979,7 +977,11 @@ where
                 }
                 let mut map_nullifiers = !*nullifier_map_limit_exceeded;
 
-                // always map nullifiers if the scanning the lowest range to be scanned for final spend detection.
+                // all transparent spend locations are known before scanning so there is no need to map outpoints from untargetted ranges.
+                // outpoints of untargetted ranges will still be checked before being discarded.
+                let map_outpoints = scan_range.priority() >= ScanPriority::FoundNote;
+
+                // always map nullifiers if scanning the lowest range to be scanned for final spend detection.
                 // this will set the range to `Scanned` (as oppose to `ScannedWithoutMapping`) and prevent immediate
                 // re-fetching of the nullifiers in this range. these will be immediately cleared after cleanup so will not
                 // have an impact on memory or wallet file size.
@@ -1021,7 +1023,7 @@ where
                     } else {
                         None
                     },
-                    if map_nullifiers {
+                    if map_outpoints {
                         Some(&mut outpoints)
                     } else {
                         None
@@ -1033,7 +1035,7 @@ where
                 .await?;
                 spend::update_transparent_spends(
                     wallet,
-                    if map_nullifiers {
+                    if map_outpoints {
                         None
                     } else {
                         Some(&mut outpoints)

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -884,7 +884,7 @@ where
             } = results;
 
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
-                // FIXME: assert this is the first non-scanned / non-scanning range
+                // TODO: error if this in not the first non-scanned / non-scanning range
 
                 spend::update_transparent_spends(wallet, Some(&mut outpoints))
                     .map_err(SyncError::WalletError)?;
@@ -950,7 +950,7 @@ where
                 }
                 let mut map_nullifiers = !*nullifier_map_limit_exceeded;
 
-                // map nullifiers if the scanning the lowest range to be scanned for final spend detection.
+                // always map nullifiers if the scanning the lowest range to be scanned for final spend detection.
                 // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
                 // re-fetching of the nullifiers in this range.
                 // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
@@ -960,19 +960,21 @@ where
                     .map_err(SyncError::WalletError)?
                     .scan_ranges()
                 {
-                    if query_scan_range.priority() != ScanPriority::Scanned
-                        && query_scan_range.priority() != ScanPriority::Scanning
-                        && query_scan_range.priority() != ScanPriority::ScannedWithoutMapping
+                    let scan_priority = query_scan_range.priority();
+                    if scan_priority != ScanPriority::Scanned
+                        && scan_priority != ScanPriority::Scanning
+                        && scan_priority != ScanPriority::ScannedWithoutMapping
                     {
                         break;
                     }
 
-                    if query_scan_range.priority() == ScanPriority::ScannedWithoutMapping
-                        && query_scan_range.block_range().start == scan_range.block_range().start
-                    {
-                        map_nullifiers = true;
-                    } else {
-                        break;
+                    match (
+                        scan_priority == ScanPriority::ScannedWithoutMapping,
+                        query_scan_range.block_range().start == scan_range.block_range().start,
+                    ) {
+                        (true, true) => map_nullifiers = true,
+                        (true, false) => break,
+                        (false, _) => (),
                     }
                 }
 

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -919,12 +919,12 @@ where
                     .iter()
                     .find(|scan_range| scan_range.priority() != ScanPriority::Scanned)
                     .expect("the scan range being processed is not yet set to scanned so at least one unscanned range must exist");
-                if !(first_unscanned_range
+                if !first_unscanned_range
                     .block_range()
                     .contains(&scan_range.block_range().start)
-                    && first_unscanned_range
+                    || !first_unscanned_range
                         .block_range()
-                        .contains(&(scan_range.block_range().end - 1)))
+                        .contains(&(scan_range.block_range().end - 1))
                 {
                     // in this rare edge case, a scanned `ScannedWithoutMapping` range was the highest priority yet it was not the first unscanned range so it must be discarded to avoid missing spends
 
@@ -937,7 +937,9 @@ where
                         ScanPriority::ScannedWithoutMapping,
                         true,
                     );
-                    tracing::debug!("Scan results discarded.");
+                    tracing::debug!(
+                        "Nullifiers discarded and will be re-fetched to avoid missing spends."
+                    );
 
                     return Ok(());
                 }
@@ -959,7 +961,7 @@ where
                         .get_sync_state_mut()
                         .map_err(SyncError::WalletError)?,
                     scan_range.block_range().clone(),
-                    true, // NOTE: although nullifiers are not actually added to the wallet's nullifier map for efficiency, there is effectively no difference as they are still checked for spends using the `additional_nullifier_map` parameter and would be removed on the following cleanup (`remove_irrelevant_data`) due to `ScannedWithoutMapping` ranges always being the first non-scanned non-scanning range and therefore always raise the wallet's fully scanned height after processing.
+                    true, // NOTE: although nullifiers are not actually added to the wallet's nullifier map for efficiency, there is effectively no difference as spends are still updated using the `additional_nullifier_map` and would be removed on the following cleanup (`remove_irrelevant_data`) due to `ScannedWithoutMapping` ranges always being the first non-scanned range and therefore always raise the wallet's fully scanned height after processing.
                 );
             } else {
                 // nullifiers and outpoints are not mapped if nullifier map size limit will be exceeded
@@ -978,8 +980,9 @@ where
                 let mut map_nullifiers = !*nullifier_map_limit_exceeded;
 
                 // always map nullifiers if the scanning the lowest range to be scanned for final spend detection.
-                // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
-                // re-fetching of the nullifiers in this range.
+                // this will set the range to `Scanned` (as oppose to `ScannedWithoutMapping`) and prevent immediate
+                // re-fetching of the nullifiers in this range. these will be immediately cleared after cleanup so will not
+                // have an impact on memory or wallet file size.
                 // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
                 // scanning.
                 for query_scan_range in wallet
@@ -990,18 +993,20 @@ where
                     let scan_priority = query_scan_range.priority();
                     if scan_priority != ScanPriority::Scanned
                         && scan_priority != ScanPriority::Scanning
-                        && scan_priority != ScanPriority::ScannedWithoutMapping
                     {
                         break;
                     }
 
-                    match (
-                        scan_priority == ScanPriority::ScannedWithoutMapping,
-                        query_scan_range.block_range().start == scan_range.block_range().start,
-                    ) {
-                        (true, true) => map_nullifiers = true,
-                        (true, false) => break,
-                        (false, _) => (),
+                    if scan_priority == ScanPriority::Scanning
+                        && query_scan_range
+                            .block_range()
+                            .contains(&scan_range.block_range().start)
+                        && query_scan_range
+                            .block_range()
+                            .contains(&(scan_range.block_range().end - 1))
+                    {
+                        map_nullifiers = true;
+                        break;
                     }
                 }
 
@@ -1696,7 +1701,7 @@ where
 fn max_nullifier_map_size(performance_level: PerformanceLevel) -> Option<usize> {
     match performance_level {
         PerformanceLevel::Low => Some(0),
-        PerformanceLevel::Medium => Some(0),
+        PerformanceLevel::Medium => Some(250_000),
         PerformanceLevel::High => Some(2_000_000),
         PerformanceLevel::Maximum => None,
     }

--- a/pepper-sync/src/sync/spend.rs
+++ b/pepper-sync/src/sync/spend.rs
@@ -299,14 +299,22 @@ where
 /// Locates any output ids of coins in the wallet's transactions which match an output id in the wallet's outpoint map.
 /// If a spend is detected, the output id is removed from the outpoint map and added to the map of spend scan targets.
 /// Finally, all coins that were detected as spent are updated with the located spending transaction.
-pub(super) fn update_transparent_spends<W>(wallet: &mut W) -> Result<(), W::Error>
+pub(super) fn update_transparent_spends<W>(
+    wallet: &mut W,
+    additional_outpoint_map: Option<&mut BTreeMap<OutputId, ScanTarget>>,
+) -> Result<(), W::Error>
 where
     W: SyncBlocks + SyncTransactions + SyncOutPoints,
 {
     let transparent_output_ids = collect_transparent_output_ids(wallet.get_wallet_transactions()?);
 
-    let transparent_spend_scan_targets =
-        detect_transparent_spends(wallet.get_outpoints_mut()?, transparent_output_ids);
+    let mut transparent_spend_scan_targets =
+        detect_transparent_spends(wallet.get_outpoints_mut()?, transparent_output_ids.clone());
+    if let Some(outpoint_map) = additional_outpoint_map {
+        let mut additional_transparent_spend_scan_targets =
+            detect_transparent_spends(outpoint_map, transparent_output_ids);
+        transparent_spend_scan_targets.append(&mut additional_transparent_spend_scan_targets);
+    }
 
     update_spent_coins(
         wallet.get_wallet_transactions_mut()?,

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -16,7 +16,6 @@ use zcash_protocol::{
 
 use crate::{
     client::{self, FetchRequest},
-    config::PerformanceLevel,
     error::{ServerError, SyncError},
     keys::transparent::TransparentAddressId,
     scan::task::ScanTask,
@@ -561,12 +560,10 @@ fn split_out_scan_range(
 /// Sets the range for scanning to `Scanning` priority in the wallet `sync_state` but returns the scan range with its
 /// initial priority.
 /// Returns `None` if there are no more ranges to scan.
-///
-/// Set `map_nullifiers` to `false` if the nullifiers are not going to be mapped to the wallet's main nullifier map.
 fn select_scan_range(
     consensus_parameters: &impl consensus::Parameters,
     sync_state: &mut SyncState,
-    map_nullifiers: bool,
+    nullifier_map_limit_exceeded: bool,
 ) -> Option<ScanRange> {
     let (first_unscanned_index, first_unscanned_range) = sync_state
         .scan_ranges
@@ -588,12 +585,12 @@ fn select_scan_range(
             // starting block height.
             // if the highest priority is `Historic` the range with the lowest starting block height is selected instead.
             // if nullifiers are not being mapped to the wallet's main nullifier map due to performance constraints
-            // (`map_nullifiers` is set `false`) then the range with the highest priority and lowest starting block
-            // height is selected to allow notes to be spendable quickly on rescan, otherwise spends would not be detected.
+            // (`nullifier_map_limit_exceeded` is set `true`) then the range with the highest priority and lowest starting block
+            // height is selected to allow notes to be spendable quickly on rescan, otherwise spends would not be detected as nullifiers will be temporarily discarded.
             // TODO: add this documentation of performance levels and order of scanning to pepper-sync doc comments
             let mut scan_ranges_priority_sorted: Vec<(usize, ScanRange)> =
                 sync_state.scan_ranges.iter().cloned().enumerate().collect();
-            if !map_nullifiers {
+            if nullifier_map_limit_exceeded {
                 scan_ranges_priority_sorted
                     .sort_by(|(_, a), (_, b)| b.block_range().start.cmp(&a.block_range().start));
             }
@@ -603,7 +600,11 @@ fn select_scan_range(
                 .last()
                 .map(|(index, highest_priority_range)| {
                     if highest_priority_range.priority() == ScanPriority::Historic {
-                        if map_nullifiers {
+                        if nullifier_map_limit_exceeded {
+                            // in this case, scan ranges are already sorted from highest to lowest and we are selecting
+                            // the last range (lowest range with historic priority)
+                            (*index, highest_priority_range.clone())
+                        } else {
                             // in this case, scan ranges are sorted from lowest to highest and we are selecting
                             // the lowest range with historic priority
                             scan_ranges_priority_sorted
@@ -611,10 +612,6 @@ fn select_scan_range(
                                 .find(|(_, range)| range.priority() == ScanPriority::Historic)
                                 .expect("range with Historic priority exists in this scope")
                                 .clone()
-                        } else {
-                            // in this case, scan ranges are already sorted from highest to lowest and we are selecting
-                            // the last range (lowest range with historic priority)
-                            (*index, highest_priority_range.clone())
                         }
                     } else {
                         // select the last range in the list
@@ -673,20 +670,15 @@ fn select_scan_range(
 pub(crate) fn create_scan_task<W>(
     consensus_parameters: &impl consensus::Parameters,
     wallet: &mut W,
-    performance_level: PerformanceLevel,
+    nullifier_map_limit_exceeded: bool,
 ) -> Result<Option<ScanTask>, W::Error>
 where
     W: SyncWallet + SyncBlocks + SyncNullifiers,
 {
-    let nullifier_map = wallet.get_nullifiers()?;
-    let max_nullifier_map_size = super::max_nullifier_map_size(performance_level);
-    let mut map_nullifiers = max_nullifier_map_size
-        .is_none_or(|max| nullifier_map.orchard.len() + nullifier_map.sapling.len() < max);
-
     if let Some(selected_range) = select_scan_range(
         consensus_parameters,
         wallet.get_sync_state_mut()?,
-        map_nullifiers,
+        nullifier_map_limit_exceeded,
     ) {
         if selected_range.priority() == ScanPriority::ScannedWithoutMapping {
             // all continuity checks and scanning is already complete, the scan worker will only re-fetch the nullifiers
@@ -697,7 +689,6 @@ where
                 None,
                 BTreeSet::new(),
                 HashMap::new(),
-                true,
             )))
         } else {
             let start_seam_block = wallet
@@ -715,31 +706,12 @@ where
                 .map(|(id, address)| (address.clone(), *id))
                 .collect();
 
-            // map nullifiers if the scanning the lowest range to be scanned for final spend detection.
-            // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
-            // re-fetching of the nullifiers in this range.
-            // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
-            // scanning.
-            for scan_range in wallet.get_sync_state()?.scan_ranges() {
-                if scan_range.priority() != ScanPriority::Scanned
-                    && scan_range.priority() != ScanPriority::ScannedWithoutMapping
-                    && scan_range.priority() != ScanPriority::Scanning
-                {
-                    break;
-                }
-
-                if scan_range.block_range() == selected_range.block_range() {
-                    map_nullifiers = true;
-                }
-            }
-
             Ok(Some(ScanTask::from_parts(
                 selected_range,
                 start_seam_block,
                 end_seam_block,
                 scan_targets,
                 transparent_addresses,
-                map_nullifiers,
             )))
         }
     } else {

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -262,7 +262,7 @@ fn set_chain_tip_scan_range(
         orchard_incomplete_shard
     };
 
-    punch_scan_priority(sync_state, chain_tip, ScanPriority::ChainTip);
+    punch_scan_priority(sync_state, chain_tip, ScanPriority::ChainTip, false);
 }
 
 /// Punches in the `shielded_protocol` shard block ranges surrounding each scan target with `ScanPriority::FoundNote`.
@@ -304,7 +304,7 @@ pub(super) fn set_found_note_scan_range(
         block_height,
         shielded_protocol,
     );
-    punch_scan_priority(sync_state, block_range, ScanPriority::FoundNote);
+    punch_scan_priority(sync_state, block_range, ScanPriority::FoundNote, false);
 }
 
 pub(super) fn set_scanned_scan_range(
@@ -367,10 +367,12 @@ pub(super) fn set_scan_priority(
 /// Any scan ranges that fully contain the `block_range` will be split out with the given `scan_priority`.
 /// Any scan ranges with `Scanning` or `Scanned` priority or with higher (or equal) priority than
 /// `scan_priority` will be ignored.
-fn punch_scan_priority(
+/// `split_scanning_ranges` is used for rare cases where a range already scanning needs to be reset back to its original priority and should be used with caution.
+pub(super) fn punch_scan_priority(
     sync_state: &mut SyncState,
     block_range: Range<BlockHeight>,
     scan_priority: ScanPriority,
+    split_scanning_ranges: bool,
 ) {
     let mut scan_ranges_contained_by_block_range = Vec::new();
     let mut scan_ranges_for_splitting = Vec::new();
@@ -378,7 +380,7 @@ fn punch_scan_priority(
     for (index, scan_range) in sync_state.scan_ranges().iter().enumerate() {
         if scan_range.priority() == ScanPriority::Scanned
             || scan_range.priority() == ScanPriority::ScannedWithoutMapping
-            || scan_range.priority() == ScanPriority::Scanning
+            || (scan_range.priority() == ScanPriority::Scanning && !split_scanning_ranges)
             || scan_range.priority() >= scan_priority
         {
             continue;
@@ -569,10 +571,7 @@ fn select_scan_range(
         .scan_ranges
         .iter()
         .enumerate()
-        .find(|(_, scan_range)| {
-            scan_range.priority() != ScanPriority::Scanned
-                && scan_range.priority() != ScanPriority::Scanning
-        })?;
+        .find(|(_, scan_range)| scan_range.priority() != ScanPriority::Scanned)?;
     let (selected_index, selected_scan_range) =
         if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
             // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -625,6 +625,10 @@ fn select_scan_range(
 
     let selected_priority = selected_scan_range.priority();
 
+    if selected_priority == ScanPriority::Scanned || selected_priority == ScanPriority::Scanning {
+        return None;
+    }
+
     // historic scan ranges can be larger than a shard block range so must be split out.
     // otherwise, just set the scan priority of selected range to `Scanning` in sync state.
     let selected_block_range = if selected_priority == ScanPriority::Historic {

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -574,7 +574,10 @@ fn select_scan_range(
         .scan_ranges
         .iter()
         .enumerate()
-        .find(|(_, scan_range)| scan_range.priority() != ScanPriority::Scanned)?;
+        .find(|(_, scan_range)| {
+            scan_range.priority() != ScanPriority::Scanned
+                && scan_range.priority() != ScanPriority::Scanning
+        })?;
     let (selected_index, selected_scan_range) =
         if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
             // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -584,12 +584,13 @@ fn select_scan_range(
         } else {
             // scan ranges are sorted from lowest to highest priority.
             // scan ranges with the same priority are sorted in block height order.
-            // the highest priority scan range is the selected from the end of the list, the highest priority with highest
+            // the highest priority scan range is then selected from the end of the list, the highest priority with highest
             // starting block height.
             // if the highest priority is `Historic` the range with the lowest starting block height is selected instead.
             // if nullifiers are not being mapped to the wallet's main nullifier map due to performance constraints
             // (`map_nullifiers` is set `false`) then the range with the highest priority and lowest starting block
             // height is selected to allow notes to be spendable quickly on rescan, otherwise spends would not be detected.
+            // TODO: add this documentation of performance levels and order of scanning to pepper-sync doc comments
             let mut scan_ranges_priority_sorted: Vec<(usize, ScanRange)> =
                 sync_state.scan_ranges.iter().cloned().enumerate().collect();
             if !map_nullifiers {
@@ -603,6 +604,8 @@ fn select_scan_range(
                 .map(|(index, highest_priority_range)| {
                     if highest_priority_range.priority() == ScanPriority::Historic {
                         if map_nullifiers {
+                            // in this case, scan ranges are sorted from lowest to highest and we are selecting
+                            // the lowest range with historic priority
                             scan_ranges_priority_sorted
                                 .iter()
                                 .find(|(_, range)| range.priority() == ScanPriority::Historic)
@@ -610,7 +613,7 @@ fn select_scan_range(
                                 .clone()
                         } else {
                             // in this case, scan ranges are already sorted from highest to lowest and we are selecting
-                            // the last range (lowest)
+                            // the last range (lowest range with historic priority)
                             (*index, highest_priority_range.clone())
                         }
                     } else {
@@ -676,12 +679,7 @@ where
     W: SyncWallet + SyncBlocks + SyncNullifiers,
 {
     let nullifier_map = wallet.get_nullifiers()?;
-    let max_nullifier_map_size = match performance_level {
-        PerformanceLevel::Low => Some(0),
-        PerformanceLevel::Medium => Some(0),
-        PerformanceLevel::High => Some(2_000_000),
-        PerformanceLevel::Maximum => None,
-    };
+    let max_nullifier_map_size = super::max_nullifier_map_size(performance_level);
     let mut map_nullifiers = max_nullifier_map_size
         .is_none_or(|max| nullifier_map.orchard.len() + nullifier_map.sapling.len() < max);
 
@@ -717,27 +715,21 @@ where
                 .map(|(id, address)| (address.clone(), *id))
                 .collect();
 
-            // chain tip nullifiers are still mapped even in lowest performance setting to allow instant spendability
-            // of new notes.
-            if selected_range.priority() == ScanPriority::ChainTip {
-                map_nullifiers = true;
-            } else {
-                // map nullifiers if the scanning the lowest range to be scanned for final spend detection.
-                // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
-                // re-fetching of the nullifiers in this range.
-                // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
-                // scanning.
-                for scan_range in wallet.get_sync_state()?.scan_ranges() {
-                    if scan_range.priority() != ScanPriority::Scanned
-                        && scan_range.priority() != ScanPriority::ScannedWithoutMapping
-                        && scan_range.priority() != ScanPriority::Scanning
-                    {
-                        break;
-                    }
+            // map nullifiers if the scanning the lowest range to be scanned for final spend detection.
+            // this will set the range to `Scanned` (as opose to `ScannedWithoutMapping`) and prevent immediate
+            // re-fetching of the nullifiers in this range.
+            // the selected range is not the lowest range to be scanned unless all ranges before it are scanned or
+            // scanning.
+            for scan_range in wallet.get_sync_state()?.scan_ranges() {
+                if scan_range.priority() != ScanPriority::Scanned
+                    && scan_range.priority() != ScanPriority::ScannedWithoutMapping
+                    && scan_range.priority() != ScanPriority::Scanning
+                {
+                    break;
+                }
 
-                    if scan_range.block_range() == selected_range.block_range() {
-                        map_nullifiers = true;
-                    }
+                if scan_range.block_range() == selected_range.block_range() {
+                    map_nullifiers = true;
                 }
             }
 

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -579,6 +579,7 @@ fn select_scan_range(
         if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
             // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first
             // unscanned range.
+            // the `first_unscanned_range` may have `Scanning` priority here as we must select a `ScannedWithoutMapping` range only when all ranges below are `Scanned`. if a `ScannedwithoutMapping` range is selected and completes *before* a lower range that is currently `Scanning`, the nullifiers will need to be discarded and re-fetched afterwards. so this avoids a race condition that results in a sync inefficiency.
             (first_unscanned_index, first_unscanned_range.clone())
         } else {
             // scan ranges are sorted from lowest to highest priority.

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -562,6 +562,9 @@ fn split_out_scan_range(
 /// Sets the range for scanning to `Scanning` priority in the wallet `sync_state` but returns the scan range with its
 /// initial priority.
 /// Returns `None` if there are no more ranges to scan.
+///
+/// Set `nullifier_map_limit_exceeded` to `true` if the nullifiers are not going to be mapped to the wallet's main
+/// nullifier map due to performance constraints.
 fn select_scan_range(
     consensus_parameters: &impl consensus::Parameters,
     sync_state: &mut SyncState,

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -574,10 +574,7 @@ fn select_scan_range(
         .scan_ranges
         .iter()
         .enumerate()
-        .find(|(_, scan_range)| {
-            scan_range.priority() != ScanPriority::Scanned
-                && scan_range.priority() != ScanPriority::Scanning
-        })?;
+        .find(|(_, scan_range)| scan_range.priority() != ScanPriority::Scanned)?;
     let (selected_index, selected_scan_range) =
         if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
             // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first


### PR DESCRIPTION
- sync only maps outpoints of targetted ranges (found note or higher priority) due to all transparent spend locations being known before scanning begins
- sync no longer maps nullifiers for chain tip on low memory settings
- each batch is now checked to ensure max nullifier map size limit is never exceeded

currently, the nullifiers collected when scanning a scan range are not added to the wallets nullifier map if the map exceeded a specified limit **before** the range started scanning. furthermore, the `map_nullifiers` bool applies to the entire scan range (usually a "shard range") as this is decided before the batcher splits these larger ranges into batches of fixed output size. as described in issue #2087, a single orchard shard range (or incomplete shard range) could contain several sapling shards which means a potentially huge number of nullifiers which need to be stored in memory and in the wallet file. combining all this with the sync engine always mapping nullifiers for the chain tip range (for improved spendable balance) and in some cases the memory usage and wallet file can become excessively large due to mapping a huge number of nullifiers. this is further exasperated by the fact that we currently *always* map outpoints even when `map_nullifiers` is false.

This PR fixes these issues firstly by introducing an `nullifier_map_limit_exceeded` bool which is assumed `false` when sync begins. This replaces the `map_nullifiers` bool for scan range selection during pre-scanning. This `nullifier_map_limit_exceeded` bool is set `true` in post-scan processing if the nullifiers in the scanned batch will cause the wallets nullifier map to exceed the maximum specified size, if added. the nullifiers in this batch and any future batches will no longer be added to the wallets nullifier map, only checked for spends and discarded. just as before, these ranges are marked `ScannedWithoutMapping` priority and the nullifiers will be re-fetched later in the sync process to ensure spends are not missed for newly added outputs.

Secondly, outpoints are only mapped for targetted ranges (found note or higher) as all transparent spend locations are known before scanning begins. `update_transparent_spends` has been improved to allow additional maps to be checked for spends in the case that the outpoints are not being added to the wallet main outpoint map, just like `update_shielded_spends`.

Thirdly, the chain tip is no longer mapped. This prevents the issue described above at the cost of improving the likelyhood of spendable notes early on in the sync process. Early note spendability will be improved in a following PR to account for this.

Finally, this PR also fixes a bug where, in rare edges cases, `ScannedWithoutMapping` scans which re-fetch nullifiers could complete before lower ranges have completed scanning, potentially missing spends. This PR improves scan range seelction to decrease the chance of this occuring and also adds logic to discard these nullifiers and reset the scan range to `ScannedWithoutMapping` again to be re-fetched safely. This resulted in an improvement to `punch_scan_priority` to allow a larger range of `Scanning` priority to be "punched in" with the potentially smaller `ScannedWithoutMapping` range in the case of batching when the initial scan range exceeded the maximum nullifier batch size.

Due to the improved logic for checking the nullifier map size limit is not exceeded, the `Medium` performance level max nullifier map size limit has been increased from 0 to 125_000 to allow an approx. 4MB nullifier map (125_000 x 32 bytes). this is much smaller than the 40MB we have observed in the case of the current chain (for medium and even low performance settings) but enough to allow some early spendable note benefits