### PR TITLE
clean up for zingolib v3.0.0 rc

### DIFF
--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -81,7 +81,7 @@ pub(crate) mod conduct_chain {
                         mnemonic: Mnemonic::from_phrase(DARKSIDE_SEED.to_string()).unwrap(),
                         no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
                     },
-                    0.into(),
+                    1.into(),
                     config.wallet_settings.clone(),
                 )
                 .unwrap(),

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -397,7 +397,7 @@ pub mod scenarios {
             assert!(self.faucet.is_none(), "Error: Faucet already exists!");
             self.faucet = Some(self.client_builder.build_client(
                 zingo_test_vectors::seeds::DARKSIDE_SEED.to_string(),
-                0,
+                1,
                 true,
                 self.configured_activation_heights,
             ));

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -27,7 +27,7 @@ async fn simple_sync() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id, wallet_dir).build_client(
         DARKSIDE_SEED.to_string(),
-        0,
+        1,
         true,
         activation_heights,
     );
@@ -71,7 +71,7 @@ async fn reorg_receipt_sync_generic() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
         DARKSIDE_SEED.to_string(),
-        0,
+        1,
         true,
         activation_heights,
     );

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -466,7 +466,7 @@ mod fast {
             client_builder.build_faucet(true, local_net.validator().get_activation_heights().await);
         let mut recipient = client_builder.build_client(
             HOSPITAL_MUSEUM_SEED.to_string(),
-            0,
+            1,
             true,
             local_net.validator().get_activation_heights().await,
         );
@@ -516,7 +516,7 @@ mod fast {
         // rebuild recipient and check the UAs don't exist in the wallet
         let mut recipient = client_builder.build_client(
             HOSPITAL_MUSEUM_SEED.to_string(),
-            0,
+            1,
             true,
             local_net.validator().get_activation_heights().await,
         );
@@ -1196,7 +1196,7 @@ mod fast {
             .to_string();
         let mut recipient = client_builder.build_client(
             seed_phrase,
-            0,
+            1,
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -1269,7 +1269,7 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
 
         let client_b = client_builder.build_client(
             HOSPITAL_MUSEUM_SEED.to_string(),
-            0,
+            1,
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -1780,7 +1780,7 @@ mod slow {
             .build_faucet(false, local_net.validator().get_activation_heights().await);
         let mut original_recipient = client_builder.build_client(
             HOSPITAL_MUSEUM_SEED.to_string(),
-            0,
+            1,
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -3399,7 +3399,7 @@ TransactionSummary {
             .build_faucet(false, local_net.validator().get_activation_heights().await);
         let mut pool_migration_client = client_builder.build_client(
             HOSPITAL_MUSEUM_SEED.to_string(),
-            0,
+            1,
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -3444,7 +3444,7 @@ TransactionSummary {
             .build_faucet(false, local_net.validator().get_activation_heights().await);
         let mut client = client_builder.build_client(
             HOSPITAL_MUSEUM_SEED.to_string(),
-            0,
+            1,
             false,
             local_net.validator().get_activation_heights().await,
         );

--- a/pepper-sync/src/error.rs
+++ b/pepper-sync/src/error.rs
@@ -29,6 +29,11 @@ where
     /// Chain error.
     #[error("wallet height {0} is more than {1} blocks ahead of best chain height {2}")]
     ChainError(u32, u32, u32),
+    /// Birthday below sapling error.
+    #[error(
+        "birthday {0} below sapling activation height {1}. pre-sapling wallets are not supported!"
+    )]
+    BirthdayBelowSapling(u32, u32),
     /// Shard tree error.
     #[error("shard tree error. {0}")]
     ShardTreeError(#[from] ShardTreeError<Infallible>),

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1,6 +1,5 @@
 //! Entrypoint for sync engine
 
-use std::cmp;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Range;
 use std::sync::Arc;
@@ -32,6 +31,7 @@ use crate::keys::transparent::TransparentAddressId;
 use crate::scan::ScanResults;
 use crate::scan::task::{Scanner, ScannerState};
 use crate::scan::transactions::scan_transaction;
+use crate::sync::state::truncate_scan_ranges;
 use crate::wallet::traits::{
     SyncBlocks, SyncNullifiers, SyncOutPoints, SyncShardTrees, SyncTransactions, SyncWallet,
 };
@@ -396,15 +396,14 @@ where
     )
     .await?;
 
-    state::update_scan_ranges(
+    let initial_reorg_detection_start_height = state::update_scan_ranges(
         consensus_parameters,
         last_known_chain_height,
         chain_height,
         wallet_guard
             .get_sync_state_mut()
             .map_err(SyncError::WalletError)?,
-    )
-    .await;
+    );
 
     state::set_initial_state(
         consensus_parameters,
@@ -413,13 +412,6 @@ where
         chain_height,
     )
     .await?;
-
-    let initial_unscanned_height = wallet_guard
-        .get_sync_state()
-        .map_err(SyncError::WalletError)?
-        .highest_scanned_height()
-        .expect("scan ranges must be non-empty")
-        + 1;
 
     expire_transactions(&mut *wallet_guard)?;
 
@@ -451,7 +443,7 @@ where
                     &ufvks,
                     scan_range,
                     scan_results,
-                    initial_unscanned_height,
+                    initial_reorg_detection_start_height,
                     config.performance_level,
                     &mut nullifier_map_limit_exceeded,
                 )
@@ -591,9 +583,9 @@ where
     })
 }
 
-/// This ensures that the height used as the initial bound of the sync is valid.
-/// The comparison takes two input heights and uses several constants to select the best height
-/// to bound the sync.
+/// This ensures that the wallet height used to calculate the lower bound for scan range creation is valid.
+/// The comparison takes two input heights and uses several constants to select the correct height.
+///
 /// The input parameter heights are:
 ///
 ///   (1) chain_height:
@@ -603,10 +595,9 @@ where
 ///
 /// The constants are:
 ///   (1) MAX_REORG_ALLOWANCE:
-///       * the number of blocks AHEAD of proxy_reported_chain_height allowed
-///   (2) Sapling Epoch Height:
+///       * the maximum number of blocks the wallet can truncate during re-org detection
+///   (2) Sapling Activation Height:
 ///       * the lower bound on the wallet birthday
-///
 fn checked_wallet_height<W, P>(
     wallet: &mut W,
     chain_height: BlockHeight,
@@ -618,7 +609,6 @@ where
 {
     let sync_state = wallet.get_sync_state().map_err(SyncError::WalletError)?;
     if let Some(last_known_chain_height) = sync_state.last_known_chain_height() {
-        dbg!(&last_known_chain_height);
         if last_known_chain_height > chain_height {
             if last_known_chain_height - chain_height >= MAX_REORG_ALLOWANCE {
                 // There's a human attention requiring problem, the wallet supplied
@@ -630,273 +620,35 @@ where
                     u32::from(chain_height),
                 ));
             }
-            truncate_wallet_data(wallet, chain_height)?;
             // The wallet reported height is above the current proxy height
             // reset to the proxy height.
+            truncate_wallet_data(wallet, chain_height)?;
             return Ok(chain_height);
         }
-        // The last wallet reported height is equal or below the proxy height
-        // since it was derived from a bday in an earlier scan, we don't check its
-        // lower bound.
-        // TODO:  Think through the possibilty of syncing to a short side chain,
-        // this logic doesn't explicitly handle the scan, but the overlap of range
-        // bounds may handle it elsewhere.
+        // The last wallet reported height is equal or below the proxy height.
         Ok(last_known_chain_height)
     } else {
-        dbg!("There was a syncstate, but no last_known_chain_height!!");
-        let raw_bday = wallet.get_birthday().map_err(SyncError::WalletError)?;
-        if raw_bday > chain_height {
-            // Human attention requiring error, a bday *above* the proxy reported
-            // chain tipe has been provided
+        // This is the wallet's first sync. Use [birthday - 1] as wallet height.
+        let sapling_activation_height = consensus_parameters
+            .activation_height(consensus::NetworkUpgrade::Sapling)
+            .expect("sapling activation height should always return Some");
+        let birthday = wallet.get_birthday().map_err(SyncError::WalletError)?;
+        if birthday > chain_height {
+            // Human attention requiring error, a birthday *above* the proxy reported
+            // chain height has been provided.
             return Err(SyncError::ChainError(
-                u32::from(raw_bday),
+                u32::from(birthday),
                 MAX_REORG_ALLOWANCE,
                 u32::from(chain_height),
             ));
-        }
-        // The bday is set with a floor of the Sapling Epoch -1
-        // TODO:  Confirm that the Sapling Epoch -1 is the correct floor
-        Ok(sapling_floored_bday(consensus_parameters, raw_bday) - 1)
-    }
-}
-#[cfg(test)]
-mod test {
-
-    mod checked_height_validation {
-        use zcash_protocol::consensus::BlockHeight;
-        use zcash_protocol::local_consensus::LocalNetwork;
-        const LOCAL_NETWORK: LocalNetwork = LocalNetwork {
-            overwinter: Some(BlockHeight::from_u32(1)),
-            sapling: Some(BlockHeight::from_u32(3)),
-            blossom: Some(BlockHeight::from_u32(3)),
-            heartwood: Some(BlockHeight::from_u32(3)),
-            canopy: Some(BlockHeight::from_u32(3)),
-            nu5: Some(BlockHeight::from_u32(3)),
-            nu6: Some(BlockHeight::from_u32(3)),
-            nu6_1: Some(BlockHeight::from_u32(3)),
-        };
-        use crate::{error::SyncError, mocks::MockWalletError, sync::checked_wallet_height};
-        // It's possible an error from an implementor's get_sync_state could bubble up to checked_wallet_height
-        // this test shows that such an error is raies wrapped in a WalletError and return as the Err variant
-        #[tokio::test]
-        async fn get_sync_state_error() {
-            let builder = crate::mocks::MockWalletBuilder::new();
-            let test_error = "get_sync_state_error";
-            let mut test_wallet = builder
-                .get_sync_state_patch(Box::new(|_| {
-                    Err(MockWalletError::AnErrorVariant(test_error.to_string()))
-                }))
-                .create_mock_wallet();
-            let res =
-                checked_wallet_height(&mut test_wallet, BlockHeight::from_u32(1), &LOCAL_NETWORK);
-            assert!(matches!(
-                res,
-                Err(SyncError::WalletError(
-                    crate::mocks::MockWalletError::AnErrorVariant(ref s)
-                )) if s == test_error
+        } else if birthday < sapling_activation_height {
+            return Err(SyncError::BirthdayBelowSapling(
+                u32::from(birthday),
+                u32::from(sapling_activation_height),
             ));
         }
 
-        mod last_known_chain_height {
-            use crate::{
-                sync::{MAX_REORG_ALLOWANCE, ScanRange},
-                wallet::SyncState,
-            };
-            const DEFAULT_START_HEIGHT: BlockHeight = BlockHeight::from_u32(1);
-            const _DEFAULT_LAST_KNOWN_HEIGHT: BlockHeight = BlockHeight::from_u32(102);
-            const DEFAULT_CHAIN_HEIGHT: BlockHeight = BlockHeight::from_u32(110);
-
-            use super::*;
-            #[tokio::test]
-            async fn above_allowance() {
-                const LAST_KNOWN_HEIGHT: BlockHeight = BlockHeight::from_u32(211);
-                let lkch = vec![ScanRange::from_parts(
-                    DEFAULT_START_HEIGHT..LAST_KNOWN_HEIGHT,
-                    crate::sync::ScanPriority::Scanned,
-                )];
-                let state = SyncState {
-                    scan_ranges: lkch,
-                    ..Default::default()
-                };
-                let builder = crate::mocks::MockWalletBuilder::new();
-                let mut test_wallet = builder.sync_state(state).create_mock_wallet();
-                let res =
-                    checked_wallet_height(&mut test_wallet, DEFAULT_CHAIN_HEIGHT, &LOCAL_NETWORK);
-                if let Err(e) = res {
-                    assert_eq!(
-                        e.to_string(),
-                        format!(
-                            "wallet height {} is more than {} blocks ahead of best chain height {}",
-                            LAST_KNOWN_HEIGHT - 1,
-                            MAX_REORG_ALLOWANCE,
-                            DEFAULT_CHAIN_HEIGHT
-                        )
-                    );
-                } else {
-                    panic!()
-                }
-            }
-            #[tokio::test]
-            async fn above_chain_height_below_allowance() {
-                // The hain_height is received from the proxy
-                // truncate uses the wallet scan start height
-                // as a
-                let lkch = vec![ScanRange::from_parts(
-                    BlockHeight::from_u32(6)..BlockHeight::from_u32(10),
-                    crate::sync::ScanPriority::Scanned,
-                )];
-                let state = SyncState {
-                    scan_ranges: lkch,
-                    ..Default::default()
-                };
-                let builder = crate::mocks::MockWalletBuilder::new();
-                let mut test_wallet = builder.sync_state(state).create_mock_wallet();
-                let chain_height = BlockHeight::from_u32(4);
-                // This will trigger a call to truncate_wallet_data with
-                // chain_height and start_height inferred from the wallet.
-                // chain must be greater than by this time which hits the Greater cmp
-                // match
-                let res = checked_wallet_height(&mut test_wallet, chain_height, &LOCAL_NETWORK);
-                assert_eq!(res.unwrap(), BlockHeight::from_u32(4));
-            }
-            #[ignore = "in progress"]
-            #[tokio::test]
-            async fn equal_or_below_chain_height_and_above_sapling() {
-                let lkch = vec![ScanRange::from_parts(
-                    BlockHeight::from_u32(1)..BlockHeight::from_u32(10),
-                    crate::sync::ScanPriority::Scanned,
-                )];
-                let state = SyncState {
-                    scan_ranges: lkch,
-                    ..Default::default()
-                };
-                let builder = crate::mocks::MockWalletBuilder::new();
-                let mut _test_wallet = builder.sync_state(state).create_mock_wallet();
-            }
-            #[ignore = "in progress"]
-            #[tokio::test]
-            async fn equal_or_below_chain_height_and_below_sapling() {
-                // This case requires that the wallet have a scan_start_below sapling
-                // which is an unexpected state.
-                let lkch = vec![ScanRange::from_parts(
-                    BlockHeight::from_u32(1)..BlockHeight::from_u32(10),
-                    crate::sync::ScanPriority::Scanned,
-                )];
-                let state = SyncState {
-                    scan_ranges: lkch,
-                    ..Default::default()
-                };
-                let builder = crate::mocks::MockWalletBuilder::new();
-                let mut _test_wallet = builder.sync_state(state).create_mock_wallet();
-            }
-            #[ignore = "in progress"]
-            #[tokio::test]
-            async fn below_sapling() {
-                let lkch = vec![ScanRange::from_parts(
-                    BlockHeight::from_u32(1)..BlockHeight::from_u32(10),
-                    crate::sync::ScanPriority::Scanned,
-                )];
-                let state = SyncState {
-                    scan_ranges: lkch,
-                    ..Default::default()
-                };
-                let builder = crate::mocks::MockWalletBuilder::new();
-                let mut _test_wallet = builder.sync_state(state).create_mock_wallet();
-            }
-        }
-        mod no_last_known_chain_height {
-            use super::*;
-            // If there are know scan_ranges in the SyncState
-            #[tokio::test]
-            async fn get_bday_error() {
-                let test_error = "get_bday_error";
-                let builder = crate::mocks::MockWalletBuilder::new();
-                let mut test_wallet = builder
-                    .get_birthday_patch(Box::new(|_| {
-                        Err(crate::mocks::MockWalletError::AnErrorVariant(
-                            test_error.to_string(),
-                        ))
-                    }))
-                    .create_mock_wallet();
-                let res = checked_wallet_height(
-                    &mut test_wallet,
-                    BlockHeight::from_u32(1),
-                    &LOCAL_NETWORK,
-                );
-                assert!(matches!(
-                    res,
-                    Err(SyncError::WalletError(
-                        crate::mocks::MockWalletError::AnErrorVariant(ref s)
-                    )) if s == test_error
-                ));
-            }
-            #[ignore = "in progress"]
-            #[tokio::test]
-            async fn raw_bday_above_chain_height() {
-                let builder = crate::mocks::MockWalletBuilder::new();
-                let mut test_wallet = builder
-                    .birthday(BlockHeight::from_u32(15))
-                    .create_mock_wallet();
-                let res = checked_wallet_height(
-                    &mut test_wallet,
-                    BlockHeight::from_u32(1),
-                    &LOCAL_NETWORK,
-                );
-                if let Err(e) = res {
-                    assert_eq!(
-                        e.to_string(),
-                        format!(
-                            "wallet height is more than {} blocks ahead of best chain height",
-                            15 - 1
-                        )
-                    );
-                } else {
-                    panic!()
-                }
-            }
-            mod sapling_height {
-                use super::*;
-                #[tokio::test]
-                async fn raw_bday_above() {
-                    let builder = crate::mocks::MockWalletBuilder::new();
-                    let mut test_wallet = builder
-                        .birthday(BlockHeight::from_u32(4))
-                        .create_mock_wallet();
-                    let res = checked_wallet_height(
-                        &mut test_wallet,
-                        BlockHeight::from_u32(5),
-                        &LOCAL_NETWORK,
-                    );
-                    assert_eq!(res.unwrap(), BlockHeight::from_u32(4 - 1));
-                }
-                #[tokio::test]
-                async fn raw_bday_equal() {
-                    let builder = crate::mocks::MockWalletBuilder::new();
-                    let mut test_wallet = builder
-                        .birthday(BlockHeight::from_u32(3))
-                        .create_mock_wallet();
-                    let res = checked_wallet_height(
-                        &mut test_wallet,
-                        BlockHeight::from_u32(5),
-                        &LOCAL_NETWORK,
-                    );
-                    assert_eq!(res.unwrap(), BlockHeight::from_u32(3 - 1));
-                }
-                #[tokio::test]
-                async fn raw_bday_below() {
-                    let builder = crate::mocks::MockWalletBuilder::new();
-                    let mut test_wallet = builder
-                        .birthday(BlockHeight::from_u32(1))
-                        .create_mock_wallet();
-                    let res = checked_wallet_height(
-                        &mut test_wallet,
-                        BlockHeight::from_u32(5),
-                        &LOCAL_NETWORK,
-                    );
-                    assert_eq!(res.unwrap(), BlockHeight::from_u32(3 - 1));
-                }
-            }
-        }
+        Ok(birthday - 1)
     }
 }
 
@@ -935,7 +687,7 @@ where
     let total_blocks_scanned = state::calculate_scanned_blocks(sync_state);
 
     let start_height = sync_state
-        .get_initial_scan_height()
+        .wallet_birthday()
         .ok_or(SyncStatusError::NoSyncData)?;
     let last_known_chain_height = sync_state
         .last_known_chain_height()
@@ -1218,7 +970,7 @@ async fn process_scan_results<W>(
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
     scan_range: ScanRange,
     scan_results: Result<ScanResults, ScanError>,
-    initial_unscanned_height: BlockHeight,
+    initial_reorg_detection_start_height: BlockHeight,
     performance_level: PerformanceLevel,
     nullifier_map_limit_exceeded: &mut bool,
 ) -> Result<(), SyncError<W::Error>>
@@ -1489,7 +1241,7 @@ where
                 );
 
                 // extend verification range to VERIFY_BLOCK_RANGE_SIZE blocks below current verification range
-                let verification_start = state::set_verify_scan_range(
+                let current_reorg_detection_start_height = state::set_verify_scan_range(
                     sync_state,
                     height - 1,
                     state::VerifyEnd::VerifyHighest,
@@ -1498,13 +1250,15 @@ where
                 .start;
                 state::merge_scan_ranges(sync_state, ScanPriority::Verify);
 
-                if initial_unscanned_height - verification_start > MAX_REORG_ALLOWANCE {
+                if initial_reorg_detection_start_height - current_reorg_detection_start_height
+                    > MAX_REORG_ALLOWANCE
+                {
                     clear_wallet_data(wallet)?;
 
                     return Err(ServerError::ChainVerificationError.into());
                 }
 
-                truncate_wallet_data(wallet, verification_start - 1)?;
+                truncate_wallet_data(wallet, current_reorg_detection_start_height - 1)?;
 
                 state::set_initial_state(
                     consensus_parameters,
@@ -1594,15 +1348,24 @@ fn truncate_wallet_data<W>(
 where
     W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints + SyncShardTrees,
 {
-    let start_height = wallet
-        .get_sync_state()
-        .map_err(SyncError::WalletError)?
-        .get_initial_scan_height()
+    let sync_state = wallet
+        .get_sync_state_mut()
+        .map_err(SyncError::WalletError)?;
+    let highest_scanned_height = sync_state
+        .highest_scanned_height()
         .expect("should be non-empty in this scope");
-    let checked_truncate_height = match truncate_height.cmp(&start_height) {
+    let wallet_birthday = sync_state
+        .wallet_birthday()
+        .expect("should be non-empty in this scope");
+    let checked_truncate_height = match truncate_height.cmp(&wallet_birthday) {
         std::cmp::Ordering::Greater | std::cmp::Ordering::Equal => truncate_height,
         std::cmp::Ordering::Less => consensus::H0,
     };
+    truncate_scan_ranges(checked_truncate_height, sync_state);
+
+    if checked_truncate_height > highest_scanned_height {
+        return Ok(());
+    }
 
     wallet
         .truncate_wallet_blocks(checked_truncate_height)
@@ -1973,8 +1736,7 @@ async fn add_initial_frontier<W>(
 where
     W: SyncWallet + SyncShardTrees,
 {
-    let raw_bday = wallet.get_birthday().map_err(SyncError::WalletError)?;
-    let birthday = sapling_floored_bday(consensus_parameters, raw_bday);
+    let birthday = wallet.get_birthday().map_err(SyncError::WalletError)?;
     if birthday
         == consensus_parameters
             .activation_height(consensus::NetworkUpgrade::Sapling)
@@ -2019,21 +1781,6 @@ where
     }
 
     Ok(())
-}
-
-/// Compares the wallet birthday to sapling activation height and returns the highest block height.
-fn sapling_floored_bday(
-    consensus_parameters: &impl consensus::Parameters,
-    raw_birthday: BlockHeight,
-) -> BlockHeight {
-    let sapling_activation_height = consensus_parameters
-        .activation_height(consensus::NetworkUpgrade::Sapling)
-        .expect("sapling activation height should always return Some");
-
-    match raw_birthday.cmp(&sapling_activation_height) {
-        cmp::Ordering::Greater => raw_birthday,
-        cmp::Ordering::Less | cmp::Ordering::Equal => sapling_activation_height,
-    }
 }
 
 /// Sets up mempool stream.
@@ -2138,5 +1885,246 @@ fn max_nullifier_map_size(performance_level: PerformanceLevel) -> Option<usize> 
         PerformanceLevel::Medium => Some(125_000),
         PerformanceLevel::High => Some(2_000_000),
         PerformanceLevel::Maximum => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    mod checked_height_validation {
+        use zcash_protocol::consensus::BlockHeight;
+        use zcash_protocol::local_consensus::LocalNetwork;
+        const LOCAL_NETWORK: LocalNetwork = LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(1)),
+            sapling: Some(BlockHeight::from_u32(3)),
+            blossom: Some(BlockHeight::from_u32(3)),
+            heartwood: Some(BlockHeight::from_u32(3)),
+            canopy: Some(BlockHeight::from_u32(3)),
+            nu5: Some(BlockHeight::from_u32(3)),
+            nu6: Some(BlockHeight::from_u32(3)),
+            nu6_1: Some(BlockHeight::from_u32(3)),
+        };
+        use crate::{error::SyncError, mocks::MockWalletError, sync::checked_wallet_height};
+        // It's possible an error from an implementor's get_sync_state could bubble up to checked_wallet_height
+        // this test shows that such an error is raies wrapped in a WalletError and return as the Err variant
+        #[tokio::test]
+        async fn get_sync_state_error() {
+            let builder = crate::mocks::MockWalletBuilder::new();
+            let test_error = "get_sync_state_error";
+            let mut test_wallet = builder
+                .get_sync_state_patch(Box::new(|_| {
+                    Err(MockWalletError::AnErrorVariant(test_error.to_string()))
+                }))
+                .create_mock_wallet();
+            let res =
+                checked_wallet_height(&mut test_wallet, BlockHeight::from_u32(1), &LOCAL_NETWORK);
+            assert!(matches!(
+                res,
+                Err(SyncError::WalletError(
+                    crate::mocks::MockWalletError::AnErrorVariant(ref s)
+                )) if s == test_error
+            ));
+        }
+
+        mod last_known_chain_height {
+            use crate::{
+                sync::{MAX_REORG_ALLOWANCE, ScanRange},
+                wallet::SyncState,
+            };
+            const DEFAULT_START_HEIGHT: BlockHeight = BlockHeight::from_u32(1);
+            const _DEFAULT_LAST_KNOWN_HEIGHT: BlockHeight = BlockHeight::from_u32(102);
+            const DEFAULT_CHAIN_HEIGHT: BlockHeight = BlockHeight::from_u32(110);
+
+            use super::*;
+            #[tokio::test]
+            async fn above_allowance() {
+                const LAST_KNOWN_HEIGHT: BlockHeight = BlockHeight::from_u32(211);
+                let lkch = vec![ScanRange::from_parts(
+                    DEFAULT_START_HEIGHT..LAST_KNOWN_HEIGHT,
+                    crate::sync::ScanPriority::Scanned,
+                )];
+                let state = SyncState {
+                    scan_ranges: lkch,
+                    ..Default::default()
+                };
+                let builder = crate::mocks::MockWalletBuilder::new();
+                let mut test_wallet = builder.sync_state(state).create_mock_wallet();
+                let res =
+                    checked_wallet_height(&mut test_wallet, DEFAULT_CHAIN_HEIGHT, &LOCAL_NETWORK);
+                if let Err(e) = res {
+                    assert_eq!(
+                        e.to_string(),
+                        format!(
+                            "wallet height {} is more than {} blocks ahead of best chain height {}",
+                            LAST_KNOWN_HEIGHT - 1,
+                            MAX_REORG_ALLOWANCE,
+                            DEFAULT_CHAIN_HEIGHT
+                        )
+                    );
+                } else {
+                    panic!()
+                }
+            }
+            #[tokio::test]
+            async fn above_chain_height_below_allowance() {
+                // The hain_height is received from the proxy
+                // truncate uses the wallet scan start height
+                // as a
+                let lkch = vec![ScanRange::from_parts(
+                    BlockHeight::from_u32(6)..BlockHeight::from_u32(10),
+                    crate::sync::ScanPriority::Scanned,
+                )];
+                let state = SyncState {
+                    scan_ranges: lkch,
+                    ..Default::default()
+                };
+                let builder = crate::mocks::MockWalletBuilder::new();
+                let mut test_wallet = builder.sync_state(state).create_mock_wallet();
+                let chain_height = BlockHeight::from_u32(4);
+                // This will trigger a call to truncate_wallet_data with
+                // chain_height and start_height inferred from the wallet.
+                // chain must be greater than by this time which hits the Greater cmp
+                // match
+                let res = checked_wallet_height(&mut test_wallet, chain_height, &LOCAL_NETWORK);
+                assert_eq!(res.unwrap(), BlockHeight::from_u32(4));
+            }
+            #[ignore = "in progress"]
+            #[tokio::test]
+            async fn equal_or_below_chain_height_and_above_sapling() {
+                let lkch = vec![ScanRange::from_parts(
+                    BlockHeight::from_u32(1)..BlockHeight::from_u32(10),
+                    crate::sync::ScanPriority::Scanned,
+                )];
+                let state = SyncState {
+                    scan_ranges: lkch,
+                    ..Default::default()
+                };
+                let builder = crate::mocks::MockWalletBuilder::new();
+                let mut _test_wallet = builder.sync_state(state).create_mock_wallet();
+            }
+            #[ignore = "in progress"]
+            #[tokio::test]
+            async fn equal_or_below_chain_height_and_below_sapling() {
+                // This case requires that the wallet have a scan_start_below sapling
+                // which is an unexpected state.
+                let lkch = vec![ScanRange::from_parts(
+                    BlockHeight::from_u32(1)..BlockHeight::from_u32(10),
+                    crate::sync::ScanPriority::Scanned,
+                )];
+                let state = SyncState {
+                    scan_ranges: lkch,
+                    ..Default::default()
+                };
+                let builder = crate::mocks::MockWalletBuilder::new();
+                let mut _test_wallet = builder.sync_state(state).create_mock_wallet();
+            }
+            #[ignore = "in progress"]
+            #[tokio::test]
+            async fn below_sapling() {
+                let lkch = vec![ScanRange::from_parts(
+                    BlockHeight::from_u32(1)..BlockHeight::from_u32(10),
+                    crate::sync::ScanPriority::Scanned,
+                )];
+                let state = SyncState {
+                    scan_ranges: lkch,
+                    ..Default::default()
+                };
+                let builder = crate::mocks::MockWalletBuilder::new();
+                let mut _test_wallet = builder.sync_state(state).create_mock_wallet();
+            }
+        }
+        mod no_last_known_chain_height {
+            use super::*;
+            // If there are know scan_ranges in the SyncState
+            #[tokio::test]
+            async fn get_bday_error() {
+                let test_error = "get_bday_error";
+                let builder = crate::mocks::MockWalletBuilder::new();
+                let mut test_wallet = builder
+                    .get_birthday_patch(Box::new(|_| {
+                        Err(crate::mocks::MockWalletError::AnErrorVariant(
+                            test_error.to_string(),
+                        ))
+                    }))
+                    .create_mock_wallet();
+                let res = checked_wallet_height(
+                    &mut test_wallet,
+                    BlockHeight::from_u32(1),
+                    &LOCAL_NETWORK,
+                );
+                assert!(matches!(
+                    res,
+                    Err(SyncError::WalletError(
+                        crate::mocks::MockWalletError::AnErrorVariant(ref s)
+                    )) if s == test_error
+                ));
+            }
+            #[ignore = "in progress"]
+            #[tokio::test]
+            async fn raw_bday_above_chain_height() {
+                let builder = crate::mocks::MockWalletBuilder::new();
+                let mut test_wallet = builder
+                    .birthday(BlockHeight::from_u32(15))
+                    .create_mock_wallet();
+                let res = checked_wallet_height(
+                    &mut test_wallet,
+                    BlockHeight::from_u32(1),
+                    &LOCAL_NETWORK,
+                );
+                if let Err(e) = res {
+                    assert_eq!(
+                        e.to_string(),
+                        format!(
+                            "wallet height is more than {} blocks ahead of best chain height",
+                            15 - 1
+                        )
+                    );
+                } else {
+                    panic!()
+                }
+            }
+            mod sapling_height {
+                use super::*;
+                #[tokio::test]
+                async fn raw_bday_above() {
+                    let builder = crate::mocks::MockWalletBuilder::new();
+                    let mut test_wallet = builder
+                        .birthday(BlockHeight::from_u32(4))
+                        .create_mock_wallet();
+                    let res = checked_wallet_height(
+                        &mut test_wallet,
+                        BlockHeight::from_u32(5),
+                        &LOCAL_NETWORK,
+                    );
+                    assert_eq!(res.unwrap(), BlockHeight::from_u32(4 - 1));
+                }
+                #[tokio::test]
+                async fn raw_bday_equal() {
+                    let builder = crate::mocks::MockWalletBuilder::new();
+                    let mut test_wallet = builder
+                        .birthday(BlockHeight::from_u32(3))
+                        .create_mock_wallet();
+                    let res = checked_wallet_height(
+                        &mut test_wallet,
+                        BlockHeight::from_u32(5),
+                        &LOCAL_NETWORK,
+                    );
+                    assert_eq!(res.unwrap(), BlockHeight::from_u32(3 - 1));
+                }
+                #[tokio::test]
+                async fn raw_bday_below() {
+                    let builder = crate::mocks::MockWalletBuilder::new();
+                    let mut test_wallet = builder
+                        .birthday(BlockHeight::from_u32(1))
+                        .create_mock_wallet();
+                    let res = checked_wallet_height(
+                        &mut test_wallet,
+                        BlockHeight::from_u32(5),
+                        &LOCAL_NETWORK,
+                    );
+                    assert_eq!(res.unwrap(), BlockHeight::from_u32(3 - 1));
+                }
+            }
+        }
     }
 }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1420,6 +1420,7 @@ where
         .get_sync_state_mut()
         .map_err(SyncError::WalletError)?;
     add_scan_targets(sync_state, &scan_targets);
+    wallet.set_save_flag().map_err(SyncError::WalletError)?;
 
     Ok(())
 }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1411,16 +1411,15 @@ where
                 })
         })
         .collect::<Vec<_>>();
-    let sync_state = wallet
-        .get_sync_state_mut()
-        .map_err(SyncError::WalletError)?;
-    *sync_state = SyncState::new();
-    add_scan_targets(sync_state, &scan_targets);
     truncate_wallet_data(wallet, consensus::H0)?;
     wallet
         .get_wallet_transactions_mut()
         .map_err(SyncError::WalletError)?
         .clear();
+    let sync_state = wallet
+        .get_sync_state_mut()
+        .map_err(SyncError::WalletError)?;
+    add_scan_targets(sync_state, &scan_targets);
 
     Ok(())
 }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -2122,7 +2122,7 @@ mod test {
                         BlockHeight::from_u32(5),
                         &LOCAL_NETWORK,
                     );
-                    assert_eq!(res.unwrap(), BlockHeight::from_u32(3 - 1));
+                    assert!(matches!(res, Err(SyncError::BirthdayBelowSapling(1, 3))));
                 }
             }
         }

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -155,7 +155,11 @@ fn create_scan_range(
 
 /// Splits the range containing [`truncate_height` + 1] and removes all ranges containing block heights above
 /// `truncate_height`.
+/// If `truncate_height` is zero, the sync state will be cleared completely.
 pub(super) fn truncate_scan_ranges(truncate_height: BlockHeight, sync_state: &mut SyncState) {
+    if truncate_height == zcash_protocol::consensus::H0 {
+        *sync_state = SyncState::new();
+    }
     let Some((index, range_to_split)) = sync_state
         .scan_ranges()
         .iter()

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -62,14 +62,15 @@ fn find_scan_targets(
 }
 
 /// Update scan ranges for scanning.
-pub(super) async fn update_scan_ranges(
+/// Returns the block height that reorg detection will start from.
+pub(super) fn update_scan_ranges(
     consensus_parameters: &impl consensus::Parameters,
     last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     sync_state: &mut SyncState,
-) {
+) -> BlockHeight {
     reset_scan_ranges(sync_state);
-    create_scan_range(last_known_chain_height, chain_height, sync_state).await;
+    create_scan_range(last_known_chain_height, chain_height, sync_state);
     let scan_targets = sync_state.scan_targets.clone();
     set_found_note_scan_ranges(
         consensus_parameters,
@@ -80,13 +81,19 @@ pub(super) async fn update_scan_ranges(
     set_chain_tip_scan_range(consensus_parameters, sync_state, chain_height);
     merge_scan_ranges(sync_state, ScanPriority::ChainTip);
 
-    let verification_height = sync_state
+    let reorg_detection_start_height = sync_state
         .highest_scanned_height()
         .expect("scan ranges must be non-empty")
         + 1;
-    if verification_height <= chain_height {
-        set_verify_scan_range(sync_state, verification_height, VerifyEnd::VerifyLowest);
+    if reorg_detection_start_height <= chain_height {
+        set_verify_scan_range(
+            sync_state,
+            reorg_detection_start_height,
+            VerifyEnd::VerifyLowest,
+        );
     }
+
+    reorg_detection_start_height
 }
 
 /// Merges all adjacent ranges of a given `scan_priority`.
@@ -127,7 +134,7 @@ pub(super) fn merge_scan_ranges(sync_state: &mut SyncState, scan_priority: ScanP
 }
 
 /// Create scan range between the wallet height and the chain height from the server.
-async fn create_scan_range(
+fn create_scan_range(
     last_known_chain_height: BlockHeight,
     chain_height: BlockHeight,
     sync_state: &mut SyncState,
@@ -144,6 +151,31 @@ async fn create_scan_range(
         ScanPriority::Historic,
     );
     sync_state.scan_ranges.push(new_scan_range);
+}
+
+/// Splits the range containing [`truncate_height` + 1] and removes all ranges containing block heights above
+/// `truncate_height`.
+pub(super) fn truncate_scan_ranges(truncate_height: BlockHeight, sync_state: &mut SyncState) {
+    let Some((index, range_to_split)) = sync_state
+        .scan_ranges()
+        .iter()
+        .cloned()
+        .enumerate()
+        .find(|(_index, range)| range.block_range().contains(&(truncate_height + 1)))
+    else {
+        return;
+    };
+
+    if let Some((first_segment, second_segment)) = range_to_split.split_at(truncate_height + 1) {
+        let split_ranges = vec![first_segment, second_segment];
+        sync_state.scan_ranges.splice(index..=index, split_ranges);
+    }
+
+    let truncated_scan_ranges = sync_state.scan_ranges[..sync_state
+        .scan_ranges()
+        .partition_point(|range| range.block_range().start > truncate_height)]
+        .to_vec();
+    sync_state.scan_ranges = truncated_scan_ranges;
 }
 
 /// Resets scan ranges to recover from previous sync interruptions.
@@ -493,7 +525,7 @@ fn determine_block_range(
                 range.end - 1
             } else {
                 sync_state
-                    .get_initial_scan_height()
+                    .wallet_birthday()
                     .expect("scan range should not be empty")
             };
             let end = sync_state
@@ -789,7 +821,7 @@ where
 {
     let sync_state = wallet.get_sync_state().map_err(SyncError::WalletError)?;
     let start_height = sync_state
-        .get_initial_scan_height()
+        .wallet_birthday()
         .expect("scan ranges must be non-empty");
     let fully_scanned_height = sync_state
         .fully_scanned_height()

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -82,9 +82,9 @@ pub struct InitialSyncState {
     pub(crate) wallet_tree_bounds: TreeBounds,
     /// Total number of blocks scanned in previous sync sessions.
     pub(crate) previously_scanned_blocks: u32,
-    /// Total number of sapling outputs to scanned in previous sync sessions.
+    /// Total number of sapling outputs scanned in previous sync sessions.
     pub(crate) previously_scanned_sapling_outputs: u32,
-    /// Total number of orchard outputs to scanned in previous sync sessions.
+    /// Total number of orchard outputs scanned in previous sync sessions.
     pub(crate) previously_scanned_orchard_outputs: u32,
 }
 

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -207,14 +207,14 @@ impl SyncState {
         {
             Some(last_scanned_range.block_range().end - 1)
         } else {
-            self.get_initial_scan_height().map(|start| start - 1)
+            self.wallet_birthday().map(|start| start - 1)
         }
     }
 
     /// Returns the wallet birthday or `None` if `self.scan_ranges` is empty.
     ///
     #[must_use]
-    pub fn get_initial_scan_height(&self) -> Option<BlockHeight> {
+    pub fn wallet_birthday(&self) -> Option<BlockHeight> {
         self.scan_ranges
             .first()
             .map(|range| range.block_range().start)

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -453,7 +453,7 @@ pub fn startup(
             })
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?;
 
-        LightClient::new(config.clone(), chain_height - 100, false)
+        LightClient::new(config.clone(), (chain_height - 100).max(1.into()), false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
     };
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -340,7 +340,7 @@ mod tests {
                     mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
                     no_of_accounts: config.no_of_accounts,
                 },
-                0.into(),
+                1.into(),
                 config.wallet_settings.clone(),
             )
             .unwrap(),
@@ -359,7 +359,7 @@ mod tests {
                     mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
                     no_of_accounts: config.no_of_accounts,
                 },
-                0.into(),
+                1.into(),
                 config.wallet_settings.clone(),
             )
             .unwrap(),

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -191,7 +191,7 @@ mod shielding {
                         .unwrap(),
                     no_of_accounts: 1.try_into().unwrap(),
                 },
-                0.into(),
+                1.into(),
                 WalletSettings {
                     sync_config: SyncConfig {
                         transparent_address_discovery:

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -68,7 +68,7 @@ pub fn build_fvk_client(fvks: &[&Fvk], config: ZingoConfig) -> LightClient {
         LightWallet::new(
             config.chain,
             WalletBase::Ufvk(ufvk),
-            0.into(),
+            1.into(),
             WalletSettings {
                 sync_config: SyncConfig {
                     transparent_address_discovery: TransparentAddressDiscovery::minimal(),

--- a/zingolib/src/testutils/chain_generics/conduct_chain.rs
+++ b/zingolib/src/testutils/chain_generics/conduct_chain.rs
@@ -32,7 +32,7 @@ pub trait ConductChain {
     /// builds an empty client
     async fn create_client(&mut self) -> LightClient {
         let config = self.zingo_config().await;
-        let mut lightclient = LightClient::new(config, 0.into(), false).unwrap();
+        let mut lightclient = LightClient::new(config, 1.into(), false).unwrap();
         lightclient
             .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
             .await

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -414,7 +414,7 @@ impl LightWallet {
             .time_historical_prices_last_updated()
             .is_none()
         {
-            let Some(start_height) = self.sync_state.get_initial_scan_height() else {
+            let Some(start_height) = self.sync_state.wallet_birthday() else {
                 return Err(PriceError::NotInitialised);
             };
             let birthday_block = match self.wallet_blocks.get(&start_height) {

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -93,7 +93,7 @@ impl LightWallet {
     where
         N: NoteInterface,
     {
-        let Some(start_height) = self.sync_state.get_initial_scan_height() else {
+        let Some(start_height) = self.sync_state.wallet_birthday() else {
             return false;
         };
         let scan_ranges = self.sync_state.scan_ranges();

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -200,7 +200,7 @@ impl ClientBuilder {
         //! A "faucet" is a lightclient that receives mining rewards
         self.build_client(
             seeds::ABANDON_ART_SEED.to_string(),
-            0,
+            1,
             overwrite,
             configured_activation_heights,
         )


### PR DESCRIPTION
- reverts naming to use wallet birthday as the code reads much clearer. to avoid previous confusion with sapling activation heights, sync now returns an error if the birthday returned is lower than the sapling activation height.
- fixed a var name and comments that were misleading or incorrect
- added scan range truncation, preventing truncated wallets to still have `last_known_chain_heights` higher than the current `chain_height`