### PR TITLE
Adding Sapling Height fallback

### DIFF
--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1614,7 +1614,7 @@ fn checked_birthday<W: SyncWallet>(
     let wallet_birthday = wallet.get_birthday()?;
     let sapling_activation_height = consensus_parameters
         .activation_height(consensus::NetworkUpgrade::Sapling)
-        .expect("sapling activation height should always return Some");
+        .unwrap_or(BlockHeight::from_u32(1));
 
     match wallet_birthday.cmp(&sapling_activation_height) {
         cmp::Ordering::Greater | cmp::Ordering::Equal => Ok(wallet_birthday),


### PR DESCRIPTION
Summary
This replaces a hard expect on sapling activation height with a safe fallback to BlockHeight::from_u32(1), avoiding a panic in
edge cases.

Changes

Use unwrap_or(BlockHeight::from_u32(1)) for sapling activation height.
Keep wallet birthday comparison logic unchanged.