### PR TITLE
Fix range resets for refetching nullifiers

### DIFF
--- a/pepper-sync/README.md
+++ b/pepper-sync/README.md
@@ -34,7 +34,7 @@ Pepper-sync is a rust-based sync engine library for wallets operating on the zca
 8. Set the first 10 blocks after the highest previously scanned blocks to "verify" priority to check for re-org.
 
 ## Scanning
-1. If the "batcher" task is idle, set the highest priority scan range to "scanning" priority and send it to the "batcher" task. If the scan priority is "historic", it first splits an orchard shard range off the lower end. If all scan ranges in the wallet's sync state are "scanned", shutdown the sync process.
+1. If the "batcher" task is idle, set the highest priority scan range to "Scanning" priority and send it to the "batcher" task. If the scan priority is "Historic", first split an orchard shard range off the lower end. If the lowest unscanned range is of "ScannedWithoutMapping" priority, prioritize this range and set it to "RefetchingNullifiers" priority. If all scan ranges in the wallet's sync state are "scanned", shutdown the sync process.
 2. Batch the scan range:
   2a. Stream compact blocks from server until a fixed threshold of outputs is reached. If the entire scan range is batched, the "batcher" task goes idle.
   2b. Store the batch and wait until it is taken by an idle "scan worker" before returning to step 2a

--- a/pepper-sync/src/lib.rs
+++ b/pepper-sync/src/lib.rs
@@ -33,7 +33,7 @@ Pepper-sync is a rust-based sync engine library for wallets operating on the zca
 8. Set the first 10 blocks after the highest previously scanned blocks to "verify" priority to check for re-org.
 
 ## Scanning
-1. If the "batcher" task is idle, set the highest priority scan range to "scanning" priority and send it to the "batcher" task. If the scan priority is "historic", it first splits an orchard shard range off the lower end. If all scan ranges in the wallet's sync state are "scanned", shutdown the sync process.
+1. If the "batcher" task is idle, set the highest priority scan range to "Scanning" priority and send it to the "batcher" task. If the scan priority is "Historic", first split an orchard shard range off the lower end. If the lowest unscanned range is of "ScannedWithoutMapping" priority, prioritize this range and set it to "RefetchingNullifiers" priority. If all scan ranges in the wallet's sync state are "scanned", shutdown the sync process.
 2. Batch the scan range:
   2a. Stream compact blocks from server until a fixed threshold of outputs is reached. If the entire scan range is batched, the "batcher" task goes idle.
   2b. Store the batch and wait until it is taken by an idle "scan worker" before returning to step 2a

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -369,6 +369,7 @@ where
         if wallet_height - chain_height >= MAX_VERIFICATION_WINDOW {
             return Err(SyncError::ChainError(MAX_VERIFICATION_WINDOW));
         }
+        // TODO: also truncate the scan ranges in the wallet's sync state
         truncate_wallet_data(&mut *wallet_guard, chain_height)?;
         wallet_height = chain_height;
     }
@@ -932,7 +933,7 @@ where
                     .map_err(SyncError::WalletError)?
                     .scan_ranges
                     .iter()
-                    .find(|scan_range| scan_range.priority() != ScanPriority::Scanned)
+                    .find(|scan_range| scan_range.priority() != ScanPriority::Scanned && scan_range.priority() != ScanPriority::RefetchingNullifiers)
                     .expect("the scan range being processed is not yet set to scanned so at least one unscanned range must exist");
                 if !first_unscanned_range
                     .block_range()
@@ -1316,7 +1317,7 @@ where
             transaction,
         );
     }
-    // add all block ranges of scan ranges with `ScanneWithoutMapping` priority above the current scan range to each note to track which ranges need the nullifiers to be re-fetched before the note is known to be unspent (in addition to all other ranges above the notes height being `Scanned` or `ScannedWithoutMapping` priority). this information is necessary as these ranges have been scanned but the nullifiers have been discarded so must be re-fetched. if ranges are scanned but the nullifiers are discarded (set to `ScannedWithoutMapping` priority) *after* this note has been added to the wallet, this is sufficient to know this note has not been spent, even if this range is not set to `Scanned` priority.
+    // add all block ranges of scan ranges with `ScannedWithoutMapping` priority above the current scan range to each note to track which ranges need the nullifiers to be re-fetched before the note is known to be unspent (in addition to all other ranges above the notes height being `Scanned` or `ScannedWithoutMapping` priority). this information is necessary as these ranges have been scanned but the nullifiers have been discarded so must be re-fetched. if ranges are scanned but the nullifiers are discarded (set to `ScannedWithoutMapping` priority) *after* this note has been added to the wallet, this is sufficient to know this note has not been spent, even if this range is not set to `Scanned` priority.
     let refetch_nullifier_ranges = {
         let scanned_without_mapping_ranges: Vec<Range<BlockHeight>> = sync_state
             .scan_ranges()

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -965,13 +965,11 @@ where
                     // in this rare edge case, a scanned `ScannedWithoutMapping` range was the highest priority yet it was not the first unscanned range so it must be discarded to avoid missing spends
 
                     // reset scan range from `RefetchingNullifiers` to `ScannedWithoutMapping`
-                    state::punch_scan_priority(
+                    state::reset_refetching_nullifiers_scan_range(
                         wallet
                             .get_sync_state_mut()
                             .map_err(SyncError::WalletError)?,
                         scan_range.block_range().clone(),
-                        ScanPriority::ScannedWithoutMapping,
-                        true,
                     );
                     tracing::debug!(
                         "Nullifiers discarded and will be re-fetched to avoid missing spends."

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -600,6 +600,8 @@ where
 }
 
 /// Creates a [`self::SyncStatus`] from the wallet's current [`crate::wallet::SyncState`].
+/// If there is still nullifiers to be re-fetched when scanning is complete, the percentages will be overrided to 99%
+/// until sync is complete.
 ///
 /// Intended to be called while [`self::sync`] is running in a separate task.
 pub async fn sync_status<W>(wallet: &W) -> Result<SyncStatus, SyncStatusError<W::Error>>
@@ -658,11 +660,11 @@ where
 
     let session_blocks_scanned =
         total_blocks_scanned - sync_state.initial_sync_state.previously_scanned_blocks;
-    let percentage_session_blocks_scanned = ((session_blocks_scanned as f32
+    let mut percentage_session_blocks_scanned = ((session_blocks_scanned as f32
         / (total_blocks - sync_state.initial_sync_state.previously_scanned_blocks) as f32)
         * 100.0)
         .clamp(0.0, 100.0);
-    let percentage_total_blocks_scanned =
+    let mut percentage_total_blocks_scanned =
         ((total_blocks_scanned as f32 / total_blocks as f32) * 100.0).clamp(0.0, 100.0);
 
     let session_sapling_outputs_scanned = total_sapling_outputs_scanned
@@ -680,12 +682,30 @@ where
         + sync_state
             .initial_sync_state
             .previously_scanned_orchard_outputs;
-    let percentage_session_outputs_scanned = ((session_outputs_scanned as f32
+    let mut percentage_session_outputs_scanned = ((session_outputs_scanned as f32
         / (total_outputs - previously_scanned_outputs) as f32)
         * 100.0)
         .clamp(0.0, 100.0);
-    let percentage_total_outputs_scanned =
+    let mut percentage_total_outputs_scanned =
         ((total_outputs_scanned as f32 / total_outputs as f32) * 100.0).clamp(0.0, 100.0);
+
+    if sync_state.scan_ranges().iter().any(|scan_range| {
+        scan_range.priority() == ScanPriority::ScannedWithoutMapping
+            || scan_range.priority() == ScanPriority::RefetchingNullifiers
+    }) {
+        if percentage_session_blocks_scanned == 100.0 {
+            percentage_session_blocks_scanned = 99.0;
+        }
+        if percentage_total_blocks_scanned == 100.0 {
+            percentage_total_blocks_scanned = 99.0;
+        }
+        if percentage_session_outputs_scanned == 100.0 {
+            percentage_session_outputs_scanned = 99.0;
+        }
+        if percentage_total_outputs_scanned == 100.0 {
+            percentage_total_outputs_scanned = 99.0;
+        }
+    }
 
     Ok(SyncStatus {
         scan_ranges: sync_state.scan_ranges.clone(),

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1374,17 +1374,26 @@ where
             transaction,
         );
     }
-    // add all block ranges of scan ranges with `ScannedWithoutMapping` priority above the current scan range to each note to track which ranges need the nullifiers to be re-fetched before the note is known to be unspent (in addition to all other ranges above the notes height being `Scanned` or `ScannedWithoutMapping` priority). this information is necessary as these ranges have been scanned but the nullifiers have been discarded so must be re-fetched. if ranges are scanned but the nullifiers are discarded (set to `ScannedWithoutMapping` priority) *after* this note has been added to the wallet, this is sufficient to know this note has not been spent, even if this range is not set to `Scanned` priority.
+    // add all block ranges of scan ranges with `ScannedWithoutMapping` or `RefetchingNullifiers` priority above the
+    // current scan range to each note to track which ranges need the nullifiers to be re-fetched before the note is
+    // known to be unspent (in addition to all other ranges above the notes height being `Scanned`,
+    // `ScannedWithoutMapping` or `RefetchingNullifiers` priority). this information is necessary as these ranges have been scanned but the
+    // nullifiers have been discarded so must be re-fetched. if ranges are scanned but the nullifiers are discarded
+    // (set to `ScannedWithoutMapping` priority) *after* this note has been added to the wallet, this is sufficient to
+    // know this note has not been spent, even if this range is not set to `Scanned` priority.
     let refetch_nullifier_ranges = {
-        let scanned_without_mapping_ranges: Vec<Range<BlockHeight>> = sync_state
+        let block_ranges: Vec<Range<BlockHeight>> = sync_state
             .scan_ranges()
             .iter()
-            .filter(|&scan_range| scan_range.priority() == ScanPriority::ScannedWithoutMapping)
+            .filter(|&scan_range| {
+                scan_range.priority() == ScanPriority::ScannedWithoutMapping
+                    || scan_range.priority() == ScanPriority::RefetchingNullifiers
+            })
             .map(|scan_range| scan_range.block_range().clone())
             .collect();
 
-        scanned_without_mapping_ranges[scanned_without_mapping_ranges
-            .partition_point(|range| range.start < scan_range.block_range().end)..]
+        block_ranges
+            [block_ranges.partition_point(|range| range.start < scan_range.block_range().end)..]
             .to_vec()
     };
     for transaction in transactions.values_mut() {

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -166,6 +166,8 @@ impl From<SyncResult> for json::JsonValue {
 /// Scanning range priority levels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ScanPriority {
+    /// Block ranges that are currently refetching nullifiers.
+    RefetchingNullifiers,
     /// Block ranges that are currently being scanned.
     Scanning,
     /// Block ranges that have already been scanned will not be re-scanned.
@@ -941,7 +943,7 @@ where
                 {
                     // in this rare edge case, a scanned `ScannedWithoutMapping` range was the highest priority yet it was not the first unscanned range so it must be discarded to avoid missing spends
 
-                    // reset scan range from `Scanning` to `ScannedWithoutMapping`
+                    // reset scan range from `RefetchingNullifiers` to `ScannedWithoutMapping`
                     state::punch_scan_priority(
                         wallet
                             .get_sync_state_mut()
@@ -1008,6 +1010,7 @@ where
                     let scan_priority = query_scan_range.priority();
                     if scan_priority != ScanPriority::Scanned
                         && scan_priority != ScanPriority::Scanning
+                        && scan_priority != ScanPriority::RefetchingNullifiers
                     {
                         break;
                     }
@@ -1458,6 +1461,7 @@ where
             scan_range.priority() == ScanPriority::Scanned
                 || scan_range.priority() == ScanPriority::ScannedWithoutMapping
                 || scan_range.priority() == ScanPriority::Scanning
+                || scan_range.priority() == ScanPriority::RefetchingNullifiers
         })
         .flat_map(|scanned_range| {
             vec![

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -936,7 +936,7 @@ where
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
                 // add missing block bounds in the case that nullifier batch limit was reached and the fetch nullifier
                 // scan range was split.
-                let full_refetch_nullifier_range = wallet
+                let full_refetching_nullifiers_range = wallet
                     .get_sync_state()
                     .map_err(SyncError::WalletError)?
                     .scan_ranges
@@ -951,17 +951,20 @@ where
                     })
                     .expect("wallet scan range containing scan range should exist!");
                 if scan_range.block_range().start
-                    != full_refetch_nullifier_range.block_range().start
+                    != full_refetching_nullifiers_range.block_range().start
                     || scan_range.block_range().end
-                        != full_refetch_nullifier_range.block_range().end
+                        != full_refetching_nullifiers_range.block_range().end
                 {
                     let mut missing_block_bounds = BTreeMap::new();
                     for block_bound in [
+                        scan_range.block_range().start - 1,
                         scan_range.block_range().start,
                         scan_range.block_range().end - 1,
                         scan_range.block_range().end,
                     ] {
-                        if block_bound >= full_refetch_nullifier_range.block_range().end {
+                        if block_bound < full_refetching_nullifiers_range.block_range().start
+                            || block_bound >= full_refetching_nullifiers_range.block_range().end
+                        {
                             continue;
                         }
                         if wallet.get_wallet_block(block_bound).is_err() {

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -953,7 +953,7 @@ where
                     .map_err(SyncError::WalletError)?
                     .scan_ranges
                     .iter()
-                    .find(|scan_range| scan_range.priority() != ScanPriority::Scanned && scan_range.priority() != ScanPriority::RefetchingNullifiers)
+                    .find(|scan_range| scan_range.priority() != ScanPriority::Scanned)
                     .expect("the scan range being processed is not yet set to scanned so at least one unscanned range must exist");
                 if !first_unscanned_range
                     .block_range()

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -920,32 +920,57 @@ where
             } = results;
 
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
-                // add missing block bounds in the case that nullifier batch limit was reached and scan range was split
-                let mut missing_block_bounds = BTreeMap::new();
-                for block_bound in [
-                    scan_range.block_range().start,
-                    scan_range.block_range().end - 1,
-                ] {
-                    if wallet.get_wallet_block(block_bound).is_err() {
-                        missing_block_bounds.insert(
-                            block_bound,
-                            WalletBlock::from_compact_block(
-                                consensus_parameters,
-                                fetch_request_sender.clone(),
-                                &client::get_compact_block(
+                // add missing block bounds in the case that nullifier batch limit was reached and the fetch nullifier
+                // scan range was split.
+                let full_refetch_nullifier_range = wallet
+                    .get_sync_state()
+                    .map_err(SyncError::WalletError)?
+                    .scan_ranges
+                    .iter()
+                    .find(|&wallet_scan_range| {
+                        wallet_scan_range
+                            .block_range()
+                            .contains(&scan_range.block_range().start)
+                            && wallet_scan_range
+                                .block_range()
+                                .contains(&(scan_range.block_range().end - 1))
+                    })
+                    .expect("wallet scan range containing scan range should exist!");
+                if scan_range.block_range().start
+                    != full_refetch_nullifier_range.block_range().start
+                    || scan_range.block_range().end
+                        != full_refetch_nullifier_range.block_range().end
+                {
+                    let mut missing_block_bounds = BTreeMap::new();
+                    for block_bound in [
+                        scan_range.block_range().start,
+                        scan_range.block_range().end - 1,
+                        scan_range.block_range().end,
+                    ] {
+                        if block_bound >= full_refetch_nullifier_range.block_range().end {
+                            continue;
+                        }
+                        if wallet.get_wallet_block(block_bound).is_err() {
+                            missing_block_bounds.insert(
+                                block_bound,
+                                WalletBlock::from_compact_block(
+                                    consensus_parameters,
                                     fetch_request_sender.clone(),
-                                    block_bound,
+                                    &client::get_compact_block(
+                                        fetch_request_sender.clone(),
+                                        block_bound,
+                                    )
+                                    .await?,
                                 )
                                 .await?,
-                            )
-                            .await?,
-                        );
+                            );
+                        }
                     }
-                }
-                if !missing_block_bounds.is_empty() {
-                    wallet
-                        .append_wallet_blocks(missing_block_bounds)
-                        .map_err(SyncError::WalletError)?;
+                    if !missing_block_bounds.is_empty() {
+                        wallet
+                            .append_wallet_blocks(missing_block_bounds)
+                            .map_err(SyncError::WalletError)?;
+                    }
                 }
 
                 let first_unscanned_range = wallet
@@ -1479,7 +1504,6 @@ where
         .filter(|scan_range| {
             scan_range.priority() == ScanPriority::Scanned
                 || scan_range.priority() == ScanPriority::ScannedWithoutMapping
-                || scan_range.priority() == ScanPriority::Scanning
                 || scan_range.priority() == ScanPriority::RefetchingNullifiers
         })
         .flat_map(|scanned_range| {

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -170,6 +170,8 @@ async fn create_scan_range(
 ///
 /// A range that was previously scanning when sync was last interrupted is set to `FoundNote` to be prioritised for
 /// scanning.
+/// A range that was previously refetching nullifiers when sync was last interrupted is set to `ScannedWithoutMapping`
+/// so the nullifiers can be fetched again.
 fn reset_scan_ranges(sync_state: &mut SyncState) {
     let previously_scanning_scan_ranges = sync_state
         .scan_ranges
@@ -182,6 +184,20 @@ fn reset_scan_ranges(sync_state: &mut SyncState) {
             sync_state,
             scan_range.block_range(),
             ScanPriority::FoundNote,
+        );
+    }
+
+    let previously_refetching_nullifiers_scan_ranges = sync_state
+        .scan_ranges
+        .iter()
+        .filter(|&range| range.priority() == ScanPriority::RefetchingNullifiers)
+        .cloned()
+        .collect::<Vec<_>>();
+    for scan_range in previously_refetching_nullifiers_scan_ranges {
+        set_scan_priority(
+            sync_state,
+            scan_range.block_range(),
+            ScanPriority::ScannedWithoutMapping,
         );
     }
 }
@@ -365,14 +381,16 @@ pub(super) fn set_scan_priority(
 /// If any scan ranges in `sync_state` are found to overlap with the given `block_range`, they will be split at the
 /// boundary and the new scan ranges contained by `block_range` will be set to `scan_priority`.
 /// Any scan ranges that fully contain the `block_range` will be split out with the given `scan_priority`.
-/// Any scan ranges with `Scanning` or `Scanned` priority or with higher (or equal) priority than
+/// Any scan ranges with `Scanning`, `RefetchingNullifiers` or `Scanned` priority or with higher (or equal) priority than
 /// `scan_priority` will be ignored.
-/// `split_scanning_ranges` is used for rare cases where a range already scanning needs to be reset back to its original priority and should be used with caution.
+/// `split_refetching_nullifier_ranges` is used for rare cases where a range is already refetching nullifiers and needs
+/// to be reset back to `ScannedWithoutMapping` priority.
+// TODO: make the `split_refetching_nullifier_ranges` logic a separate fn
 pub(super) fn punch_scan_priority(
     sync_state: &mut SyncState,
     block_range: Range<BlockHeight>,
     scan_priority: ScanPriority,
-    split_scanning_ranges: bool,
+    split_refetching_nullifier_ranges: bool,
 ) {
     let mut scan_ranges_contained_by_block_range = Vec::new();
     let mut scan_ranges_for_splitting = Vec::new();
@@ -380,7 +398,9 @@ pub(super) fn punch_scan_priority(
     for (index, scan_range) in sync_state.scan_ranges().iter().enumerate() {
         if scan_range.priority() == ScanPriority::Scanned
             || scan_range.priority() == ScanPriority::ScannedWithoutMapping
-            || (scan_range.priority() == ScanPriority::Scanning && !split_scanning_ranges)
+            || scan_range.priority() == ScanPriority::Scanning
+            || (scan_range.priority() == ScanPriority::RefetchingNullifiers
+                && !split_refetching_nullifier_ranges)
             || scan_range.priority() >= scan_priority
         {
             continue;
@@ -560,7 +580,10 @@ fn split_out_scan_range(
 /// Selects and prepares the next scan range for scanning.
 ///
 /// Sets the range for scanning to `Scanning` priority in the wallet `sync_state` but returns the scan range with its
-/// initial priority.
+/// initial priority for use in scanning and post-scan processing.
+/// If the selected range if of `ScannedWithoutMapping` priority, the range is set to `RefetchingNullifiers` in the
+/// wallet `sync_state` but returns the scan range with priority `ScannedWithoutMapping` for use in scanning and
+/// post-scan processing.
 /// Returns `None` if there are no more ranges to scan.
 ///
 /// Set `nullifier_map_limit_exceeded` to `true` if the nullifiers are not going to be mapped to the wallet's main
@@ -574,7 +597,10 @@ fn select_scan_range(
         .scan_ranges
         .iter()
         .enumerate()
-        .find(|(_, scan_range)| scan_range.priority() != ScanPriority::Scanned)?;
+        .find(|(_, scan_range)| {
+            scan_range.priority() != ScanPriority::Scanned
+                && scan_range.priority() != ScanPriority::RefetchingNullifiers
+        })?;
     let (selected_index, selected_scan_range) =
         if first_unscanned_range.priority() == ScanPriority::ScannedWithoutMapping {
             // prioritise re-fetching the nullifiers when a range with priority `ScannedWithoutMapping` is the first
@@ -625,46 +651,67 @@ fn select_scan_range(
 
     let selected_priority = selected_scan_range.priority();
 
-    if selected_priority == ScanPriority::Scanned || selected_priority == ScanPriority::Scanning {
+    if selected_priority == ScanPriority::Scanned
+        || selected_priority == ScanPriority::Scanning
+        || selected_priority == ScanPriority::RefetchingNullifiers
+    {
         return None;
     }
 
     // historic scan ranges can be larger than a shard block range so must be split out.
     // otherwise, just set the scan priority of selected range to `Scanning` in sync state.
-    let selected_block_range = if selected_priority == ScanPriority::Historic {
-        let shard_block_range = determine_block_range(
-            consensus_parameters,
-            sync_state,
-            selected_scan_range.block_range().start,
-            Some(ShieldedProtocol::Orchard),
-        );
-        let split_ranges = split_out_scan_range(
-            selected_scan_range,
-            shard_block_range,
-            ScanPriority::Scanning,
-        );
-        let selected_block_range = split_ranges
-            .first()
-            .expect("split ranges should always be non-empty")
-            .block_range()
-            .clone();
-        sync_state
-            .scan_ranges
-            .splice(selected_index..=selected_index, split_ranges);
+    // if the selected range is of `ScannedWithoutMapping` priority, set the range to `RefetchingNullifiers` priority
+    // instead of `Scanning`.
+    let selected_block_range = match selected_priority {
+        ScanPriority::Historic => {
+            let shard_block_range = determine_block_range(
+                consensus_parameters,
+                sync_state,
+                selected_scan_range.block_range().start,
+                Some(ShieldedProtocol::Orchard),
+            );
+            let split_ranges = split_out_scan_range(
+                selected_scan_range,
+                shard_block_range,
+                ScanPriority::Scanning,
+            );
+            let selected_block_range = split_ranges
+                .first()
+                .expect("split ranges should always be non-empty")
+                .block_range()
+                .clone();
+            sync_state
+                .scan_ranges
+                .splice(selected_index..=selected_index, split_ranges);
 
-        selected_block_range
-    } else {
-        let selected_scan_range = sync_state
-            .scan_ranges
-            .get_mut(selected_index)
-            .expect("scan range should exist due to previous logic");
+            selected_block_range
+        }
+        ScanPriority::ScannedWithoutMapping => {
+            let selected_scan_range = sync_state
+                .scan_ranges
+                .get_mut(selected_index)
+                .expect("scan range should exist due to previous logic");
 
-        *selected_scan_range = ScanRange::from_parts(
-            selected_scan_range.block_range().clone(),
-            ScanPriority::Scanning,
-        );
+            *selected_scan_range = ScanRange::from_parts(
+                selected_scan_range.block_range().clone(),
+                ScanPriority::RefetchingNullifiers,
+            );
 
-        selected_scan_range.block_range().clone()
+            selected_scan_range.block_range().clone()
+        }
+        _ => {
+            let selected_scan_range = sync_state
+                .scan_ranges
+                .get_mut(selected_index)
+                .expect("scan range should exist due to previous logic");
+
+            *selected_scan_range = ScanRange::from_parts(
+                selected_scan_range.block_range().clone(),
+                ScanPriority::Scanning,
+            );
+
+            selected_scan_range.block_range().clone()
+        }
     };
 
     Some(ScanRange::from_parts(

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -581,7 +581,7 @@ fn split_out_scan_range(
 ///
 /// Sets the range for scanning to `Scanning` priority in the wallet `sync_state` but returns the scan range with its
 /// initial priority for use in scanning and post-scan processing.
-/// If the selected range if of `ScannedWithoutMapping` priority, the range is set to `RefetchingNullifiers` in the
+/// If the selected range is of `ScannedWithoutMapping` priority, the range is set to `RefetchingNullifiers` in the
 /// wallet `sync_state` but returns the scan range with priority `ScannedWithoutMapping` for use in scanning and
 /// post-scan processing.
 /// Returns `None` if there are no more ranges to scan.

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -278,7 +278,7 @@ fn set_chain_tip_scan_range(
         orchard_incomplete_shard
     };
 
-    punch_scan_priority(sync_state, chain_tip, ScanPriority::ChainTip, false);
+    punch_scan_priority(sync_state, chain_tip, ScanPriority::ChainTip);
 }
 
 /// Punches in the `shielded_protocol` shard block ranges surrounding each scan target with `ScanPriority::FoundNote`.
@@ -320,7 +320,7 @@ pub(super) fn set_found_note_scan_range(
         block_height,
         shielded_protocol,
     );
-    punch_scan_priority(sync_state, block_range, ScanPriority::FoundNote, false);
+    punch_scan_priority(sync_state, block_range, ScanPriority::FoundNote);
 }
 
 pub(super) fn set_scanned_scan_range(
@@ -349,6 +349,35 @@ pub(super) fn set_scanned_scan_range(
         } else {
             ScanPriority::ScannedWithoutMapping
         },
+    );
+    sync_state.scan_ranges.splice(index..=index, split_ranges);
+}
+
+pub(super) fn reset_refetching_nullifiers_scan_range(
+    sync_state: &mut SyncState,
+    invalid_refetch_range: Range<BlockHeight>,
+) {
+    let Some((index, scan_range)) =
+        sync_state
+            .scan_ranges
+            .iter()
+            .enumerate()
+            .find(|(_, scan_range)| {
+                scan_range
+                    .block_range()
+                    .contains(&invalid_refetch_range.start)
+                    && scan_range
+                        .block_range()
+                        .contains(&(invalid_refetch_range.end - 1))
+            })
+    else {
+        panic!("scan range containing invalid refetch range should exist!");
+    };
+
+    let split_ranges = split_out_scan_range(
+        scan_range.clone(),
+        invalid_refetch_range.clone(),
+        ScanPriority::ScannedWithoutMapping,
     );
     sync_state.scan_ranges.splice(index..=index, split_ranges);
 }
@@ -383,14 +412,10 @@ pub(super) fn set_scan_priority(
 /// Any scan ranges that fully contain the `block_range` will be split out with the given `scan_priority`.
 /// Any scan ranges with `Scanning`, `RefetchingNullifiers` or `Scanned` priority or with higher (or equal) priority than
 /// `scan_priority` will be ignored.
-/// `split_refetching_nullifier_ranges` is used for rare cases where a range is already refetching nullifiers and needs
-/// to be reset back to `ScannedWithoutMapping` priority.
-// TODO: make the `split_refetching_nullifier_ranges` logic a separate fn
 pub(super) fn punch_scan_priority(
     sync_state: &mut SyncState,
     block_range: Range<BlockHeight>,
     scan_priority: ScanPriority,
-    split_refetching_nullifier_ranges: bool,
 ) {
     let mut scan_ranges_contained_by_block_range = Vec::new();
     let mut scan_ranges_for_splitting = Vec::new();
@@ -399,8 +424,7 @@ pub(super) fn punch_scan_priority(
         if scan_range.priority() == ScanPriority::Scanned
             || scan_range.priority() == ScanPriority::ScannedWithoutMapping
             || scan_range.priority() == ScanPriority::Scanning
-            || (scan_range.priority() == ScanPriority::RefetchingNullifiers
-                && !split_refetching_nullifier_ranges)
+            || scan_range.priority() == ScanPriority::RefetchingNullifiers
             || scan_range.priority() >= scan_priority
         {
             continue;

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -846,6 +846,7 @@ pub(super) fn calculate_scanned_blocks(sync_state: &SyncState) -> u32 {
         .filter(|scan_range| {
             scan_range.priority() == ScanPriority::Scanned
                 || scan_range.priority() == ScanPriority::ScannedWithoutMapping
+                || scan_range.priority() == ScanPriority::RefetchingNullifiers
         })
         .map(super::ScanRange::block_range)
         .fold(0, |acc, block_range| {
@@ -864,6 +865,7 @@ where
         .filter(|scan_range| {
             scan_range.priority() == ScanPriority::Scanned
                 || scan_range.priority() == ScanPriority::ScannedWithoutMapping
+                || scan_range.priority() == ScanPriority::RefetchingNullifiers
         })
         .map(|scanned_range| scanned_range_tree_bounds(wallet, scanned_range.block_range().clone()))
         .collect::<Result<Vec<_>, _>>()?

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -201,6 +201,7 @@ impl SyncState {
             .filter(|scan_range| {
                 scan_range.priority() == ScanPriority::Scanned
                     || scan_range.priority() == ScanPriority::ScannedWithoutMapping
+                    || scan_range.priority() == ScanPriority::RefetchingNullifiers
             })
             .next_back()
         {
@@ -711,8 +712,9 @@ pub trait NoteInterface: OutputInterface {
     fn memo(&self) -> &Memo;
 
     /// List of block ranges where the nullifiers must be re-fetched to guarantee the note has not been spent.
-    /// These scan ranges were marked `ScannedWithoutMapping` priority before this note was scanned, meaning the
-    /// nullifiers were discarded due to memory constraints and will be re-fetched later in the sync process.
+    /// These scan ranges were marked `ScannedWithoutMapping` or `RefetchingNullifiers` priority before this note was
+    /// scanned, meaning the nullifiers were discarded due to memory constraints and will be re-fetched later in the
+    /// sync process.
     fn refetch_nullifier_ranges(&self) -> &[Range<BlockHeight>];
 }
 
@@ -806,8 +808,9 @@ pub struct WalletNote<N, Nf: Copy> {
     /// If `None`, output is not spent.
     pub(crate) spending_transaction: Option<TxId>,
     /// List of block ranges where the nullifiers must be re-fetched to guarantee the note has not been spent.
-    /// These scan ranges were marked `ScannedWithoutMapping` priority before this note was scanned, meaning the
-    /// nullifiers were discarded due to memory constraints and will be re-fetched later in the sync process.
+    /// These scan ranges were marked `ScannedWithoutMapping` or `RefetchingNullifiers` priority before this note was
+    /// scanned, meaning the nullifiers were discarded due to memory constraints and will be re-fetched later in the
+    /// sync process.
     pub(crate) refetch_nullifier_ranges: Vec<Range<BlockHeight>>,
 }
 

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -89,7 +89,7 @@ impl ScanTarget {
 
 impl SyncState {
     fn serialized_version() -> u8 {
-        2
+        3
     }
 
     /// Deserialize into `reader`
@@ -98,8 +98,23 @@ impl SyncState {
         let scan_ranges = Vector::read(&mut reader, |r| {
             let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
             let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
-            let priority = if version >= 2 {
-                match r.read_u8()? {
+            let priority = match version {
+                3.. => match r.read_u8()? {
+                    0 => Ok(ScanPriority::RefetchingNullifiers),
+                    1 => Ok(ScanPriority::Scanning),
+                    2 => Ok(ScanPriority::Scanned),
+                    3 => Ok(ScanPriority::ScannedWithoutMapping),
+                    4 => Ok(ScanPriority::Historic),
+                    5 => Ok(ScanPriority::OpenAdjacent),
+                    6 => Ok(ScanPriority::FoundNote),
+                    7 => Ok(ScanPriority::ChainTip),
+                    8 => Ok(ScanPriority::Verify),
+                    _ => Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "invalid scan priority",
+                    )),
+                }?,
+                2 => match r.read_u8()? {
                     0 => Ok(ScanPriority::Scanning),
                     1 => Ok(ScanPriority::Scanned),
                     2 => Ok(ScanPriority::ScannedWithoutMapping),
@@ -112,9 +127,8 @@ impl SyncState {
                         std::io::ErrorKind::InvalidData,
                         "invalid scan priority",
                     )),
-                }?
-            } else {
-                match r.read_u8()? {
+                }?,
+                0 | 1 => match r.read_u8()? {
                     0 => Ok(ScanPriority::Scanning),
                     1 => Ok(ScanPriority::Scanned),
                     2 => Ok(ScanPriority::Historic),
@@ -126,7 +140,7 @@ impl SyncState {
                         std::io::ErrorKind::InvalidData,
                         "invalid scan priority",
                     )),
-                }?
+                }?,
             };
 
             Ok(ScanRange::from_parts(start..end, priority))

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -193,7 +193,6 @@ impl LightWallet {
                 if all_spends_known {
                     scan_range.priority() >= ScanPriority::FoundNote
                         || scan_range.priority() == ScanPriority::Scanning
-                        || scan_range.priority() == ScanPriority::RefetchingNullifiers
                 } else {
                     scan_range.priority() != ScanPriority::Scanned
                         && scan_range.priority() != ScanPriority::ScannedWithoutMapping

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -196,6 +196,7 @@ impl LightWallet {
                 } else {
                     scan_range.priority() != ScanPriority::Scanned
                         && scan_range.priority() != ScanPriority::ScannedWithoutMapping
+                        && scan_range.priority() != ScanPriority::RefetchingNullifiers
                 }
             })
         {

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -174,7 +174,7 @@ impl LightWallet {
     }
 
     /// Returns the block height at which all blocks equal to and above this height are scanned (scan ranges set to
-    /// `Scanned` or `ScannedWithoutMapping` priority).
+    /// `Scanned`, `ScannedWithoutMapping` or `RefetchingNullifiers` priority).
     /// Returns `None` if `self.scan_ranges` is empty.
     ///
     /// Useful for determining which height all the nullifiers have been mapped from for guaranteeing if a note is

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -193,6 +193,7 @@ impl LightWallet {
                 if all_spends_known {
                     scan_range.priority() >= ScanPriority::FoundNote
                         || scan_range.priority() == ScanPriority::Scanning
+                        || scan_range.priority() == ScanPriority::RefetchingNullifiers
                 } else {
                     scan_range.priority() != ScanPriority::Scanned
                         && scan_range.priority() != ScanPriority::ScannedWithoutMapping

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -330,6 +330,7 @@ fn check_note_shards_are_scanned(
         .filter(|scan_range| {
             scan_range.priority() == ScanPriority::Scanned
                 || scan_range.priority() == ScanPriority::ScannedWithoutMapping
+                || scan_range.priority() == ScanPriority::RefetchingNullifiers
         })
         .cloned()
         .collect::<Vec<_>>();


### PR DESCRIPTION
on top of #2097 

fixes #2116 

As described in the issue above, this PR creates a new `RefetchingNullifiers` scan range priority which is used to allow the wallet to store information about which ranges were already scanned but were being partially re-scanned only to re-fetch the nullifiers. This also allows the sync completion % to never drop when nullifiers are being re-fetched which is confusing to the user.