### PR TITLE
Zingo config rework pt2

### DIFF
--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -77,7 +77,7 @@ pub(crate) mod conduct_chain {
                 .client_builder
                 .make_unique_data_dir_and_load_config(self.configured_activation_heights);
             let wallet = LightWallet::new(
-                config.network_type(),
+                config.chain_type(),
                 WalletBase::Mnemonic {
                     mnemonic: Mnemonic::from_phrase(DARKSIDE_SEED.to_string()).unwrap(),
                     no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -148,7 +148,7 @@ mod fast {
     use zingo_common_components::protocol::ActivationHeights;
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingolib::{
-        config::ZENNIES_FOR_ZINGO_REGTEST_ADDRESS,
+        ZENNIES_FOR_ZINGO_REGTEST_ADDRESS,
         testutils::{
             chain_generics::conduct_chain::ConductChain,
             lightclient::{from_inputs, get_base_address},
@@ -1786,7 +1786,7 @@ mod slow {
         );
         let zingo_config = ZingoConfig::builder()
             .set_indexer_uri(client_builder.server_id)
-            .set_network_type(ChainType::Regtest(
+            .set_chain_type(ChainType::Regtest(
                 local_net.validator().get_activation_heights().await,
             ))
             .set_wallet_dir(client_builder.zingo_datadir.path().to_path_buf())
@@ -4578,7 +4578,7 @@ mod testnet_test {
     use pepper_sync::sync_status;
     use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
     use zingolib::{
-        config::{ChainType, DEFAULT_TESTNET_LIGHTWALLETD_SERVER, ZingoConfig},
+        config::{ChainType, DEFAULT_INDEXER_URI_TESTNET, ZingoConfig},
         lightclient::LightClient,
         testutils::tempfile::TempDir,
         wallet::{LightWallet, WalletBase},
@@ -4597,12 +4597,8 @@ mod testnet_test {
         while test_count < NUM_TESTS {
             let wallet_dir = TempDir::new().unwrap();
             let config = ZingoConfig::builder()
-                .set_network_type(ChainType::Testnet)
-                .set_indexer_uri(
-                    (DEFAULT_TESTNET_LIGHTWALLETD_SERVER)
-                        .parse::<http::Uri>()
-                        .unwrap(),
-                )
+                .set_chain_type(ChainType::Testnet)
+                .set_indexer_uri((DEFAULT_INDEXER_URI_TESTNET).parse::<http::Uri>().unwrap())
                 .set_wallet_dir(wallet_dir.path().to_path_buf())
                 .build();
             let wallet = LightWallet::new(

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -13,7 +13,7 @@ use zingolib::testutils::paths::get_cargo_manifest_dir;
 use zingolib::testutils::tempfile::TempDir;
 use zingolib::wallet::LightWallet;
 use zingolib::{
-    config::{DEFAULT_LIGHTWALLETD_SERVER, construct_lightwalletd_uri},
+    config::{DEFAULT_INDEXER_URI, construct_lightwalletd_uri},
     get_base_address_macro,
     lightclient::LightClient,
     testutils::lightclient::from_inputs::{self},
@@ -29,12 +29,12 @@ async fn sync_mainnet_test() {
         .expect("Ring to work as a default");
     tracing_subscriber::fmt().init();
 
-    let uri = construct_lightwalletd_uri(Some(DEFAULT_LIGHTWALLETD_SERVER.to_string()));
+    let uri = construct_lightwalletd_uri(Some(DEFAULT_INDEXER_URI.to_string())).unwrap();
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path().to_path_buf();
     let config = ZingoConfig::builder()
         .set_indexer_uri(uri.clone())
-        .set_network_type(ChainType::Mainnet)
+        .set_chain_type(ChainType::Mainnet)
         .set_wallet_dir(temp_path)
         .set_wallet_name("".to_string())
         .set_wallet_settings(WalletSettings {
@@ -47,7 +47,7 @@ async fn sync_mainnet_test() {
         .set_no_of_accounts(NonZeroU32::try_from(1).unwrap())
         .build();
     let wallet = LightWallet::new(
-        config.network_type(),
+        config.chain_type(),
         WalletBase::Mnemonic {
             mnemonic: Mnemonic::from_phrase(HOSPITAL_MUSEUM_SEED.to_string()).unwrap(),
             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
@@ -94,12 +94,12 @@ async fn sync_status() {
         .expect("Ring to work as a default");
     tracing_subscriber::fmt().init();
 
-    let uri = construct_lightwalletd_uri(Some(DEFAULT_LIGHTWALLETD_SERVER.to_string()));
+    let uri = construct_lightwalletd_uri(Some(DEFAULT_INDEXER_URI.to_string())).unwrap();
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path().to_path_buf();
     let config = ZingoConfig::builder()
         .set_indexer_uri(uri.clone())
-        .set_network_type(ChainType::Mainnet)
+        .set_chain_type(ChainType::Mainnet)
         .set_wallet_dir(temp_path)
         .set_wallet_name("".to_string())
         .set_wallet_settings(WalletSettings {
@@ -112,7 +112,7 @@ async fn sync_status() {
         .set_no_of_accounts(NonZeroU32::try_from(1).unwrap())
         .build();
     let wallet = LightWallet::new(
-        config.network_type(),
+        config.chain_type(),
         WalletBase::Mnemonic {
             mnemonic: Mnemonic::from_phrase(HOSPITAL_MUSEUM_SEED.to_string()).unwrap(),
             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -756,7 +756,7 @@ impl Command for NewUnifiedAddressCommand {
         }
 
         RT.block_on(async move {
-            let network = lightclient.chain_type();
+            let chain_type = lightclient.chain_type();
             let mut wallet = lightclient.wallet().write().await;
             let receivers = ReceiverSelection {
                 orchard: args[0].contains('o'),
@@ -770,7 +770,7 @@ impl Command for NewUnifiedAddressCommand {
                         "has_orchard" => unified_address.has_orchard(),
                         "has_sapling" => unified_address.has_sapling(),
                         "has_transparent" => unified_address.has_transparent(),
-                        "encoded_address" => unified_address.encode(&network),
+                        "encoded_address" => unified_address.encode(&chain_type),
                     }
                 }
                 Err(e) => object! { "error" => e.to_string() },
@@ -797,7 +797,7 @@ impl Command for NewTransparentAddressCommand {
 
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
         RT.block_on(async move {
-            let network = lightclient.chain_type();
+            let chain_type = lightclient.chain_type();
             let mut wallet = lightclient.wallet().write().await;
             match wallet.generate_transparent_address(zip32::AccountId::ZERO, true) {
                 Ok((id, transparent_address)) => {
@@ -805,7 +805,7 @@ impl Command for NewTransparentAddressCommand {
                         "account" => u32::from(id.account_id()),
                         "address_index" => id.address_index().index(),
                         "scope" => id.scope().to_string(),
-                        "encoded_address" => transparent::encode_address(&network,  transparent_address),
+                        "encoded_address" => transparent::encode_address(&chain_type,  transparent_address),
                     }
                 }
                 Err(e) => object! { "error" => e.to_string() },
@@ -848,7 +848,7 @@ impl Command for NewTransparentAddressAllowGapCommand {
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
         RT.block_on(async move {
             // Generate without enforcing the no-gap constraint
-            let network = lightclient.chain_type();
+            let chain_type= lightclient.chain_type();
             let mut wallet = lightclient.wallet().write().await;
 
             match wallet.generate_transparent_address(zip32::AccountId::ZERO, false) {
@@ -857,7 +857,7 @@ impl Command for NewTransparentAddressAllowGapCommand {
                         "account" => u32::from(id.account_id()),
                         "address_index" => id.address_index().index(),
                         "scope" => id.scope().to_string(),
-                        "encoded_address" => transparent::encode_address(&network, transparent_address),
+                        "encoded_address" => transparent::encode_address(&chain_type, transparent_address),
                     }
                 }
                 Err(e) => object! { "error" => e.to_string() },

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -65,7 +65,7 @@ pub fn build_clap_app() -> clap::ArgMatches {
                 .value_name("server")
                 .help("Lightwalletd server to connect to.")
                 .value_parser(parse_uri)
-                .default_value(zingolib::config::DEFAULT_LIGHTWALLETD_SERVER))
+                .default_value(zingolib::config::DEFAULT_INDEXER_URI))
             .arg(Arg::new("data-dir")
                 .long("data-dir")
                 .value_name("data-dir")
@@ -336,7 +336,8 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
             .get_one::<http::Uri>("server")
             .map(ToString::to_string);
         log::info!("data_dir: {}", &data_dir.to_str().unwrap());
-        let server = zingolib::config::construct_lightwalletd_uri(server);
+        let server =
+            zingolib::config::construct_lightwalletd_uri(server).map_err(|e| e.to_string())?;
         let chaintype = if let Some(chain) = matches.get_one::<String>("chain") {
             ChainType::try_from(chain.as_str()).map_err(|e| e.to_string())?
         } else {
@@ -382,7 +383,7 @@ pub fn startup(
 ) -> std::io::Result<(Sender<CommandRequest>, Receiver<CommandResponse>)> {
     let config = ZingoConfig::builder()
         .set_indexer_uri(filled_template.server.clone())
-        .set_network_type(filled_template.chaintype)
+        .set_chain_type(filled_template.chaintype)
         .set_wallet_dir(filled_template.data_dir.clone())
         .set_wallet_settings(WalletSettings {
             sync_config: SyncConfig {
@@ -397,7 +398,7 @@ pub fn startup(
 
     let mut lightclient = if let Some(seed_phrase) = filled_template.seed.clone() {
         let wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::Mnemonic {
                 mnemonic: Mnemonic::from_phrase(seed_phrase).map_err(|e| {
                     std::io::Error::new(
@@ -416,7 +417,7 @@ pub fn startup(
     } else if let Some(ufvk) = filled_template.ufvk.clone() {
         // Create client from UFVK
         let wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::Ufvk(ufvk),
             (filled_template.birthday as u32).into(),
             config.wallet_settings(),

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -21,23 +21,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `mnemonic_phrase` method: lock-free access to the wallet's mnemonic phrase
   - `wallet` method: returns `&Arc<RwLock<LightWallet>>`, replacing the former public field
   - `indexer: GrpcIndexer` field: owning the indexer connection directly
+- re-export `zingo_common_components::protocol::ActivationHeights` so test crates can unify zingo common types with
+  zingolib lightclient construction 
 
 ### Changed
 - `LightClient`:
   - `server_uri`: renamed `indexer_uri`
   - `set_server`: renamed `set_indexer_uri`
   - `pub wallet: Arc<RwLock<LightWallet>>` field is now private. replaced by `wallet` method.
-- `config::ChainType`: `Regtest` activation heights tuple variant field changed from zebra type to zingo common components type.
-- `config::ZingoConfig`: reworked. public fields now private with public getter methods to constrain public API:
-  - `wallet_dir` replaces `get_zingo_wallet_dir`
-  - `network_type` method replaces `chain` field
-  - `indexer_uri` method replaces `lightwalletd_uri` field and `get_lightwalletd_uri` method
-  - `build` renamed `builder`
-- `config::ZingoConfigBuilder`: reworked. public fields now private with public setter methods to constrain public API:
-  - `create` renamed `build`
+- `config` module:
+  - `ChainType`: `Regtest` activation heights tuple variant field changed from zebra type to zingo common components type.
+  - `ZingoConfig`: reworked. public fields now private with public getter methods to constrain public API:
+    - `wallet_dir` replaces `get_zingo_wallet_dir`
+    - `chain_type` method replaces `chain` field
+    - `indexer_uri` method replaces `lightwalletd_uri` field and `get_lightwalletd_uri` method
+    - `build` renamed `builder`
+  - `ZingoConfigBuilder`: reworked. public fields now private with public setter methods to constrain public API:
+    - `create` renamed `build`
+  - `DEFAULT_LIGHTWALLETD_SERVER` const: renamed `DEFAULT_INDEXER_URI`
+  - `DEFAULT_TESTNET_LIGHTWALLETD_SERVER` const: renamed `DEFAULT_INDEXER_URI_TESTNET`
+  - `DEVELOPER_DONATION_ADDRESS` const: moved to lib.rs
+  - `ZENNIES_FOR_ZINGO_DONATION_ADDRESS` const: moved to lib.rs
+  - `ZENNIES_FOR_ZINGO_TESTNET_ADDRESS` const: moved to lib.rs
+  - `ZENNIES_FOR_ZINGO_REGTEST_ADDRESS` const: moved to lib.rs
+  - `ZENNIES_FOR_ZINGO_AMOUNT` const: moved to lib.rs
+  - `get_donation_address_for_chain` fn moved to lib.rs and renamed `get_zennies_for_zingo_address`
+      now takes `ChainType` instead of `&ChainType`
+  - `construct_lightwalletd_uri` fn: now returns result for handling URI errors
 - `wallet::LightWallet`:
   - `pub network: ChainType` field is now private. Use `LightClient::chain_type()`.
   - `pub birthday: BlockHeight` field is now private. Use `LightClient::birthday()`.
+- `wallet::keys::unified::UnifiedKeyStore`:
+  - `new_from_seed` method: now takes `ChainType` instead of `&ChainType`
+  - `new_from_mnemonic` method: now takes `ChainType` instead of `&ChainType`
+  - `new_from_ufvk` method: now takes `ChainType` instead of `&ChainType`
 
 ### Removed
 - `log4rs` dependency

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   zingolib lightclient construction 
 
 ### Changed
-- `LightClient`:
+- `lightclient::LightClient`:
   - `server_uri`: renamed `indexer_uri`
   - `set_server`: renamed `set_indexer_uri`
   - `pub wallet: Arc<RwLock<LightWallet>>` field is now private. replaced by `wallet` method.
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wallet::LightWallet`:
   - `pub network: ChainType` field is now private. Use `LightClient::chain_type()`.
   - `pub birthday: BlockHeight` field is now private. Use `LightClient::birthday()`.
+  - new wallet serialization version 40 due to changes to chain type fmt::Display. chain type is now encoded as u8.
 - `wallet::keys::unified::UnifiedKeyStore`:
   - `new_from_seed` method: now takes `ChainType` instead of `&ChainType`
   - `new_from_mnemonic` method: now takes `ChainType` instead of `&ChainType`

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -1,5 +1,4 @@
-//! `ZingConfig`
-//! TODO: Add Crate Description Here!
+//! Module for configuration and construction of a lightclient.
 
 use std::{
     io,
@@ -8,44 +7,21 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use http::uri::InvalidUri;
 use log::info;
-
-use zcash_protocol::consensus::{
-    BlockHeight, MAIN_NETWORK, NetworkType, NetworkUpgrade, Parameters, TEST_NETWORK,
-};
 
 use zingo_common_components::protocol::ActivationHeights;
 
 use crate::wallet::WalletSettings;
 
-/// TODO: Add Doc Comment Here!
-pub const DEVELOPER_DONATION_ADDRESS: &str = "u1w47nzy4z5g9zvm4h2s4ztpl8vrdmlclqz5sz02742zs5j3tz232u4safvv9kplg7g06wpk5fx0k0rx3r9gg4qk6nkg4c0ey57l0dyxtatqf8403xat7vyge7mmen7zwjcgvryg22khtg3327s6mqqkxnpwlnrt27kxhwg37qys2kpn2d2jl2zkk44l7j7hq9az82594u3qaescr3c9v";
-/// TODO: Add Doc Comment Here!
-pub const ZENNIES_FOR_ZINGO_DONATION_ADDRESS: &str = "u1p32nu0pgev5cr0u6t4ja9lcn29kaw37xch8nyglwvp7grl07f72c46hxvw0u3q58ks43ntg324fmulc2xqf4xl3pv42s232m25vaukp05s6av9z76s3evsstax4u6f5g7tql5yqwuks9t4ef6vdayfmrsymenqtshgxzj59hdydzygesqa7pdpw463hu7afqf4an29m69kfasdwr494";
-/// TODO: Add Doc Comment Here!
-pub const ZENNIES_FOR_ZINGO_TESTNET_ADDRESS: &str = "utest19zd9laj93deq4lkay48xcfyh0tjec786x6yrng38fp6zusgm0c84h3el99fngh8eks4kxv020r2h2njku6pf69anpqmjq5c3suzcjtlyhvpse0aqje09la48xk6a2cnm822s2yhuzfr47pp4dla9rakdk90g0cee070z57d3trqk87wwj4swz6uf6ts6p5z6lep3xyvueuvt7392tww";
-/// Regtest address for donation in test environments
-pub const ZENNIES_FOR_ZINGO_REGTEST_ADDRESS: &str = "uregtest14emvr2anyul683p43d0ck55c04r65ld6f0shetcn77z8j7m64hm4ku3wguf60s75f0g3s7r7g89z22f3ff5tsfgr45efj4pe2gyg5krqp5vvl3afu0280zp9ru2379zat5y6nkqkwjxsvpq5900kchcgzaw8v8z3ggt5yymnuj9hymtv3p533fcrk2wnj48g5vg42vle08c2xtanq0e";
-/// TODO: Add Doc Comment Here!
-pub const ZENNIES_FOR_ZINGO_AMOUNT: u64 = 1_000_000;
-/// The lightserver that handles blockchain requests
-pub const DEFAULT_LIGHTWALLETD_SERVER: &str = "https://zec.rocks:443";
-/// Used for testnet
-pub const DEFAULT_TESTNET_LIGHTWALLETD_SERVER: &str = "https://testnet.zec.rocks";
-/// TODO: Add Doc Comment Here!
+/// Default indexer uri
+pub const DEFAULT_INDEXER_URI: &str = "https://zec.rocks:443";
+/// Default indexer uri (testnet)
+pub const DEFAULT_INDEXER_URI_TESTNET: &str = "https://testnet.zec.rocks";
+/// Default wallet file name
 pub const DEFAULT_WALLET_NAME: &str = "zingo-wallet.dat";
 
-/// Gets the appropriate donation address for the given chain type
-#[must_use]
-pub fn get_donation_address_for_chain(chain: &ChainType) -> &'static str {
-    match chain {
-        ChainType::Mainnet => ZENNIES_FOR_ZINGO_DONATION_ADDRESS,
-        ChainType::Testnet => ZENNIES_FOR_ZINGO_TESTNET_ADDRESS,
-        ChainType::Regtest(_) => ZENNIES_FOR_ZINGO_REGTEST_ADDRESS,
-    }
-}
-
-/// The networks a zingolib client can run against
+/// The network types a lightclient can connect to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ChainType {
     /// Mainnet
@@ -59,44 +35,11 @@ pub enum ChainType {
 impl std::fmt::Display for ChainType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let chain = match self {
-            ChainType::Mainnet => "main",
-            ChainType::Testnet => "test",
+            ChainType::Mainnet => "mainnet",
+            ChainType::Testnet => "testnet",
             ChainType::Regtest(_) => "regtest",
         };
         write!(f, "{chain}")
-    }
-}
-
-// TODO: can we rework the library so we dont have implement Parameters on the public API facing ChainType?
-// this trait impl exposes external (zcash_protocol) types to the public API
-impl Parameters for ChainType {
-    fn network_type(&self) -> NetworkType {
-        match self {
-            ChainType::Mainnet => NetworkType::Main,
-            ChainType::Testnet => NetworkType::Test,
-            ChainType::Regtest(_) => NetworkType::Regtest,
-        }
-    }
-
-    fn activation_height(&self, nu: NetworkUpgrade) -> Option<BlockHeight> {
-        match self {
-            ChainType::Mainnet => MAIN_NETWORK.activation_height(nu),
-            ChainType::Testnet => TEST_NETWORK.activation_height(nu),
-            ChainType::Regtest(activation_heights) => match nu {
-                NetworkUpgrade::Overwinter => {
-                    activation_heights.overwinter().map(BlockHeight::from_u32)
-                }
-                NetworkUpgrade::Sapling => activation_heights.sapling().map(BlockHeight::from_u32),
-                NetworkUpgrade::Blossom => activation_heights.blossom().map(BlockHeight::from_u32),
-                NetworkUpgrade::Heartwood => {
-                    activation_heights.heartwood().map(BlockHeight::from_u32)
-                }
-                NetworkUpgrade::Canopy => activation_heights.canopy().map(BlockHeight::from_u32),
-                NetworkUpgrade::Nu5 => activation_heights.nu5().map(BlockHeight::from_u32),
-                NetworkUpgrade::Nu6 => activation_heights.nu6().map(BlockHeight::from_u32),
-                NetworkUpgrade::Nu6_1 => activation_heights.nu6_1().map(BlockHeight::from_u32),
-            },
-        }
     }
 }
 
@@ -113,6 +56,51 @@ impl TryFrom<&str> for ChainType {
     }
 }
 
+pub(crate) mod consealed {
+    use zcash_protocol::consensus::{
+        BlockHeight, MAIN_NETWORK, NetworkType, NetworkUpgrade, Parameters, TEST_NETWORK,
+    };
+
+    use super::ChainType;
+
+    impl Parameters for ChainType {
+        fn network_type(&self) -> NetworkType {
+            match self {
+                ChainType::Mainnet => NetworkType::Main,
+                ChainType::Testnet => NetworkType::Test,
+                ChainType::Regtest(_) => NetworkType::Regtest,
+            }
+        }
+
+        fn activation_height(&self, nu: NetworkUpgrade) -> Option<BlockHeight> {
+            match self {
+                ChainType::Mainnet => MAIN_NETWORK.activation_height(nu),
+                ChainType::Testnet => TEST_NETWORK.activation_height(nu),
+                ChainType::Regtest(activation_heights) => match nu {
+                    NetworkUpgrade::Overwinter => {
+                        activation_heights.overwinter().map(BlockHeight::from_u32)
+                    }
+                    NetworkUpgrade::Sapling => {
+                        activation_heights.sapling().map(BlockHeight::from_u32)
+                    }
+                    NetworkUpgrade::Blossom => {
+                        activation_heights.blossom().map(BlockHeight::from_u32)
+                    }
+                    NetworkUpgrade::Heartwood => {
+                        activation_heights.heartwood().map(BlockHeight::from_u32)
+                    }
+                    NetworkUpgrade::Canopy => {
+                        activation_heights.canopy().map(BlockHeight::from_u32)
+                    }
+                    NetworkUpgrade::Nu5 => activation_heights.nu5().map(BlockHeight::from_u32),
+                    NetworkUpgrade::Nu6 => activation_heights.nu6().map(BlockHeight::from_u32),
+                    NetworkUpgrade::Nu6_1 => activation_heights.nu6_1().map(BlockHeight::from_u32),
+                },
+            }
+        }
+    }
+}
+
 /// Invalid chain type.
 #[derive(thiserror::Error, Debug)]
 #[error("Invalid chain type '{0}'. Expected one of: 'mainnet', 'testnet' or 'regtest'.")]
@@ -121,20 +109,20 @@ pub struct InvalidChainType(String);
 /// Creates a zingo config for lightclient construction.
 #[deprecated(note = "replaced by ZingoConfig builder pattern")]
 pub fn load_clientconfig(
-    lightwallet_uri: http::Uri,
+    indexer_uri: http::Uri,
     data_dir: Option<PathBuf>,
-    chain: ChainType,
+    chain_type: ChainType,
     wallet_settings: WalletSettings,
     no_of_accounts: NonZeroU32,
     wallet_name: String,
 ) -> std::io::Result<ZingoConfig> {
-    check_indexer_uri(&lightwallet_uri);
+    check_indexer_uri(&indexer_uri);
     let wallet_name = wallet_name_or_default(Some(wallet_name));
-    let wallet_dir = wallet_dir_or_default(data_dir, chain);
+    let wallet_dir = wallet_dir_or_default(data_dir, chain_type);
 
     let config = ZingoConfig {
-        indexer_uri: lightwallet_uri,
-        network_type: chain,
+        indexer_uri,
+        chain_type,
         wallet_dir,
         wallet_name,
         wallet_settings,
@@ -144,52 +132,48 @@ pub fn load_clientconfig(
     Ok(config)
 }
 
-/// Constructs a http::Uri from a `server` string. If `server` is `None` use the `DEFAULT_LIGHTWALLETD_SERVER`.
+/// Constructs a http::Uri from a `server` string. If `server` is `None` use the `DEFAULT_INDEXER_URI`.
 /// If the provided string is missing the http prefix, a prefix of `http://` will be added.
 /// If the provided string is missing a port, a port of `:9067` will be added.
-// TODO: handle errors
-#[must_use]
-pub fn construct_lightwalletd_uri(server: Option<String>) -> http::Uri {
+pub fn construct_lightwalletd_uri(server: Option<String>) -> Result<http::Uri, InvalidUri> {
     match server {
         Some(s) => {
             if s.is_empty() {
-                return http::Uri::default();
+                return Ok(http::Uri::default());
             } else {
                 let mut s = if s.starts_with("http") {
                     s
                 } else {
                     "http://".to_string() + &s
                 };
-                let uri: http::Uri = s.parse().unwrap();
+                let uri: http::Uri = s.parse()?;
                 if uri.port().is_none() {
                     s += ":9067";
                 }
                 s
             }
         }
-        None => DEFAULT_LIGHTWALLETD_SERVER.to_string(),
+        None => DEFAULT_INDEXER_URI.to_string(),
     }
     .parse()
-    .unwrap()
 }
 
-/// Configuration data for the creation of a `LightClient`.
+/// Configuration data for the construction of a [`crate::lightclient::LightClient`].
 // TODO: this config should only be used to create a lightclient, the data should then be moved into fields of
 // lightclient or lightwallet if it needs to retained in memory.
 #[derive(Clone, Debug)]
 pub struct ZingoConfig {
-    /// The URI of the indexer the lightclient is connected to.
+    /// URI of the indexer the lightclient is connected to.
     indexer_uri: http::Uri,
-    /// The network type of the blockchain the lightclient is connected to.
-    // TODO: change for zingo common public API safe type
-    network_type: ChainType,
-    /// The directory where the wallet will be created. By default, this will be in ~/.zcash on Linux and %APPDATA%\Zcash on Windows.
+    /// Chain type of the blockchain the lightclient is connected to.
+    chain_type: ChainType,
+    /// Directory where the wallet file will be created. By default, this will be in ~/.zcash on Linux and %APPDATA%\Zcash on Windows.
     wallet_dir: PathBuf,
-    /// The filename of the wallet. This will be created in the `wallet_dir`.
+    /// Wallet file name. This will be created in the `wallet_dir`.
     wallet_name: String,
     /// Wallet settings.
     wallet_settings: WalletSettings,
-    /// Number of accounts
+    /// Number of accounts.
     no_of_accounts: NonZeroU32,
 }
 
@@ -208,8 +192,8 @@ impl ZingoConfig {
 
     /// Returns wallet directory.
     #[must_use]
-    pub fn network_type(&self) -> ChainType {
-        self.network_type
+    pub fn chain_type(&self) -> ChainType {
+        self.chain_type
     }
 
     /// Returns wallet directory.
@@ -263,7 +247,7 @@ impl ZingoConfig {
     #[must_use]
     pub fn get_wallet_path(&self) -> Box<Path> {
         let mut wallet_path = self.wallet_dir();
-        wallet_path.push(&self.wallet_name);
+        wallet_path.push(self.wallet_name());
 
         wallet_path.into_boxed_path()
     }
@@ -283,7 +267,7 @@ impl ZingoConfig {
             "zingo-wallet.backup.{}.dat",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
+                .expect("should never fail when comparing with an instant so far in the past")
                 .as_secs()
         ));
 
@@ -300,12 +284,8 @@ impl ZingoConfig {
     #[must_use]
     pub fn create_testnet() -> ZingoConfig {
         ZingoConfig::builder()
-            .set_network_type(ChainType::Testnet)
-            .set_indexer_uri(
-                (DEFAULT_TESTNET_LIGHTWALLETD_SERVER)
-                    .parse::<http::Uri>()
-                    .unwrap(),
-            )
+            .set_chain_type(ChainType::Testnet)
+            .set_indexer_uri((DEFAULT_INDEXER_URI_TESTNET).parse::<http::Uri>().unwrap())
             .build()
     }
 
@@ -313,8 +293,8 @@ impl ZingoConfig {
     #[must_use]
     pub fn create_mainnet() -> ZingoConfig {
         ZingoConfig::builder()
-            .set_network_type(ChainType::Mainnet)
-            .set_indexer_uri((DEFAULT_LIGHTWALLETD_SERVER).parse::<http::Uri>().unwrap())
+            .set_chain_type(ChainType::Mainnet)
+            .set_indexer_uri((DEFAULT_INDEXER_URI).parse::<http::Uri>().unwrap())
             .build()
     }
 
@@ -323,11 +303,11 @@ impl ZingoConfig {
     pub fn create_unconnected(chain: ChainType, dir: Option<PathBuf>) -> ZingoConfig {
         if let Some(dir) = dir {
             ZingoConfig::builder()
-                .set_network_type(chain)
+                .set_chain_type(chain)
                 .set_wallet_dir(dir)
                 .build()
         } else {
-            ZingoConfig::builder().set_network_type(chain).build()
+            ZingoConfig::builder().set_chain_type(chain).build()
         }
     }
 }
@@ -336,7 +316,7 @@ impl ZingoConfig {
 #[derive(Clone, Debug)]
 pub struct ZingoConfigBuilder {
     indexer_uri: Option<http::Uri>,
-    network_type: ChainType,
+    chain_type: ChainType,
     wallet_dir: Option<PathBuf>,
     wallet_name: Option<String>,
     wallet_settings: WalletSettings,
@@ -346,21 +326,7 @@ pub struct ZingoConfigBuilder {
 impl ZingoConfigBuilder {
     /// Constructs a new builder for [`ZingoConfig`].
     pub fn new() -> Self {
-        Self {
-            indexer_uri: None,
-            wallet_dir: None,
-            wallet_name: None,
-            network_type: ChainType::Mainnet,
-            wallet_settings: WalletSettings {
-                sync_config: pepper_sync::config::SyncConfig {
-                    transparent_address_discovery:
-                        pepper_sync::config::TransparentAddressDiscovery::minimal(),
-                    performance_level: pepper_sync::config::PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(3).unwrap(),
-            },
-            no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
-        }
+        Self::default()
     }
 
     /// Set indexer URI.
@@ -376,16 +342,16 @@ impl ZingoConfigBuilder {
         self
     }
 
-    /// Set network type.
+    /// Set chain type.
     /// # Examples
     /// ```
     /// use zingolib::config::ZingoConfig;
     /// use zingolib::config::ChainType;
-    /// let config = ZingoConfig::builder().set_network_type(ChainType::Testnet).build();
-    /// assert_eq!(config.network_type(), ChainType::Testnet);
+    /// let config = ZingoConfig::builder().set_chain_type(ChainType::Testnet).build();
+    /// assert_eq!(config.chain_type(), ChainType::Testnet);
     /// ```
-    pub fn set_network_type(mut self, network_type: ChainType) -> Self {
-        self.network_type = network_type;
+    pub fn set_chain_type(mut self, chain_type: ChainType) -> Self {
+        self.chain_type = chain_type;
         self
     }
 
@@ -423,11 +389,11 @@ impl ZingoConfigBuilder {
 
     /// Build a [`ZingoConfig`] from the builder.
     pub fn build(self) -> ZingoConfig {
-        let wallet_dir = wallet_dir_or_default(self.wallet_dir, self.network_type);
+        let wallet_dir = wallet_dir_or_default(self.wallet_dir, self.chain_type);
         let wallet_name = wallet_name_or_default(self.wallet_name);
         ZingoConfig {
             indexer_uri: self.indexer_uri.clone().unwrap_or_default(),
-            network_type: self.network_type,
+            chain_type: self.chain_type,
             wallet_dir,
             wallet_name,
             wallet_settings: self.wallet_settings,
@@ -438,7 +404,21 @@ impl ZingoConfigBuilder {
 
 impl Default for ZingoConfigBuilder {
     fn default() -> Self {
-        Self::new()
+        Self {
+            indexer_uri: None,
+            wallet_dir: None,
+            wallet_name: None,
+            chain_type: ChainType::Mainnet,
+            wallet_settings: WalletSettings {
+                sync_config: pepper_sync::config::SyncConfig {
+                    transparent_address_discovery:
+                        pepper_sync::config::TransparentAddressDiscovery::minimal(),
+                    performance_level: pepper_sync::config::PerformanceLevel::High,
+                },
+                min_confirmations: NonZeroU32::try_from(3).unwrap(),
+            },
+            no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
+        }
     }
 }
 
@@ -532,8 +512,9 @@ mod tests {
         tracing_subscriber::fmt().init();
 
         let valid_uri = crate::config::construct_lightwalletd_uri(Some(
-            crate::config::DEFAULT_LIGHTWALLETD_SERVER.to_string(),
-        ));
+            crate::config::DEFAULT_INDEXER_URI.to_string(),
+        ))
+        .unwrap();
         // let invalid_uri = construct_lightwalletd_uri(Some("Invalid URI".to_string()));
         let temp_dir = tempfile::TempDir::new().unwrap();
 
@@ -542,7 +523,7 @@ mod tests {
 
         let valid_config = ZingoConfig::builder()
             .set_indexer_uri(valid_uri.clone())
-            .set_network_type(ChainType::Mainnet)
+            .set_chain_type(ChainType::Mainnet)
             .set_wallet_dir(temp_path)
             .set_wallet_settings(WalletSettings {
                 sync_config: SyncConfig {
@@ -556,7 +537,7 @@ mod tests {
             .build();
 
         assert_eq!(valid_config.indexer_uri(), valid_uri);
-        assert_eq!(valid_config.network_type, ChainType::Mainnet);
+        assert_eq!(valid_config.chain_type, ChainType::Mainnet);
 
         // let invalid_config = load_clientconfig_serverless(
         //     invalid_uri.clone(),

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -1,4 +1,4 @@
-//! Module for configuration and construction of a lightclient.
+//! Module for configuration and construction of a [`crate::lightclient::LightClient`] and/or [`crate::wallet::LightWallet`].
 
 use std::{
     io,

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -3,6 +3,8 @@
 //! `ZingoLib`
 //! Zingo backend library
 
+use crate::config::ChainType;
+
 pub mod config;
 pub mod data;
 pub mod lightclient;
@@ -23,3 +25,24 @@ extern crate rust_embed;
 #[derive(RustEmbed)]
 #[folder = "zcash-params/"]
 pub struct SaplingParams;
+
+/// Developer donation address
+pub const DEVELOPER_DONATION_ADDRESS: &str = "u1w47nzy4z5g9zvm4h2s4ztpl8vrdmlclqz5sz02742zs5j3tz232u4safvv9kplg7g06wpk5fx0k0rx3r9gg4qk6nkg4c0ey57l0dyxtatqf8403xat7vyge7mmen7zwjcgvryg22khtg3327s6mqqkxnpwlnrt27kxhwg37qys2kpn2d2jl2zkk44l7j7hq9az82594u3qaescr3c9v";
+/// Zennies for zingo donation address
+pub const ZENNIES_FOR_ZINGO_DONATION_ADDRESS: &str = "u1p32nu0pgev5cr0u6t4ja9lcn29kaw37xch8nyglwvp7grl07f72c46hxvw0u3q58ks43ntg324fmulc2xqf4xl3pv42s232m25vaukp05s6av9z76s3evsstax4u6f5g7tql5yqwuks9t4ef6vdayfmrsymenqtshgxzj59hdydzygesqa7pdpw463hu7afqf4an29m69kfasdwr494";
+/// Zennies for zingo donation address (testnet)
+pub const ZENNIES_FOR_ZINGO_TESTNET_ADDRESS: &str = "utest19zd9laj93deq4lkay48xcfyh0tjec786x6yrng38fp6zusgm0c84h3el99fngh8eks4kxv020r2h2njku6pf69anpqmjq5c3suzcjtlyhvpse0aqje09la48xk6a2cnm822s2yhuzfr47pp4dla9rakdk90g0cee070z57d3trqk87wwj4swz6uf6ts6p5z6lep3xyvueuvt7392tww";
+/// Zennies for zingo donation address (regtest)
+pub const ZENNIES_FOR_ZINGO_REGTEST_ADDRESS: &str = "uregtest14emvr2anyul683p43d0ck55c04r65ld6f0shetcn77z8j7m64hm4ku3wguf60s75f0g3s7r7g89z22f3ff5tsfgr45efj4pe2gyg5krqp5vvl3afu0280zp9ru2379zat5y6nkqkwjxsvpq5900kchcgzaw8v8z3ggt5yymnuj9hymtv3p533fcrk2wnj48g5vg42vle08c2xtanq0e";
+/// Zennies for zingo donation amount
+pub const ZENNIES_FOR_ZINGO_AMOUNT: u64 = 1_000_000;
+
+/// Gets the appropriate zennies for zingo donation address for the given chain type.
+#[must_use]
+pub fn get_zennies_for_zingo_address(chain_type: &ChainType) -> &'static str {
+    match chain_type {
+        ChainType::Mainnet => ZENNIES_FOR_ZINGO_DONATION_ADDRESS,
+        ChainType::Testnet => ZENNIES_FOR_ZINGO_TESTNET_ADDRESS,
+        ChainType::Regtest(_) => ZENNIES_FOR_ZINGO_REGTEST_ADDRESS,
+    }
+}

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -16,6 +16,8 @@ pub mod mocks;
 #[cfg(any(test, feature = "testutils"))]
 pub mod testutils;
 
+pub use zingo_common_components::protocol::ActivationHeights;
+
 // This line includes the generated `git_description()` function directly into this scope.
 include!(concat!(env!("OUT_DIR"), "/git_description.rs"));
 
@@ -39,7 +41,7 @@ pub const ZENNIES_FOR_ZINGO_AMOUNT: u64 = 1_000_000;
 
 /// Gets the appropriate zennies for zingo donation address for the given chain type.
 #[must_use]
-pub fn get_zennies_for_zingo_address(chain_type: &ChainType) -> &'static str {
+pub fn get_zennies_for_zingo_address(chain_type: ChainType) -> &'static str {
     match chain_type {
         ChainType::Mainnet => ZENNIES_FOR_ZINGO_DONATION_ADDRESS,
         ChainType::Testnet => ZENNIES_FOR_ZINGO_TESTNET_ADDRESS,

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -101,13 +101,13 @@ impl LightClient {
         overwrite: bool,
     ) -> Result<Self, LightClientError> {
         let sapling_activation_height = config
-            .network_type()
+            .chain_type()
             .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
             .expect("should have some sapling activation height");
         let birthday = sapling_activation_height.max(chain_height - 100);
 
         let wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::FreshEntropy {
                 no_of_accounts: config.no_of_accounts(),
             },
@@ -167,8 +167,8 @@ impl LightClient {
         };
 
         let buffer = BufReader::new(File::open(wallet_path).map_err(LightClientError::FileError)?);
-        let wallet = LightWallet::read(buffer, config.network_type())
-            .map_err(LightClientError::FileError)?;
+        let wallet =
+            LightWallet::read(buffer, config.chain_type()).map_err(LightClientError::FileError)?;
 
         Self::create_from_wallet(wallet, config, true)
     }
@@ -388,12 +388,12 @@ mod tests {
     async fn new_wallet_from_phrase() {
         let temp_dir = TempDir::new().unwrap();
         let config = ZingoConfig::builder()
-            .set_network_type(ChainType::Regtest(ActivationHeights::default()))
+            .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
             .set_wallet_dir(temp_dir.path().to_path_buf())
             .build();
 
         let wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::Mnemonic {
                 mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
                 no_of_accounts: config.no_of_accounts(),
@@ -408,7 +408,7 @@ mod tests {
         lc.wait_for_save().await;
 
         let wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::Mnemonic {
                 mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
                 no_of_accounts: config.no_of_accounts(),

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -4,20 +4,20 @@ use zcash_address::ZcashAddress;
 use zcash_client_backend::zip321::TransactionRequest;
 use zcash_protocol::value::Zatoshis;
 
-use crate::config::ZENNIES_FOR_ZINGO_AMOUNT;
-use crate::config::get_donation_address_for_chain;
+use crate::ZENNIES_FOR_ZINGO_AMOUNT;
 use crate::data::proposal::ProportionalFeeProposal;
 use crate::data::proposal::ProportionalFeeShieldProposal;
 use crate::data::proposal::ZingoProposal;
 use crate::data::receivers::Receiver;
 use crate::data::receivers::transaction_request_from_receivers;
+use crate::get_zennies_for_zingo_address;
 use crate::lightclient::LightClient;
 use crate::wallet::error::ProposeSendError;
 use crate::wallet::error::ProposeShieldError;
 
 impl LightClient {
     fn append_zingo_zenny_receiver(&self, receivers: &mut Vec<Receiver>) {
-        let zfz_address = get_donation_address_for_chain(&self.chain_type());
+        let zfz_address = get_zennies_for_zingo_address(&self.chain_type());
         let dev_donation_receiver = Receiver::new(
             crate::utils::conversion::address_from_str(zfz_address).expect("Hard coded str"),
             Zatoshis::from_u64(ZENNIES_FOR_ZINGO_AMOUNT).expect("Hard coded u64."),
@@ -184,7 +184,7 @@ mod shielding {
     fn create_basic_client() -> LightClient {
         let config = ZingoConfigBuilder::default().build();
         let wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::Mnemonic {
                 mnemonic: Mnemonic::from_phrase(seeds::HOSPITAL_MUSEUM_SEED.to_string()).unwrap(),
                 no_of_accounts: 1.try_into().unwrap(),
@@ -202,6 +202,7 @@ mod shielding {
         .unwrap();
         LightClient::create_from_wallet(wallet, config, true).unwrap()
     }
+
     #[tokio::test]
     async fn propose_shield_missing_scan_prerequisite() {
         let basic_client = create_basic_client();

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -17,7 +17,7 @@ use crate::wallet::error::ProposeShieldError;
 
 impl LightClient {
     fn append_zingo_zenny_receiver(&self, receivers: &mut Vec<Receiver>) {
-        let zfz_address = get_zennies_for_zingo_address(&self.chain_type());
+        let zfz_address = get_zennies_for_zingo_address(self.chain_type());
         let dev_donation_receiver = Receiver::new(
             crate::utils::conversion::address_from_str(zfz_address).expect("Hard coded str"),
             Zatoshis::from_u64(ZENNIES_FOR_ZINGO_AMOUNT).expect("Hard coded u64."),

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -243,7 +243,7 @@ mod test {
     async fn complete_and_broadcast_unconnected_error() {
         let config = ZingoConfig::builder().build();
         let wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::Mnemonic {
                 mnemonic: Mnemonic::from_phrase(ABANDON_ART_SEED.to_string()).unwrap(),
                 no_of_accounts: 1.try_into().unwrap(),

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -28,7 +28,7 @@ impl LightClient {
         }
 
         let client = self.indexer.get_client().await?;
-        let network = self.chain_type();
+        let chain_type = self.chain_type();
         let sync_config = self
             .wallet()
             .read()
@@ -39,7 +39,7 @@ impl LightClient {
         let wallet = self.wallet().clone();
         let sync_mode = self.sync_mode.clone();
         let sync_handle = tokio::spawn(async move {
-            pepper_sync::sync(client, &network, wallet, sync_mode, sync_config).await
+            pepper_sync::sync(client, &chain_type, wallet, sync_mode, sync_config).await
         });
         self.sync_handle = Some(sync_handle);
 

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -65,7 +65,7 @@ pub fn build_fvk_client(fvks: &[&Fvk], config: ZingoConfig) -> LightClient {
         &zcash_protocol::consensus::NetworkType::Regtest,
     );
     let wallet = LightWallet::new(
-        config.network_type(),
+        config.chain_type(),
         WalletBase::Ufvk(ufvk),
         1.into(),
         WalletSettings {

--- a/zingolib/src/testutils/chain_generics/conduct_chain.rs
+++ b/zingolib/src/testutils/chain_generics/conduct_chain.rs
@@ -44,7 +44,7 @@ pub trait ConductChain {
 
     /// loads a client from bytes
     fn load_client(&mut self, config: ZingoConfig, data: &[u8]) -> LightClient {
-        let wallet = LightWallet::read(data, config.network_type()).unwrap();
+        let wallet = LightWallet::read(data, config.chain_type()).unwrap();
         LightClient::create_from_wallet(wallet, config, false).unwrap()
     }
 

--- a/zingolib/src/testutils/chain_generics/networked.rs
+++ b/zingolib/src/testutils/chain_generics/networked.rs
@@ -7,7 +7,7 @@ use zcash_protocol::consensus::BlockHeight;
 use zingo_netutils::Indexer as _;
 
 use super::conduct_chain::ConductChain;
-use crate::{config::DEFAULT_TESTNET_LIGHTWALLETD_SERVER, lightclient::LightClient};
+use crate::{config::DEFAULT_INDEXER_URI_TESTNET, lightclient::LightClient};
 
 /// this is essentially a placeholder.
 /// allows using existing `ChainGeneric` functions with `TestNet` wallets
@@ -30,8 +30,7 @@ impl NetworkedTestEnvironment {
 impl ConductChain for NetworkedTestEnvironment {
     async fn setup() -> Self {
         Self {
-            indexer_uri: <Uri as std::str::FromStr>::from_str(DEFAULT_TESTNET_LIGHTWALLETD_SERVER)
-                .unwrap(),
+            indexer_uri: <Uri as std::str::FromStr>::from_str(DEFAULT_INDEXER_URI_TESTNET).unwrap(),
             latest_known_server_height: None,
         }
     }

--- a/zingolib/src/testutils/lightclient.rs
+++ b/zingolib/src/testutils/lightclient.rs
@@ -23,6 +23,7 @@ pub async fn new_client_from_save_buffer(
         .map_err(LightClientError::FileError)?;
     LightClient::create_from_wallet(wallet, template_client.config.clone(), false)
 }
+
 /// gets the first address that will allow a sender to send to a specific pool, as a string
 pub async fn get_base_address(client: &LightClient, pooltype: PoolType) -> String {
     match pooltype {

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -104,7 +104,7 @@ impl WalletBase {
     #[allow(clippy::result_large_err)]
     fn resolve_keys(
         self,
-        network: &ChainType,
+        chain_type: ChainType,
     ) -> Result<
         (
             BTreeMap<zip32::AccountId, UnifiedKeyStore>,
@@ -117,7 +117,7 @@ impl WalletBase {
                 mnemonic: Mnemonic::generate(bip0039::Count::Words24),
                 no_of_accounts,
             }
-            .resolve_keys(network),
+            .resolve_keys(chain_type),
             WalletBase::Mnemonic {
                 mnemonic,
                 no_of_accounts,
@@ -128,7 +128,7 @@ impl WalletBase {
                         let account_id = zip32::AccountId::try_from(account_index)?;
                         Ok((
                             account_id,
-                            UnifiedKeyStore::new_from_mnemonic(network, &mnemonic, account_id)?,
+                            UnifiedKeyStore::new_from_mnemonic(chain_type, &mnemonic, account_id)?,
                         ))
                     })
                     .collect::<Result<BTreeMap<_, _>, KeyError>>()?;
@@ -138,7 +138,7 @@ impl WalletBase {
                 let mut unified_key_store = BTreeMap::new();
                 unified_key_store.insert(
                     zip32::AccountId::ZERO,
-                    UnifiedKeyStore::new_from_ufvk(network, ufvk_encoded)?,
+                    UnifiedKeyStore::new_from_ufvk(chain_type, ufvk_encoded)?,
                 );
                 Ok((unified_key_store, None))
             }
@@ -217,7 +217,7 @@ impl LightWallet {
         birthday: BlockHeight,
         wallet_settings: WalletSettings,
     ) -> Result<Self, WalletError> {
-        let (unified_key_store, mnemonic) = wallet_base.resolve_keys(&chain_type)?;
+        let (unified_key_store, mnemonic) = wallet_base.resolve_keys(chain_type)?;
         Self::from_keys(
             chain_type,
             unified_key_store,
@@ -413,7 +413,7 @@ impl LightWallet {
         self.unified_key_store.insert(
             account_id,
             UnifiedKeyStore::new_from_mnemonic(
-                &self.chain_type,
+                self.chain_type(),
                 self.mnemonic().ok_or(WalletError::MnemonicNotFound)?,
                 account_id,
             )?,

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -171,8 +171,8 @@ pub struct LightWallet {
     current_version: u64,
     /// Wallet version that was read from on wallet load.
     read_version: u64,
-    /// Network type
-    network: ChainType,
+    /// Blockchain network type
+    chain_type: ChainType,
     /// The seed for the wallet, stored as a zip339 Mnemonic, and the account index.
     mnemonic: Option<Mnemonic>,
     /// The block height at which the wallet was created.
@@ -212,14 +212,14 @@ impl LightWallet {
     /// of block chain to protect from re-orgs.
     #[allow(clippy::result_large_err)]
     pub fn new(
-        network: ChainType,
+        chain_type: ChainType,
         wallet_base: WalletBase,
         birthday: BlockHeight,
         wallet_settings: WalletSettings,
     ) -> Result<Self, WalletError> {
-        let (unified_key_store, mnemonic) = wallet_base.resolve_keys(&network)?;
+        let (unified_key_store, mnemonic) = wallet_base.resolve_keys(&chain_type)?;
         Self::from_keys(
-            network,
+            chain_type,
             unified_key_store,
             mnemonic,
             birthday,
@@ -230,13 +230,13 @@ impl LightWallet {
     /// Construct a wallet from pre-resolved keys.
     #[allow(clippy::result_large_err)]
     pub(crate) fn from_keys(
-        network: ChainType,
+        chain_type: ChainType,
         unified_key_store: BTreeMap<zip32::AccountId, UnifiedKeyStore>,
         mnemonic: Option<Mnemonic>,
         birthday: BlockHeight,
         wallet_settings: WalletSettings,
     ) -> Result<Self, WalletError> {
-        let sapling_activation_height = network
+        let sapling_activation_height = chain_type
             .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
             .expect("should have some sapling activation height");
         if birthday < sapling_activation_height {
@@ -273,7 +273,7 @@ impl LightWallet {
             Ok(first_transparent_address) => {
                 transparent_addresses.insert(
                     transparent_address_id,
-                    transparent::encode_address(&network, first_transparent_address),
+                    transparent::encode_address(&chain_type, first_transparent_address),
                 );
             }
             Err(KeyError::NoViewCapability) => (),
@@ -283,7 +283,7 @@ impl LightWallet {
         Ok(Self {
             current_version: LightWallet::serialized_version(),
             read_version: LightWallet::serialized_version(),
-            network,
+            chain_type,
             mnemonic,
             birthday: BlockHeight::from_u32(birthday.into()),
             unified_key_store,
@@ -323,7 +323,7 @@ impl LightWallet {
     /// Returns chain type wallet is connected to.
     #[must_use]
     pub fn chain_type(&self) -> ChainType {
-        self.network
+        self.chain_type
     }
 
     /// Returns the wallet's mnemonic for internal operations.
@@ -357,7 +357,7 @@ impl LightWallet {
                         "has_orchard" => unified_address.has_orchard(),
                         "has_sapling" => unified_address.has_sapling(),
                         "has_transparent" => unified_address.has_transparent(),
-                        "encoded_address" => unified_address.encode(&self.network),
+                        "encoded_address" => unified_address.encode(&self.chain_type),
                     }
                 })
                 .collect::<Vec<_>>(),
@@ -413,7 +413,7 @@ impl LightWallet {
         self.unified_key_store.insert(
             account_id,
             UnifiedKeyStore::new_from_mnemonic(
-                &self.network,
+                &self.chain_type,
                 self.mnemonic().ok_or(WalletError::MnemonicNotFound)?,
                 account_id,
             )?,
@@ -430,9 +430,9 @@ impl LightWallet {
     /// `self.save_required` status, writing the returned wallet bytes to persistance.
     pub fn save(&mut self) -> std::io::Result<Option<Vec<u8>>> {
         if self.save_required {
-            let network = self.network;
+            let chain_type = self.chain_type;
             let mut wallet_bytes: Vec<u8> = vec![];
-            self.write(&mut wallet_bytes, &network)?;
+            self.write(&mut wallet_bytes, &chain_type)?;
             self.save_required = false;
             Ok(Some(wallet_bytes))
         } else {

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -132,7 +132,7 @@ impl LightWallet {
         info!("Reading wallet version {version}");
         match version {
             ..32 => Self::read_v0(reader, chain_type, version),
-            32..=39 => Self::read_v32(reader, chain_type, version),
+            32..=40 => Self::read_v32(reader, chain_type, version),
             _ => Err(io::Error::new(
                 ErrorKind::InvalidData,
                 format!(

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -55,7 +55,7 @@ impl LightWallet {
         consensus_parameters: &impl consensus::Parameters,
     ) -> io::Result<()> {
         writer.write_u64::<LittleEndian>(Self::serialized_version())?;
-        utils::write_string(&mut writer, &self.network.to_string())?;
+        utils::write_string(&mut writer, &self.chain_type.to_string())?;
         let seed_bytes = match &self.mnemonic {
             Some(m) => m.clone().into_entropy(),
             None => vec![],
@@ -67,7 +67,7 @@ impl LightWallet {
             &self.unified_key_store.iter().collect::<Vec<_>>(),
             |w, (account_id, unified_key)| {
                 w.write_u32::<LittleEndian>(u32::from(**account_id))?;
-                unified_key.write(w, self.network)
+                unified_key.write(w, self.chain_type)
             },
         )?;
         // TODO: also store receiver selections in encoded memos.
@@ -122,12 +122,12 @@ impl LightWallet {
 
     /// Deserialize into `reader`
     // TODO: update to return WalletError
-    pub fn read<R: Read>(mut reader: R, network: ChainType) -> io::Result<Self> {
+    pub fn read<R: Read>(mut reader: R, chain_type: ChainType) -> io::Result<Self> {
         let version = reader.read_u64::<LittleEndian>()?;
         info!("Reading wallet version {version}");
         match version {
-            ..32 => Self::read_v0(reader, network, version),
-            32..=39 => Self::read_v32(reader, network, version),
+            ..32 => Self::read_v0(reader, chain_type, version),
+            32..=39 => Self::read_v32(reader, chain_type, version),
             _ => Err(io::Error::new(
                 ErrorKind::InvalidData,
                 format!(
@@ -138,8 +138,8 @@ impl LightWallet {
         }
     }
 
-    fn read_v0<R: Read>(mut reader: R, network: ChainType, version: u64) -> io::Result<Self> {
-        let mut wallet_capability = WalletCapability::read(&mut reader, network)?;
+    fn read_v0<R: Read>(mut reader: R, chain_type: ChainType, version: u64) -> io::Result<Self> {
+        let mut wallet_capability = WalletCapability::read(&mut reader, chain_type)?;
         let mut _blocks = Vector::read(&mut reader, |r| BlockData::read(r))?;
         let transactions = if version <= 14 {
             TxMap::read_old(&mut reader, &wallet_capability)?
@@ -148,10 +148,10 @@ impl LightWallet {
         };
 
         let chain_name = utils::read_string(&mut reader)?;
-        if chain_name != network.to_string() {
+        if chain_name != chain_type.to_string() {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("Wallet chain name {chain_name} doesn't match expected {network}"),
+                format!("Wallet chain name {chain_name} doesn't match expected {chain_type}"),
             ));
         }
 
@@ -231,7 +231,7 @@ impl LightWallet {
             if let Some(mnemonic) = mnemonic.as_ref() {
                 wallet_capability.unified_key_store = UnifiedKeyStore::Spend(Box::new(
                     UnifiedSpendingKey::from_seed(
-                        &network,
+                        &chain_type,
                         &mnemonic.to_seed(""),
                         AccountId::ZERO,
                     )
@@ -281,7 +281,7 @@ impl LightWallet {
             Ok(first_transparent_address) => {
                 transparent_addresses.insert(
                     transparent_address_id,
-                    transparent::encode_address(&network, first_transparent_address),
+                    transparent::encode_address(&chain_type, first_transparent_address),
                 );
             }
             Err(KeyError::NoViewCapability) => (),
@@ -329,7 +329,7 @@ impl LightWallet {
             sync_state,
             transparent_addresses,
             unified_addresses,
-            network,
+            chain_type,
             send_proposal: None,
             save_required: false,
             wallet_settings: WalletSettings {
@@ -344,12 +344,12 @@ impl LightWallet {
         Ok(lw)
     }
 
-    fn read_v32<R: Read>(mut reader: R, network: ChainType, version: u64) -> io::Result<Self> {
+    fn read_v32<R: Read>(mut reader: R, chain_type: ChainType, version: u64) -> io::Result<Self> {
         let saved_network = utils::read_string(&mut reader)?;
-        if saved_network != network.to_string() {
+        if saved_network != chain_type.to_string() {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("wallet chain name {saved_network} doesn't match expected {network}"),
+                format!("wallet chain name {saved_network} doesn't match expected {chain_type}"),
             ));
         }
 
@@ -372,7 +372,7 @@ impl LightWallet {
                 Ok((
                     zip32::AccountId::try_from(r.read_u32::<LittleEndian>()?)
                         .expect("only valid account ids are stored"),
-                    UnifiedKeyStore::read(r, network)?,
+                    UnifiedKeyStore::read(r, chain_type)?,
                 ))
             })?
             .into_iter()
@@ -381,7 +381,7 @@ impl LightWallet {
             let mut keys = BTreeMap::new();
             keys.insert(
                 zip32::AccountId::ZERO,
-                UnifiedKeyStore::read(&mut reader, network)?,
+                UnifiedKeyStore::read(&mut reader, chain_type)?,
             );
             keys
         };
@@ -422,7 +422,7 @@ impl LightWallet {
             Ok((
                 TransparentAddressId::new(account_id, scope, address_index),
                 transparent::encode_address(
-                    &network,
+                    &chain_type,
                     unified_key_store
                         .get(&account_id)
                         .ok_or(Error::new(
@@ -470,7 +470,7 @@ impl LightWallet {
                 Ok(first_transparent_address) => {
                     transparent_addresses.insert(
                         transparent_address_id,
-                        transparent::encode_address(&network, first_transparent_address),
+                        transparent::encode_address(&chain_type, first_transparent_address),
                     );
                 }
                 Err(KeyError::NoViewCapability) => (),
@@ -488,7 +488,7 @@ impl LightWallet {
             .map(|block| (block.block_height(), block))
             .collect::<BTreeMap<_, _>>();
         let wallet_transactions =
-            Vector::read(&mut reader, |r| WalletTransaction::read(r, &network))?
+            Vector::read(&mut reader, |r| WalletTransaction::read(r, &chain_type))?
                 .into_iter()
                 .map(|transaction| (transaction.txid(), transaction))
                 .collect::<HashMap<_, _>>();
@@ -545,7 +545,7 @@ impl LightWallet {
         Ok(Self {
             current_version: LightWallet::serialized_version(),
             read_version: version,
-            network,
+            chain_type,
             mnemonic,
             birthday,
             unified_key_store,

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -17,6 +17,7 @@ use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::{self, BlockHeight};
 use zcash_transparent::keys::NonHardenedChildIndex;
+use zingo_common_components::protocol::ActivationHeights;
 use zingo_price::PriceList;
 use zip32::AccountId;
 
@@ -45,7 +46,7 @@ impl LightWallet {
     /// - sync state updated serialized version
     #[must_use]
     pub const fn serialized_version() -> u64 {
-        39
+        40
     }
 
     /// Serialize into `writer`
@@ -55,7 +56,11 @@ impl LightWallet {
         consensus_parameters: &impl consensus::Parameters,
     ) -> io::Result<()> {
         writer.write_u64::<LittleEndian>(Self::serialized_version())?;
-        utils::write_string(&mut writer, &self.chain_type.to_string())?;
+        writer.write_u8(match self.chain_type() {
+            ChainType::Mainnet => 0,
+            ChainType::Testnet => 1,
+            ChainType::Regtest(_) => 2,
+        })?;
         let seed_bytes = match &self.mnemonic {
             Some(m) => m.clone().into_entropy(),
             None => vec![],
@@ -345,12 +350,46 @@ impl LightWallet {
     }
 
     fn read_v32<R: Read>(mut reader: R, chain_type: ChainType, version: u64) -> io::Result<Self> {
-        let saved_network = utils::read_string(&mut reader)?;
-        if saved_network != chain_type.to_string() {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                format!("wallet chain name {saved_network} doesn't match expected {chain_type}"),
-            ));
+        if version >= 40 {
+            let saved_network = match reader.read_u8()? {
+                0 => ChainType::Mainnet,
+                1 => ChainType::Testnet,
+                2 => ChainType::Regtest(ActivationHeights::default()),
+                other => {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("invalid chain type index stored in wallet file: {}", other,),
+                    ));
+                }
+            };
+            if saved_network.to_string() != chain_type.to_string() {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "wallet chain name {saved_network} doesn't match expected {chain_type}"
+                    ),
+                ));
+            }
+        } else {
+            let saved_network = match utils::read_string(&mut reader)?.as_str() {
+                "main" => "mainnet",
+                "test" => "testnet",
+                "regtest" => "regtest",
+                other => {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        format!("invalid chain type stored in wallet file: {}", other,),
+                    ));
+                }
+            };
+            if saved_network != chain_type.to_string() {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "wallet chain name {saved_network} doesn't match expected {chain_type}"
+                    ),
+                ));
+            }
         }
 
         let seed_bytes = Vector::read(&mut reader, byteorder::ReadBytesExt::read_u8)?;

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -152,11 +152,21 @@ impl LightWallet {
             TxMap::read(&mut reader, &wallet_capability)?
         };
 
-        let chain_name = utils::read_string(&mut reader)?;
-        if chain_name != chain_type.to_string() {
+        let saved_network = match utils::read_string(&mut reader)?.as_str() {
+            "main" => "mainnet",
+            "test" => "testnet",
+            "regtest" => "regtest",
+            other => {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("invalid chain type stored in wallet file: {}", other,),
+                ));
+            }
+        };
+        if saved_network != chain_type.to_string() {
             return Err(Error::new(
                 ErrorKind::InvalidData,
-                format!("Wallet chain name {chain_name} doesn't match expected {chain_type}"),
+                format!("wallet chain name {saved_network} doesn't match expected {chain_type}"),
             ));
         }
 

--- a/zingolib/src/wallet/disk/testing.rs
+++ b/zingolib/src/wallet/disk/testing.rs
@@ -30,7 +30,7 @@ pub async fn assert_wallet_capability_matches_seed(
         Mnemonic::<bip0039::English>::from_phrase(expected_seed_phrase).unwrap();
 
     let expected_keys = crate::wallet::keys::unified::UnifiedKeyStore::new_from_mnemonic(
-        &wallet.chain_type,
+        wallet.chain_type,
         &expected_mnemonic,
         zip32::AccountId::ZERO,
     )

--- a/zingolib/src/wallet/disk/testing.rs
+++ b/zingolib/src/wallet/disk/testing.rs
@@ -30,7 +30,7 @@ pub async fn assert_wallet_capability_matches_seed(
         Mnemonic::<bip0039::English>::from_phrase(expected_seed_phrase).unwrap();
 
     let expected_keys = crate::wallet::keys::unified::UnifiedKeyStore::new_from_mnemonic(
-        &wallet.network,
+        &wallet.chain_type,
         &expected_mnemonic,
         zip32::AccountId::ZERO,
     )

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -9,7 +9,7 @@ use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscov
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds;
 
-use crate::config::{ChainType, DEFAULT_LIGHTWALLETD_SERVER, ZingoConfig};
+use crate::config::{ChainType, DEFAULT_INDEXER_URI, ZingoConfig};
 use crate::lightclient::LightClient;
 use crate::wallet::{LightWallet, WalletSettings};
 
@@ -278,11 +278,11 @@ impl NetworkSeedVersion {
         let config = match self {
             NetworkSeedVersion::Regtest(_) => {
                 // Probably should be undefined. For the purpose of these tests, I hope it doesnt matter.
-                let lightwalletd_uri = DEFAULT_LIGHTWALLETD_SERVER.parse::<Uri>().unwrap();
+                let lightwalletd_uri = DEFAULT_INDEXER_URI.parse::<Uri>().unwrap();
 
                 ZingoConfig::builder()
                     .set_indexer_uri(lightwalletd_uri)
-                    .set_network_type(ChainType::Regtest(ActivationHeights::default()))
+                    .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
                     .set_wallet_name("".to_string())
                     .set_wallet_settings(WalletSettings {
                         sync_config: SyncConfig {
@@ -298,7 +298,7 @@ impl NetworkSeedVersion {
             NetworkSeedVersion::Mainnet(_) => crate::config::ZingoConfig::create_mainnet(),
         };
 
-        let wallet = self.load_example_wallet(config.network_type());
+        let wallet = self.load_example_wallet(config.chain_type());
 
         LightClient::create_from_wallet(wallet, config, true).unwrap()
     }

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -248,7 +248,7 @@ async fn reload_wallet_from_buffer() {
     let expected_mnemonic = Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap();
 
     let expected_keys = UnifiedKeyStore::new_from_mnemonic(
-        &mid_client_network,
+        mid_client_network,
         &expected_mnemonic,
         zip32::AccountId::ZERO,
     )

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -237,8 +237,12 @@ async fn reload_wallet_from_buffer() {
         .unwrap();
 
     let config = ZingoConfig::create_testnet();
-    let wallet = LightWallet::read(&mid_buffer[..], config.network_type()).unwrap();
-    let client = LightClient::create_from_wallet(wallet, config, true).unwrap();
+    let client = LightClient::create_from_wallet(
+        LightWallet::read(&mid_buffer[..], config.chain_type()).unwrap(),
+        config,
+        true,
+    )
+    .unwrap();
     let wallet = client.wallet().read().await;
 
     let expected_mnemonic = Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap();
@@ -282,11 +286,11 @@ async fn reload_wallet_from_buffer() {
     }
 
     let ufvk = usk.to_unified_full_viewing_key();
-    let network = client.chain_type();
-    let ufvk_string = ufvk.encode(&network);
+    let chain_type = client.chain_type();
+    let ufvk_string = ufvk.encode(&chain_type);
     let ufvk_base = WalletBase::Ufvk(ufvk_string.clone());
     let view_wallet = LightWallet::new(
-        network,
+        chain_type,
         ufvk_base,
         client.birthday(),
         wallet.wallet_settings.clone(),
@@ -299,7 +303,7 @@ async fn reload_wallet_from_buffer() {
     else {
         panic!("should be viewing key!");
     };
-    let v_ufvk_string = v_ufvk.encode(&view_wallet.network);
+    let v_ufvk_string = v_ufvk.encode(&view_wallet.chain_type);
     assert_eq!(ufvk_string, v_ufvk_string);
 
     // NOTE: removed balance check as need to sync to restore transaction data.

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -118,7 +118,7 @@ impl LightWallet {
             .generate_transparent_address(address_id.address_index(), address_id.scope())?;
         self.transparent_addresses.insert(
             address_id,
-            transparent::encode_address(&self.network, external_address),
+            transparent::encode_address(&self.chain_type, external_address),
         );
         self.save_required = true;
 
@@ -164,7 +164,7 @@ impl LightWallet {
 
                 self.transparent_addresses.insert(
                     address_id,
-                    transparent::encode_address(&self.network, refund_address),
+                    transparent::encode_address(&self.chain_type, refund_address),
                 );
 
                 Ok((address_id, refund_address))
@@ -182,7 +182,7 @@ impl LightWallet {
         &self,
         encoded_address: &str,
     ) -> Result<Option<WalletAddressRef>, KeyError> {
-        Ok(match decode_address(&self.network, encoded_address)? {
+        Ok(match decode_address(&self.chain_type, encoded_address)? {
             zcash_keys::address::Address::Unified(address) => {
                 let orchard = address
                     .orchard()
@@ -263,7 +263,7 @@ impl LightWallet {
         &self,
         encoded_address: &str,
     ) -> Result<Option<WalletAddressRef>, KeyError> {
-        Ok(match decode_address(&self.network, encoded_address)? {
+        Ok(match decode_address(&self.chain_type, encoded_address)? {
             zcash_keys::address::Address::Unified(address) => {
                 let orchard = address
                     .orchard()
@@ -376,7 +376,7 @@ impl LightWallet {
         &self,
         address: &TransparentAddress,
     ) -> Option<TransparentAddressId> {
-        let encoded_address = transparent::encode_address(&self.network, *address);
+        let encoded_address = transparent::encode_address(&self.chain_type, *address);
 
         self.transparent_addresses
             .iter()
@@ -475,7 +475,7 @@ mod test {
                         account_id: zip32::AccountId::ZERO,
                     })
                     .unwrap()
-                    .encode(&self.network),
+                    .encode(&self.chain_type),
                 PoolType::SAPLING => self
                     .unified_addresses()
                     .get(&UnifiedAddressId {
@@ -483,7 +483,7 @@ mod test {
                         account_id: zip32::AccountId::ZERO,
                     })
                     .unwrap()
-                    .encode(&self.network),
+                    .encode(&self.chain_type),
                 PoolType::Transparent => {
                     self.transparent_addresses.values().next().unwrap().clone()
                 }

--- a/zingolib/src/wallet/keys/legacy/extended_transparent.rs
+++ b/zingolib/src/wallet/keys/legacy/extended_transparent.rs
@@ -112,7 +112,7 @@ impl ExtendedPrivKey {
             .derive_private_key(KeyIndex::hardened_from_normalize_index(44).unwrap())
             .unwrap()
             .derive_private_key(
-                KeyIndex::hardened_from_normalize_index(config.network_type().coin_type()).unwrap(),
+                KeyIndex::hardened_from_normalize_index(config.chain_type().coin_type()).unwrap(),
             )
             .unwrap()
             .derive_private_key(KeyIndex::hardened_from_normalize_index(position).unwrap())

--- a/zingolib/src/wallet/keys/unified.rs
+++ b/zingolib/src/wallet/keys/unified.rs
@@ -45,11 +45,11 @@ pub enum UnifiedKeyStore {
 impl UnifiedKeyStore {
     /// Create a unified key store from raw entropy (64-byte seed).
     pub fn new_from_seed(
-        network: &ChainType,
+        chain_type: ChainType,
         seed: &[u8; 64],
         account_index: zip32::AccountId,
     ) -> Result<Self, KeyError> {
-        let usk = UnifiedSpendingKey::from_seed(network, seed, account_index)
+        let usk = UnifiedSpendingKey::from_seed(&chain_type, seed, account_index)
             .map_err(KeyError::KeyDerivationError)?;
 
         Ok(UnifiedKeyStore::Spend(Box::new(usk)))
@@ -59,12 +59,12 @@ impl UnifiedKeyStore {
     ///
     /// Refer to BIP-0039 for details on seed generation from mnemonic phrases.
     pub fn new_from_mnemonic(
-        network: &ChainType,
+        chain_type: ChainType,
         mnemonic: &Mnemonic,
         account_index: zip32::AccountId,
     ) -> Result<Self, KeyError> {
         let seed = mnemonic.to_seed("");
-        Self::new_from_seed(network, &seed, account_index)
+        Self::new_from_seed(chain_type, &seed, account_index)
     }
 
     /// Create a unified key store from unified spending key bytes.
@@ -76,13 +76,13 @@ impl UnifiedKeyStore {
     }
 
     /// Create a unified key store from unified full viewing key encoded string.
-    pub fn new_from_ufvk(network: &ChainType, ufvk_encoded: String) -> Result<Self, KeyError> {
-        if ufvk_encoded.starts_with(network.hrp_sapling_extended_full_viewing_key()) {
+    pub fn new_from_ufvk(chain_type: ChainType, ufvk_encoded: String) -> Result<Self, KeyError> {
+        if ufvk_encoded.starts_with(chain_type.hrp_sapling_extended_full_viewing_key()) {
             return Err(KeyError::InvalidFormat);
         }
         let (network_type, ufvk) =
             Ufvk::decode(&ufvk_encoded).map_err(|_| KeyError::KeyDecodingError)?;
-        if network_type != network.network_type() {
+        if network_type != chain_type.network_type() {
             return Err(KeyError::NetworkMismatch);
         }
         let ufvk = UnifiedFullViewingKey::parse(&ufvk).map_err(|_| KeyError::KeyDecodingError)?;

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -37,7 +37,7 @@ impl LightWallet {
             ShieldedProtocol::Orchard,
             DustOutputPolicy::new(DustAction::AllowDustChange, None),
         );
-        let network = self.network;
+        let chain_type = self.chain_type;
 
         zcash_client_backend::data_api::wallet::propose_transfer::<
             LightWallet,
@@ -50,7 +50,7 @@ impl LightWallet {
             WalletError,
         >(
             self,
-            &network,
+            &chain_type,
             account_id,
             &input_selector,
             &change_strategy,
@@ -80,7 +80,7 @@ impl LightWallet {
             ShieldedProtocol::Orchard,
             DustOutputPolicy::new(DustAction::AllowDustChange, None),
         );
-        let network = self.network;
+        let chain_type = self.chain_type;
 
         // TODO: store t addrs as concrete types instead of encoded
         let transparent_addresses = self
@@ -89,7 +89,7 @@ impl LightWallet {
             .map(|address| {
                 Ok(zcash_address::ZcashAddress::try_from_encoded(address)?
                     .convert_if_network::<zcash_transparent::address::TransparentAddress>(
-                        self.network.network_type(),
+                        self.chain_type.network_type(),
                     )
                     .expect("incorrect network should be checked on wallet load"))
             })
@@ -106,7 +106,7 @@ impl LightWallet {
             WalletError,
         >(
             self,
-            &network,
+            &chain_type,
             &input_selector,
             &change_strategy,
             Zatoshis::const_from_u64(10_000),
@@ -155,7 +155,7 @@ impl LightWallet {
             if let Ok(address) = payment
                 .recipient_address()
                 .clone()
-                .convert_if_network::<zcash_keys::address::Address>(self.network.network_type())
+                .convert_if_network::<zcash_keys::address::Address>(self.chain_type.network_type())
             {
                 match address {
                     zcash_keys::address::Address::Unified(unified_address) => {
@@ -170,7 +170,7 @@ impl LightWallet {
             }
         }
         let uas_bytes = match zingo_memo::create_wallet_internal_memo_version_1(
-            &self.network,
+            &self.chain_type,
             recipient_uas.as_slice(),
             refund_address_indexes.as_slice(),
         ) {

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -38,7 +38,7 @@ impl LightWallet {
                             .recipient_address()
                             .clone()
                             .convert_if_network::<zcash_keys::address::Address>(
-                                self.network.network_type()
+                                self.chain_type.network_type()
                             ),
                         Ok(zcash_keys::address::Address::Tex(_))
                     )
@@ -60,7 +60,7 @@ impl LightWallet {
         proposal: Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, NoteRef>,
         sending_account: zip32::AccountId,
     ) -> Result<NonEmpty<TxId>, CalculateTransactionError<NoteRef>> {
-        let network = self.network;
+        let chain_type = self.chain_type;
         let usk: zcash_keys::keys::UnifiedSpendingKey = self
             .unified_key_store
             .get(&sending_account)
@@ -75,7 +75,7 @@ impl LightWallet {
             zcash_proofs::prover::LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
         zcash_client_backend::data_api::wallet::create_proposed_transactions(
             self,
-            &network,
+            &chain_type,
             &sapling_prover,
             &sapling_prover,
             &SpendingKeys::new(usk),

--- a/zingolib/src/wallet/summary.rs
+++ b/zingolib/src/wallet/summary.rs
@@ -120,10 +120,10 @@ impl LightWallet {
                             memo,
                             value: note.value(),
                             recipient: note
-                                .encoded_recipient(&self.network)
+                                .encoded_recipient(&self.chain_type)
                                 .map_err(zcash_address::ParseError::Unified)?,
                             recipient_unified_address: note
-                                .encoded_recipient_full_unified_address(&self.network),
+                                .encoded_recipient_full_unified_address(&self.chain_type),
                             output_index: note.output_id().output_index(),
                             account_id: note.key_id().account_id,
                             scope: Scope::from(note.key_id().scope),
@@ -144,9 +144,11 @@ impl LightWallet {
                             output_index: note.output_id().output_index(),
                             memo,
                             value: note.value(),
-                            recipient: note.encoded_recipient(&self.network).expect("infallible"),
+                            recipient: note
+                                .encoded_recipient(&self.chain_type)
+                                .expect("infallible"),
                             recipient_unified_address: note
-                                .encoded_recipient_full_unified_address(&self.network),
+                                .encoded_recipient_full_unified_address(&self.chain_type),
                             account_id: note.key_id().account_id,
                             scope: Scope::from(note.key_id().scope),
                         }
@@ -168,7 +170,7 @@ impl LightWallet {
                                         OutgoingCoinSummary {
                                             value: transparent_output.value().into_u64(),
                                             recipient: transparent::encode_address(
-                                                &self.network,
+                                                &self.chain_type,
                                                 address,
                                             ),
                                             output_index: output_index as u16,

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -118,7 +118,7 @@ impl LightWallet {
         &self,
         transaction: &WalletTransaction,
     ) -> Result<TransactionKind, SpendError> {
-        let zfz_address = get_zennies_for_zingo_address(&self.chain_type);
+        let zfz_address = get_zennies_for_zingo_address(self.chain_type);
 
         let transparent_spends = self.find_spends::<TransparentCoin>(transaction, false)?;
         let sapling_spends = self.find_spends::<SaplingNote>(transaction, false)?;

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -9,7 +9,7 @@ use pepper_sync::wallet::{
 use super::LightWallet;
 use super::error::{FeeError, SpendError};
 use super::summary::data::{SendType, TransactionKind};
-use crate::config::get_donation_address_for_chain;
+use crate::get_zennies_for_zingo_address;
 use crate::wallet::error::WalletError;
 
 impl LightWallet {
@@ -118,7 +118,7 @@ impl LightWallet {
         &self,
         transaction: &WalletTransaction,
     ) -> Result<TransactionKind, SpendError> {
-        let zfz_address = get_donation_address_for_chain(&self.network);
+        let zfz_address = get_zennies_for_zingo_address(&self.chain_type);
 
         let transparent_spends = self.find_spends::<TransparentCoin>(transaction, false)?;
         let sapling_spends = self.find_spends::<SaplingNote>(transaction, false)?;
@@ -151,7 +151,7 @@ impl LightWallet {
                         .is_some()
                         || outgoing_note.key_id().scope == zip32::Scope::Internal
                         || outgoing_note
-                            .encoded_recipient_full_unified_address(&self.network)
+                            .encoded_recipient_full_unified_address(&self.chain_type)
                             .is_some_and(|unified_address| unified_address == *zfz_address)
                 })
             && transaction
@@ -162,7 +162,7 @@ impl LightWallet {
                         .is_some()
                         || outgoing_note.key_id().scope == zip32::Scope::Internal
                         || outgoing_note
-                            .encoded_recipient_full_unified_address(&self.network)
+                            .encoded_recipient_full_unified_address(&self.chain_type)
                             .is_some_and(|unified_address| unified_address == *zfz_address)
                 })
         {
@@ -192,7 +192,7 @@ mod tests {
     fn test_wallet() -> LightWallet {
         let config = ZingoConfig::builder().build();
         LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::FreshEntropy {
                 no_of_accounts: 1.try_into().unwrap(),
             },

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -111,7 +111,7 @@ impl WalletRead for LightWallet {
         let Some((account_id, unified_key)) =
             self.unified_key_store.iter().find(|(_, unified_key)| {
                 UnifiedFullViewingKey::try_from(*unified_key).is_ok_and(|account_ufvk| {
-                    account_ufvk.encode(&self.network) == *ufvk.encode(&self.network)
+                    account_ufvk.encode(&self.chain_type) == *ufvk.encode(&self.chain_type)
                 })
             })
         else {
@@ -259,7 +259,7 @@ impl WalletRead for LightWallet {
             })
             .map(|(address_id, encoded_address)| {
                 let address = ZcashAddress::try_from_encoded(encoded_address)?
-                    .convert_if_network::<TransparentAddress>(self.network.network_type())
+                    .convert_if_network::<TransparentAddress>(self.chain_type.network_type())
                     .expect("incorrect network should be checked on wallet load");
                 let address_metadata = TransparentAddressMetadata::derived(
                     address_id.scope().into(),
@@ -286,7 +286,7 @@ impl WalletRead for LightWallet {
             })
             .map(|(address_id, encoded_address)| {
                 let address = ZcashAddress::try_from_encoded(encoded_address)?
-                    .convert_if_network::<TransparentAddress>(self.network.network_type())
+                    .convert_if_network::<TransparentAddress>(self.chain_type.network_type())
                     .expect("incorrect network should be checked on wallet load");
                 let address_metadata = TransparentAddressMetadata::derived(
                     address_id.scope().into(),
@@ -430,7 +430,7 @@ impl WalletWrite for LightWallet {
         &mut self,
         transactions: &[zcash_client_backend::data_api::SentTransaction<Self::AccountId>],
     ) -> Result<(), Self::Error> {
-        let network = self.network;
+        let chain_type = self.chain_type;
 
         for sent_transaction in transactions {
             // this is a workaround as Transaction does not implement Clone
@@ -442,14 +442,14 @@ impl WalletWrite for LightWallet {
             let transaction = Transaction::read(
                 transaction_bytes.as_slice(),
                 consensus::BranchId::for_height(
-                    &self.network,
+                    &self.chain_type,
                     sent_transaction.target_height().into(),
                 ),
             )
             .map_err(WalletError::TransactionRead)?;
 
             match pepper_sync::scan_pending_transaction(
-                &network,
+                &chain_type,
                 &SyncWallet::get_unified_full_viewing_keys(self)?,
                 self,
                 transaction,
@@ -832,7 +832,7 @@ impl InputSource for LightWallet {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
     ) -> Result<Vec<WalletUtxo>, Self::Error> {
-        let address = transparent::encode_address(&self.network, *address);
+        let address = transparent::encode_address(&self.chain_type, *address);
 
         // TODO: add recipient key scope metadata
         Ok(self

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -175,7 +175,7 @@ impl ClientBuilder {
         std::fs::create_dir(&conf_path).unwrap();
         ZingoConfig::builder()
             .set_indexer_uri(self.server_id.clone())
-            .set_network_type(ChainType::Regtest(configured_activation_heights))
+            .set_chain_type(ChainType::Regtest(configured_activation_heights))
             .set_wallet_dir(conf_path)
             .set_wallet_name("".to_string())
             .set_wallet_settings(WalletSettings {
@@ -216,7 +216,7 @@ impl ClientBuilder {
         let mnemonic = Mnemonic::from_phrase(mnemonic_phrase).unwrap();
         let birthday = (birthday as u32).into();
         let mut wallet = LightWallet::new(
-            config.network_type(),
+            config.chain_type(),
             WalletBase::Mnemonic {
                 mnemonic,
                 no_of_accounts: 1.try_into().unwrap(),


### PR DESCRIPTION
preliminary work for fixing #2269. continued in PR #2266 

- removes `zcash_protocol` from public API by consealing Parameters impl on ChainType
- consistent `chain_type` naming throughout codebase
- moves non-config consts and fns out of config module and renames to reflect move from LWD to indexer
- `construct_lightwalletd_uri` now returns result for handling uri errors
- new wallet serialization version 40. `ChainType` serialized as u8 instead of string to decouple from fmt::Display and reduce bytes stored.

