### PR TITLE
change MAX_VERIFICATION_WINDOW -> MAX_REORG_ALLOWANCE

### DIFF
--- a/pepper-sync/README.md
+++ b/pepper-sync/README.md
@@ -16,7 +16,7 @@ Pepper-sync is a rust-based sync engine library for wallets operating on the zca
 ## Terminology
 - Chain height - highest block height of best chain from the server.
 - Chain tip - the range of blocks at the top of the blockchain; Starting from the lowest block which contains the last note commitment to the latest shard of each shielded protocol; Ending at the chain height.
-- Wallet height - highest block height of blockchain known to the wallet.
+- Last Known Chain Height - highest block height of blockchain known to the wallet.
 - Fully scanned height - block height in which the wallet has completed scanning all blocks equal to and below this height.
 - Shard range - the range of blocks that contain all note commitments to a fully completed shard for a given shielded protocol.
 - Nullifier map - a map of all the nullifiers collected from each transaction's shielded inputs/spends during scanning.

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -49,7 +49,7 @@ pub(crate) mod state;
 pub(crate) mod transparent;
 
 const MEMPOOL_SPEND_INVALIDATION_THRESHOLD: u32 = 3;
-pub(crate) const MAX_VERIFICATION_WINDOW: u32 = 100;
+pub(crate) const MAX_REORG_ALLOWANCE: u32 = 100;
 const VERIFY_BLOCK_RANGE_SIZE: u32 = 10;
 
 /// A snapshot of the current state of sync. Useful for displaying the status of sync to a user / consumer.
@@ -367,8 +367,8 @@ where
         .wallet_height()
     {
         if height > chain_height {
-            if height - chain_height >= MAX_VERIFICATION_WINDOW {
-                return Err(SyncError::ChainError(MAX_VERIFICATION_WINDOW));
+            if height - chain_height >= MAX_REORG_ALLOWANCE {
+                return Err(SyncError::ChainError(MAX_REORG_ALLOWANCE));
             }
             truncate_wallet_data(&mut *wallet_guard, chain_height)?;
             height = chain_height;
@@ -1125,7 +1125,7 @@ where
                 .start;
                 state::merge_scan_ranges(sync_state, ScanPriority::Verify);
 
-                if initial_verification_height - verification_start > MAX_VERIFICATION_WINDOW {
+                if initial_verification_height - verification_start > MAX_REORG_ALLOWANCE {
                     clear_wallet_data(wallet)?;
 
                     return Err(ServerError::ChainVerificationError.into());
@@ -1453,7 +1453,7 @@ where
         .collect::<Vec<_>>();
 
     wallet.get_wallet_blocks_mut()?.retain(|height, _| {
-        *height >= highest_scanned_height.saturating_sub(MAX_VERIFICATION_WINDOW)
+        *height >= highest_scanned_height.saturating_sub(MAX_REORG_ALLOWANCE)
             || scanned_range_bounds.contains(height)
             || wallet_transaction_heights.contains(height)
     });
@@ -1481,7 +1481,7 @@ where
         .collect::<Vec<_>>();
 
     scanned_blocks.retain(|height, _| {
-        *height >= highest_scanned_height.saturating_sub(MAX_VERIFICATION_WINDOW)
+        *height >= highest_scanned_height.saturating_sub(MAX_REORG_ALLOWANCE)
             || *height == scan_range.block_range().start
             || *height == scan_range.block_range().end - 1
             || wallet_transaction_heights.contains(height)

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -361,10 +361,10 @@ where
     if chain_height == 0.into() {
         return Err(SyncError::ServerError(ServerError::GenesisBlockOnly));
     }
-    let wallet_height = if let Some(mut height) = wallet_guard
+    let last_known_chain_height = if let Some(mut height) = wallet_guard
         .get_sync_state()
         .map_err(SyncError::WalletError)?
-        .wallet_height()
+        .last_known_chain_height()
     {
         if height > chain_height {
             if height - chain_height >= MAX_REORG_ALLOWANCE {
@@ -394,7 +394,7 @@ where
         &mut *wallet_guard,
         fetch_request_sender.clone(),
         &ufvks,
-        wallet_height,
+        last_known_chain_height,
         chain_height,
         config.transparent_address_discovery,
     )
@@ -417,7 +417,7 @@ where
 
     state::update_scan_ranges(
         consensus_parameters,
-        wallet_height,
+        last_known_chain_height,
         chain_height,
         wallet_guard
             .get_sync_state_mut()
@@ -632,10 +632,10 @@ where
     let birthday = sync_state
         .wallet_birthday()
         .ok_or(SyncStatusError::NoSyncData)?;
-    let wallet_height = sync_state
-        .wallet_height()
+    let last_known_chain_height = sync_state
+        .last_known_chain_height()
         .ok_or(SyncStatusError::NoSyncData)?;
-    let total_blocks = wallet_height - birthday + 1;
+    let total_blocks = last_known_chain_height - birthday + 1;
     let total_sapling_outputs = sync_state
         .initial_sync_state
         .wallet_tree_bounds
@@ -1104,8 +1104,8 @@ where
                 let sync_state = wallet
                     .get_sync_state_mut()
                     .map_err(SyncError::WalletError)?;
-                let wallet_height = sync_state
-                    .wallet_height()
+                let last_known_chain_height = sync_state
+                    .last_known_chain_height()
                     .expect("scan ranges should be non-empty in this scope");
 
                 // reset scan range from `Scanning` to `Verify`
@@ -1137,7 +1137,7 @@ where
                     consensus_parameters,
                     fetch_request_sender.clone(),
                     wallet,
-                    wallet_height,
+                    last_known_chain_height,
                 )
                 .await?;
             } else {
@@ -1166,7 +1166,7 @@ where
     let mempool_height = wallet
         .get_sync_state()
         .map_err(SyncError::WalletError)?
-        .wallet_height()
+        .last_known_chain_height()
         .expect("wallet height must exist after sync is initialised")
         + 1;
 
@@ -1681,10 +1681,10 @@ fn reset_invalid_spends<W>(wallet: &mut W) -> Result<(), SyncError<W::Error>>
 where
     W: SyncWallet + SyncTransactions,
 {
-    let wallet_height = wallet
+    let last_known_chain_height = wallet
         .get_sync_state()
         .map_err(SyncError::WalletError)?
-        .wallet_height()
+        .last_known_chain_height()
         .expect("wallet height must exist after scan ranges have been updated");
     let wallet_transactions = wallet
         .get_wallet_transactions_mut()
@@ -1695,7 +1695,7 @@ where
         .filter(|transaction| {
             matches!(transaction.status(), ConfirmationStatus::Mempool(_))
                 && transaction.status().get_height()
-                    <= wallet_height - MEMPOOL_SPEND_INVALIDATION_THRESHOLD
+                    <= last_known_chain_height - MEMPOOL_SPEND_INVALIDATION_THRESHOLD
         })
         .map(super::wallet::WalletTransaction::txid)
         .chain(
@@ -1704,7 +1704,7 @@ where
                 .filter(|transaction| {
                     (matches!(transaction.status(), ConfirmationStatus::Calculated(_))
                         || matches!(transaction.status(), ConfirmationStatus::Transmitted(_)))
-                        && wallet_height >= transaction.transaction().expiry_height()
+                        && last_known_chain_height >= transaction.transaction().expiry_height()
                 })
                 .map(super::wallet::WalletTransaction::txid),
         )

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -64,12 +64,12 @@ fn find_scan_targets(
 /// Update scan ranges for scanning.
 pub(super) async fn update_scan_ranges(
     consensus_parameters: &impl consensus::Parameters,
-    wallet_height: BlockHeight,
+    last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     sync_state: &mut SyncState,
 ) {
     reset_scan_ranges(sync_state);
-    create_scan_range(wallet_height, chain_height, sync_state).await;
+    create_scan_range(last_known_chain_height, chain_height, sync_state).await;
     let scan_targets = sync_state.scan_targets.clone();
     set_found_note_scan_ranges(
         consensus_parameters,
@@ -128,17 +128,17 @@ pub(super) fn merge_scan_ranges(sync_state: &mut SyncState, scan_priority: ScanP
 
 /// Create scan range between the wallet height and the chain height from the server.
 async fn create_scan_range(
-    wallet_height: BlockHeight,
+    last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     sync_state: &mut SyncState,
 ) {
-    if wallet_height == chain_height {
+    if last_known_chain_height == chain_height {
         return;
     }
 
     let new_scan_range = ScanRange::from_parts(
         Range {
-            start: wallet_height + 1,
+            start: last_known_chain_height + 1,
             end: chain_height + 1,
         },
         ScanPriority::Historic,
@@ -453,7 +453,7 @@ fn determine_block_range(
                     .expect("scan range should not be empty")
             };
             let end = sync_state
-                .wallet_height()
+                .last_known_chain_height()
                 .expect("scan range should not be empty")
                 + 1;
 

--- a/pepper-sync/src/sync/transparent.rs
+++ b/pepper-sync/src/sync/transparent.rs
@@ -17,7 +17,7 @@ use crate::keys::transparent::{TransparentAddressId, TransparentScope};
 use crate::wallet::traits::SyncWallet;
 use crate::wallet::{KeyIdInterface, ScanTarget};
 
-use super::MAX_VERIFICATION_WINDOW;
+use super::MAX_REORG_ALLOWANCE;
 
 /// Discovers all addresses in use by the wallet and returns `scan_targets` for any new relevant transactions to scan transparent
 /// bundles.
@@ -42,7 +42,7 @@ pub(crate) async fn update_addresses_and_scan_targets<W: SyncWallet>(
     let sapling_activation_height = consensus_parameters
         .activation_height(consensus::NetworkUpgrade::Sapling)
         .expect("sapling activation height should always return Some");
-    let block_range_start = wallet_height.saturating_sub(MAX_VERIFICATION_WINDOW) + 1;
+    let block_range_start = wallet_height.saturating_sub(MAX_REORG_ALLOWANCE) + 1;
     let checked_block_range_start = match block_range_start.cmp(&sapling_activation_height) {
         cmp::Ordering::Greater | cmp::Ordering::Equal => block_range_start,
         cmp::Ordering::Less => sapling_activation_height,
@@ -63,7 +63,7 @@ pub(crate) async fn update_addresses_and_scan_targets<W: SyncWallet>(
         .await?;
 
         // The transaction is not scanned here, instead the scan target is stored to be later sent to a scan task for these reasons:
-        // - We must search for all relevant transactions MAX_VERIFICATION_WINDOW blocks below wallet height in case of re-org.
+        // - We must search for all relevant transactions MAX_REORG_ALLOWANCE blocks below wallet height in case of re-org.
         // These would be scanned again which would be inefficient
         // - In case of re-org, any scanned transactions with heights within the re-org range would be wrongly invalidated
         // - The scan target will cause the surrounding range to be set to high priority which will often also contain shielded notes

--- a/pepper-sync/src/sync/transparent.rs
+++ b/pepper-sync/src/sync/transparent.rs
@@ -21,13 +21,13 @@ use super::MAX_REORG_ALLOWANCE;
 
 /// Discovers all addresses in use by the wallet and returns `scan_targets` for any new relevant transactions to scan transparent
 /// bundles.
-/// `wallet_height` should be the value before updating to latest chain height.
+/// `last_known_chain_height` should be the value before updating to latest chain height.
 pub(crate) async fn update_addresses_and_scan_targets<W: SyncWallet>(
     consensus_parameters: &impl consensus::Parameters,
     wallet: &mut W,
     fetch_request_sender: mpsc::UnboundedSender<FetchRequest>,
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
-    wallet_height: BlockHeight,
+    last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     config: TransparentAddressDiscovery,
 ) -> Result<(), SyncError<W::Error>> {
@@ -42,7 +42,7 @@ pub(crate) async fn update_addresses_and_scan_targets<W: SyncWallet>(
     let sapling_activation_height = consensus_parameters
         .activation_height(consensus::NetworkUpgrade::Sapling)
         .expect("sapling activation height should always return Some");
-    let block_range_start = wallet_height.saturating_sub(MAX_REORG_ALLOWANCE) + 1;
+    let block_range_start = last_known_chain_height.saturating_sub(MAX_REORG_ALLOWANCE) + 1;
     let checked_block_range_start = match block_range_start.cmp(&sapling_activation_height) {
         cmp::Ordering::Greater | cmp::Ordering::Equal => block_range_start,
         cmp::Ordering::Less => sapling_activation_height,

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -40,7 +40,7 @@ use crate::{
     error::{ServerError, SyncModeError},
     keys::{self, KeyId, transparent::TransparentAddressId},
     scan::compact_blocks::calculate_block_tree_bounds,
-    sync::{MAX_VERIFICATION_WINDOW, ScanPriority, ScanRange},
+    sync::{MAX_REORG_ALLOWANCE, ScanPriority, ScanRange},
     witness,
 };
 
@@ -1144,10 +1144,8 @@ impl ShardTrees {
     /// Create new `ShardTrees`
     #[must_use]
     pub fn new() -> Self {
-        let mut sapling =
-            ShardTree::new(MemoryShardStore::empty(), MAX_VERIFICATION_WINDOW as usize);
-        let mut orchard =
-            ShardTree::new(MemoryShardStore::empty(), MAX_VERIFICATION_WINDOW as usize);
+        let mut sapling = ShardTree::new(MemoryShardStore::empty(), MAX_REORG_ALLOWANCE as usize);
+        let mut orchard = ShardTree::new(MemoryShardStore::empty(), MAX_REORG_ALLOWANCE as usize);
 
         sapling
             .checkpoint(BlockHeight::from_u32(0))

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -222,7 +222,7 @@ impl SyncState {
 
     /// Returns the last known chain height to the wallet or `None` if `self.scan_ranges` is empty.
     #[must_use]
-    pub fn wallet_height(&self) -> Option<BlockHeight> {
+    pub fn last_known_chain_height(&self) -> Option<BlockHeight> {
         self.scan_ranges
             .last()
             .map(|range| range.block_range().end - 1)

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -34,7 +34,7 @@ use crate::{
         KeyId, decode_unified_address,
         transparent::{TransparentAddressId, TransparentScope},
     },
-    sync::{MAX_VERIFICATION_WINDOW, ScanPriority, ScanRange},
+    sync::{MAX_REORG_ALLOWANCE, ScanPriority, ScanRange},
     wallet::ScanTarget,
 };
 
@@ -1001,7 +1001,7 @@ impl ShardTrees {
 
         Ok(shardtree::ShardTree::new(
             store,
-            MAX_VERIFICATION_WINDOW as usize,
+            MAX_REORG_ALLOWANCE as usize,
         ))
     }
 
@@ -1082,7 +1082,7 @@ impl ShardTrees {
         macro_rules! write_with_error_handling {
             ($writer: ident, $from: ident) => {
                 if let Err(e) = $writer(&mut writer, &$from) {
-                    *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+                    *shardtree = shardtree::ShardTree::new(store, MAX_REORG_ALLOWANCE as usize);
                     return Err(e);
                 }
             };
@@ -1094,13 +1094,10 @@ impl ShardTrees {
         // Write checkpoints
         let mut checkpoints = Vec::new();
         store
-            .with_checkpoints(
-                MAX_VERIFICATION_WINDOW as usize,
-                |checkpoint_id, checkpoint| {
-                    checkpoints.push((*checkpoint_id, checkpoint.clone()));
-                    Ok(())
-                },
-            )
+            .with_checkpoints(MAX_REORG_ALLOWANCE as usize, |checkpoint_id, checkpoint| {
+                checkpoints.push((*checkpoint_id, checkpoint.clone()));
+                Ok(())
+            })
             .expect("Infallible");
         write_with_error_handling!(write_checkpoints, checkpoints);
 
@@ -1108,7 +1105,7 @@ impl ShardTrees {
         let cap = store.get_cap().expect("Infallible");
         write_with_error_handling!(write_shard, cap);
 
-        *shardtree = shardtree::ShardTree::new(store, MAX_VERIFICATION_WINDOW as usize);
+        *shardtree = shardtree::ShardTree::new(store, MAX_REORG_ALLOWANCE as usize);
 
         Ok(())
     }

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -17,7 +17,7 @@ use zcash_protocol::{PoolType, ShieldedProtocol};
 
 use crate::error::{ServerError, SyncError};
 use crate::keys::transparent::TransparentAddressId;
-use crate::sync::{MAX_VERIFICATION_WINDOW, ScanRange};
+use crate::sync::{MAX_REORG_ALLOWANCE, ScanRange};
 use crate::wallet::{
     NullifierMap, OutputId, ShardTrees, SyncState, WalletBlock, WalletTransaction,
 };
@@ -251,22 +251,22 @@ pub trait SyncShardTrees: SyncWallet {
         async move {
             let shard_trees = self.get_shard_trees_mut().map_err(SyncError::WalletError)?;
 
-            // limit the range that checkpoints are manually added to the top MAX_VERIFICATION_WINDOW scanned blocks for efficiency.
+            // limit the range that checkpoints are manually added to the top MAX_REORG_ALLOWANCE scanned blocks for efficiency.
             // As we sync the chain tip first and have spend-before-sync, we will always choose anchors very close to chain
             // height and we will also never need to truncate to checkpoints lower than this height.
             let checkpoint_range = if scan_range.block_range().start > highest_scanned_height {
                 let verification_window_start = scan_range
                     .block_range()
                     .end
-                    .saturating_sub(MAX_VERIFICATION_WINDOW);
+                    .saturating_sub(MAX_REORG_ALLOWANCE);
 
                 std::cmp::max(scan_range.block_range().start, verification_window_start)
                     ..scan_range.block_range().end
             } else if scan_range.block_range().end
-                > highest_scanned_height.saturating_sub(MAX_VERIFICATION_WINDOW) + 1
+                > highest_scanned_height.saturating_sub(MAX_REORG_ALLOWANCE) + 1
             {
                 let verification_window_start =
-                    highest_scanned_height.saturating_sub(MAX_VERIFICATION_WINDOW) + 1;
+                    highest_scanned_height.saturating_sub(MAX_REORG_ALLOWANCE) + 1;
 
                 std::cmp::max(scan_range.block_range().start, verification_window_start)
                     ..scan_range.block_range().end
@@ -333,9 +333,9 @@ pub trait SyncShardTrees: SyncWallet {
         if truncate_height == zcash_protocol::consensus::H0 {
             let shard_trees = self.get_shard_trees_mut().map_err(SyncError::WalletError)?;
             shard_trees.sapling =
-                ShardTree::new(MemoryShardStore::empty(), MAX_VERIFICATION_WINDOW as usize);
+                ShardTree::new(MemoryShardStore::empty(), MAX_REORG_ALLOWANCE as usize);
             shard_trees.orchard =
-                ShardTree::new(MemoryShardStore::empty(), MAX_VERIFICATION_WINDOW as usize);
+                ShardTree::new(MemoryShardStore::empty(), MAX_REORG_ALLOWANCE as usize);
         } else {
             if !self
                 .get_shard_trees_mut()

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1755,7 +1755,7 @@ impl Command for HeightCommand {
 
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
         RT.block_on(async move {
-            object! { "height" => json::JsonValue::from(lightclient.wallet.read().await.sync_state.wallet_height().map_or(0, u32::from))}.pretty(2)
+            object! { "height" => json::JsonValue::from(lightclient.wallet.read().await.sync_state.last_known_chain_height().map_or(0, u32::from))}.pretty(2)
         })
     }
 }

--- a/zingolib/src/testutils/chain_generics/with_assertions.rs
+++ b/zingolib/src/testutils/chain_generics/with_assertions.rs
@@ -127,14 +127,14 @@ where
             .unwrap()
             .height as u32,
     );
-    let wallet_height_at_send = sender
+    let last_known_chain_height = sender
         .wallet
         .read()
         .await
         .sync_state
-        .wallet_height()
+        .last_known_chain_height()
         .unwrap();
-    timestamped_test_log(format!("wallet height at send {wallet_height_at_send}").as_str());
+    timestamped_test_log(format!("wallet height at send {last_known_chain_height}").as_str());
 
     // check that each record has the expected fee and status, returning the fee
     let (sender_recorded_fees, (sender_recorded_outputs, sender_recorded_statuses)): (
@@ -164,10 +164,10 @@ where
     for status in sender_recorded_statuses {
         if !matches!(
             status,
-            ConfirmationStatus::Transmitted(transmitted_status_height) if transmitted_status_height == wallet_height_at_send + 1
+            ConfirmationStatus::Transmitted(transmitted_status_height) if transmitted_status_height == last_known_chain_height + 1
         ) {
             tracing::debug!("{status:?}");
-            tracing::debug!("{wallet_height_at_send:?}");
+            tracing::debug!("{last_known_chain_height:?}");
             panic!();
         }
     }
@@ -260,14 +260,14 @@ where
         timestamped_test_log("syncking transaction confirmation.");
         // chain scan shows the same
         sender.sync_and_await().await.unwrap();
-        let wallet_height_at_confirmation = sender
+        let last_known_chain_height = sender
             .wallet
             .read()
             .await
             .sync_state
-            .wallet_height()
+            .last_known_chain_height()
             .unwrap();
-        timestamped_test_log(format!("wallet height now {wallet_height_at_confirmation}").as_str());
+        timestamped_test_log(format!("wallet height now {last_known_chain_height}").as_str());
         timestamped_test_log("cross-checking confirmed records.");
 
         // check that each record has the expected fee and status, returning the fee and outputs
@@ -312,7 +312,7 @@ where
                     any_transaction_not_yet_confirmed = true;
                 }
                 ConfirmationStatus::Confirmed(confirmed_height) => {
-                    assert!(wallet_height_at_confirmation >= confirmed_height);
+                    assert!(last_known_chain_height >= confirmed_height);
                 }
             }
         }

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -157,7 +157,10 @@ impl LightWallet {
             .is_some_and(|bundle| bundle.is_coinbase());
 
         if is_coinbase {
-            let current_height = self.sync_state.wallet_height().unwrap_or(self.birthday);
+            let current_height = self
+                .sync_state
+                .last_known_chain_height()
+                .unwrap_or(self.birthday);
             let tx_height = transaction.status().get_height();
 
             // Work with u32 values

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -329,7 +329,10 @@ impl LightWallet {
                     .status()
                     .get_confirmed_height()
                     .expect("transaction must be confirmed in this scope")
-                    > self.sync_state.wallet_height().unwrap_or(self.birthday)
+                    > self
+                        .sync_state
+                        .last_known_chain_height()
+                        .unwrap_or(self.birthday)
                 {
                     return Vec::new();
                 }

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -403,11 +403,11 @@ mod tests {
         fn birthday_within_note_shard_range() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(20);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![
@@ -429,11 +429,11 @@ mod tests {
         fn note_within_complete_shard() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(70);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![
@@ -455,11 +455,11 @@ mod tests {
         fn note_within_incomplete_shard() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(170);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![
@@ -481,11 +481,11 @@ mod tests {
         fn note_height_on_shard_boundary() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(100);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -151,7 +151,7 @@ impl WalletRead for LightWallet {
     }
 
     fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
-        Ok(self.sync_state.wallet_height())
+        Ok(self.sync_state.last_known_chain_height())
     }
 
     fn get_block_hash(&self, _block_height: BlockHeight) -> Result<Option<BlockHash>, Self::Error> {
@@ -184,7 +184,7 @@ impl WalletRead for LightWallet {
         &self,
         min_confirmations: NonZeroU32,
     ) -> Result<Option<(TargetHeight, BlockHeight)>, Self::Error> {
-        let target_height = if let Some(height) = self.sync_state.wallet_height() {
+        let target_height = if let Some(height) = self.sync_state.last_known_chain_height() {
             height + 1
         } else {
             return Ok(None);


### PR DESCRIPTION
Use "REORG" and "ALLOWANCE" to give hints to naive readers. 

The MAX_REORG_ALLOWANCE is the number of blocks above the proxy-reported best-chain-height, that the wallet is allowed to have recorded as its fully scanned height.

If the wallet has scanned more that MAX_REORG_ALLOWANCE blocks ABOVE the proxy's best height this is evidence that there is a deviation from normal consensus parameter values.

Most likely there has been a (massive) reorganization.

I chose this name to reflect this:

MAX:                   this is an upper bound (tolerance)
REORG:              this is why the threshold might be exceeded
ALLOWANCE:    values less than this are allowed to recover


Other names that seem viable to me might involve the word "TOLERANCE" instead of "ALLOWANCE".

It's also the case that this value is only exceeded in catastrophic cases, so perhaps that information could somehow be incorporated?

I don't think this name is perfect, but I think it's a bit more explicit than the current name.