### PR TITLE
Refactor remove failed transaction

### DIFF
--- a/pepper-sync/Cargo.toml
+++ b/pepper-sync/Cargo.toml
@@ -17,6 +17,8 @@ default = ["wallet_essentials"]
 wallet_essentials = ["dep:byteorder", "dep:zcash_encoding"]
 # removes failing calls to `GetSubTreeRoots` in darkside testing
 darkside_test = []
+# exposes test constructors for wallet types
+test-features = []
 
 [dependencies]
 # Zingo

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -611,6 +611,42 @@ impl WalletTransaction {
     }
 }
 
+#[cfg(feature = "test-features")]
+impl WalletTransaction {
+    /// Creates a minimal `WalletTransaction` for testing purposes.
+    ///
+    /// Constructs a valid v5 transaction with empty bundles and the given `txid` and `status`.
+    pub fn new_for_test(txid: TxId, status: ConfirmationStatus) -> Self {
+        use zcash_primitives::transaction::{TransactionData, TxVersion};
+        use zcash_protocol::consensus::BranchId;
+
+        let transaction = TransactionData::from_parts(
+            TxVersion::V5,
+            BranchId::Nu5,
+            0,
+            BlockHeight::from_u32(0),
+            None,
+            None,
+            None,
+            None,
+        )
+        .freeze()
+        .expect("empty v5 transaction should always be valid");
+
+        Self {
+            txid,
+            status,
+            transaction,
+            datetime: 0,
+            transparent_coins: Vec::new(),
+            sapling_notes: Vec::new(),
+            orchard_notes: Vec::new(),
+            outgoing_sapling_notes: Vec::new(),
+            outgoing_orchard_notes: Vec::new(),
+        }
+    }
+}
+
 #[cfg(feature = "wallet_essentials")]
 impl WalletTransaction {
     /// Returns the total value sent to receivers, excluding value sent to the wallet's own addresses.

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -113,6 +113,7 @@ tempfile = { workspace = true, optional = true }
 rust-embed = { workspace = true, features = ["debug-embed"] }
 
 [dev-dependencies]
+pepper-sync = { workspace = true, features = ["test-features"] }
 portpicker = { workspace = true }
 tempfile = { workspace = true }
 zingolib = { workspace = true, features = ["testutils"] }

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -98,18 +98,19 @@ impl LightWallet {
     ///
     /// Returns error if transaction is not `Failed` or does not exist in the wallet.
     pub fn remove_failed_transaction(&mut self, txid: TxId) -> Result<(), WalletError> {
-        if let Some(transaction) = self.wallet_transactions.get(&txid) {
-            if !transaction.status().is_failed() {
-                return Err(WalletError::RemovalError);
+        match self
+            .wallet_transactions
+            .get(&txid)
+            .map(|tx| tx.status().is_failed())
+        {
+            Some(true) => {
+                self.wallet_transactions.remove(&txid);
+                self.save_required = true;
+                Ok(())
             }
-        } else {
-            return Err(WalletError::TransactionNotFound(txid));
+            Some(false) => Err(WalletError::RemovalError),
+            None => Err(WalletError::TransactionNotFound(txid)),
         }
-
-        self.wallet_transactions.remove(&txid);
-        self.save_required = true;
-
-        Ok(())
     }
 
     /// Determine the kind of transaction from the current state of wallet data.

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -172,3 +172,80 @@ impl LightWallet {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use pepper_sync::{
+        config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery},
+        wallet::WalletTransaction,
+    };
+    use zcash_primitives::transaction::TxId;
+    use zingo_status::confirmation_status::ConfirmationStatus;
+
+    use crate::{
+        config::ZingoConfigBuilder,
+        wallet::{LightWallet, WalletBase, WalletSettings, error::WalletError},
+    };
+
+    fn test_wallet() -> LightWallet {
+        let config = ZingoConfigBuilder::default().create();
+        LightWallet::new(
+            config.chain,
+            WalletBase::FreshEntropy {
+                no_of_accounts: 1.try_into().unwrap(),
+            },
+            1.into(),
+            WalletSettings {
+                sync_config: SyncConfig {
+                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                    performance_level: PerformanceLevel::High,
+                },
+                min_confirmations: NonZeroU32::try_from(1).unwrap(),
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn remove_failed_transaction_not_found() {
+        let mut wallet = test_wallet();
+        let txid = TxId::from_bytes([0u8; 32]);
+
+        let result = wallet.remove_failed_transaction(txid);
+
+        assert!(matches!(result, Err(WalletError::TransactionNotFound(id)) if id == txid));
+    }
+
+    #[test]
+    fn remove_failed_transaction_not_failed() {
+        let mut wallet = test_wallet();
+        let txid = TxId::from_bytes([1u8; 32]);
+        let status = ConfirmationStatus::Calculated(1.into());
+        wallet
+            .wallet_transactions
+            .insert(txid, WalletTransaction::new_for_test(txid, status));
+
+        let result = wallet.remove_failed_transaction(txid);
+
+        assert!(matches!(result, Err(WalletError::RemovalError)));
+        assert!(wallet.wallet_transactions.contains_key(&txid));
+    }
+
+    #[test]
+    fn remove_failed_transaction_success() {
+        let mut wallet = test_wallet();
+        let txid = TxId::from_bytes([2u8; 32]);
+        let status = ConfirmationStatus::Failed(1.into());
+        wallet
+            .wallet_transactions
+            .insert(txid, WalletTransaction::new_for_test(txid, status));
+
+        let result = wallet.remove_failed_transaction(txid);
+
+        assert!(result.is_ok());
+        assert!(!wallet.wallet_transactions.contains_key(&txid));
+        assert!(wallet.save_required);
+    }
+}


### PR DESCRIPTION
Fixes: #2183 

This refactor makes remove_failed_transaction slightly more readable and coherent and tests each of the three obvious cases.