### PR TITLE
convert wallet_height to last_known_chain_height

### DIFF
--- a/pepper-sync/README.md
+++ b/pepper-sync/README.md
@@ -16,7 +16,7 @@ Pepper-sync is a rust-based sync engine library for wallets operating on the zca
 ## Terminology
 - Chain height - highest block height of best chain from the server.
 - Chain tip - the range of blocks at the top of the blockchain; Starting from the lowest block which contains the last note commitment to the latest shard of each shielded protocol; Ending at the chain height.
-- Wallet height - highest block height of blockchain known to the wallet.
+- Last Known Chain Height - highest block height of blockchain known to the wallet.
 - Fully scanned height - block height in which the wallet has completed scanning all blocks equal to and below this height.
 - Shard range - the range of blocks that contain all note commitments to a fully completed shard for a given shielded protocol.
 - Nullifier map - a map of all the nullifiers collected from each transaction's shielded inputs/spends during scanning.

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -361,10 +361,10 @@ where
     if chain_height == 0.into() {
         return Err(SyncError::ServerError(ServerError::GenesisBlockOnly));
     }
-    let wallet_height = if let Some(mut height) = wallet_guard
+    let last_known_chain_height = if let Some(mut height) = wallet_guard
         .get_sync_state()
         .map_err(SyncError::WalletError)?
-        .wallet_height()
+        .last_known_chain_height()
     {
         if height > chain_height {
             if height - chain_height >= MAX_REORG_ALLOWANCE {
@@ -394,7 +394,7 @@ where
         &mut *wallet_guard,
         fetch_request_sender.clone(),
         &ufvks,
-        wallet_height,
+        last_known_chain_height,
         chain_height,
         config.transparent_address_discovery,
     )
@@ -417,7 +417,7 @@ where
 
     state::update_scan_ranges(
         consensus_parameters,
-        wallet_height,
+        last_known_chain_height,
         chain_height,
         wallet_guard
             .get_sync_state_mut()
@@ -632,10 +632,10 @@ where
     let birthday = sync_state
         .wallet_birthday()
         .ok_or(SyncStatusError::NoSyncData)?;
-    let wallet_height = sync_state
-        .wallet_height()
+    let last_known_chain_height = sync_state
+        .last_known_chain_height()
         .ok_or(SyncStatusError::NoSyncData)?;
-    let total_blocks = wallet_height - birthday + 1;
+    let total_blocks = last_known_chain_height - birthday + 1;
     let total_sapling_outputs = sync_state
         .initial_sync_state
         .wallet_tree_bounds
@@ -1104,8 +1104,8 @@ where
                 let sync_state = wallet
                     .get_sync_state_mut()
                     .map_err(SyncError::WalletError)?;
-                let wallet_height = sync_state
-                    .wallet_height()
+                let last_known_chain_height = sync_state
+                    .last_known_chain_height()
                     .expect("scan ranges should be non-empty in this scope");
 
                 // reset scan range from `Scanning` to `Verify`
@@ -1137,7 +1137,7 @@ where
                     consensus_parameters,
                     fetch_request_sender.clone(),
                     wallet,
-                    wallet_height,
+                    last_known_chain_height,
                 )
                 .await?;
             } else {
@@ -1166,7 +1166,7 @@ where
     let mempool_height = wallet
         .get_sync_state()
         .map_err(SyncError::WalletError)?
-        .wallet_height()
+        .last_known_chain_height()
         .expect("wallet height must exist after sync is initialised")
         + 1;
 
@@ -1681,10 +1681,10 @@ fn reset_invalid_spends<W>(wallet: &mut W) -> Result<(), SyncError<W::Error>>
 where
     W: SyncWallet + SyncTransactions,
 {
-    let wallet_height = wallet
+    let last_known_chain_height = wallet
         .get_sync_state()
         .map_err(SyncError::WalletError)?
-        .wallet_height()
+        .last_known_chain_height()
         .expect("wallet height must exist after scan ranges have been updated");
     let wallet_transactions = wallet
         .get_wallet_transactions_mut()
@@ -1695,7 +1695,7 @@ where
         .filter(|transaction| {
             matches!(transaction.status(), ConfirmationStatus::Mempool(_))
                 && transaction.status().get_height()
-                    <= wallet_height - MEMPOOL_SPEND_INVALIDATION_THRESHOLD
+                    <= last_known_chain_height - MEMPOOL_SPEND_INVALIDATION_THRESHOLD
         })
         .map(super::wallet::WalletTransaction::txid)
         .chain(
@@ -1704,7 +1704,7 @@ where
                 .filter(|transaction| {
                     (matches!(transaction.status(), ConfirmationStatus::Calculated(_))
                         || matches!(transaction.status(), ConfirmationStatus::Transmitted(_)))
-                        && wallet_height >= transaction.transaction().expiry_height()
+                        && last_known_chain_height >= transaction.transaction().expiry_height()
                 })
                 .map(super::wallet::WalletTransaction::txid),
         )

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -64,12 +64,12 @@ fn find_scan_targets(
 /// Update scan ranges for scanning.
 pub(super) async fn update_scan_ranges(
     consensus_parameters: &impl consensus::Parameters,
-    wallet_height: BlockHeight,
+    last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     sync_state: &mut SyncState,
 ) {
     reset_scan_ranges(sync_state);
-    create_scan_range(wallet_height, chain_height, sync_state).await;
+    create_scan_range(last_known_chain_height, chain_height, sync_state).await;
     let scan_targets = sync_state.scan_targets.clone();
     set_found_note_scan_ranges(
         consensus_parameters,
@@ -128,17 +128,17 @@ pub(super) fn merge_scan_ranges(sync_state: &mut SyncState, scan_priority: ScanP
 
 /// Create scan range between the wallet height and the chain height from the server.
 async fn create_scan_range(
-    wallet_height: BlockHeight,
+    last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     sync_state: &mut SyncState,
 ) {
-    if wallet_height == chain_height {
+    if last_known_chain_height == chain_height {
         return;
     }
 
     let new_scan_range = ScanRange::from_parts(
         Range {
-            start: wallet_height + 1,
+            start: last_known_chain_height + 1,
             end: chain_height + 1,
         },
         ScanPriority::Historic,
@@ -453,7 +453,7 @@ fn determine_block_range(
                     .expect("scan range should not be empty")
             };
             let end = sync_state
-                .wallet_height()
+                .last_known_chain_height()
                 .expect("scan range should not be empty")
                 + 1;
 

--- a/pepper-sync/src/sync/transparent.rs
+++ b/pepper-sync/src/sync/transparent.rs
@@ -21,13 +21,13 @@ use super::MAX_REORG_ALLOWANCE;
 
 /// Discovers all addresses in use by the wallet and returns `scan_targets` for any new relevant transactions to scan transparent
 /// bundles.
-/// `wallet_height` should be the value before updating to latest chain height.
+/// `last_known_chain_height` should be the value before updating to latest chain height.
 pub(crate) async fn update_addresses_and_scan_targets<W: SyncWallet>(
     consensus_parameters: &impl consensus::Parameters,
     wallet: &mut W,
     fetch_request_sender: mpsc::UnboundedSender<FetchRequest>,
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
-    wallet_height: BlockHeight,
+    last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     config: TransparentAddressDiscovery,
 ) -> Result<(), SyncError<W::Error>> {
@@ -42,7 +42,7 @@ pub(crate) async fn update_addresses_and_scan_targets<W: SyncWallet>(
     let sapling_activation_height = consensus_parameters
         .activation_height(consensus::NetworkUpgrade::Sapling)
         .expect("sapling activation height should always return Some");
-    let block_range_start = wallet_height.saturating_sub(MAX_REORG_ALLOWANCE) + 1;
+    let block_range_start = last_known_chain_height.saturating_sub(MAX_REORG_ALLOWANCE) + 1;
     let checked_block_range_start = match block_range_start.cmp(&sapling_activation_height) {
         cmp::Ordering::Greater | cmp::Ordering::Equal => block_range_start,
         cmp::Ordering::Less => sapling_activation_height,

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -222,7 +222,7 @@ impl SyncState {
 
     /// Returns the last known chain height to the wallet or `None` if `self.scan_ranges` is empty.
     #[must_use]
-    pub fn wallet_height(&self) -> Option<BlockHeight> {
+    pub fn last_known_chain_height(&self) -> Option<BlockHeight> {
         self.scan_ranges
             .last()
             .map(|range| range.block_range().end - 1)

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1755,7 +1755,7 @@ impl Command for HeightCommand {
 
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
         RT.block_on(async move {
-            object! { "height" => json::JsonValue::from(lightclient.wallet.read().await.sync_state.wallet_height().map_or(0, u32::from))}.pretty(2)
+            object! { "height" => json::JsonValue::from(lightclient.wallet.read().await.sync_state.last_known_chain_height().map_or(0, u32::from))}.pretty(2)
         })
     }
 }

--- a/zingolib/src/testutils/chain_generics/with_assertions.rs
+++ b/zingolib/src/testutils/chain_generics/with_assertions.rs
@@ -127,14 +127,14 @@ where
             .unwrap()
             .height as u32,
     );
-    let wallet_height_at_send = sender
+    let last_known_chain_height = sender
         .wallet
         .read()
         .await
         .sync_state
-        .wallet_height()
+        .last_known_chain_height()
         .unwrap();
-    timestamped_test_log(format!("wallet height at send {wallet_height_at_send}").as_str());
+    timestamped_test_log(format!("wallet height at send {last_known_chain_height}").as_str());
 
     // check that each record has the expected fee and status, returning the fee
     let (sender_recorded_fees, (sender_recorded_outputs, sender_recorded_statuses)): (
@@ -164,10 +164,10 @@ where
     for status in sender_recorded_statuses {
         if !matches!(
             status,
-            ConfirmationStatus::Transmitted(transmitted_status_height) if transmitted_status_height == wallet_height_at_send + 1
+            ConfirmationStatus::Transmitted(transmitted_status_height) if transmitted_status_height == last_known_chain_height + 1
         ) {
             tracing::debug!("{status:?}");
-            tracing::debug!("{wallet_height_at_send:?}");
+            tracing::debug!("{last_known_chain_height:?}");
             panic!();
         }
     }
@@ -260,14 +260,14 @@ where
         timestamped_test_log("syncking transaction confirmation.");
         // chain scan shows the same
         sender.sync_and_await().await.unwrap();
-        let wallet_height_at_confirmation = sender
+        let last_known_chain_height = sender
             .wallet
             .read()
             .await
             .sync_state
-            .wallet_height()
+            .last_known_chain_height()
             .unwrap();
-        timestamped_test_log(format!("wallet height now {wallet_height_at_confirmation}").as_str());
+        timestamped_test_log(format!("wallet height now {last_known_chain_height}").as_str());
         timestamped_test_log("cross-checking confirmed records.");
 
         // check that each record has the expected fee and status, returning the fee and outputs
@@ -312,7 +312,7 @@ where
                     any_transaction_not_yet_confirmed = true;
                 }
                 ConfirmationStatus::Confirmed(confirmed_height) => {
-                    assert!(wallet_height_at_confirmation >= confirmed_height);
+                    assert!(last_known_chain_height >= confirmed_height);
                 }
             }
         }

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -157,7 +157,10 @@ impl LightWallet {
             .is_some_and(|bundle| bundle.is_coinbase());
 
         if is_coinbase {
-            let current_height = self.sync_state.wallet_height().unwrap_or(self.birthday);
+            let current_height = self
+                .sync_state
+                .last_known_chain_height()
+                .unwrap_or(self.birthday);
             let tx_height = transaction.status().get_height();
 
             // Work with u32 values

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -329,7 +329,10 @@ impl LightWallet {
                     .status()
                     .get_confirmed_height()
                     .expect("transaction must be confirmed in this scope")
-                    > self.sync_state.wallet_height().unwrap_or(self.birthday)
+                    > self
+                        .sync_state
+                        .last_known_chain_height()
+                        .unwrap_or(self.birthday)
                 {
                     return Vec::new();
                 }

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -403,11 +403,11 @@ mod tests {
         fn birthday_within_note_shard_range() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(20);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![
@@ -429,11 +429,11 @@ mod tests {
         fn note_within_complete_shard() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(70);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![
@@ -455,11 +455,11 @@ mod tests {
         fn note_within_incomplete_shard() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(170);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![
@@ -481,11 +481,11 @@ mod tests {
         fn note_height_on_shard_boundary() {
             let min_confirmations = 3;
             let wallet_birthday = BlockHeight::from_u32(10);
-            let wallet_height = BlockHeight::from_u32(202);
+            let last_known_chain_height = BlockHeight::from_u32(202);
             let note_height = BlockHeight::from_u32(100);
-            let anchor_height = wallet_height + 1 - min_confirmations;
+            let anchor_height = last_known_chain_height + 1 - min_confirmations;
             let scan_ranges = vec![ScanRange::from_parts(
-                wallet_birthday..wallet_height + 1,
+                wallet_birthday..last_known_chain_height + 1,
                 ScanPriority::Scanned,
             )];
             let shard_ranges = vec![

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -151,7 +151,7 @@ impl WalletRead for LightWallet {
     }
 
     fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
-        Ok(self.sync_state.wallet_height())
+        Ok(self.sync_state.last_known_chain_height())
     }
 
     fn get_block_hash(&self, _block_height: BlockHeight) -> Result<Option<BlockHash>, Self::Error> {
@@ -184,7 +184,7 @@ impl WalletRead for LightWallet {
         &self,
         min_confirmations: NonZeroU32,
     ) -> Result<Option<(TargetHeight, BlockHeight)>, Self::Error> {
-        let target_height = if let Some(height) = self.sync_state.wallet_height() {
+        let target_height = if let Some(height) = self.sync_state.last_known_chain_height() {
             height + 1
         } else {
             return Ok(None);


### PR DESCRIPTION
This builds on the #2140.

A reviewer could merge this into the feature branch first, and then merge that PR into dev..  or if that lands in dev...  then we could update this to point at dev (if necessary). 


As with PR #2140 the intention is to cleanly encapsulate a name change into one PR and commit.

As with #2140 the rationale is that a slightly more descriptive name makes the code more readable to people new to the code.

In this case the "new" name is a verbatim copy from the doc-comment associated with the updated method.