### PR TITLE
Improve note spendability

### DIFF
--- a/pepper-sync/src/scan/transactions.rs
+++ b/pepper-sync/src/scan/transactions.rs
@@ -389,6 +389,7 @@ where
                 position,
                 memo: Memo::from_bytes(memo_bytes.as_ref())?,
                 spending_transaction: None,
+                refetch_nullifier_ranges: Vec::new(),
             });
         }
     }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -552,6 +552,19 @@ where
             panic!("sync data must exist!");
         }
     };
+    // once sync is complete, all nullifiers will have been re-fetched so this note metadata can be discarded.
+    for transaction in wallet_guard
+        .get_wallet_transactions_mut()
+        .map_err(SyncError::WalletError)?
+        .values_mut()
+    {
+        for note in transaction.sapling_notes.as_mut_slice() {
+            note.refetch_nullifier_ranges = Vec::new();
+        }
+        for note in transaction.orchard_notes.as_mut_slice() {
+            note.refetch_nullifier_ranges = Vec::new();
+        }
+    }
     wallet_guard
         .set_save_flag()
         .map_err(SyncError::WalletError)?;
@@ -1271,7 +1284,7 @@ async fn update_wallet_data<W>(
     scan_range: &ScanRange,
     nullifiers: Option<&mut NullifierMap>,
     outpoints: Option<&mut BTreeMap<OutputId, ScanTarget>>,
-    transactions: HashMap<TxId, WalletTransaction>,
+    mut transactions: HashMap<TxId, WalletTransaction>,
     sapling_located_trees: Vec<LocatedTreeData<sapling_crypto::Node>>,
     orchard_located_trees: Vec<LocatedTreeData<MerkleHashOrchard>>,
 ) -> Result<(), SyncError<W::Error>>
@@ -1284,6 +1297,12 @@ where
     let highest_scanned_height = sync_state
         .highest_scanned_height()
         .expect("scan ranges should not be empty in this scope");
+    let scanned_without_mapping_ranges: Vec<Range<BlockHeight>> = sync_state
+        .scan_ranges()
+        .iter()
+        .filter(|&scan_range| scan_range.priority() == ScanPriority::ScannedWithoutMapping)
+        .map(|scan_range| scan_range.block_range().clone())
+        .collect();
     for transaction in transactions.values() {
         state::update_found_note_shard_priority(
             consensus_parameters,
@@ -1297,6 +1316,19 @@ where
             ShieldedProtocol::Orchard,
             transaction,
         );
+    }
+    // add all block ranges of scan ranges with `ScanneWithoutMapping` priority above each transactions height to each note to track which ranges need the nullifiers to be re-fetched before the note is known to be unspent (in addition to all other ranges above the notes height being `Scanned` or `ScannedWithoutMapping` priority). this information is necessary as these ranges have been scanned but the nullifiers have been discarded so must be re-fetched. if ranges are scanned but the nullifiers are discarded (set to `ScannedWithoutMapping` priority) *after* this note has been added to the wallet, this is sufficient to know this note has not been spent, even if this range is not set to `Scanned` priority.
+    for transaction in transactions.values_mut() {
+        let refetch_nullifier_ranges = scanned_without_mapping_ranges
+            [scanned_without_mapping_ranges
+                .partition_point(|range| range.start <= transaction.status().get_height())..]
+            .to_vec();
+        for note in transaction.sapling_notes.as_mut_slice() {
+            note.refetch_nullifier_ranges = refetch_nullifier_ranges.clone();
+        }
+        for note in transaction.orchard_notes.as_mut_slice() {
+            note.refetch_nullifier_ranges = refetch_nullifier_ranges.clone();
+        }
     }
     for transaction in transactions.values() {
         discover_unified_addresses(wallet, ufvks, transaction).map_err(SyncError::WalletError)?;

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1299,12 +1299,6 @@ where
     let highest_scanned_height = sync_state
         .highest_scanned_height()
         .expect("scan ranges should not be empty in this scope");
-    let scanned_without_mapping_ranges: Vec<Range<BlockHeight>> = sync_state
-        .scan_ranges()
-        .iter()
-        .filter(|&scan_range| scan_range.priority() == ScanPriority::ScannedWithoutMapping)
-        .map(|scan_range| scan_range.block_range().clone())
-        .collect();
     for transaction in transactions.values() {
         state::update_found_note_shard_priority(
             consensus_parameters,
@@ -1319,12 +1313,20 @@ where
             transaction,
         );
     }
-    // add all block ranges of scan ranges with `ScanneWithoutMapping` priority above each transactions height to each note to track which ranges need the nullifiers to be re-fetched before the note is known to be unspent (in addition to all other ranges above the notes height being `Scanned` or `ScannedWithoutMapping` priority). this information is necessary as these ranges have been scanned but the nullifiers have been discarded so must be re-fetched. if ranges are scanned but the nullifiers are discarded (set to `ScannedWithoutMapping` priority) *after* this note has been added to the wallet, this is sufficient to know this note has not been spent, even if this range is not set to `Scanned` priority.
+    // add all block ranges of scan ranges with `ScanneWithoutMapping` priority above the current scan range to each note to track which ranges need the nullifiers to be re-fetched before the note is known to be unspent (in addition to all other ranges above the notes height being `Scanned` or `ScannedWithoutMapping` priority). this information is necessary as these ranges have been scanned but the nullifiers have been discarded so must be re-fetched. if ranges are scanned but the nullifiers are discarded (set to `ScannedWithoutMapping` priority) *after* this note has been added to the wallet, this is sufficient to know this note has not been spent, even if this range is not set to `Scanned` priority.
+    let refetch_nullifier_ranges = {
+        let scanned_without_mapping_ranges: Vec<Range<BlockHeight>> = sync_state
+            .scan_ranges()
+            .iter()
+            .filter(|&scan_range| scan_range.priority() == ScanPriority::ScannedWithoutMapping)
+            .map(|scan_range| scan_range.block_range().clone())
+            .collect();
+
+        scanned_without_mapping_ranges[scanned_without_mapping_ranges
+            .partition_point(|range| range.start < scan_range.block_range().end)..]
+            .to_vec()
+    };
     for transaction in transactions.values_mut() {
-        let refetch_nullifier_ranges = scanned_without_mapping_ranges
-            [scanned_without_mapping_ranges
-                .partition_point(|range| range.start <= transaction.status().get_height())..]
-            .to_vec();
         for note in transaction.sapling_notes.as_mut_slice() {
             note.refetch_nullifier_ranges = refetch_nullifier_ranges.clone();
         }

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -710,7 +710,9 @@ pub trait NoteInterface: OutputInterface {
     /// Memo
     fn memo(&self) -> &Memo;
 
-    /// FIXME: add doc comment
+    /// List of block ranges where the nullifiers must be re-fetched to guarantee the note has not been spent.
+    /// These scan ranges were marked `ScannedWithoutMapping` priority before this note was scanned, meaning the
+    /// nullifiers were discarded due to memory constraints and will be re-fetched later in the sync process.
     fn refetch_nullifier_ranges(&self) -> &[Range<BlockHeight>];
 }
 
@@ -803,7 +805,9 @@ pub struct WalletNote<N, Nf: Copy> {
     /// Transaction ID of transaction this output was spent.
     /// If `None`, output is not spent.
     pub(crate) spending_transaction: Option<TxId>,
-    /// FIXME: add doc comment and update serialization
+    /// List of block ranges where the nullifiers must be re-fetched to guarantee the note has not been spent.
+    /// These scan ranges were marked `ScannedWithoutMapping` priority before this note was scanned, meaning the
+    /// nullifiers were discarded due to memory constraints and will be re-fetched later in the sync process.
     pub(crate) refetch_nullifier_ranges: Vec<Range<BlockHeight>>,
 }
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -709,6 +709,9 @@ pub trait NoteInterface: OutputInterface {
 
     /// Memo
     fn memo(&self) -> &Memo;
+
+    /// FIXME: add doc comment
+    fn refetch_nullifier_ranges(&self) -> &[Range<BlockHeight>];
 }
 
 ///  Transparent coin (output) with metadata relevant to the wallet.
@@ -800,6 +803,8 @@ pub struct WalletNote<N, Nf: Copy> {
     /// Transaction ID of transaction this output was spent.
     /// If `None`, output is not spent.
     pub(crate) spending_transaction: Option<TxId>,
+    /// FIXME: add doc comment and update serialization
+    pub(crate) refetch_nullifier_ranges: Vec<Range<BlockHeight>>,
 }
 
 /// Sapling note.
@@ -865,6 +870,10 @@ impl NoteInterface for SaplingNote {
     fn memo(&self) -> &Memo {
         &self.memo
     }
+
+    fn refetch_nullifier_ranges(&self) -> &[Range<BlockHeight>] {
+        &self.refetch_nullifier_ranges
+    }
 }
 
 /// Orchard note.
@@ -929,6 +938,10 @@ impl NoteInterface for OrchardNote {
 
     fn memo(&self) -> &Memo {
         &self.memo
+    }
+
+    fn refetch_nullifier_ranges(&self) -> &[Range<BlockHeight>] {
+        &self.refetch_nullifier_ranges
     }
 }
 

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -566,6 +566,7 @@ impl SaplingNote {
             position,
             memo,
             spending_transaction,
+            refetch_nullifier_ranges: Vec::new(), // FIXME: add serialization!
         })
     }
 
@@ -673,6 +674,7 @@ impl OrchardNote {
             position,
             memo,
             spending_transaction,
+            refetch_nullifier_ranges: Vec::new(), // FIXME: add serialization!
         })
     }
 

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::{Read, Write},
+    ops::Range,
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -483,6 +484,31 @@ impl<N, Nf: Copy> WalletNote<N, Nf> {
     }
 }
 
+fn read_refetch_nullifier_ranges(
+    reader: &mut impl Read,
+    version: u8,
+) -> std::io::Result<Vec<Range<BlockHeight>>> {
+    if version >= 1 {
+        Vector::read(reader, |r| {
+            let start = r.read_u32::<LittleEndian>()?;
+            let end = r.read_u32::<LittleEndian>()?;
+            Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
+        })
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+fn write_refetch_nullifier_ranges(
+    writer: &mut impl Write,
+    ranges: &[Range<BlockHeight>],
+) -> std::io::Result<()> {
+    Vector::write(writer, ranges, |w, range| {
+        w.write_u32::<LittleEndian>(range.start.into())?;
+        w.write_u32::<LittleEndian>(range.end.into())
+    })
+}
+
 impl SaplingNote {
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
@@ -557,17 +583,7 @@ impl SaplingNote {
         })?;
 
         let spending_transaction = Optional::read(&mut reader, TxId::read)?;
-
-        let refetch_nullifier_ranges = if version >= 1 {
-            Vector::read(&mut reader, |r| {
-                let start = r.read_u32::<LittleEndian>()?;
-                let end = r.read_u32::<LittleEndian>()?;
-
-                Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
-            })?
-        } else {
-            Vec::new()
-        };
+        let refetch_nullifier_ranges = read_refetch_nullifier_ranges(&mut reader, version)?;
 
         Ok(Self {
             output_id: OutputId::new(txid, output_index),
@@ -616,10 +632,7 @@ impl SaplingNote {
             txid.write(w)
         })?;
 
-        Vector::write(&mut writer, &self.refetch_nullifier_ranges, |w, range| {
-            w.write_u32::<LittleEndian>(range.start.into())?;
-            w.write_u32::<LittleEndian>(range.end.into())
-        })
+        write_refetch_nullifier_ranges(&mut writer, &self.refetch_nullifier_ranges)
     }
 }
 
@@ -680,17 +693,7 @@ impl OrchardNote {
         })?;
 
         let spending_transaction = Optional::read(&mut reader, TxId::read)?;
-
-        let refetch_nullifier_ranges = if version >= 1 {
-            Vector::read(&mut reader, |r| {
-                let start = r.read_u32::<LittleEndian>()?;
-                let end = r.read_u32::<LittleEndian>()?;
-
-                Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
-            })?
-        } else {
-            Vec::new()
-        };
+        let refetch_nullifier_ranges = read_refetch_nullifier_ranges(&mut reader, version)?;
 
         Ok(Self {
             output_id: OutputId::new(txid, output_index),
@@ -731,10 +734,7 @@ impl OrchardNote {
             txid.write(w)
         })?;
 
-        Vector::write(&mut writer, &self.refetch_nullifier_ranges, |w, range| {
-            w.write_u32::<LittleEndian>(range.start.into())?;
-            w.write_u32::<LittleEndian>(range.end.into())
-        })
+        write_refetch_nullifier_ranges(&mut writer, &self.refetch_nullifier_ranges)
     }
 }
 

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -479,14 +479,14 @@ impl TransparentCoin {
 
 impl<N, Nf: Copy> WalletNote<N, Nf> {
     fn serialized_version() -> u8 {
-        0
+        1
     }
 }
 
 impl SaplingNote {
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
+        let version = reader.read_u8()?;
 
         let txid = TxId::read(&mut reader)?;
         let output_index = reader.read_u16::<LittleEndian>()?;
@@ -558,6 +558,17 @@ impl SaplingNote {
 
         let spending_transaction = Optional::read(&mut reader, TxId::read)?;
 
+        let refetch_nullifier_ranges = if version >= 1 {
+            Vector::read(&mut reader, |r| {
+                let start = r.read_u32::<LittleEndian>()?;
+                let end = r.read_u32::<LittleEndian>()?;
+
+                Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
+            })?
+        } else {
+            Vec::new()
+        };
+
         Ok(Self {
             output_id: OutputId::new(txid, output_index),
             key_id: KeyId::from_parts(account_id, scope),
@@ -566,7 +577,7 @@ impl SaplingNote {
             position,
             memo,
             spending_transaction,
-            refetch_nullifier_ranges: Vec::new(), // FIXME: add serialization!
+            refetch_nullifier_ranges,
         })
     }
 
@@ -603,6 +614,11 @@ impl SaplingNote {
 
         Optional::write(&mut writer, self.spending_transaction, |w, txid| {
             txid.write(w)
+        })?;
+
+        Vector::write(&mut writer, &self.refetch_nullifier_ranges, |w, range| {
+            w.write_u32::<LittleEndian>(range.start.into())?;
+            w.write_u32::<LittleEndian>(range.end.into())
         })
     }
 }
@@ -610,7 +626,7 @@ impl SaplingNote {
 impl OrchardNote {
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
+        let version = reader.read_u8()?;
 
         let txid = TxId::read(&mut reader)?;
         let output_index = reader.read_u16::<LittleEndian>()?;
@@ -665,6 +681,17 @@ impl OrchardNote {
 
         let spending_transaction = Optional::read(&mut reader, TxId::read)?;
 
+        let refetch_nullifier_ranges = if version >= 1 {
+            Vector::read(&mut reader, |r| {
+                let start = r.read_u32::<LittleEndian>()?;
+                let end = r.read_u32::<LittleEndian>()?;
+
+                Ok(BlockHeight::from_u32(start)..BlockHeight::from_u32(end))
+            })?
+        } else {
+            Vec::new()
+        };
+
         Ok(Self {
             output_id: OutputId::new(txid, output_index),
             key_id: KeyId::from_parts(account_id, scope),
@@ -674,7 +701,7 @@ impl OrchardNote {
             position,
             memo,
             spending_transaction,
-            refetch_nullifier_ranges: Vec::new(), // FIXME: add serialization!
+            refetch_nullifier_ranges,
         })
     }
 
@@ -704,7 +731,10 @@ impl OrchardNote {
             txid.write(w)
         })?;
 
-        Ok(())
+        Vector::write(&mut writer, &self.refetch_nullifier_ranges, |w, range| {
+            w.write_u32::<LittleEndian>(range.start.into())?;
+            w.write_u32::<LittleEndian>(range.end.into())
+        })
     }
 }
 

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -463,10 +463,10 @@ impl LightWallet {
     /// - not dust (note value larger than `5_000` zats)
     /// - the wallet can build a witness for the note's commitment
     /// - satisfy the number of minimum confirmations set by the wallet
-    /// - the nullifier derived from the note has not yet been found in a transaction input on chain
+    /// - the nullifier derived from the note does not appear in a transaction input (spend) on chain
     ///
     /// If `include_potentially_spent_notes` is `true`, notes will be included even if the wallet's current sync state
-    /// cannot guarantee the notes are unspent.
+    /// is incomplete and it is unknown if the note has already been spent (the nullifier has not appeared on chain *yet*).
     ///
     /// # Error
     ///
@@ -503,6 +503,7 @@ impl LightWallet {
                         true
                     } else {
                         transaction.status().get_height() >= spend_horizon
+                        // FIXME: add check to notes `refetch_nullifier_ranges` field here
                     }
             },
             account_id,

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -1,11 +1,8 @@
 //! Balance methods and types for `crate::wallet::LightWallet`.
 
-use pepper_sync::{
-    sync::ScanPriority,
-    wallet::{
-        KeyIdInterface, NoteInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin,
-        WalletTransaction,
-    },
+use pepper_sync::wallet::{
+    KeyIdInterface, NoteInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin,
+    WalletTransaction,
 };
 use zcash_client_backend::data_api::WalletRead;
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
@@ -502,26 +499,12 @@ impl LightWallet {
                     && transaction.status().get_height() <= anchor_height
                     && note.position().is_some()
                     && self.can_build_witness::<N>(transaction.status().get_height(), anchor_height)
-                    && if include_potentially_spent_notes {
-                        true
-                    } else {
-                        // checks all ranges above the note height are scanned and that the nullifiers were re-fetched
-                        // if any of these ranges discarded the nullifiers *before* the note was scanned (due to memory constraints).
-                        transaction.status().get_height() >= spend_horizon
-                            && note.refetch_nullifier_ranges().iter().all(
-                                |refetch_nullifier_range| {
-                                    self.sync_state.scan_ranges().iter().any(|scan_range| {
-                                        scan_range.priority() == ScanPriority::Scanned
-                                            && scan_range
-                                                .block_range()
-                                                .contains(&refetch_nullifier_range.start)
-                                            && scan_range
-                                                .block_range()
-                                                .contains(&(refetch_nullifier_range.end - 1))
-                                    })
-                                },
-                            )
-                    }
+                    && (include_potentially_spent_notes
+                        || self.note_spends_confirmed(
+                            transaction.status().get_height(),
+                            spend_horizon,
+                            note.refetch_nullifier_ranges(),
+                        ))
             },
             account_id,
         )?;

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -485,7 +485,7 @@ impl LightWallet {
     where
         N: NoteInterface,
     {
-        let Some(spend_horizon) = self.spend_horizon() else {
+        let Some(spend_horizon) = self.spend_horizon(false) else {
             return Ok(Zatoshis::ZERO);
         };
         let Some((_, anchor_height)) = self

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -1,8 +1,11 @@
 //! Balance methods and types for `crate::wallet::LightWallet`.
 
-use pepper_sync::wallet::{
-    KeyIdInterface, NoteInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin,
-    WalletTransaction,
+use pepper_sync::{
+    sync::ScanPriority,
+    wallet::{
+        KeyIdInterface, NoteInterface, OrchardNote, OutputInterface, SaplingNote, TransparentCoin,
+        WalletTransaction,
+    },
 };
 use zcash_client_backend::data_api::WalletRead;
 use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
@@ -502,8 +505,22 @@ impl LightWallet {
                     && if include_potentially_spent_notes {
                         true
                     } else {
+                        // checks all ranges above the note height are scanned and that the nullifiers were re-fetched
+                        // if any of these ranges discarded the nullifiers *before* the note was scanned (due to memory constraints).
                         transaction.status().get_height() >= spend_horizon
-                        // FIXME: add check to notes `refetch_nullifier_ranges` field here
+                            && note.refetch_nullifier_ranges().iter().all(
+                                |refetch_nullifier_range| {
+                                    self.sync_state.scan_ranges().iter().any(|scan_range| {
+                                        scan_range.priority() == ScanPriority::Scanned
+                                            && scan_range
+                                                .block_range()
+                                                .contains(&refetch_nullifier_range.start)
+                                            && scan_range
+                                                .block_range()
+                                                .contains(&(refetch_nullifier_range.end - 1))
+                                    })
+                                },
+                            )
                     }
             },
             account_id,

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -1,6 +1,5 @@
 //! All things needed to create, manaage, and use notes
 
-use pepper_sync::sync::ScanPriority;
 use pepper_sync::wallet::KeyIdInterface;
 use shardtree::store::ShardStore;
 use zcash_primitives::consensus::BlockHeight;
@@ -294,29 +293,12 @@ impl LightWallet {
                                 )
                                 && !exclude.contains(&note.output_id())
                                 && note.key_id().account_id() == account
-                                && if include_potentially_spent_notes {
-                                    true
-                                } else {
-                                    // checks all ranges above the note height are scanned and that the nullifiers were re-fetched
-                                    // if any of these ranges discarded the nullifiers *before* the note was scanned (due to memory constraints).
-                                    transaction.status().get_height() >= spend_horizon
-                                        && note.refetch_nullifier_ranges().iter().all(
-                                            |refetch_nullifier_range| {
-                                                self.sync_state.scan_ranges().iter().any(
-                                                    |scan_range| {
-                                                        scan_range.priority()
-                                                            == ScanPriority::Scanned
-                                                            && scan_range.block_range().contains(
-                                                                &refetch_nullifier_range.start,
-                                                            )
-                                                            && scan_range.block_range().contains(
-                                                                &(refetch_nullifier_range.end - 1),
-                                                            )
-                                                    },
-                                                )
-                                            },
-                                        )
-                                }
+                                && (include_potentially_spent_notes
+                                    || self.note_spends_confirmed(
+                                        transaction.status().get_height(),
+                                        spend_horizon,
+                                        note.refetch_nullifier_ranges(),
+                                    ))
                         })
                         .collect::<Vec<_>>()
                 } else {

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -1,5 +1,7 @@
 //! All things needed to create, manaage, and use notes
 
+use pepper_sync::sync::ScanPriority;
+use pepper_sync::wallet::KeyIdInterface;
 use shardtree::store::ShardStore;
 use zcash_primitives::consensus::BlockHeight;
 use zcash_primitives::transaction::TxId;
@@ -10,8 +12,6 @@ use zcash_protocol::value::Zatoshis;
 
 use super::LightWallet;
 use super::error::WalletError;
-use super::transaction::transaction_unspent_coins;
-use super::transaction::transaction_unspent_notes;
 use pepper_sync::wallet::NoteInterface;
 use pepper_sync::wallet::OutputId;
 use pepper_sync::wallet::OutputInterface;
@@ -244,7 +244,7 @@ impl LightWallet {
         account: zip32::AccountId,
         include_potentially_spent_notes: bool,
     ) -> Result<Vec<&'a N>, WalletError> {
-        let Some(spend_horizon) = self.spend_horizon() else {
+        let Some(spend_horizon) = self.spend_horizon(false) else {
             return Err(WalletError::NoSyncData);
         };
         if self
@@ -282,38 +282,58 @@ impl LightWallet {
                     .status()
                     .is_confirmed_before_or_at(&anchor_height)
                 {
-                    transaction_unspent_notes::<N>(
-                        transaction,
-                        exclude,
-                        account,
-                        spend_horizon,
-                        include_potentially_spent_notes,
-                    )
-                    .collect::<Vec<_>>()
+                    N::transaction_outputs(transaction)
+                        .iter()
+                        .filter(move |&note| {
+                            note.spending_transaction().is_none()
+                                && note.nullifier().is_some()
+                                && note.position().is_some()
+                                && self.can_build_witness::<N>(
+                                    transaction.status().get_height(),
+                                    anchor_height,
+                                )
+                                && !exclude.contains(&note.output_id())
+                                && note.key_id().account_id() == account
+                                && if include_potentially_spent_notes {
+                                    true
+                                } else {
+                                    // checks all ranges above the note height are scanned and that the nullifiers were re-fetched
+                                    // if any of these ranges discarded the nullifiers *before* the note was scanned (due to memory constraints).
+                                    transaction.status().get_height() >= spend_horizon
+                                        && note.refetch_nullifier_ranges().iter().all(
+                                            |refetch_nullifier_range| {
+                                                self.sync_state.scan_ranges().iter().any(
+                                                    |scan_range| {
+                                                        scan_range.priority()
+                                                            == ScanPriority::Scanned
+                                                            && scan_range.block_range().contains(
+                                                                &refetch_nullifier_range.start,
+                                                            )
+                                                            && scan_range.block_range().contains(
+                                                                &(refetch_nullifier_range.end - 1),
+                                                            )
+                                                    },
+                                                )
+                                            },
+                                        )
+                                }
+                        })
+                        .collect::<Vec<_>>()
                 } else {
                     Vec::new()
                 }
-                .into_iter()
-                .filter(|&note| {
-                    note.nullifier().is_some()
-                        && note.position().is_some()
-                        && self.can_build_witness::<N>(
-                            transaction.status().get_height(),
-                            anchor_height,
-                        )
-                })
             })
             .collect())
     }
 
     /// Returns all spendable transparent coins for a given `account` confirmed at or below `target_height`.
     ///
-    /// Any coins with output IDs in `exclude` will not be returned.
     /// Any coins from a coinbase transaction will not be returned without 100 additional confirmations.
     pub(crate) fn spendable_transparent_coins(
         &self,
         target_height: BlockHeight,
         allow_zero_conf_shielding: bool,
+        include_potentially_spent_coins: bool,
     ) -> Vec<&TransparentCoin> {
         // TODO: add support for zero conf shielding
         assert!(
@@ -321,19 +341,13 @@ impl LightWallet {
             "zero conf shielding not currently supported!"
         );
 
+        let Some(spend_horizon) = self.spend_horizon(true) else {
+            return Vec::new();
+        };
+
         self.wallet_transactions
             .values()
-            .filter(|&transaction| transaction.status().is_confirmed())
             .flat_map(|transaction| {
-                if transaction
-                    .status()
-                    .get_confirmed_height()
-                    .expect("transaction must be confirmed in this scope")
-                    > self.sync_state.wallet_height().unwrap_or(self.birthday)
-                {
-                    return Vec::new();
-                }
-
                 let additional_confirmations = transaction
                     .transaction()
                     .transparent_bundle()
@@ -343,7 +357,20 @@ impl LightWallet {
                     .status()
                     .is_confirmed_before_or_at(&(target_height - additional_confirmations))
                 {
-                    transaction_unspent_coins(transaction).collect()
+                    TransparentCoin::transaction_outputs(transaction)
+                        .iter()
+                        .filter(move |&coin| {
+                            coin.spending_transaction().is_none()
+                                && if include_potentially_spent_coins {
+                                    true
+                                } else {
+                                    // checks all ranges with `FoundNote` priority or higher above the coin height are
+                                    // scanned as all relevant transactions containing transparent spends are known and
+                                    // targetted before scanning begins.
+                                    transaction.status().get_height() >= spend_horizon
+                                }
+                        })
+                        .collect()
                 } else {
                     Vec::new()
                 }

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -192,6 +192,7 @@ impl LightWallet {
             .find(|scan_range| {
                 if all_spends_known {
                     scan_range.priority() >= ScanPriority::FoundNote
+                        || scan_range.priority() == ScanPriority::Scanning
                 } else {
                     scan_range.priority() != ScanPriority::Scanned
                         && scan_range.priority() != ScanPriority::ScannedWithoutMapping

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -179,16 +179,23 @@ impl LightWallet {
     ///
     /// Useful for determining which height all the nullifiers have been mapped from for guaranteeing if a note is
     /// unspent.
-    // FIXME: check other calls to this method still work correctly with the inclusion on ScannedWithoutMapping ranges
-    pub(crate) fn spend_horizon(&self) -> Option<BlockHeight> {
+    ///
+    /// `all_spends_known` may be set if all the spend locations are already known before scanning starts. For example,
+    /// the location of all transparent spends are known due to the pre-scan gRPC calls. In this case, the height returned
+    /// is the lowest height where there are no higher scan ranges with `FoundNote` or higher scan priority.
+    pub(crate) fn spend_horizon(&self, all_spends_known: bool) -> Option<BlockHeight> {
         if let Some(scan_range) = self
             .sync_state
             .scan_ranges()
             .iter()
             .rev()
             .find(|scan_range| {
-                scan_range.priority() != ScanPriority::Scanned
-                    && scan_range.priority() != ScanPriority::ScannedWithoutMapping
+                if all_spends_known {
+                    scan_range.priority() >= ScanPriority::FoundNote
+                } else {
+                    scan_range.priority() != ScanPriority::Scanned
+                        && scan_range.priority() != ScanPriority::ScannedWithoutMapping
+                }
             })
         {
             Some(scan_range.block_range().end)

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -207,6 +207,27 @@ impl LightWallet {
                 .map(|range| range.block_range().start)
         }
     }
+
+    /// Returns `true` if all nullifiers above `note_height` have been checked for this note's spend status.
+    ///
+    /// Requires that `note_height >= spend_horizon` (all ranges above the note are scanned) and that every
+    /// `refetch_nullifier_range` recorded on the note is fully contained within a `Scanned` scan range
+    /// (nullifiers that were discarded due to memory constraints have since been re-fetched).
+    pub(crate) fn note_spends_confirmed(
+        &self,
+        note_height: BlockHeight,
+        spend_horizon: BlockHeight,
+        refetch_nullifier_ranges: &[std::ops::Range<BlockHeight>],
+    ) -> bool {
+        note_height >= spend_horizon
+            && refetch_nullifier_ranges.iter().all(|refetch_range| {
+                self.sync_state.scan_ranges().iter().any(|scan_range| {
+                    scan_range.priority() == ScanPriority::Scanned
+                        && scan_range.block_range().contains(&refetch_range.start)
+                        && scan_range.block_range().contains(&(refetch_range.end - 1))
+                })
+            })
+    }
 }
 
 #[cfg(test)]

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -173,18 +173,23 @@ impl LightWallet {
         MemoBytes::from(Memo::Arbitrary(Box::new(uas_bytes)))
     }
 
-    /// Returns the block height at which all blocks equal to and above this height are scanned.
+    /// Returns the block height at which all blocks equal to and above this height are scanned (scan ranges set to
+    /// `Scanned` or `ScannedWithoutMapping` priority).
     /// Returns `None` if `self.scan_ranges` is empty.
     ///
     /// Useful for determining which height all the nullifiers have been mapped from for guaranteeing if a note is
     /// unspent.
+    // FIXME: check other calls to this method still work correctly with the inclusion on ScannedWithoutMapping ranges
     pub(crate) fn spend_horizon(&self) -> Option<BlockHeight> {
         if let Some(scan_range) = self
             .sync_state
             .scan_ranges()
             .iter()
             .rev()
-            .find(|scan_range| scan_range.priority() != ScanPriority::Scanned)
+            .find(|scan_range| {
+                scan_range.priority() != ScanPriority::Scanned
+                    && scan_range.priority() != ScanPriority::ScannedWithoutMapping
+            })
         {
             Some(scan_range.block_range().end)
         } else {

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -278,7 +278,7 @@ impl LightWallet {
         Ok(NonEmpty::from_vec(txids).expect("should be non-empty"))
     }
 
-    // TODO: check with adjacent scanned and scannedwithoutmapping ranges merged in case shard ranges are scanend across
+    // FIXME: check with adjacent scanned and scannedwithoutmapping ranges merged in case shard ranges are scanend across
     // the two priorities
     pub(crate) fn can_build_witness<N>(
         &self,

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -278,8 +278,6 @@ impl LightWallet {
         Ok(NonEmpty::from_vec(txids).expect("should be non-empty"))
     }
 
-    // TODO: check with adjacent scanned and scannedwithoutmapping ranges merged in case shard ranges are scanend across
-    // the two priorities
     pub(crate) fn can_build_witness<N>(
         &self,
         note_height: BlockHeight,
@@ -327,18 +325,49 @@ fn check_note_shards_are_scanned(
     let mut shard_ranges = shard_ranges.to_vec();
     shard_ranges.push(incomplete_shard_range);
 
+    let mut scanned_ranges = scan_ranges
+        .iter()
+        .filter(|scan_range| {
+            scan_range.priority() == ScanPriority::Scanned
+                || scan_range.priority() == ScanPriority::ScannedWithoutMapping
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    'main: loop {
+        if scanned_ranges.is_empty() {
+            break;
+        }
+        let mut peekable_ranges = scanned_ranges.iter().enumerate().peekable();
+        while let Some((index, range)) = peekable_ranges.next() {
+            if let Some((next_index, next_range)) = peekable_ranges.peek() {
+                if range.block_range().end == next_range.block_range().start {
+                    assert!(*next_index == index + 1);
+                    scanned_ranges.splice(
+                        index..=*next_index,
+                        vec![ScanRange::from_parts(
+                            Range {
+                                start: range.block_range().start,
+                                end: next_range.block_range().end,
+                            },
+                            ScanPriority::Scanned,
+                        )],
+                    );
+                    continue 'main;
+                }
+            } else {
+                break 'main;
+            }
+        }
+    }
+
     // a single block may contain two shards at the boundary so we check both are scanned in this case
     shard_ranges
         .iter()
         .filter(|&shard_range| shard_range.contains(&note_height))
         .all(|note_shard_range| {
-            scan_ranges
+            scanned_ranges
                 .iter()
-                .filter(|&scan_range| {
-                    scan_range.priority() == ScanPriority::Scanned
-                        || scan_range.priority() == ScanPriority::ScannedWithoutMapping
-                })
-                .map(pepper_sync::sync::ScanRange::block_range)
+                .map(ScanRange::block_range)
                 .any(|block_range| {
                     block_range.contains(&(note_shard_range.end - 1))
                         && (block_range.contains(&note_shard_range.start)

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -278,7 +278,7 @@ impl LightWallet {
         Ok(NonEmpty::from_vec(txids).expect("should be non-empty"))
     }
 
-    // FIXME: check with adjacent scanned and scannedwithoutmapping ranges merged in case shard ranges are scanend across
+    // TODO: check with adjacent scanned and scannedwithoutmapping ranges merged in case shard ranges are scanend across
     // the two priorities
     pub(crate) fn can_build_witness<N>(
         &self,

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -1,10 +1,9 @@
 use zcash_primitives::transaction::TxId;
-use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
 
 use pepper_sync::wallet::{
-    KeyIdInterface, NoteInterface, OrchardNote, OutgoingNoteInterface, OutputId, OutputInterface,
-    SaplingNote, TransparentCoin, WalletTransaction,
+    OrchardNote, OutgoingNoteInterface, OutputId, OutputInterface, SaplingNote, TransparentCoin,
+    WalletTransaction,
 };
 
 use super::LightWallet;
@@ -173,43 +172,4 @@ impl LightWallet {
             Ok(TransactionKind::Sent(SendType::Send))
         }
     }
-}
-
-/// Returns all unspent notes of the specified pool and `account` in the given `transaction`.
-///
-/// Any output IDs in `exclude` will not be returned.
-/// `spend_horizon` is the block height from which all nullifiers have been mapped, guaranteeing a note from a block
-/// equal to or above this height is unspent.
-/// If `include_potentially_spent_notes` is `true`, notes will be included even if the wallet's current sync state
-/// cannot guarantee the notes are unspent. In this case, the `spend_horizon` is not used.
-pub(crate) fn transaction_unspent_notes<'a, N: NoteInterface + 'a>(
-    transaction: &'a WalletTransaction,
-    exclude: &'a [OutputId],
-    account: zip32::AccountId,
-    spend_horizon: BlockHeight,
-    include_potentially_unspent_notes: bool,
-) -> impl Iterator<Item = &'a N> + 'a {
-    let guaranteed_unspent = if include_potentially_unspent_notes {
-        true
-    } else {
-        transaction.status().get_height() >= spend_horizon
-    };
-
-    N::transaction_outputs(transaction)
-        .iter()
-        .filter(move |&note| {
-            note.spending_transaction().is_none()
-                && !exclude.contains(&note.output_id())
-                && note.key_id().account_id() == account
-                && guaranteed_unspent
-        })
-}
-
-/// Returns all unspent transparent outputs in the given `transaction`.
-pub(crate) fn transaction_unspent_coins(
-    transaction: &WalletTransaction,
-) -> impl Iterator<Item = &TransparentCoin> {
-    TransparentCoin::transaction_outputs(transaction)
-        .iter()
-        .filter(move |&coin| coin.spending_transaction().is_none())
 }

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -697,11 +697,13 @@ impl InputSource for LightWallet {
                 (selected_sapling_notes, selected_orchard_notes)
             }
             TargetValue::AllFunds(max_spend_mode) => {
+                // FIXME: this is not the criteria for `MaxSpendMode::Everything`. this should return an error if sync is not complete in this case.
                 let include_potentially_spent_notes = matches!(
                     max_spend_mode,
                     zcash_client_backend::data_api::MaxSpendMode::Everything
                 );
                 (
+                    // FIXME: note filters implemented in `spendable_notes_by_pool` have been missed here such as filtering dust
                     self.spendable_notes::<SaplingNote>(
                         anchor_height,
                         &exclude_sapling,
@@ -832,6 +834,7 @@ impl InputSource for LightWallet {
             .spendable_transparent_coins(
                 target_height.into(),
                 confirmations_policy.allow_zero_conf_shielding(),
+                false,
             )
             .into_iter()
             .filter(|&output| output.address() == address)


### PR DESCRIPTION
ontop of #2125

fixes #2102 

The problem stated in #2101 is solved in this PR by adding a 'refetched_nullifier_ranges' field to wallet notes which are all the scan ranges with `ScannedWithoutMapping` priority above the newly scanned note. This provides the data necessary to check whether the ranges where nullifier were not mapped had been refetched which allows the "spend horizon" to also include `ScannedWithoutMapping` ranges, massively improving note spendability