### PR TITLE
Zingo config rework pt3

### DIFF
--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -39,6 +39,7 @@ pub(crate) mod conduct_chain {
     use incrementalmerkletree::frontier::CommitmentTree;
     use orchard::tree::MerkleHashOrchard;
 
+    use zcash_protocol::consensus::BlockHeight;
     use zingo_netutils::Indexer as _;
 
     use zingolib::lightclient::LightClient;
@@ -73,20 +74,16 @@ pub(crate) mod conduct_chain {
         async fn create_faucet(&mut self) -> LightClient {
             self.stage_transaction(ABANDON_TO_DARKSIDE_SAP_10_000_000_ZAT)
                 .await;
-            let config = self
-                .client_builder
-                .make_unique_data_dir_and_load_config(self.configured_activation_heights);
-            let wallet = LightWallet::new(
-                config.chain_type(),
-                WalletBase::Mnemonic {
-                    mnemonic: Mnemonic::from_phrase(DARKSIDE_SEED.to_string()).unwrap(),
-                    no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-                },
-                1.into(),
-                config.wallet_settings(),
-            )
-            .unwrap();
-            let mut lightclient = LightClient::create_from_wallet(wallet, config, true).unwrap();
+            let wallet_base = WalletBase::Mnemonic {
+                mnemonic: Mnemonic::from_phrase(DARKSIDE_SEED.to_string()).unwrap(),
+                no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
+                birthday: BlockHeight::from_u32(1),
+            };
+            let config = self.client_builder.make_unique_data_dir_and_create_config(
+                self.configured_activation_heights,
+                wallet_base,
+            );
+            let mut lightclient = LightClient::new(config, true).unwrap();
 
             lightclient
                 .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
@@ -97,8 +94,9 @@ pub(crate) mod conduct_chain {
         }
 
         async fn zingo_config(&mut self) -> zingolib::config::ZingoConfig {
-            self.client_builder
-                .make_unique_data_dir_and_load_config(self.configured_activation_heights)
+            // self.client_builder
+            //     .make_unique_data_dir_and_create_config(self.configured_activation_heights)
+            todo!()
         }
 
         async fn increase_chain_height(&mut self) {

--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -42,10 +42,10 @@ pub(crate) mod conduct_chain {
     use zcash_protocol::consensus::BlockHeight;
     use zingo_netutils::Indexer as _;
 
+    use zingolib::config::WalletBase;
     use zingolib::lightclient::LightClient;
     use zingolib::testutils::chain_generics::conduct_chain::ConductChain;
     use zingolib::wallet::LightWallet;
-    use zingolib::wallet::WalletBase;
     use zingolib::wallet::keys::unified::ReceiverSelection;
 
     use crate::constants::ABANDON_TO_DARKSIDE_SAP_10_000_000_ZAT;
@@ -74,8 +74,8 @@ pub(crate) mod conduct_chain {
         async fn create_faucet(&mut self) -> LightClient {
             self.stage_transaction(ABANDON_TO_DARKSIDE_SAP_10_000_000_ZAT)
                 .await;
-            let wallet_base = WalletBase::Mnemonic {
-                mnemonic: Mnemonic::from_phrase(DARKSIDE_SEED.to_string()).unwrap(),
+            let wallet_base = WalletBase::MnemonicPhrase {
+                mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
                 birthday: BlockHeight::from_u32(1),
             };

--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -42,9 +42,10 @@ pub(crate) mod conduct_chain {
     use zcash_protocol::consensus::BlockHeight;
     use zingo_netutils::Indexer as _;
 
-    use zingolib::config::WalletBase;
+    use zingolib::config::WalletConfig;
     use zingolib::lightclient::LightClient;
     use zingolib::testutils::chain_generics::conduct_chain::ConductChain;
+    use zingolib::testutils::default_test_wallet_settings;
     use zingolib::wallet::LightWallet;
     use zingolib::wallet::keys::unified::ReceiverSelection;
 
@@ -74,14 +75,15 @@ pub(crate) mod conduct_chain {
         async fn create_faucet(&mut self) -> LightClient {
             self.stage_transaction(ABANDON_TO_DARKSIDE_SAP_10_000_000_ZAT)
                 .await;
-            let wallet_base = WalletBase::MnemonicPhrase {
+            let wallet_config = WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
                 birthday: BlockHeight::from_u32(1),
+                wallet_settings: default_test_wallet_settings(),
             };
             let config = self.client_builder.make_unique_data_dir_and_create_config(
                 self.configured_activation_heights,
-                wallet_base,
+                wallet_config,
             );
             let mut lightclient = LightClient::new(config, true).unwrap();
 
@@ -93,12 +95,13 @@ pub(crate) mod conduct_chain {
             lightclient
         }
 
-        async fn zingo_config(&mut self) -> zingolib::config::ZingoConfig {
+        async fn zingo_config(&mut self) -> zingolib::config::ClientConfig {
             self.client_builder.make_unique_data_dir_and_create_config(
                 self.configured_activation_heights,
-                WalletBase::FreshEntropy {
+                WalletConfig::NewSeed {
                     no_of_accounts: 1.try_into().unwrap(),
                     chain_height: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
             )
         }

--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -78,7 +78,7 @@ pub(crate) mod conduct_chain {
             let wallet_config = WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-                birthday: BlockHeight::from_u32(1),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             };
             let config = self.client_builder.make_unique_data_dir_and_create_config(
@@ -100,7 +100,7 @@ pub(crate) mod conduct_chain {
                 self.configured_activation_heights,
                 WalletConfig::NewSeed {
                     no_of_accounts: 1.try_into().unwrap(),
-                    chain_height: 1.into(),
+                    chain_height: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
             )

--- a/darkside-tests/src/chain_generics.rs
+++ b/darkside-tests/src/chain_generics.rs
@@ -94,9 +94,13 @@ pub(crate) mod conduct_chain {
         }
 
         async fn zingo_config(&mut self) -> zingolib::config::ZingoConfig {
-            // self.client_builder
-            //     .make_unique_data_dir_and_create_config(self.configured_activation_heights)
-            todo!()
+            self.client_builder.make_unique_data_dir_and_create_config(
+                self.configured_activation_heights,
+                WalletBase::FreshEntropy {
+                    no_of_accounts: 1.try_into().unwrap(),
+                    chain_height: 1.into(),
+                },
+            )
         }
 
         async fn increase_chain_height(&mut self) {

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -327,12 +327,14 @@ fn write_transaction(transaction: Transaction, mut chainbuild_file: &File) {
 
 pub mod scenarios {
     use std::fs::File;
+    use std::num::NonZeroU32;
     use std::ops::Add;
 
     use zcash_local_net::indexer::lightwalletd::Lightwalletd;
     use zcash_protocol::consensus::{BlockHeight, BranchId};
     use zcash_protocol::{PoolType, ShieldedProtocol};
     use zingo_common_components::protocol::ActivationHeights;
+    use zingolib::config::WalletBase;
 
     use super::{
         DarksideConnector, init_darksidewalletd, update_tree_states_for_transaction,
@@ -342,7 +344,7 @@ pub mod scenarios {
         constants,
         darkside_types::{RawTransaction, TreeState},
     };
-    use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
+    use zingo_test_vectors::seeds::{DARKSIDE_SEED, HOSPITAL_MUSEUM_SEED};
     use zingolib::lightclient::LightClient;
     use zingolib_testutils::scenarios::ClientBuilder;
 
@@ -397,12 +399,19 @@ pub mod scenarios {
         /// The staged block with the funding transaction is not applied and the faucet is not synced
         pub async fn build_faucet(&mut self, funded_pool: PoolType) -> &mut DarksideEnvironment {
             assert!(self.faucet.is_none(), "Error: Faucet already exists!");
-            self.faucet = Some(self.client_builder.build_client(
-                zingo_test_vectors::seeds::DARKSIDE_SEED.to_string(),
-                1,
-                true,
-                self.configured_activation_heights,
-            ));
+            self.faucet = Some(
+                self.client_builder
+                    .build_client(
+                        WalletBase::MnemonicPhrase {
+                            mnemonic_phrase: DARKSIDE_SEED.to_string(),
+                            no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
+                            birthday: BlockHeight::from_u32(1),
+                        },
+                        true,
+                        self.configured_activation_heights,
+                    )
+                    .await,
+            );
 
             let faucet_funding_transaction = match funded_pool {
                 PoolType::Shielded(ShieldedProtocol::Orchard) => {
@@ -426,12 +435,18 @@ pub mod scenarios {
             seed: String,
             birthday: u64,
         ) -> &mut DarksideEnvironment {
-            let lightclient = self.client_builder.build_client(
-                seed,
-                birthday,
-                true,
-                self.configured_activation_heights,
-            );
+            let lightclient = self
+                .client_builder
+                .build_client(
+                    WalletBase::MnemonicPhrase {
+                        mnemonic_phrase: seed,
+                        no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
+                        birthday: BlockHeight::from_u32(birthday as u32),
+                    },
+                    true,
+                    self.configured_activation_heights,
+                )
+                .await;
             self.lightclients.push(lightclient);
             self
         }

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -406,7 +406,7 @@ pub mod scenarios {
                         WalletConfig::MnemonicPhrase {
                             mnemonic_phrase: DARKSIDE_SEED.to_string(),
                             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-                            birthday: BlockHeight::from_u32(1),
+                            birthday: 1,
                             wallet_settings: default_test_wallet_settings(),
                         },
                         true,
@@ -443,7 +443,7 @@ pub mod scenarios {
                     WalletConfig::MnemonicPhrase {
                         mnemonic_phrase: seed,
                         no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-                        birthday: BlockHeight::from_u32(birthday as u32),
+                        birthday: birthday as u32,
                         wallet_settings: default_test_wallet_settings(),
                     },
                     true,

--- a/darkside-tests/src/utils.rs
+++ b/darkside-tests/src/utils.rs
@@ -334,7 +334,8 @@ pub mod scenarios {
     use zcash_protocol::consensus::{BlockHeight, BranchId};
     use zcash_protocol::{PoolType, ShieldedProtocol};
     use zingo_common_components::protocol::ActivationHeights;
-    use zingolib::config::WalletBase;
+    use zingolib::config::WalletConfig;
+    use zingolib::testutils::default_test_wallet_settings;
 
     use super::{
         DarksideConnector, init_darksidewalletd, update_tree_states_for_transaction,
@@ -402,10 +403,11 @@ pub mod scenarios {
             self.faucet = Some(
                 self.client_builder
                     .build_client(
-                        WalletBase::MnemonicPhrase {
+                        WalletConfig::MnemonicPhrase {
                             mnemonic_phrase: DARKSIDE_SEED.to_string(),
                             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
                             birthday: BlockHeight::from_u32(1),
+                            wallet_settings: default_test_wallet_settings(),
                         },
                         true,
                         self.configured_activation_heights,
@@ -438,10 +440,11 @@ pub mod scenarios {
             let lightclient = self
                 .client_builder
                 .build_client(
-                    WalletBase::MnemonicPhrase {
+                    WalletConfig::MnemonicPhrase {
                         mnemonic_phrase: seed,
                         no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
                         birthday: BlockHeight::from_u32(birthday as u32),
+                        wallet_settings: default_test_wallet_settings(),
                     },
                     true,
                     self.configured_activation_heights,

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -44,7 +44,7 @@ async fn reorg_changes_incoming_tx_height() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 202.into(),
+                birthday: 202,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -208,7 +208,7 @@ async fn reorg_changes_incoming_tx_index() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 202.into(),
+                birthday: 202,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -372,7 +372,7 @@ async fn reorg_expires_incoming_tx() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 202.into(),
+                birthday: 202,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -558,7 +558,7 @@ async fn reorg_changes_outgoing_tx_height() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 202.into(),
+                birthday: 202,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -819,7 +819,7 @@ async fn reorg_expires_outgoing_tx_height() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 202.into(),
+                birthday: 202,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -1025,7 +1025,7 @@ async fn reorg_changes_outgoing_tx_index() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 202.into(),
+                birthday: 202,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -15,9 +15,12 @@ use tokio::time::sleep;
 use zcash_local_net::indexer::Indexer;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_common_components::protocol::ActivationHeights;
-use zingolib::testutils::{port_to_localhost_uri, tempfile::TempDir};
 use zingolib::wallet::summary::data::SentValueTransfer;
 use zingolib::wallet::summary::data::ValueTransferKind;
+use zingolib::{
+    config::WalletBase,
+    testutils::{port_to_localhost_uri, tempfile::TempDir},
+};
 use zingolib::{
     testutils::{lightclient::from_inputs, paths::get_cargo_manifest_dir},
     wallet::balance::AccountBalance,
@@ -36,12 +39,17 @@ async fn reorg_changes_incoming_tx_height() {
         .unwrap();
 
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
-        202,
-        true,
-        ActivationHeights::default(),
-    );
+    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 202.into(),
+            },
+            true,
+            ActivationHeights::default(),
+        )
+        .await;
 
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
@@ -194,12 +202,17 @@ async fn reorg_changes_incoming_tx_index() {
         .unwrap();
 
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
-        202,
-        true,
-        ActivationHeights::default(),
-    );
+    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 202.into(),
+            },
+            true,
+            ActivationHeights::default(),
+        )
+        .await;
 
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
@@ -352,12 +365,17 @@ async fn reorg_expires_incoming_tx() {
         .unwrap();
 
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
-        202,
-        true,
-        ActivationHeights::default(),
-    );
+    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 202.into(),
+            },
+            true,
+            ActivationHeights::default(),
+        )
+        .await;
 
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
@@ -532,12 +550,17 @@ async fn reorg_changes_outgoing_tx_height() {
         .unwrap();
 
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
-        202,
-        true,
-        ActivationHeights::default(),
-    );
+    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 202.into(),
+            },
+            true,
+            ActivationHeights::default(),
+        )
+        .await;
 
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
@@ -787,12 +810,17 @@ async fn reorg_expires_outgoing_tx_height() {
         .unwrap();
 
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
-        202,
-        true,
-        ActivationHeights::default(),
-    );
+    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 202.into(),
+            },
+            true,
+            ActivationHeights::default(),
+        )
+        .await;
 
     let expected_initial_balance = AccountBalance {
         total_sapling_balance: Some(0.try_into().unwrap()),
@@ -987,12 +1015,17 @@ async fn reorg_changes_outgoing_tx_index() {
         .unwrap();
 
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
-        202,
-        true,
-        ActivationHeights::default(),
-    );
+    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 202.into(),
+            },
+            true,
+            ActivationHeights::default(),
+        )
+        .await;
 
     light_client.sync_and_await().await.unwrap();
     assert_eq!(

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -16,11 +16,11 @@ use zcash_local_net::indexer::Indexer;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_common_components::protocol::ActivationHeights;
 use zingolib::wallet::summary::data::SentValueTransfer;
-use zingolib::wallet::summary::data::ValueTransferKind;
 use zingolib::{
-    config::WalletBase,
+    config::WalletConfig,
     testutils::{port_to_localhost_uri, tempfile::TempDir},
 };
+use zingolib::{testutils::default_test_wallet_settings, wallet::summary::data::ValueTransferKind};
 use zingolib::{
     testutils::{lightclient::from_inputs, paths::get_cargo_manifest_dir},
     wallet::balance::AccountBalance,
@@ -41,10 +41,11 @@ async fn reorg_changes_incoming_tx_height() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 202.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             ActivationHeights::default(),
@@ -204,10 +205,11 @@ async fn reorg_changes_incoming_tx_index() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 202.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             ActivationHeights::default(),
@@ -367,10 +369,11 @@ async fn reorg_expires_incoming_tx() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 202.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             ActivationHeights::default(),
@@ -552,10 +555,11 @@ async fn reorg_changes_outgoing_tx_height() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 202.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             ActivationHeights::default(),
@@ -812,10 +816,11 @@ async fn reorg_expires_outgoing_tx_height() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 202.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             ActivationHeights::default(),
@@ -1017,10 +1022,11 @@ async fn reorg_changes_outgoing_tx_index() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: ADVANCED_REORG_TESTS_USER_WALLET.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 202.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             ActivationHeights::default(),

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use darkside_tests::darkside_connector::DarksideConnector;
 use darkside_tests::utils::prepare_darksidewalletd;
 use darkside_tests::utils::update_tree_states_for_transaction;
@@ -5,6 +7,7 @@ use tempfile::TempDir;
 use zcash_local_net::indexer::Indexer;
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds::DARKSIDE_SEED;
+use zingolib::config::ChainType;
 use zingolib::config::WalletBase;
 use zingolib::config::ZingoConfig;
 use zingolib::get_base_address_macro;
@@ -12,6 +15,10 @@ use zingolib::lightclient::LightClient;
 use zingolib::testutils::lightclient::from_inputs;
 use zingolib::testutils::port_to_localhost_uri;
 use zingolib::testutils::tempfile;
+use zingolib::wallet::PerformanceLevel;
+use zingolib::wallet::SyncConfig;
+use zingolib::wallet::TransparentAddressDiscovery;
+use zingolib::wallet::WalletSettings;
 use zingolib::wallet::balance::AccountBalance;
 use zingolib_testutils::scenarios::ClientBuilder;
 
@@ -28,15 +35,17 @@ async fn simple_sync() {
         .unwrap();
     let activation_heights = ActivationHeights::default();
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id, wallet_dir).build_client(
-        WalletBase::MnemonicPhrase {
-            mnemonic_phrase: DARKSIDE_SEED.to_string(),
-            no_of_accounts: 1.try_into().unwrap(),
-            birthday: 1.into(),
-        },
-        true,
-        activation_heights,
-    );
+    let mut light_client = ClientBuilder::new(server_id, wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: DARKSIDE_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            activation_heights,
+        )
+        .await;
 
     let result = light_client.sync_and_await().await.unwrap();
 
@@ -75,15 +84,17 @@ async fn reorg_receipt_sync_generic() {
 
     let activation_heights = ActivationHeights::default();
     let wallet_dir = TempDir::new().unwrap();
-    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        WalletBase::MnemonicPhrase {
-            mnemonic_phrase: DARKSIDE_SEED.to_string(),
-            no_of_accounts: 1.try_into().unwrap(),
-            birthday: 1.into(),
-        },
-        true,
-        activation_heights,
-    );
+    let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: DARKSIDE_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            activation_heights,
+        )
+        .await;
     light_client.sync_and_await().await.unwrap();
 
     assert_eq!(
@@ -150,15 +161,17 @@ async fn sent_transaction_reorged_into_mempool() {
             activation_heights,
         )
         .await;
-    let mut recipient = client_manager.build_client(
-        WalletBase::MnemonicPhrase {
-            mnemonic_phrase: zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-            no_of_accounts: 1.try_into().unwrap(),
-            birthday: 1.into(),
-        },
-        true,
-        activation_heights,
-    );
+    let mut recipient = client_manager
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            activation_heights,
+        )
+        .await;
 
     light_client.sync_and_await().await.unwrap();
     assert_eq!(
@@ -250,7 +263,7 @@ async fn sent_transaction_reorged_into_mempool() {
     let config = ZingoConfig::builder()
         .set_indexer_uri(client_manager.server_id.clone())
         .set_chain_type(ChainType::Regtest(activation_heights))
-        .set_wallet_dir(light_client.wallet_dir())
+        .set_wallet_dir(light_client.wallet_dir().unwrap())
         .set_wallet_base(WalletBase::Read)
         .set_wallet_settings(WalletSettings {
             sync_config: SyncConfig {

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -35,7 +35,7 @@ async fn simple_sync() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -85,7 +85,7 @@ async fn reorg_receipt_sync_generic() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -152,7 +152,7 @@ async fn sent_transaction_reorged_into_mempool() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -164,7 +164,7 @@ async fn sent_transaction_reorged_into_mempool() {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU32;
-
 use darkside_tests::darkside_connector::DarksideConnector;
 use darkside_tests::utils::prepare_darksidewalletd;
 use darkside_tests::utils::update_tree_states_for_transaction;
@@ -8,17 +6,14 @@ use zcash_local_net::indexer::Indexer;
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds::DARKSIDE_SEED;
 use zingolib::config::ChainType;
-use zingolib::config::WalletBase;
-use zingolib::config::ZingoConfig;
+use zingolib::config::ClientConfig;
+use zingolib::config::WalletConfig;
 use zingolib::get_base_address_macro;
 use zingolib::lightclient::LightClient;
+use zingolib::testutils::default_test_wallet_settings;
 use zingolib::testutils::lightclient::from_inputs;
 use zingolib::testutils::port_to_localhost_uri;
 use zingolib::testutils::tempfile;
-use zingolib::wallet::PerformanceLevel;
-use zingolib::wallet::SyncConfig;
-use zingolib::wallet::TransparentAddressDiscovery;
-use zingolib::wallet::WalletSettings;
 use zingolib::wallet::balance::AccountBalance;
 use zingolib_testutils::scenarios::ClientBuilder;
 
@@ -37,10 +32,11 @@ async fn simple_sync() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id, wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             activation_heights,
@@ -86,10 +82,11 @@ async fn reorg_receipt_sync_generic() {
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir)
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             activation_heights,
@@ -152,10 +149,11 @@ async fn sent_transaction_reorged_into_mempool() {
     let activation_heights = ActivationHeights::default();
     let mut light_client = client_manager
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: DARKSIDE_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             activation_heights,
@@ -163,10 +161,11 @@ async fn sent_transaction_reorged_into_mempool() {
         .await;
     let mut recipient = client_manager
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             activation_heights,
@@ -260,18 +259,11 @@ async fn sent_transaction_reorged_into_mempool() {
     light_client.wait_for_save().await;
     light_client.shutdown_save_task().await.unwrap();
 
-    let config = ZingoConfig::builder()
+    let config = ClientConfig::builder()
         .set_indexer_uri(client_manager.server_id.clone())
         .set_chain_type(ChainType::Regtest(activation_heights))
         .set_wallet_dir(light_client.wallet_dir().unwrap())
-        .set_wallet_base(WalletBase::Read)
-        .set_wallet_settings(WalletSettings {
-            sync_config: SyncConfig {
-                transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                performance_level: PerformanceLevel::High,
-            },
-            min_confirmations: NonZeroU32::try_from(1).unwrap(),
-        })
+        .set_wallet_config(WalletConfig::Read)
         .build();
     let mut loaded_client = LightClient::new(config, true).unwrap();
 

--- a/darkside-tests/tests/tests.rs
+++ b/darkside-tests/tests/tests.rs
@@ -5,7 +5,10 @@ use tempfile::TempDir;
 use zcash_local_net::indexer::Indexer;
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds::DARKSIDE_SEED;
+use zingolib::config::WalletBase;
+use zingolib::config::ZingoConfig;
 use zingolib::get_base_address_macro;
+use zingolib::lightclient::LightClient;
 use zingolib::testutils::lightclient::from_inputs;
 use zingolib::testutils::port_to_localhost_uri;
 use zingolib::testutils::tempfile;
@@ -26,8 +29,11 @@ async fn simple_sync() {
     let activation_heights = ActivationHeights::default();
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id, wallet_dir).build_client(
-        DARKSIDE_SEED.to_string(),
-        1,
+        WalletBase::MnemonicPhrase {
+            mnemonic_phrase: DARKSIDE_SEED.to_string(),
+            no_of_accounts: 1.try_into().unwrap(),
+            birthday: 1.into(),
+        },
         true,
         activation_heights,
     );
@@ -70,8 +76,11 @@ async fn reorg_receipt_sync_generic() {
     let activation_heights = ActivationHeights::default();
     let wallet_dir = TempDir::new().unwrap();
     let mut light_client = ClientBuilder::new(server_id.clone(), wallet_dir).build_client(
-        DARKSIDE_SEED.to_string(),
-        1,
+        WalletBase::MnemonicPhrase {
+            mnemonic_phrase: DARKSIDE_SEED.to_string(),
+            no_of_accounts: 1.try_into().unwrap(),
+            birthday: 1.into(),
+        },
         true,
         activation_heights,
     );
@@ -130,11 +139,23 @@ async fn sent_transaction_reorged_into_mempool() {
     let wallet_dir = TempDir::new().unwrap();
     let mut client_manager = ClientBuilder::new(server_id.clone(), wallet_dir);
     let activation_heights = ActivationHeights::default();
-    let mut light_client =
-        client_manager.build_client(DARKSIDE_SEED.to_string(), 0, true, activation_heights);
+    let mut light_client = client_manager
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: DARKSIDE_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            activation_heights,
+        )
+        .await;
     let mut recipient = client_manager.build_client(
-        zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-        1,
+        WalletBase::MnemonicPhrase {
+            mnemonic_phrase: zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+            no_of_accounts: 1.try_into().unwrap(),
+            birthday: 1.into(),
+        },
         true,
         activation_heights,
     );
@@ -221,10 +242,26 @@ async fn sent_transaction_reorged_into_mempool() {
             .await
             .unwrap()
     );
-    let mut loaded_client =
-        zingolib::testutils::lightclient::new_client_from_save_buffer(&mut light_client)
-            .await
-            .unwrap();
+
+    light_client.save_task().await;
+    light_client.wait_for_save().await;
+    light_client.shutdown_save_task().await.unwrap();
+
+    let config = ZingoConfig::builder()
+        .set_indexer_uri(client_manager.server_id.clone())
+        .set_chain_type(ChainType::Regtest(activation_heights))
+        .set_wallet_dir(light_client.wallet_dir())
+        .set_wallet_base(WalletBase::Read)
+        .set_wallet_settings(WalletSettings {
+            sync_config: SyncConfig {
+                transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                performance_level: PerformanceLevel::High,
+            },
+            min_confirmations: NonZeroU32::try_from(1).unwrap(),
+        })
+        .build();
+    let mut loaded_client = LightClient::new(config, true).unwrap();
+
     loaded_client.sync_and_await().await.unwrap();
     assert_eq!(
         loaded_client

--- a/libtonode-tests/src/chain_generics.rs
+++ b/libtonode-tests/src/chain_generics.rs
@@ -42,9 +42,10 @@ impl ConductChain for LibtonodeEnvironment {
     }
 
     async fn zingo_config(&mut self) -> zingolib::config::ZingoConfig {
-        self.client_builder.make_unique_data_dir_and_load_config(
-            self.local_net.validator().get_activation_heights().await,
-        )
+        // self.client_builder.make_unique_data_dir_and_create_config(
+        //     self.local_net.validator().get_activation_heights().await,
+        // )
+        todo!()
     }
 
     async fn increase_chain_height(&mut self) {

--- a/libtonode-tests/src/chain_generics.rs
+++ b/libtonode-tests/src/chain_generics.rs
@@ -35,10 +35,12 @@ impl ConductChain for LibtonodeEnvironment {
     }
 
     async fn create_faucet(&mut self) -> LightClient {
-        self.client_builder.build_faucet(
-            false,
-            self.local_net.validator().get_activation_heights().await,
-        )
+        self.client_builder
+            .build_faucet(
+                false,
+                self.local_net.validator().get_activation_heights().await,
+            )
+            .await
     }
 
     async fn zingo_config(&mut self) -> zingolib::config::ZingoConfig {

--- a/libtonode-tests/src/chain_generics.rs
+++ b/libtonode-tests/src/chain_generics.rs
@@ -4,9 +4,10 @@ use zcash_local_net::LocalNet;
 use zcash_local_net::indexer::Indexer;
 use zcash_local_net::validator::Validator;
 
-use zingolib::config::WalletBase;
+use zingolib::config::WalletConfig;
 use zingolib::lightclient::LightClient;
 use zingolib::testutils::chain_generics::conduct_chain::ConductChain;
+use zingolib::testutils::default_test_wallet_settings;
 use zingolib::testutils::port_to_localhost_uri;
 use zingolib::testutils::timestamped_test_log;
 
@@ -44,12 +45,13 @@ impl ConductChain for LibtonodeEnvironment {
             .await
     }
 
-    async fn zingo_config(&mut self) -> zingolib::config::ZingoConfig {
+    async fn zingo_config(&mut self) -> zingolib::config::ClientConfig {
         self.client_builder.make_unique_data_dir_and_create_config(
             self.local_net.validator().get_activation_heights().await,
-            WalletBase::FreshEntropy {
+            WalletConfig::NewSeed {
                 no_of_accounts: 1.try_into().unwrap(),
                 chain_height: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
         )
     }

--- a/libtonode-tests/src/chain_generics.rs
+++ b/libtonode-tests/src/chain_generics.rs
@@ -50,7 +50,7 @@ impl ConductChain for LibtonodeEnvironment {
             self.local_net.validator().get_activation_heights().await,
             WalletConfig::NewSeed {
                 no_of_accounts: 1.try_into().unwrap(),
-                chain_height: 1.into(),
+                chain_height: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
         )

--- a/libtonode-tests/src/chain_generics.rs
+++ b/libtonode-tests/src/chain_generics.rs
@@ -4,6 +4,7 @@ use zcash_local_net::LocalNet;
 use zcash_local_net::indexer::Indexer;
 use zcash_local_net::validator::Validator;
 
+use zingolib::config::WalletBase;
 use zingolib::lightclient::LightClient;
 use zingolib::testutils::chain_generics::conduct_chain::ConductChain;
 use zingolib::testutils::port_to_localhost_uri;
@@ -44,10 +45,13 @@ impl ConductChain for LibtonodeEnvironment {
     }
 
     async fn zingo_config(&mut self) -> zingolib::config::ZingoConfig {
-        // self.client_builder.make_unique_data_dir_and_create_config(
-        //     self.local_net.validator().get_activation_heights().await,
-        // )
-        todo!()
+        self.client_builder.make_unique_data_dir_and_create_config(
+            self.local_net.validator().get_activation_heights().await,
+            WalletBase::FreshEntropy {
+                no_of_accounts: 1.try_into().unwrap(),
+                chain_height: 1.into(),
+            },
+        )
     }
 
     async fn increase_chain_height(&mut self) {

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -462,8 +462,9 @@ mod fast {
     #[tokio::test]
     async fn unified_address_discovery() {
         let (local_net, mut client_builder) = scenarios::custom_clients_default().await;
-        let mut faucet =
-            client_builder.build_faucet(true, local_net.validator().get_activation_heights().await);
+        let mut faucet = client_builder
+            .build_faucet(true, local_net.validator().get_activation_heights().await)
+            .await;
         let mut recipient = client_builder
             .build_client(
                 WalletBase::MnemonicPhrase {
@@ -519,15 +520,17 @@ mod fast {
         local_net.validator().generate_blocks(1).await.unwrap();
 
         // rebuild recipient and check the UAs don't exist in the wallet
-        let mut recipient = client_builder.build_client(
-            WalletBase::MnemonicPhrase {
-                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
-            },
-            true,
-            local_net.validator().get_activation_heights().await,
-        );
+        let mut recipient = client_builder
+            .build_client(
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 1.into(),
+                },
+                true,
+                local_net.validator().get_activation_heights().await,
+            )
+            .await;
         if let Some(_ua) =
             recipient
                 .wallet()
@@ -1206,15 +1209,17 @@ mod fast {
         let seed_phrase = Mnemonic::<bip0039::English>::from_entropy([1; 32])
             .unwrap()
             .to_string();
-        let mut recipient = client_builder.build_client(
-            WalletBase::MnemonicPhrase {
-                mnemonic_phrase: seed_phrase,
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
-            },
-            false,
-            local_net.validator().get_activation_heights().await,
-        );
+        let mut recipient = client_builder
+            .build_client(
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: seed_phrase,
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 1.into(),
+                },
+                false,
+                local_net.validator().get_activation_heights().await,
+            )
+            .await;
         let network = recipient.chain_type();
         let (new_address_id, new_address) = recipient
             .generate_unified_address(ReceiverSelection::all_shielded(), zip32::AccountId::ZERO)
@@ -1282,15 +1287,17 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
         // The first taddr generated on commit 9e71a14eb424631372fd08503b1bd83ea763c7fb
         let transparent_address = "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i";
 
-        let client_b = client_builder.build_client(
-            WalletBase::MnemonicPhrase {
-                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
-            },
-            false,
-            local_net.validator().get_activation_heights().await,
-        );
+        let client_b = client_builder
+            .build_client(
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 1.into(),
+                },
+                false,
+                local_net.validator().get_activation_heights().await,
+            )
+            .await;
 
         assert_eq!(
             get_base_address_macro!(client_b, "transparent"),
@@ -1474,10 +1481,11 @@ mod slow {
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingo_test_vectors::TEST_TXID;
     use zingolib::config::{ChainType, WalletBase, ZingoConfig};
+    use zingolib::lightclient::LightClient;
     use zingolib::lightclient::error::{LightClientError, SendError};
     use zingolib::testutils::lightclient::{from_inputs, get_fees_paid_by_client};
     use zingolib::testutils::{
-        assert_transaction_summary_equality, assert_transaction_summary_exists, build_fvk_client,
+        assert_transaction_summary_equality, assert_transaction_summary_exists,
         build_fvks_from_unified_keystore, encoded_sapling_address_from_ua,
     };
     use zingolib::utils;
@@ -1791,16 +1799,19 @@ mod slow {
 
         let (local_net, mut client_builder) = scenarios::custom_clients_default().await;
         let mut faucet = client_builder
-            .build_faucet(false, local_net.validator().get_activation_heights().await);
-        let mut original_recipient = client_builder.build_client(
-            WalletBase::MnemonicPhrase {
-                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
-            },
-            false,
-            local_net.validator().get_activation_heights().await,
-        );
+            .build_faucet(false, local_net.validator().get_activation_heights().await)
+            .await;
+        let mut original_recipient = client_builder
+            .build_client(
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 1.into(),
+                },
+                false,
+                local_net.validator().get_activation_heights().await,
+            )
+            .await;
 
         let (recipient_taddr, recipient_sapling, recipient_unified) = (
             get_base_address_macro!(original_recipient, "transparent"),
@@ -1877,12 +1888,11 @@ mod slow {
         &zcash_protocol::consensus::NetworkType::Regtest,
     );
             let zingo_config = ZingoConfig::builder()
-                .set_indexer_uri(client_builder.server_id)
+                .set_indexer_uri(client_builder.server_id.clone())
                 .set_chain_type(ChainType::Regtest(
                     local_net.validator().get_activation_heights().await,
                 ))
                 .set_wallet_dir(client_builder.zingo_datadir.path().to_path_buf())
-                .set_wallet_name("".to_string())
                 .set_wallet_base(WalletBase::Ufvk {
                     ufvk,
                     birthday: 1.into(),
@@ -3424,16 +3434,19 @@ TransactionSummary {
         // Check that list_value_transfers behaves correctly given different fee scenarios
         let (local_net, mut client_builder) = scenarios::custom_clients_default().await;
         let mut faucet = client_builder
-            .build_faucet(false, local_net.validator().get_activation_heights().await);
-        let mut pool_migration_client = client_builder.build_client(
-            WalletBase::MnemonicPhrase {
-                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
-            },
-            false,
-            local_net.validator().get_activation_heights().await,
-        );
+            .build_faucet(false, local_net.validator().get_activation_heights().await)
+            .await;
+        let mut pool_migration_client = client_builder
+            .build_client(
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 1.into(),
+                },
+                false,
+                local_net.validator().get_activation_heights().await,
+            )
+            .await;
         let pmc_taddr = get_base_address_macro!(pool_migration_client, "transparent");
         let pmc_sapling = get_base_address_macro!(pool_migration_client, "sapling");
         let pmc_unified = get_base_address_macro!(pool_migration_client, "unified");
@@ -3472,16 +3485,19 @@ TransactionSummary {
         // Test all possible promoting note source combinations
         let (local_net, mut client_builder) = scenarios::custom_clients_default().await;
         let mut faucet = client_builder
-            .build_faucet(false, local_net.validator().get_activation_heights().await);
-        let mut client = client_builder.build_client(
-            WalletBase::MnemonicPhrase {
-                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
-            },
-            false,
-            local_net.validator().get_activation_heights().await,
-        );
+            .build_faucet(false, local_net.validator().get_activation_heights().await)
+            .await;
+        let mut client = client_builder
+            .build_client(
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 1.into(),
+                },
+                false,
+                local_net.validator().get_activation_heights().await,
+            )
+            .await;
         let pmc_taddr = get_base_address_macro!(client, "transparent");
         let pmc_sapling = get_base_address_macro!(client, "sapling");
         let pmc_unified = get_base_address_macro!(client, "unified");
@@ -4607,14 +4623,12 @@ mod send_all {
 }
 
 mod testnet_test {
-    use bip0039::Mnemonic;
     use pepper_sync::sync_status;
     use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
     use zingolib::{
         config::{ChainType, DEFAULT_INDEXER_URI_TESTNET, WalletBase, ZingoConfig},
         lightclient::LightClient,
         testutils::tempfile::TempDir,
-        wallet::{LightWallet, WalletBase},
     };
 
     #[ignore = "testnet cannot be run offline"]

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -149,6 +149,7 @@ mod fast {
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingolib::{
         ZENNIES_FOR_ZINGO_REGTEST_ADDRESS,
+        config::WalletBase,
         testutils::{
             chain_generics::conduct_chain::ConductChain,
             lightclient::{from_inputs, get_base_address},
@@ -463,12 +464,17 @@ mod fast {
         let (local_net, mut client_builder) = scenarios::custom_clients_default().await;
         let mut faucet =
             client_builder.build_faucet(true, local_net.validator().get_activation_heights().await);
-        let mut recipient = client_builder.build_client(
-            HOSPITAL_MUSEUM_SEED.to_string(),
-            1,
-            true,
-            local_net.validator().get_activation_heights().await,
-        );
+        let mut recipient = client_builder
+            .build_client(
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 1.into(),
+                },
+                true,
+                local_net.validator().get_activation_heights().await,
+            )
+            .await;
         let network = recipient.chain_type();
 
         // create a range of UAs to be discovered when recipient is reset
@@ -514,8 +520,11 @@ mod fast {
 
         // rebuild recipient and check the UAs don't exist in the wallet
         let mut recipient = client_builder.build_client(
-            HOSPITAL_MUSEUM_SEED.to_string(),
-            1,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
             true,
             local_net.validator().get_activation_heights().await,
         );
@@ -1198,8 +1207,11 @@ mod fast {
             .unwrap()
             .to_string();
         let mut recipient = client_builder.build_client(
-            seed_phrase,
-            1,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seed_phrase,
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -1271,8 +1283,11 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
         let transparent_address = "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i";
 
         let client_b = client_builder.build_client(
-            HOSPITAL_MUSEUM_SEED.to_string(),
-            1,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -1458,7 +1473,7 @@ mod slow {
     use zingo_common_components::protocol::ActivationHeights;
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingo_test_vectors::TEST_TXID;
-    use zingolib::config::{ChainType, ZingoConfig};
+    use zingolib::config::{ChainType, WalletBase, ZingoConfig};
     use zingolib::lightclient::error::{LightClientError, SendError};
     use zingolib::testutils::lightclient::{from_inputs, get_fees_paid_by_client};
     use zingolib::testutils::{
@@ -1774,32 +1789,18 @@ mod slow {
         //     4.3. rescan
         //     4.4. check that notes and utxos were detected by the wallet
 
-        tracing_subscriber::fmt().init();
         let (local_net, mut client_builder) = scenarios::custom_clients_default().await;
         let mut faucet = client_builder
             .build_faucet(false, local_net.validator().get_activation_heights().await);
         let mut original_recipient = client_builder.build_client(
-            HOSPITAL_MUSEUM_SEED.to_string(),
-            1,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
             false,
             local_net.validator().get_activation_heights().await,
         );
-        let zingo_config = ZingoConfig::builder()
-            .set_indexer_uri(client_builder.server_id)
-            .set_chain_type(ChainType::Regtest(
-                local_net.validator().get_activation_heights().await,
-            ))
-            .set_wallet_dir(client_builder.zingo_datadir.path().to_path_buf())
-            .set_wallet_name("".to_string())
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(1).unwrap(),
-            })
-            .set_no_of_accounts(NonZeroU32::try_from(1).unwrap())
-            .build();
 
         let (recipient_taddr, recipient_sapling, recipient_unified) = (
             get_base_address_macro!(original_recipient, "transparent"),
@@ -1868,7 +1869,33 @@ mod slow {
             tracing::info!("    sapling fvk: {}", fvks.contains(&&s_fvk));
             tracing::info!("    transparent fvk: {}", fvks.contains(&&t_fvk));
 
-            let mut watch_client = build_fvk_client(fvks, zingo_config.clone());
+            let ufvk = zcash_address::unified::Encoding::encode(
+        &<zcash_address::unified::Ufvk as zcash_address::unified::Encoding>::try_from_items(
+            fvks.iter().copied().cloned().collect(),
+        )
+        .unwrap(),
+        &zcash_protocol::consensus::NetworkType::Regtest,
+    );
+            let zingo_config = ZingoConfig::builder()
+                .set_indexer_uri(client_builder.server_id)
+                .set_chain_type(ChainType::Regtest(
+                    local_net.validator().get_activation_heights().await,
+                ))
+                .set_wallet_dir(client_builder.zingo_datadir.path().to_path_buf())
+                .set_wallet_name("".to_string())
+                .set_wallet_base(WalletBase::Ufvk {
+                    ufvk,
+                    birthday: 1.into(),
+                })
+                .set_wallet_settings(WalletSettings {
+                    sync_config: SyncConfig {
+                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                        performance_level: PerformanceLevel::High,
+                    },
+                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
+                })
+                .build();
+            let mut watch_client = LightClient::new(zingo_config, false).unwrap();
             // assert empty wallet before rescan
             let balance = watch_client
                 .account_balance(zip32::AccountId::ZERO)
@@ -3399,8 +3426,11 @@ TransactionSummary {
         let mut faucet = client_builder
             .build_faucet(false, local_net.validator().get_activation_heights().await);
         let mut pool_migration_client = client_builder.build_client(
-            HOSPITAL_MUSEUM_SEED.to_string(),
-            1,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -3444,8 +3474,11 @@ TransactionSummary {
         let mut faucet = client_builder
             .build_faucet(false, local_net.validator().get_activation_heights().await);
         let mut client = client_builder.build_client(
-            HOSPITAL_MUSEUM_SEED.to_string(),
-            1,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
             false,
             local_net.validator().get_activation_heights().await,
         );
@@ -4578,7 +4611,7 @@ mod testnet_test {
     use pepper_sync::sync_status;
     use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
     use zingolib::{
-        config::{ChainType, DEFAULT_INDEXER_URI_TESTNET, ZingoConfig},
+        config::{ChainType, DEFAULT_INDEXER_URI_TESTNET, WalletBase, ZingoConfig},
         lightclient::LightClient,
         testutils::tempfile::TempDir,
         wallet::{LightWallet, WalletBase},
@@ -4599,21 +4632,15 @@ mod testnet_test {
             let config = ZingoConfig::builder()
                 .set_chain_type(ChainType::Testnet)
                 .set_indexer_uri((DEFAULT_INDEXER_URI_TESTNET).parse::<http::Uri>().unwrap())
+                .set_wallet_base(WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+                    no_of_accounts: 1.try_into().unwrap(),
+                    birthday: 2_000_000.into(),
+                })
                 .set_wallet_dir(wallet_dir.path().to_path_buf())
                 .build();
-            let wallet = LightWallet::new(
-                ChainType::Testnet,
-                WalletBase::Mnemonic {
-                    mnemonic: Mnemonic::from_phrase(HOSPITAL_MUSEUM_SEED).unwrap(),
-                    no_of_accounts: config.no_of_accounts(),
-                },
-                2_000_000.into(),
-                config.wallet_settings(),
-            )
-            .unwrap();
 
-            let mut lightclient =
-                LightClient::create_from_wallet(wallet, config.clone(), true).unwrap();
+            let mut lightclient = LightClient::new(config, true).unwrap();
             lightclient.save_task().await;
             lightclient.sync().await.unwrap();
             let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
@@ -4632,7 +4659,13 @@ mod testnet_test {
             lightclient.shutdown_save_task().await.unwrap();
 
             // will fail if there were any reload errors due to bad file write code i.e. no flushing or file syncing
-            LightClient::create_from_wallet_path(config).unwrap();
+            let config = ZingoConfig::builder()
+                .set_chain_type(ChainType::Testnet)
+                .set_indexer_uri((DEFAULT_INDEXER_URI_TESTNET).parse::<http::Uri>().unwrap())
+                .set_wallet_base(WalletBase::Read)
+                .set_wallet_dir(wallet_dir.path().to_path_buf())
+                .build();
+            LightClient::new(config, true).unwrap();
 
             test_count += 1;
         }

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -471,7 +471,7 @@ mod fast {
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
                 true,
@@ -527,7 +527,7 @@ mod fast {
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
                 true,
@@ -1217,7 +1217,7 @@ mod fast {
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: seed_phrase,
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
                 false,
@@ -1296,7 +1296,7 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
                 false,
@@ -1809,7 +1809,7 @@ mod slow {
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
                 false,
@@ -1899,7 +1899,7 @@ mod slow {
                 .set_wallet_dir(client_builder.zingo_datadir.path().to_path_buf())
                 .set_wallet_config(WalletConfig::Ufvk {
                     ufvk,
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 })
                 .build();
@@ -3439,7 +3439,7 @@ TransactionSummary {
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
                 false,
@@ -3491,7 +3491,7 @@ TransactionSummary {
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 1.into(),
+                    birthday: 1,
                     wallet_settings: default_test_wallet_settings(),
                 },
                 false,
@@ -4649,7 +4649,7 @@ mod testnet_test {
                 .set_wallet_config(WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
-                    birthday: 2_000_000.into(),
+                    birthday: 2_000_000,
                     wallet_settings: default_test_wallet_settings(),
                 })
                 .set_wallet_dir(wallet_dir.path().to_path_buf())

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -149,9 +149,10 @@ mod fast {
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingolib::{
         ZENNIES_FOR_ZINGO_REGTEST_ADDRESS,
-        config::WalletBase,
+        config::WalletConfig,
         testutils::{
             chain_generics::conduct_chain::ConductChain,
+            default_test_wallet_settings,
             lightclient::{from_inputs, get_base_address},
         },
         wallet::{
@@ -467,10 +468,11 @@ mod fast {
             .await;
         let mut recipient = client_builder
             .build_client(
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
                 true,
                 local_net.validator().get_activation_heights().await,
@@ -522,10 +524,11 @@ mod fast {
         // rebuild recipient and check the UAs don't exist in the wallet
         let mut recipient = client_builder
             .build_client(
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
                 true,
                 local_net.validator().get_activation_heights().await,
@@ -1211,10 +1214,11 @@ mod fast {
             .to_string();
         let mut recipient = client_builder
             .build_client(
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: seed_phrase,
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
                 false,
                 local_net.validator().get_activation_heights().await,
@@ -1289,10 +1293,11 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
 
         let client_b = client_builder
             .build_client(
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
                 false,
                 local_net.validator().get_activation_heights().await,
@@ -1464,9 +1469,6 @@ tmQuMoTTjU3GFfTjrhPiBYihbTVfYmPk5Gr"
     }
 }
 mod slow {
-    use std::num::NonZeroU32;
-
-    use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
     use pepper_sync::wallet::{
         NoteInterface, OrchardNote, OutgoingNoteInterface, OutputInterface, SaplingNote,
         TransparentCoin,
@@ -1480,23 +1482,24 @@ mod slow {
     use zingo_common_components::protocol::ActivationHeights;
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingo_test_vectors::TEST_TXID;
-    use zingolib::config::{ChainType, WalletBase, ZingoConfig};
+    use zingolib::config::{ChainType, ClientConfig, WalletConfig};
     use zingolib::lightclient::LightClient;
     use zingolib::lightclient::error::{LightClientError, SendError};
     use zingolib::testutils::lightclient::{from_inputs, get_fees_paid_by_client};
     use zingolib::testutils::{
         assert_transaction_summary_equality, assert_transaction_summary_exists,
-        build_fvks_from_unified_keystore, encoded_sapling_address_from_ua,
+        build_fvks_from_unified_keystore, default_test_wallet_settings,
+        encoded_sapling_address_from_ua,
     };
     use zingolib::utils;
     use zingolib::utils::conversion::txid_from_hex_encoded_str;
     use zingolib::wallet::error::{CalculateTransactionError, ProposeSendError};
     use zingolib::wallet::keys::unified::UnifiedAddressId;
     use zingolib::wallet::output::SpendStatus;
+    use zingolib::wallet::summary;
     use zingolib::wallet::summary::data::{
         BasicNoteSummary, OutgoingNoteSummary, SendType, TransactionKind, TransactionSummary,
     };
-    use zingolib::wallet::{WalletSettings, summary};
     use zingolib_testutils::scenarios::increase_height_and_wait_for_client;
     use zip32::AccountId;
 
@@ -1803,10 +1806,11 @@ mod slow {
             .await;
         let mut original_recipient = client_builder
             .build_client(
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
                 false,
                 local_net.validator().get_activation_heights().await,
@@ -1887,22 +1891,16 @@ mod slow {
         .unwrap(),
         &zcash_protocol::consensus::NetworkType::Regtest,
     );
-            let zingo_config = ZingoConfig::builder()
+            let zingo_config = ClientConfig::builder()
                 .set_indexer_uri(client_builder.server_id.clone())
                 .set_chain_type(ChainType::Regtest(
                     local_net.validator().get_activation_heights().await,
                 ))
                 .set_wallet_dir(client_builder.zingo_datadir.path().to_path_buf())
-                .set_wallet_base(WalletBase::Ufvk {
+                .set_wallet_config(WalletConfig::Ufvk {
                     ufvk,
                     birthday: 1.into(),
-                })
-                .set_wallet_settings(WalletSettings {
-                    sync_config: SyncConfig {
-                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                        performance_level: PerformanceLevel::High,
-                    },
-                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
+                    wallet_settings: default_test_wallet_settings(),
                 })
                 .build();
             let mut watch_client = LightClient::new(zingo_config, false).unwrap();
@@ -3438,10 +3436,11 @@ TransactionSummary {
             .await;
         let mut pool_migration_client = client_builder
             .build_client(
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
                 false,
                 local_net.validator().get_activation_heights().await,
@@ -3489,10 +3488,11 @@ TransactionSummary {
             .await;
         let mut client = client_builder
             .build_client(
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 1.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 },
                 false,
                 local_net.validator().get_activation_heights().await,
@@ -4626,9 +4626,9 @@ mod testnet_test {
     use pepper_sync::sync_status;
     use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
     use zingolib::{
-        config::{ChainType, DEFAULT_INDEXER_URI_TESTNET, WalletBase, ZingoConfig},
+        config::{ChainType, ClientConfig, DEFAULT_INDEXER_URI_TESTNET, WalletConfig},
         lightclient::LightClient,
-        testutils::tempfile::TempDir,
+        testutils::{default_test_wallet_settings, tempfile::TempDir},
     };
 
     #[ignore = "testnet cannot be run offline"]
@@ -4643,13 +4643,14 @@ mod testnet_test {
 
         while test_count < NUM_TESTS {
             let wallet_dir = TempDir::new().unwrap();
-            let config = ZingoConfig::builder()
+            let config = ClientConfig::builder()
                 .set_chain_type(ChainType::Testnet)
                 .set_indexer_uri((DEFAULT_INDEXER_URI_TESTNET).parse::<http::Uri>().unwrap())
-                .set_wallet_base(WalletBase::MnemonicPhrase {
+                .set_wallet_config(WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                     no_of_accounts: 1.try_into().unwrap(),
                     birthday: 2_000_000.into(),
+                    wallet_settings: default_test_wallet_settings(),
                 })
                 .set_wallet_dir(wallet_dir.path().to_path_buf())
                 .build();
@@ -4673,10 +4674,10 @@ mod testnet_test {
             lightclient.shutdown_save_task().await.unwrap();
 
             // will fail if there were any reload errors due to bad file write code i.e. no flushing or file syncing
-            let config = ZingoConfig::builder()
+            let config = ClientConfig::builder()
                 .set_chain_type(ChainType::Testnet)
                 .set_indexer_uri((DEFAULT_INDEXER_URI_TESTNET).parse::<http::Uri>().unwrap())
-                .set_wallet_base(WalletBase::Read)
+                .set_wallet_config(WalletConfig::Read)
                 .set_wallet_dir(wallet_dir.path().to_path_buf())
                 .build();
             LightClient::new(config, true).unwrap();

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -1,23 +1,21 @@
 use std::{num::NonZeroU32, time::Duration};
 
-use bip0039::Mnemonic;
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use shardtree::store::ShardStore;
 use zcash_local_net::validator::Validator;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
-use zingolib::config::{ChainType, ZingoConfig};
+use zingolib::config::{ChainType, WalletBase, ZingoConfig};
 use zingolib::testutils::lightclient::from_inputs::quick_send;
 use zingolib::testutils::paths::get_cargo_manifest_dir;
 use zingolib::testutils::tempfile::TempDir;
-use zingolib::wallet::LightWallet;
 use zingolib::{
     config::{DEFAULT_INDEXER_URI, construct_lightwalletd_uri},
     get_base_address_macro,
     lightclient::LightClient,
     testutils::lightclient::from_inputs::{self},
-    wallet::{WalletBase, WalletSettings},
+    wallet::WalletSettings,
 };
 use zingolib_testutils::scenarios::{self, increase_height_and_wait_for_client};
 
@@ -36,7 +34,11 @@ async fn sync_mainnet_test() {
         .set_indexer_uri(uri.clone())
         .set_chain_type(ChainType::Mainnet)
         .set_wallet_dir(temp_path)
-        .set_wallet_name("".to_string())
+        .set_wallet_base(WalletBase::MnemonicPhrase {
+            mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+            no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
+            birthday: 1_500_000.into(),
+        })
         .set_wallet_settings(WalletSettings {
             sync_config: SyncConfig {
                 transparent_address_discovery: TransparentAddressDiscovery::minimal(),
@@ -44,19 +46,8 @@ async fn sync_mainnet_test() {
             },
             min_confirmations: NonZeroU32::try_from(1).unwrap(),
         })
-        .set_no_of_accounts(NonZeroU32::try_from(1).unwrap())
         .build();
-    let wallet = LightWallet::new(
-        config.chain_type(),
-        WalletBase::Mnemonic {
-            mnemonic: Mnemonic::from_phrase(HOSPITAL_MUSEUM_SEED.to_string()).unwrap(),
-            no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-        },
-        1_500_000.into(),
-        config.wallet_settings(),
-    )
-    .unwrap();
-    let mut lightclient = LightClient::create_from_wallet(wallet, config, true).unwrap();
+    let mut lightclient = LightClient::new(config, true).unwrap();
 
     lightclient.sync().await.unwrap();
     let mut interval = tokio::time::interval(Duration::from_secs(5));
@@ -101,7 +92,11 @@ async fn sync_status() {
         .set_indexer_uri(uri.clone())
         .set_chain_type(ChainType::Mainnet)
         .set_wallet_dir(temp_path)
-        .set_wallet_name("".to_string())
+        .set_wallet_base(WalletBase::MnemonicPhrase {
+            mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
+            no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
+            birthday: 2_496_152.into(),
+        })
         .set_wallet_settings(WalletSettings {
             sync_config: SyncConfig {
                 transparent_address_discovery: TransparentAddressDiscovery::minimal(),
@@ -109,19 +104,8 @@ async fn sync_status() {
             },
             min_confirmations: NonZeroU32::try_from(1).unwrap(),
         })
-        .set_no_of_accounts(NonZeroU32::try_from(1).unwrap())
         .build();
-    let wallet = LightWallet::new(
-        config.chain_type(),
-        WalletBase::Mnemonic {
-            mnemonic: Mnemonic::from_phrase(HOSPITAL_MUSEUM_SEED.to_string()).unwrap(),
-            no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-        },
-        2_496_152.into(),
-        config.wallet_settings(),
-    )
-    .unwrap();
-    let mut lightclient = LightClient::create_from_wallet(wallet, config, true).unwrap();
+    let mut lightclient = LightClient::new(config, true).unwrap();
 
     lightclient.sync_and_await().await.unwrap();
 }

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -36,7 +36,7 @@ async fn sync_mainnet_test() {
         .set_wallet_config(WalletConfig::MnemonicPhrase {
             mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-            birthday: 1_500_000.into(),
+            birthday: 1_500_000,
             wallet_settings: default_test_wallet_settings(),
         })
         .build();
@@ -88,7 +88,7 @@ async fn sync_status() {
         .set_wallet_config(WalletConfig::MnemonicPhrase {
             mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-            birthday: 2_496_152.into(),
+            birthday: 2_496_152,
             wallet_settings: default_test_wallet_settings(),
         })
         .build();

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -1,12 +1,12 @@
 use std::{num::NonZeroU32, time::Duration};
 
-use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use shardtree::store::ShardStore;
 use zcash_local_net::validator::Validator;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
-use zingolib::config::{ChainType, WalletBase, ZingoConfig};
+use zingolib::config::{ChainType, ClientConfig, WalletConfig};
+use zingolib::testutils::default_test_wallet_settings;
 use zingolib::testutils::lightclient::from_inputs::quick_send;
 use zingolib::testutils::paths::get_cargo_manifest_dir;
 use zingolib::testutils::tempfile::TempDir;
@@ -15,7 +15,6 @@ use zingolib::{
     get_base_address_macro,
     lightclient::LightClient,
     testutils::lightclient::from_inputs::{self},
-    wallet::WalletSettings,
 };
 use zingolib_testutils::scenarios::{self, increase_height_and_wait_for_client};
 
@@ -30,21 +29,15 @@ async fn sync_mainnet_test() {
     let uri = construct_lightwalletd_uri(Some(DEFAULT_INDEXER_URI.to_string())).unwrap();
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path().to_path_buf();
-    let config = ZingoConfig::builder()
+    let config = ClientConfig::builder()
         .set_indexer_uri(uri.clone())
         .set_chain_type(ChainType::Mainnet)
         .set_wallet_dir(temp_path)
-        .set_wallet_base(WalletBase::MnemonicPhrase {
+        .set_wallet_config(WalletConfig::MnemonicPhrase {
             mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
             birthday: 1_500_000.into(),
-        })
-        .set_wallet_settings(WalletSettings {
-            sync_config: SyncConfig {
-                transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                performance_level: PerformanceLevel::High,
-            },
-            min_confirmations: NonZeroU32::try_from(1).unwrap(),
+            wallet_settings: default_test_wallet_settings(),
         })
         .build();
     let mut lightclient = LightClient::new(config, true).unwrap();
@@ -88,21 +81,15 @@ async fn sync_status() {
     let uri = construct_lightwalletd_uri(Some(DEFAULT_INDEXER_URI.to_string())).unwrap();
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path().to_path_buf();
-    let config = ZingoConfig::builder()
+    let config = ClientConfig::builder()
         .set_indexer_uri(uri.clone())
         .set_chain_type(ChainType::Mainnet)
         .set_wallet_dir(temp_path)
-        .set_wallet_base(WalletBase::MnemonicPhrase {
+        .set_wallet_config(WalletConfig::MnemonicPhrase {
             mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
             no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
             birthday: 2_496_152.into(),
-        })
-        .set_wallet_settings(WalletSettings {
-            sync_config: SyncConfig {
-                transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                performance_level: PerformanceLevel::High,
-            },
-            min_confirmations: NonZeroU32::try_from(1).unwrap(),
+            wallet_settings: default_test_wallet_settings(),
         })
         .build();
     let mut lightclient = LightClient::new(config, true).unwrap();

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1382,7 +1382,7 @@ impl Command for DeleteCommand {
             match lightclient.do_delete().await {
                 Ok(()) => {
                     let r = object! { "result" => "success",
-                    "wallet_path" => lightclient.config.get_wallet_path().to_str().expect("should be valid UTF-8") };
+                    "wallet_path" => lightclient.wallet_path().to_str().expect("should be valid UTF-8") };
                     r.pretty(2)
                 }
                 Err(e) => {

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1035,7 +1035,7 @@ impl Command for ExportUfvkCommand {
             };
             object! {
                 "ufvk" => ufvk.encode(&lightclient.chain_type()),
-                "birthday" => u32::from(lightclient.birthday())
+                "birthday" => lightclient.birthday()
             }
             .pretty(2)
         })

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -13,8 +13,6 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use clap::{self, Arg};
 use log::{error, info};
 
-use zcash_protocol::consensus::BlockHeight;
-
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use zingo_netutils::Indexer as _;
 use zingolib::config::{ChainType, ClientConfig, DEFAULT_WALLET_NAME, WalletConfig};
@@ -390,7 +388,7 @@ pub fn startup(
             .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seed_phrase,
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-                birthday: BlockHeight::from_u32(filled_template.birthday as u32),
+                birthday: filled_template.birthday as u32,
                 wallet_settings: WalletSettings {
                     sync_config: SyncConfig {
                         transparent_address_discovery: TransparentAddressDiscovery::minimal(),
@@ -410,7 +408,7 @@ pub fn startup(
             .set_wallet_dir(filled_template.data_dir.clone())
             .set_wallet_config(WalletConfig::Ufvk {
                 ufvk,
-                birthday: BlockHeight::from_u32(filled_template.birthday as u32),
+                birthday: filled_template.birthday as u32,
                 wallet_settings: WalletSettings {
                     sync_config: SyncConfig {
                         transparent_address_discovery: TransparentAddressDiscovery::minimal(),
@@ -440,7 +438,7 @@ pub fn startup(
                 zingo_netutils::GrpcIndexer::new(filled_template.server.clone())
                     .get_latest_block()
                     .await
-                    .map(|block_id| BlockHeight::from_u32(block_id.height as u32))
+                    .map(|block_id| block_id.height as u32)
                     .map_err(|e| format!("{e:?}"))
             })
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?;

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -10,7 +10,6 @@ use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, Sender, channel};
 
-use bip0039::Mnemonic;
 use clap::{self, Arg};
 use log::{error, info};
 
@@ -18,9 +17,9 @@ use zcash_protocol::consensus::BlockHeight;
 
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use zingo_netutils::Indexer as _;
-use zingolib::config::{ChainType, ZingoConfig};
+use zingolib::config::{ChainType, DEFAULT_WALLET_NAME, WalletBase, ZingoConfig};
 use zingolib::lightclient::LightClient;
-use zingolib::wallet::{LightWallet, WalletBase, WalletSettings};
+use zingolib::wallet::WalletSettings;
 
 use crate::commands::{RT, ShortCircuitedCommand};
 
@@ -381,64 +380,71 @@ pub type CommandResponse = String;
 pub fn startup(
     filled_template: &ConfigTemplate,
 ) -> std::io::Result<(Sender<CommandRequest>, Receiver<CommandResponse>)> {
-    let config = ZingoConfig::builder()
-        .set_indexer_uri(filled_template.server.clone())
-        .set_chain_type(filled_template.chaintype)
-        .set_wallet_dir(filled_template.data_dir.clone())
-        .set_wallet_settings(WalletSettings {
-            sync_config: SyncConfig {
-                transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                performance_level: PerformanceLevel::High,
-            },
-            min_confirmations: NonZeroU32::try_from(3).unwrap(),
-        })
-        .set_no_of_accounts(NonZeroU32::try_from(1).expect("hard-coded non-zero integer"))
-        .set_wallet_name("".to_string())
-        .build();
-
+    let wallet_path = filled_template.data_dir.clone().join(DEFAULT_WALLET_NAME);
     let mut lightclient = if let Some(seed_phrase) = filled_template.seed.clone() {
-        let wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::Mnemonic {
-                mnemonic: Mnemonic::from_phrase(seed_phrase).map_err(|e| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        format!("Invalid seed phrase. {e}"),
-                    )
-                })?,
+        // Create client from seed phrase
+        let config = ZingoConfig::builder()
+            .set_indexer_uri(filled_template.server.clone())
+            .set_chain_type(filled_template.chaintype)
+            .set_wallet_dir(filled_template.data_dir.clone())
+            .set_wallet_base(WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seed_phrase,
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
-            },
-            (filled_template.birthday as u32).into(),
-            config.wallet_settings(),
-        )
-        .map_err(|e| std::io::Error::other(format!("Failed to create wallet. {e}")))?;
-        LightClient::create_from_wallet(wallet, config.clone(), false)
+                birthday: BlockHeight::from_u32(filled_template.birthday as u32),
+            })
+            .set_wallet_settings(WalletSettings {
+                sync_config: SyncConfig {
+                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                    performance_level: PerformanceLevel::High,
+                },
+                min_confirmations: NonZeroU32::try_from(3).unwrap(),
+            })
+            .build();
+        LightClient::new(config, false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
     } else if let Some(ufvk) = filled_template.ufvk.clone() {
         // Create client from UFVK
-        let wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::Ufvk(ufvk),
-            (filled_template.birthday as u32).into(),
-            config.wallet_settings(),
-        )
-        .map_err(|e| std::io::Error::other(format!("Failed to create wallet. {e}")))?;
-        LightClient::create_from_wallet(wallet, config.clone(), false)
+        let config = ZingoConfig::builder()
+            .set_indexer_uri(filled_template.server.clone())
+            .set_chain_type(filled_template.chaintype)
+            .set_wallet_dir(filled_template.data_dir.clone())
+            .set_wallet_base(WalletBase::Ufvk {
+                ufvk,
+                birthday: BlockHeight::from_u32(filled_template.birthday as u32),
+            })
+            .set_wallet_settings(WalletSettings {
+                sync_config: SyncConfig {
+                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                    performance_level: PerformanceLevel::High,
+                },
+                min_confirmations: NonZeroU32::try_from(3).unwrap(),
+            })
+            .build();
+        LightClient::new(config, false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
-    } else if config.get_wallet_path().exists() {
-        // Open existing wallet from path
-        LightClient::create_from_wallet_path(config.clone())
+    } else if wallet_path.exists() {
+        // Create client from wallet file
+        let config = ZingoConfig::builder()
+            .set_indexer_uri(filled_template.server.clone())
+            .set_chain_type(filled_template.chaintype)
+            .set_wallet_dir(filled_template.data_dir.clone())
+            .set_wallet_base(WalletBase::Read)
+            .set_wallet_settings(WalletSettings {
+                sync_config: SyncConfig {
+                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                    performance_level: PerformanceLevel::High,
+                },
+                min_confirmations: NonZeroU32::try_from(3).unwrap(),
+            })
+            .build();
+        LightClient::new(config, false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
     } else {
-        // Fresh wallet: query chain tip and initialize at tip-100 to guard against reorgs
+        // Create client from a new wallet
         println!("Creating a new wallet");
-        // Call the lightwalletd server to get the current block-height
-        // Do a getinfo first, before opening the wallet
-        let server_uri = config.indexer_uri();
-
         let chain_height = RT
             .block_on(async move {
-                zingo_netutils::GrpcIndexer::new(server_uri)
+                zingo_netutils::GrpcIndexer::new(filled_template.server.clone())
                     .get_latest_block()
                     .await
                     .map(|block_id| BlockHeight::from_u32(block_id.height as u32))
@@ -446,7 +452,23 @@ pub fn startup(
             })
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?;
 
-        LightClient::new(config.clone(), chain_height, false)
+        let config = ZingoConfig::builder()
+            .set_indexer_uri(filled_template.server.clone())
+            .set_chain_type(filled_template.chaintype)
+            .set_wallet_dir(filled_template.data_dir.clone())
+            .set_wallet_base(WalletBase::FreshEntropy {
+                no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
+                chain_height,
+            })
+            .set_wallet_settings(WalletSettings {
+                sync_config: SyncConfig {
+                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                    performance_level: PerformanceLevel::High,
+                },
+                min_confirmations: NonZeroU32::try_from(3).unwrap(),
+            })
+            .build();
+        LightClient::new(config, false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
     };
 
@@ -454,9 +476,7 @@ pub fn startup(
         // Print startup Messages
         info!(""); // Blank line
         info!("Starting Zingo-CLI");
-        info!("Light Client config {config:?}");
-
-        info!("Lightclient connecting to {}", config.indexer_uri());
+        info!("Lightclient connecting to {}", filled_template.server);
     }
 
     if filled_template.sync {
@@ -490,6 +510,7 @@ pub fn startup(
 
     Ok((command_transmitter, resp_receiver))
 }
+
 fn start_cli_service(
     cli_config: &ConfigTemplate,
 ) -> (Sender<(String, Vec<String>)>, Receiver<String>) {

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -17,7 +17,7 @@ use zcash_protocol::consensus::BlockHeight;
 
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use zingo_netutils::Indexer as _;
-use zingolib::config::{ChainType, DEFAULT_WALLET_NAME, WalletBase, ZingoConfig};
+use zingolib::config::{ChainType, ClientConfig, DEFAULT_WALLET_NAME, WalletConfig};
 use zingolib::lightclient::LightClient;
 use zingolib::wallet::WalletSettings;
 
@@ -383,59 +383,52 @@ pub fn startup(
     let wallet_path = filled_template.data_dir.clone().join(DEFAULT_WALLET_NAME);
     let mut lightclient = if let Some(seed_phrase) = filled_template.seed.clone() {
         // Create client from seed phrase
-        let config = ZingoConfig::builder()
+        let config = ClientConfig::builder()
             .set_indexer_uri(filled_template.server.clone())
             .set_chain_type(filled_template.chaintype)
             .set_wallet_dir(filled_template.data_dir.clone())
-            .set_wallet_base(WalletBase::MnemonicPhrase {
+            .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seed_phrase,
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
                 birthday: BlockHeight::from_u32(filled_template.birthday as u32),
-            })
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
+                wallet_settings: WalletSettings {
+                    sync_config: SyncConfig {
+                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                        performance_level: PerformanceLevel::High,
+                    },
+                    min_confirmations: NonZeroU32::try_from(3).unwrap(),
                 },
-                min_confirmations: NonZeroU32::try_from(3).unwrap(),
             })
             .build();
         LightClient::new(config, false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
     } else if let Some(ufvk) = filled_template.ufvk.clone() {
         // Create client from UFVK
-        let config = ZingoConfig::builder()
+        let config = ClientConfig::builder()
             .set_indexer_uri(filled_template.server.clone())
             .set_chain_type(filled_template.chaintype)
             .set_wallet_dir(filled_template.data_dir.clone())
-            .set_wallet_base(WalletBase::Ufvk {
+            .set_wallet_config(WalletConfig::Ufvk {
                 ufvk,
                 birthday: BlockHeight::from_u32(filled_template.birthday as u32),
-            })
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
+                wallet_settings: WalletSettings {
+                    sync_config: SyncConfig {
+                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                        performance_level: PerformanceLevel::High,
+                    },
+                    min_confirmations: NonZeroU32::try_from(3).unwrap(),
                 },
-                min_confirmations: NonZeroU32::try_from(3).unwrap(),
             })
             .build();
         LightClient::new(config, false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
     } else if wallet_path.exists() {
         // Create client from wallet file
-        let config = ZingoConfig::builder()
+        let config = ClientConfig::builder()
             .set_indexer_uri(filled_template.server.clone())
             .set_chain_type(filled_template.chaintype)
             .set_wallet_dir(filled_template.data_dir.clone())
-            .set_wallet_base(WalletBase::Read)
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(3).unwrap(),
-            })
+            .set_wallet_config(WalletConfig::Read)
             .build();
         LightClient::new(config, false)
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
@@ -452,20 +445,20 @@ pub fn startup(
             })
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?;
 
-        let config = ZingoConfig::builder()
+        let config = ClientConfig::builder()
             .set_indexer_uri(filled_template.server.clone())
             .set_chain_type(filled_template.chaintype)
             .set_wallet_dir(filled_template.data_dir.clone())
-            .set_wallet_base(WalletBase::FreshEntropy {
+            .set_wallet_config(WalletConfig::NewSeed {
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
                 chain_height,
-            })
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
+                wallet_settings: WalletSettings {
+                    sync_config: SyncConfig {
+                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                        performance_level: PerformanceLevel::High,
+                    },
+                    min_confirmations: NonZeroU32::try_from(3).unwrap(),
                 },
-                min_confirmations: NonZeroU32::try_from(3).unwrap(),
             })
             .build();
         LightClient::new(config, false)

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Deprecated
-- `config::load_clientconfig`: being replaced by zingo config builder pattern (`ZingoConfigBuilder`)
-
 ### Added
 - impl TryFrom<&str> for `config::ChainType`
 - `config::InvalidChainType`
@@ -17,27 +14,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stored outside the lock.
 - `lightclient::LightClient`:
   - `chain_type` method: lock-free access to `ChainType`
-  - `birthday` method: lock-free access to wallet birthday `BlockHeight`
+  - `birthday` method: lock-free access to wallet birthday as `u32`
   - `mnemonic_phrase` method: lock-free access to the wallet's mnemonic phrase
+  - `wallet_path` method returns wallet file path
+  - `wallet_dir` method returns path to directory which holds wallet file
   - `wallet` method: returns `&Arc<RwLock<LightWallet>>`, replacing the former public field
   - `indexer: GrpcIndexer` field: owning the indexer connection directly
+  - `backup_wallet_file` method to replace `ZingoConfig` method
+  - updated `Debug` impl
 - re-export `zingo_common_components::protocol::ActivationHeights` so test crates can unify zingo common types with
-  zingolib lightclient construction 
+  zingolib lightclient construction
+- `wallet::utils`: added `get_zcash_params_path` fn to replace `ZingoConfig` method.
+- `config::WalletConfig` enum: replaces functionality of `wallet::WalletBase`. now encapsulates all wallet config for creation
+  of a `wallet::Lightwallet` for each variant i.e. from seed or ufvk
+- `testutils::default_test_wallet_settings`
+- `wallet::WalletSettings`: `default` impl
 
 ### Changed
 - `lightclient::LightClient`:
   - `server_uri`: renamed `indexer_uri`
   - `set_server`: renamed `set_indexer_uri`
   - `pub wallet: Arc<RwLock<LightWallet>>` field is now private. replaced by `wallet` method.
+  - `new` constructor: removed `chain_height` parameter which is now within the config
 - `config` module:
-  - `ChainType`: `Regtest` activation heights tuple variant field changed from zebra type to zingo common components type.
-  - `ZingoConfig`: reworked. public fields now private with public getter methods to constrain public API:
-    - `wallet_dir` replaces `get_zingo_wallet_dir`
-    - `chain_type` method replaces `chain` field
-    - `indexer_uri` method replaces `lightwalletd_uri` field and `get_lightwalletd_uri` method
-    - `build` renamed `builder`
-  - `ZingoConfigBuilder`: reworked. public fields now private with public setter methods to constrain public API:
-    - `create` renamed `build`
+  - `ChainType`:
+    - `Regtest` activation heights tuple variant field changed from zebra type to zingo common components type.
+    - `fmt::Display` impl changed to give full network type names.
+    - `zcash_protocol::consensus::Parameters` impl is no longer public to constrain external types in public API.
+  - `ZingoConfig`:
+    - renamed: `ClientConfig`
+    - `wallet_settings` and `no_of_accounts` fields replaced by `wallet_config` field
+    - `network_type` field renamed `chain_type`
+    - reworked. public fields now private with public getter methods to constrain public API:
+      - `wallet_dir` replaces `get_zingo_wallet_dir`
+      - `chain_type` method replaces `chain` field
+      - `indexer_uri` method replaces `lightwalletd_uri` field and `get_lightwalletd_uri` method
+      - `build` renamed `builder`
+      - `wallet_settings` and `no_of_accounts` methods replaced by `wallet_config` method
+      - `get_zcash_params_path` replaced by `utils::get_zcash_params_path` fn
+      - `backup_existing_wallet` replaced by `LightClient::backup_wallet_file`
+  - `ZingoConfigBuilder`:
+    - renamed: ClientConfigBuilder
+    - reworked. public fields now private with public setter methods to constrain public API:
+      - `create` renamed `build`
   - `DEFAULT_LIGHTWALLETD_SERVER` const: renamed `DEFAULT_INDEXER_URI`
   - `DEFAULT_TESTNET_LIGHTWALLETD_SERVER` const: renamed `DEFAULT_INDEXER_URI_TESTNET`
   - `DEVELOPER_DONATION_ADDRESS` const: moved to lib.rs
@@ -51,38 +70,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wallet::LightWallet`:
   - `pub network: ChainType` field is now private. Use `LightClient::chain_type()`.
   - `pub birthday: BlockHeight` field is now private. Use `LightClient::birthday()`.
+  - `new` constructor:
+    - `network` parameter renamed `chain_type`
+    - `wallet_base`, `birthday` and `wallet_settings` fields replaced by `wallet_config` field
   - new wallet serialization version 40 due to changes to chain type fmt::Display. chain type is now encoded as u8.
 - `wallet::keys::unified::UnifiedKeyStore`:
-  - `new_from_seed` method: now takes `ChainType` instead of `&ChainType`
-  - `new_from_mnemonic` method: now takes `ChainType` instead of `&ChainType`
-  - `new_from_ufvk` method: now takes `ChainType` instead of `&ChainType`
+  - `new_from_seed` method: `network` parameter renamed `chain_type` and now takes `ChainType` instead of `&ChainType`
+  - `new_from_mnemonic` method: `network` parameter renamed `chain_type` and now takes `ChainType` instead of `&ChainType`
+  - `new_from_ufvk` method: `network` parameter renamed `chain_type` and now takes `ChainType` instead of `&ChainType`
+- `wallet::disk::read`: `network` parameter renamed `chain_type`
+- `wallet::error::WalletError`: added `WalletAlreadyCreated` variant
+- `wallet::error::KeyError`: added `InvalidMnemonicPhrase` variant
 
 ### Removed
-- `log4rs` dependency
-- `config::DEFAULT_LOGFILE_NAME` constant
-- `config::ZingoConfig`:
-  - `logfile_name` method
-  - `get_log_config` method
-  - `get_log_path` method
-- `config::ZingoConfigBuilder`:
-  - `set_logfile_name` method
 - `regtest` feature: production binaries can now be tested in regtest mode.
-- `config::ChainFromStingError`: replaced by `InvalidChainType` error struct.
-- `config::chain_from_str`: replaced by impl TryFrom<&str> for `config::ChainType`
-- `config::ZingoConfig`:
-  - `get_wallet_with_name_pathbuf`
-  - `get_wallet_with_name_path`
-  - `wallet_with_name_path_exists`
-  - `get_wallet_pathbuf`
-  - `wallet_exists(`
-- `config::DEFAULT_LOGFILE_NAME` constant.
-- `config::ZingoConfig`:
-  - `logfile_name` field
-  - `logfile_name()` method
-  - `get_log_config()` method
-  - `get_log_path()` method
-- `config::ZingoConfigBuilder::set_logfile_name()` method.
+- `config` module:
+  - `DEFAULT_LOGFILE_NAME` constant
+  - `ZingoConfig`:
+    - `logfile_name` method
+    - `get_log_config` method
+    - `get_log_path` method
+    - `create_testnet` method
+    - `create_mainnet` method
+    - `create_unconnected` method
+  - `ZingoConfigBuilder`:
+    - `set_logfile_name` method
+  - `ChainFromStingError`: replaced by `InvalidChainType` error struct.
+  - `chain_from_str`: replaced by impl TryFrom<&str> for `ChainType`
+  - `ZingoConfig`:
+    - `get_wallet_with_name_pathbuf`
+    - `get_wallet_with_name_path`
+    - `wallet_with_name_path_exists`
+    - `get_wallet_pathbuf`
+    - `wallet_exists(`
+  - `DEFAULT_LOGFILE_NAME` constant.
+  - `ZingoConfig`:
+    - `logfile_name` field
+    - `logfile_name()` method
+    - `get_log_config()` method
+    - `get_log_path()` method
+  - `ZingoConfigBuilder::set_logfile_name()` method.
+  - `load_clientconfig`: replaced by zingo config builder pattern (`ZingoConfigBuilder`)
 - `wallet::LightWallet::mnemonic()`
+- `testutils::lightclient::new_client_from_save_buffer`
+- `wallet::WalletBase`: no longer public. public functionality replaced by `config::WalletConfig`
+- `lightclient::LightClient`:
+  - `create_from_wallet` constructor: no longer needed as now covered by `new` due to config rework
+  - `create_from_wallet_path` constructor: no longer needed as now covered by `new` due to config rework
+- `testutils::build_fvk_client`
 
 ## [3.0.0] - 2026-03-02
 

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -324,7 +324,7 @@ impl ClientConfig {
     }
 }
 
-/// Builder for [`ZingoConfig`].
+/// Builder for [`ClientConfig`].
 #[derive(Clone, Debug)]
 pub struct ClientConfigBuilder {
     indexer_uri: Option<http::Uri>,
@@ -335,46 +335,24 @@ pub struct ClientConfigBuilder {
 }
 
 impl ClientConfigBuilder {
-    /// Constructs a new builder for [`ZingoConfig`].
+    /// Constructs a new builder for [`ClientConfig`].
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Set indexer URI.
-    /// # Examples
-    /// ```
-    /// use zingolib::config::ZingoConfig;
-    /// use http::Uri;
-    /// let config = ZingoConfig::builder().set_indexer_uri(("https://zcash.mysideoftheweb.com:19067").parse::<Uri>().unwrap()).build();
-    /// assert_eq!(config.indexer_uri(), "https://zcash.mysideoftheweb.com:19067");
-    /// ```
     pub fn set_indexer_uri(mut self, indexer_uri: http::Uri) -> Self {
         self.indexer_uri = Some(indexer_uri);
         self
     }
 
     /// Set chain type.
-    /// # Examples
-    /// ```
-    /// use zingolib::config::ZingoConfig;
-    /// use zingolib::config::ChainType;
-    /// let config = ZingoConfig::builder().set_chain_type(ChainType::Testnet).build();
-    /// assert_eq!(config.chain_type(), ChainType::Testnet);
-    /// ```
     pub fn set_chain_type(mut self, chain_type: ChainType) -> Self {
         self.chain_type = chain_type;
         self
     }
 
     /// Set wallet directory.
-    /// # Examples
-    /// ```
-    /// use zingolib::config::ZingoConfig;
-    /// use tempfile::TempDir;
-    /// let dir = tempfile::TempDir::with_prefix("zingo_doc_test").unwrap().path().to_path_buf();
-    /// let config = ZingoConfig::builder().set_wallet_dir(dir.clone()).build();
-    /// assert_eq!(config.wallet_dir(), dir);
-    /// ```
     pub fn set_wallet_dir(mut self, dir: PathBuf) -> Self {
         self.wallet_dir = Some(dir);
         self
@@ -392,7 +370,7 @@ impl ClientConfigBuilder {
         self
     }
 
-    /// Build a [`ZingoConfig`] from the builder.
+    /// Build a [`ClientConfig`] from the builder.
     pub fn build(self) -> ClientConfig {
         let wallet_dir = wallet_dir_or_default(self.wallet_dir, self.chain_type);
         let wallet_name = wallet_name_or_default(self.wallet_name);

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -305,40 +305,6 @@ impl ZingoConfig {
     }
 }
 
-#[cfg(any(test, feature = "testutils"))]
-impl ZingoConfig {
-    /// create a `ZingoConfig` that helps a `LightClient` connect to a server.
-    #[must_use]
-    pub fn create_testnet() -> ZingoConfig {
-        ZingoConfig::builder()
-            .set_chain_type(ChainType::Testnet)
-            .set_indexer_uri((DEFAULT_INDEXER_URI_TESTNET).parse::<http::Uri>().unwrap())
-            .build()
-    }
-
-    /// create a `ZingoConfig` that helps a `LightClient` connect to a server.
-    #[must_use]
-    pub fn create_mainnet() -> ZingoConfig {
-        ZingoConfig::builder()
-            .set_chain_type(ChainType::Mainnet)
-            .set_indexer_uri((DEFAULT_INDEXER_URI).parse::<http::Uri>().unwrap())
-            .build()
-    }
-
-    /// create a `ZingoConfig` that signals a `LightClient` not to connect to a server.
-    #[must_use]
-    pub fn create_unconnected(chain: ChainType, dir: Option<PathBuf>) -> ZingoConfig {
-        if let Some(dir) = dir {
-            ZingoConfig::builder()
-                .set_chain_type(chain)
-                .set_wallet_dir(dir)
-                .build()
-        } else {
-            ZingoConfig::builder().set_chain_type(chain).build()
-        }
-    }
-}
-
 /// Builder for [`ZingoConfig`].
 #[derive(Clone, Debug)]
 pub struct ZingoConfigBuilder {

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -1,17 +1,24 @@
 //! Module for configuration and construction of a [`crate::lightclient::LightClient`] and/or [`crate::wallet::LightWallet`].
 
 use std::{
+    collections::BTreeMap,
     net::ToSocketAddrs,
     num::NonZeroU32,
     path::{Path, PathBuf},
 };
 
+use bip0039::{English, Mnemonic};
 use http::uri::InvalidUri;
 use log::info;
 
+use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zingo_common_components::protocol::ActivationHeights;
 
-use crate::wallet::WalletSettings;
+use crate::wallet::{
+    WalletSettings,
+    error::{KeyError, WalletError},
+    keys::unified::UnifiedKeyStore,
+};
 
 /// Default indexer uri
 pub const DEFAULT_INDEXER_URI: &str = "https://zec.rocks:443";
@@ -105,30 +112,101 @@ pub(crate) mod consealed {
 #[error("Invalid chain type '{0}'. Expected one of: 'mainnet', 'testnet' or 'regtest'.")]
 pub struct InvalidChainType(String);
 
-/// Creates a zingo config for lightclient construction.
-#[deprecated(note = "replaced by ZingoConfig builder pattern")]
-pub fn load_clientconfig(
-    indexer_uri: http::Uri,
-    data_dir: Option<PathBuf>,
-    chain_type: ChainType,
-    wallet_settings: WalletSettings,
-    no_of_accounts: NonZeroU32,
-    wallet_name: String,
-) -> std::io::Result<ZingoConfig> {
-    check_indexer_uri(&indexer_uri);
-    let wallet_name = wallet_name_or_default(Some(wallet_name));
-    let wallet_dir = wallet_dir_or_default(data_dir, chain_type);
+/// Base data used to construct a [`crate::wallet::LightWallet`].
+#[derive(Clone, Debug)]
+pub enum WalletBase {
+    /// Generate a wallet with a new seed for a number of accounts.
+    FreshEntropy {
+        no_of_accounts: NonZeroU32,
+        chain_height: BlockHeight,
+    },
+    /// Generate a wallet from a mnemonic (phrase or entropy) for a number of accounts.
+    MnemonicPhrase {
+        mnemonic_phrase: String,
+        no_of_accounts: NonZeroU32,
+        birthday: BlockHeight,
+    },
+    /// Generate a wallet from a unified full viewing key.
+    // TODO: take concrete UFVK type
+    Ufvk { ufvk: String, birthday: BlockHeight },
+    /// Generate a wallet from a unified spending key.
+    // TODO: take concrete USK type
+    Usk { usk: Vec<u8>, birthday: BlockHeight },
+    /// Read from wallet file.
+    Read,
+}
 
-    let config = ZingoConfig {
-        indexer_uri,
-        chain_type,
-        wallet_dir,
-        wallet_name,
-        wallet_settings,
-        no_of_accounts,
-    };
+impl WalletBase {
+    /// Resolves the wallet base into a unified key store, optional mnemonic and birthday.
+    ///
+    /// `FreshEntropy` generates a new 24-word mnemonic and then resolves as `Mnemonic`.
+    #[allow(clippy::result_large_err)]
+    pub(crate) fn resolve_keys(
+        self,
+        chain_type: ChainType,
+    ) -> Result<
+        (
+            BTreeMap<zip32::AccountId, UnifiedKeyStore>,
+            Option<Mnemonic>,
+            BlockHeight,
+        ),
+        WalletError,
+    > {
+        match self {
+            WalletBase::FreshEntropy {
+                no_of_accounts,
+                chain_height,
+            } => {
+                let sapling_activation_height = chain_type
+                    .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
+                    .expect("should have some sapling activation height");
+                let birthday = sapling_activation_height.max(chain_height - 100);
 
-    Ok(config)
+                WalletBase::MnemonicPhrase {
+                    mnemonic_phrase: Mnemonic::<English>::generate(bip0039::Count::Words24)
+                        .into_phrase(),
+                    no_of_accounts,
+                    birthday,
+                }
+                .resolve_keys(chain_type)
+            }
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: mnemonic,
+                no_of_accounts,
+                birthday,
+            } => {
+                let mnemonic = Mnemonic::from_phrase(mnemonic)?;
+                let no_of_accounts = u32::from(no_of_accounts);
+                let unified_key_store = (0..no_of_accounts)
+                    .map(|account_index| {
+                        let account_id = zip32::AccountId::try_from(account_index)?;
+                        Ok((
+                            account_id,
+                            UnifiedKeyStore::new_from_mnemonic(chain_type, &mnemonic, account_id)?,
+                        ))
+                    })
+                    .collect::<Result<BTreeMap<_, _>, KeyError>>()?;
+                Ok((unified_key_store, Some(mnemonic), birthday))
+            }
+            WalletBase::Ufvk { ufvk, birthday } => {
+                let mut unified_key_store = BTreeMap::new();
+                unified_key_store.insert(
+                    zip32::AccountId::ZERO,
+                    UnifiedKeyStore::new_from_ufvk(chain_type, ufvk)?,
+                );
+                Ok((unified_key_store, None, birthday))
+            }
+            WalletBase::Usk { usk, birthday } => {
+                let mut unified_key_store = BTreeMap::new();
+                unified_key_store.insert(
+                    zip32::AccountId::ZERO,
+                    UnifiedKeyStore::new_from_usk(usk.as_slice())?,
+                );
+                Ok((unified_key_store, None, birthday))
+            }
+            WalletBase::Read => Err(WalletError::InvalidWalletBase),
+        }
+    }
 }
 
 /// Constructs a http::Uri from a `server` string. If `server` is `None` use the `DEFAULT_INDEXER_URI`.
@@ -158,8 +236,6 @@ pub fn construct_lightwalletd_uri(server: Option<String>) -> Result<http::Uri, I
 }
 
 /// Configuration data for the construction of a [`crate::lightclient::LightClient`].
-// TODO: this config should only be used to create a lightclient, the data should then be moved into fields of
-// lightclient or lightwallet if it needs to retained in memory.
 #[derive(Clone, Debug)]
 pub struct ZingoConfig {
     /// URI of the indexer the lightclient is connected to.
@@ -170,6 +246,8 @@ pub struct ZingoConfig {
     wallet_dir: PathBuf,
     /// Wallet file name. This will be created in the `wallet_dir`.
     wallet_name: String,
+    /// Wallet base
+    wallet_base: WalletBase,
     /// Wallet settings.
     wallet_settings: WalletSettings,
     /// Number of accounts.
@@ -207,13 +285,19 @@ impl ZingoConfig {
         &self.wallet_name
     }
 
-    /// Returns wallet settings..
+    /// Returns wallet base.
+    #[must_use]
+    pub fn wallet_base(&self) -> WalletBase {
+        self.wallet_base.clone()
+    }
+
+    /// Returns wallet settings.
     #[must_use]
     pub fn wallet_settings(&self) -> WalletSettings {
         self.wallet_settings.clone()
     }
 
-    /// Returns number of accounts..
+    /// Returns number of accounts.
     #[must_use]
     pub fn no_of_accounts(&self) -> NonZeroU32 {
         self.no_of_accounts
@@ -270,6 +354,7 @@ pub struct ZingoConfigBuilder {
     chain_type: ChainType,
     wallet_dir: Option<PathBuf>,
     wallet_name: Option<String>,
+    wallet_base: WalletBase,
     wallet_settings: WalletSettings,
     no_of_accounts: NonZeroU32,
 }
@@ -326,6 +411,12 @@ impl ZingoConfigBuilder {
         self
     }
 
+    /// Set wallet base.
+    pub fn set_wallet_base(mut self, wallet_base: WalletBase) -> Self {
+        self.wallet_base = wallet_base;
+        self
+    }
+
     /// Set wallet settings.
     pub fn set_wallet_settings(mut self, wallet_settings: WalletSettings) -> Self {
         self.wallet_settings = wallet_settings;
@@ -347,6 +438,7 @@ impl ZingoConfigBuilder {
             chain_type: self.chain_type,
             wallet_dir,
             wallet_name,
+            wallet_base: self.wallet_base,
             wallet_settings: self.wallet_settings,
             no_of_accounts: self.no_of_accounts,
         }
@@ -360,13 +452,17 @@ impl Default for ZingoConfigBuilder {
             wallet_dir: None,
             wallet_name: None,
             chain_type: ChainType::Mainnet,
+            wallet_base: WalletBase::FreshEntropy {
+                no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
+                chain_height: BlockHeight::from_u32(1),
+            },
             wallet_settings: WalletSettings {
                 sync_config: pepper_sync::config::SyncConfig {
                     transparent_address_discovery:
                         pepper_sync::config::TransparentAddressDiscovery::minimal(),
                     performance_level: pepper_sync::config::PerformanceLevel::High,
                 },
-                min_confirmations: NonZeroU32::try_from(3).unwrap(),
+                min_confirmations: NonZeroU32::try_from(3).expect("hard coded non-zero integer"),
             },
             no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
         }

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -9,11 +9,12 @@ use std::{
 use bip0039::{English, Mnemonic};
 use http::uri::InvalidUri;
 
+use pepper_sync::config::{SyncConfig, TransparentAddressDiscovery};
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zingo_common_components::protocol::ActivationHeights;
 
 use crate::wallet::{
-    WalletSettings,
+    WalletBase, WalletSettings,
     error::{KeyError, WalletError},
     keys::unified::UnifiedKeyStore,
 };
@@ -110,69 +111,72 @@ pub(crate) mod consealed {
 #[error("Invalid chain type '{0}'. Expected one of: 'mainnet', 'testnet' or 'regtest'.")]
 pub struct InvalidChainType(String);
 
-/// Base data used to construct a [`crate::wallet::LightWallet`].
+/// Configuration data for the construction of a [`crate::wallet::LightWallet`].
 #[derive(Clone, Debug)]
-pub enum WalletBase {
+pub enum WalletConfig {
     /// Generate a wallet with a new seed for a number of accounts.
-    FreshEntropy {
+    NewSeed {
         no_of_accounts: NonZeroU32,
         chain_height: BlockHeight,
+        wallet_settings: WalletSettings,
     },
     /// Generate a wallet from a mnemonic phrase for a number of accounts.
     MnemonicPhrase {
         mnemonic_phrase: String,
         no_of_accounts: NonZeroU32,
         birthday: BlockHeight,
+        wallet_settings: WalletSettings,
     },
     /// Generate a wallet from an encoded unified full viewing key.
     // TODO: take concrete UFVK type
-    Ufvk { ufvk: String, birthday: BlockHeight },
+    Ufvk {
+        ufvk: String,
+        birthday: BlockHeight,
+        wallet_settings: WalletSettings,
+    },
     /// Generate a wallet from a unified spending key.
     // TODO: take concrete USK type
-    Usk { usk: Vec<u8>, birthday: BlockHeight },
+    Usk {
+        usk: Vec<u8>,
+        birthday: BlockHeight,
+        wallet_settings: WalletSettings,
+    },
     /// Read from wallet file.
     Read,
 }
 
-impl WalletBase {
-    /// Resolves the wallet base into a unified key store, optional mnemonic and birthday.
+impl WalletConfig {
+    /// Resolves the wallet config into the base data needed to construct the wallet.
     ///
-    /// `FreshEntropy` generates a new 24-word mnemonic and then resolves as `Mnemonic`.
+    /// `NewSeed` generates the wallet base data from a new 24-word mnemonic.
     #[allow(clippy::result_large_err)]
     #[allow(clippy::type_complexity)]
-    pub(crate) fn resolve_keys(
-        self,
-        chain_type: ChainType,
-    ) -> Result<
-        (
-            BTreeMap<zip32::AccountId, UnifiedKeyStore>,
-            Option<Mnemonic>,
-            BlockHeight,
-        ),
-        WalletError,
-    > {
+    pub(crate) fn resolve(self, chain_type: ChainType) -> Result<WalletBase, WalletError> {
         match self {
-            WalletBase::FreshEntropy {
+            WalletConfig::NewSeed {
                 no_of_accounts,
                 chain_height,
+                wallet_settings,
             } => {
                 let sapling_activation_height = chain_type
                     .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
                     .expect("should have some sapling activation height");
                 let birthday = sapling_activation_height.max(chain_height - 100);
 
-                WalletBase::MnemonicPhrase {
+                WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: Mnemonic::<English>::generate(bip0039::Count::Words24)
                         .into_phrase(),
                     no_of_accounts,
                     birthday,
+                    wallet_settings,
                 }
-                .resolve_keys(chain_type)
+                .resolve(chain_type)
             }
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: mnemonic,
                 no_of_accounts,
                 birthday,
+                wallet_settings,
             } => {
                 let mnemonic = Mnemonic::from_phrase(mnemonic)?;
                 let no_of_accounts = u32::from(no_of_accounts);
@@ -185,25 +189,48 @@ impl WalletBase {
                         ))
                     })
                     .collect::<Result<BTreeMap<_, _>, KeyError>>()?;
-                Ok((unified_key_store, Some(mnemonic), birthday))
+                Ok(WalletBase {
+                    unified_key_store,
+                    mnemonic: Some(mnemonic),
+                    birthday,
+                    wallet_settings,
+                })
             }
-            WalletBase::Ufvk { ufvk, birthday } => {
+            WalletConfig::Ufvk {
+                ufvk,
+                birthday,
+                wallet_settings,
+            } => {
                 let mut unified_key_store = BTreeMap::new();
                 unified_key_store.insert(
                     zip32::AccountId::ZERO,
                     UnifiedKeyStore::new_from_ufvk(chain_type, ufvk)?,
                 );
-                Ok((unified_key_store, None, birthday))
+                Ok(WalletBase {
+                    unified_key_store,
+                    mnemonic: None,
+                    birthday,
+                    wallet_settings,
+                })
             }
-            WalletBase::Usk { usk, birthday } => {
+            WalletConfig::Usk {
+                usk,
+                birthday,
+                wallet_settings,
+            } => {
                 let mut unified_key_store = BTreeMap::new();
                 unified_key_store.insert(
                     zip32::AccountId::ZERO,
                     UnifiedKeyStore::new_from_usk(usk.as_slice())?,
                 );
-                Ok((unified_key_store, None, birthday))
+                Ok(WalletBase {
+                    unified_key_store,
+                    mnemonic: None,
+                    birthday,
+                    wallet_settings,
+                })
             }
-            WalletBase::Read => Err(WalletError::InvalidWalletBase),
+            WalletConfig::Read => Err(WalletError::WalletAlreadyCreated),
         }
     }
 }
@@ -236,7 +263,7 @@ pub fn construct_lightwalletd_uri(server: Option<String>) -> Result<http::Uri, I
 
 /// Configuration data for the construction of a [`crate::lightclient::LightClient`].
 #[derive(Clone, Debug)]
-pub struct ZingoConfig {
+pub struct ClientConfig {
     /// URI of the indexer the lightclient is connected to.
     indexer_uri: http::Uri,
     /// Chain type of the blockchain the lightclient is connected to.
@@ -245,17 +272,15 @@ pub struct ZingoConfig {
     wallet_dir: PathBuf,
     /// Wallet file name. This will be created in the `wallet_dir`.
     wallet_name: String,
-    /// Wallet base
-    wallet_base: WalletBase,
-    /// Wallet settings.
-    wallet_settings: WalletSettings,
+    /// Wallet config.
+    wallet_config: WalletConfig,
 }
 
-impl ZingoConfig {
+impl ClientConfig {
     /// Constructs a default builder.
     #[must_use]
-    pub fn builder() -> ZingoConfigBuilder {
-        ZingoConfigBuilder::default()
+    pub fn builder() -> ClientConfigBuilder {
+        ClientConfigBuilder::default()
     }
 
     /// Returns indexer URI.
@@ -282,16 +307,10 @@ impl ZingoConfig {
         &self.wallet_name
     }
 
-    /// Returns wallet base.
+    /// Returns wallet config.
     #[must_use]
-    pub fn wallet_base(&self) -> WalletBase {
-        self.wallet_base.clone()
-    }
-
-    /// Returns wallet settings.
-    #[must_use]
-    pub fn wallet_settings(&self) -> WalletSettings {
-        self.wallet_settings.clone()
+    pub fn wallet_config(&self) -> WalletConfig {
+        self.wallet_config.clone()
     }
 
     /// Returns full path to wallet file.
@@ -306,16 +325,15 @@ impl ZingoConfig {
 
 /// Builder for [`ZingoConfig`].
 #[derive(Clone, Debug)]
-pub struct ZingoConfigBuilder {
+pub struct ClientConfigBuilder {
     indexer_uri: Option<http::Uri>,
     chain_type: ChainType,
     wallet_dir: Option<PathBuf>,
     wallet_name: Option<String>,
-    wallet_base: WalletBase,
-    wallet_settings: WalletSettings,
+    wallet_config: WalletConfig,
 }
 
-impl ZingoConfigBuilder {
+impl ClientConfigBuilder {
     /// Constructs a new builder for [`ZingoConfig`].
     pub fn new() -> Self {
         Self::default()
@@ -367,51 +385,44 @@ impl ZingoConfigBuilder {
         self
     }
 
-    /// Set wallet base.
-    pub fn set_wallet_base(mut self, wallet_base: WalletBase) -> Self {
-        self.wallet_base = wallet_base;
-        self
-    }
-
-    /// Set wallet settings.
-    pub fn set_wallet_settings(mut self, wallet_settings: WalletSettings) -> Self {
-        self.wallet_settings = wallet_settings;
+    /// Set wallet config.
+    pub fn set_wallet_config(mut self, wallet_config: WalletConfig) -> Self {
+        self.wallet_config = wallet_config;
         self
     }
 
     /// Build a [`ZingoConfig`] from the builder.
-    pub fn build(self) -> ZingoConfig {
+    pub fn build(self) -> ClientConfig {
         let wallet_dir = wallet_dir_or_default(self.wallet_dir, self.chain_type);
         let wallet_name = wallet_name_or_default(self.wallet_name);
-        ZingoConfig {
+        ClientConfig {
             indexer_uri: self.indexer_uri.clone().unwrap_or_default(),
             chain_type: self.chain_type,
             wallet_dir,
             wallet_name,
-            wallet_base: self.wallet_base,
-            wallet_settings: self.wallet_settings,
+            wallet_config: self.wallet_config,
         }
     }
 }
 
-impl Default for ZingoConfigBuilder {
+impl Default for ClientConfigBuilder {
     fn default() -> Self {
         Self {
             indexer_uri: None,
             wallet_dir: None,
             wallet_name: None,
             chain_type: ChainType::Mainnet,
-            wallet_base: WalletBase::FreshEntropy {
+            wallet_config: WalletConfig::NewSeed {
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
                 chain_height: BlockHeight::from_u32(1),
-            },
-            wallet_settings: WalletSettings {
-                sync_config: pepper_sync::config::SyncConfig {
-                    transparent_address_discovery:
-                        pepper_sync::config::TransparentAddressDiscovery::minimal(),
-                    performance_level: pepper_sync::config::PerformanceLevel::High,
+                wallet_settings: WalletSettings {
+                    sync_config: SyncConfig {
+                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                        performance_level: pepper_sync::config::PerformanceLevel::High,
+                    },
+                    min_confirmations: NonZeroU32::try_from(3)
+                        .expect("hard coded non-zero integer"),
                 },
-                min_confirmations: NonZeroU32::try_from(3).expect("hard coded non-zero integer"),
             },
         }
     }
@@ -472,7 +483,7 @@ fn wallet_dir_or_default(opt_wallet_dir: Option<PathBuf>, chain: ChainType) -> P
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{ChainType, ZingoConfig};
+    use crate::config::{ChainType, ClientConfig};
 
     #[tokio::test]
     async fn test_load_clientconfig() {
@@ -484,7 +495,7 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let temp_path = temp_dir.path().to_path_buf();
 
-        let valid_config = ZingoConfig::builder()
+        let valid_config = ClientConfig::builder()
             .set_indexer_uri(valid_uri.clone())
             .set_chain_type(ChainType::Mainnet)
             .set_wallet_dir(temp_path)

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -250,8 +250,6 @@ pub struct ZingoConfig {
     wallet_base: WalletBase,
     /// Wallet settings.
     wallet_settings: WalletSettings,
-    /// Number of accounts.
-    no_of_accounts: NonZeroU32,
 }
 
 impl ZingoConfig {
@@ -295,12 +293,6 @@ impl ZingoConfig {
     #[must_use]
     pub fn wallet_settings(&self) -> WalletSettings {
         self.wallet_settings.clone()
-    }
-
-    /// Returns number of accounts.
-    #[must_use]
-    pub fn no_of_accounts(&self) -> NonZeroU32 {
-        self.no_of_accounts
     }
 
     /// Returns full path to wallet file.
@@ -356,7 +348,6 @@ pub struct ZingoConfigBuilder {
     wallet_name: Option<String>,
     wallet_base: WalletBase,
     wallet_settings: WalletSettings,
-    no_of_accounts: NonZeroU32,
 }
 
 impl ZingoConfigBuilder {
@@ -423,12 +414,6 @@ impl ZingoConfigBuilder {
         self
     }
 
-    /// Set number of accounts.
-    pub fn set_no_of_accounts(mut self, no_of_accounts: NonZeroU32) -> Self {
-        self.no_of_accounts = no_of_accounts;
-        self
-    }
-
     /// Build a [`ZingoConfig`] from the builder.
     pub fn build(self) -> ZingoConfig {
         let wallet_dir = wallet_dir_or_default(self.wallet_dir, self.chain_type);
@@ -440,7 +425,6 @@ impl ZingoConfigBuilder {
             wallet_name,
             wallet_base: self.wallet_base,
             wallet_settings: self.wallet_settings,
-            no_of_accounts: self.no_of_accounts,
         }
     }
 }
@@ -464,7 +448,6 @@ impl Default for ZingoConfigBuilder {
                 },
                 min_confirmations: NonZeroU32::try_from(3).expect("hard coded non-zero integer"),
             },
-            no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
         }
     }
 }

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -1,7 +1,6 @@
 //! Module for configuration and construction of a [`crate::lightclient::LightClient`] and/or [`crate::wallet::LightWallet`].
 
 use std::{
-    io,
     net::ToSocketAddrs,
     num::NonZeroU32,
     path::{Path, PathBuf},
@@ -220,29 +219,6 @@ impl ZingoConfig {
         self.no_of_accounts
     }
 
-    /// Returns the directory that the Zcash proving parameters are located in.
-    pub fn get_zcash_params_path(&self) -> io::Result<Box<Path>> {
-        #[cfg(any(target_os = "ios", target_os = "android"))]
-        {
-            Ok(self.wallet_dir().into_boxed_path())
-        }
-
-        //TODO:  This fn is not correct for regtest mode
-        #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        {
-            if dirs::home_dir().is_none() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Couldn't determine home directory!",
-                ));
-            }
-
-            let zcash_params_dir = zcash_proofs::default_params_folder().unwrap();
-
-            Ok(zcash_params_dir.into_boxed_path())
-        }
-    }
-
     /// Returns full path to wallet file.
     #[must_use]
     pub fn get_wallet_path(&self) -> Box<Path> {
@@ -250,31 +226,6 @@ impl ZingoConfig {
         wallet_path.push(self.wallet_name());
 
         wallet_path.into_boxed_path()
-    }
-
-    /// Creates a backup file of the current wallet file in the wallet directory.
-    // TODO: move to lightclient or lightwallet
-    pub fn backup_existing_wallet(&self) -> Result<String, String> {
-        if !self.get_wallet_path().exists() {
-            return Err(format!(
-                "Couldn't find existing wallet to backup. Looked in {}",
-                self.get_wallet_path().display()
-            ));
-        }
-
-        let mut backup_file_path = self.wallet_dir();
-        backup_file_path.push(format!(
-            "zingo-wallet.backup.{}.dat",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("should never fail when comparing with an instant so far in the past")
-                .as_secs()
-        ));
-
-        let backup_file_str = backup_file_path.to_string_lossy().to_string();
-        std::fs::copy(self.get_wallet_path(), backup_file_path).map_err(|e| format!("{e}"))?;
-
-        Ok(backup_file_str)
     }
 }
 

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -1,4 +1,4 @@
-//! Module for configuration and construction of a [`crate::lightclient::LightClient`] and/or [`crate::wallet::LightWallet`].
+//! Module for configuration and construction of [`crate::lightclient::LightClient`] and [`crate::wallet::LightWallet`].
 
 use std::{
     collections::BTreeMap,
@@ -9,8 +9,9 @@ use std::{
 use bip0039::{English, Mnemonic};
 use http::uri::InvalidUri;
 
-use pepper_sync::config::{SyncConfig, TransparentAddressDiscovery};
 use zcash_protocol::consensus::{BlockHeight, Parameters};
+
+use pepper_sync::config::{SyncConfig, TransparentAddressDiscovery};
 use zingo_common_components::protocol::ActivationHeights;
 
 use crate::wallet::{
@@ -117,28 +118,28 @@ pub enum WalletConfig {
     /// Generate a wallet with a new seed for a number of accounts.
     NewSeed {
         no_of_accounts: NonZeroU32,
-        chain_height: BlockHeight,
+        chain_height: u32,
         wallet_settings: WalletSettings,
     },
     /// Generate a wallet from a mnemonic phrase for a number of accounts.
     MnemonicPhrase {
         mnemonic_phrase: String,
         no_of_accounts: NonZeroU32,
-        birthday: BlockHeight,
+        birthday: u32,
         wallet_settings: WalletSettings,
     },
     /// Generate a wallet from an encoded unified full viewing key.
     // TODO: take concrete UFVK type
     Ufvk {
         ufvk: String,
-        birthday: BlockHeight,
+        birthday: u32,
         wallet_settings: WalletSettings,
     },
     /// Generate a wallet from a unified spending key.
     // TODO: take concrete USK type
     Usk {
         usk: Vec<u8>,
-        birthday: BlockHeight,
+        birthday: u32,
         wallet_settings: WalletSettings,
     },
     /// Read from wallet file.
@@ -150,7 +151,6 @@ impl WalletConfig {
     ///
     /// `NewSeed` generates the wallet base data from a new 24-word mnemonic.
     #[allow(clippy::result_large_err)]
-    #[allow(clippy::type_complexity)]
     pub(crate) fn resolve(self, chain_type: ChainType) -> Result<WalletBase, WalletError> {
         match self {
             WalletConfig::NewSeed {
@@ -161,13 +161,14 @@ impl WalletConfig {
                 let sapling_activation_height = chain_type
                     .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
                     .expect("should have some sapling activation height");
-                let birthday = sapling_activation_height.max(chain_height - 100);
+                let birthday =
+                    sapling_activation_height.max(BlockHeight::from_u32(chain_height) - 100);
 
                 WalletConfig::MnemonicPhrase {
                     mnemonic_phrase: Mnemonic::<English>::generate(bip0039::Count::Words24)
                         .into_phrase(),
                     no_of_accounts,
-                    birthday,
+                    birthday: u32::from(birthday),
                     wallet_settings,
                 }
                 .resolve(chain_type)
@@ -192,7 +193,7 @@ impl WalletConfig {
                 Ok(WalletBase {
                     unified_key_store,
                     mnemonic: Some(mnemonic),
-                    birthday,
+                    birthday: BlockHeight::from_u32(birthday),
                     wallet_settings,
                 })
             }
@@ -209,7 +210,7 @@ impl WalletConfig {
                 Ok(WalletBase {
                     unified_key_store,
                     mnemonic: None,
-                    birthday,
+                    birthday: BlockHeight::from_u32(birthday),
                     wallet_settings,
                 })
             }
@@ -226,7 +227,7 @@ impl WalletConfig {
                 Ok(WalletBase {
                     unified_key_store,
                     mnemonic: None,
-                    birthday,
+                    birthday: BlockHeight::from_u32(birthday),
                     wallet_settings,
                 })
             }
@@ -414,7 +415,7 @@ impl Default for ClientConfigBuilder {
             chain_type: ChainType::Mainnet,
             wallet_config: WalletConfig::NewSeed {
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard coded non-zero integer"),
-                chain_height: BlockHeight::from_u32(1),
+                chain_height: 1,
                 wallet_settings: WalletSettings {
                     sync_config: SyncConfig {
                         transparent_address_discovery: TransparentAddressDiscovery::minimal(),

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -2,14 +2,12 @@
 
 use std::{
     collections::BTreeMap,
-    net::ToSocketAddrs,
     num::NonZeroU32,
     path::{Path, PathBuf},
 };
 
 use bip0039::{English, Mnemonic};
 use http::uri::InvalidUri;
-use log::info;
 
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zingo_common_components::protocol::ActivationHeights;
@@ -141,6 +139,7 @@ impl WalletBase {
     ///
     /// `FreshEntropy` generates a new 24-word mnemonic and then resolves as `Mnemonic`.
     #[allow(clippy::result_large_err)]
+    #[allow(clippy::type_complexity)]
     pub(crate) fn resolve_keys(
         self,
         chain_type: ChainType,
@@ -418,24 +417,6 @@ impl Default for ZingoConfigBuilder {
     }
 }
 
-// TODO: return errors
-fn check_indexer_uri(indexer_uri: &http::Uri) {
-    if let Some(host) = indexer_uri.host()
-        && let Some(port) = indexer_uri.port()
-    {
-        match format!("{}:{}", host, port,).to_socket_addrs() {
-            Ok(_) => {
-                info!("Connected to {indexer_uri}");
-            }
-            Err(e) => {
-                info!("Couldn't resolve server: {e}");
-            }
-        }
-    } else {
-        info!("Using offline mode");
-    }
-}
-
 fn wallet_name_or_default(opt_wallet_name: Option<String>) -> String {
     let wallet_name = opt_wallet_name.unwrap_or_else(|| DEFAULT_WALLET_NAME.into());
     if wallet_name.is_empty() {
@@ -491,56 +472,25 @@ fn wallet_dir_or_default(opt_wallet_dir: Option<PathBuf>, chain: ChainType) -> P
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
-
-    use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
-
-    use crate::{
-        config::{ChainType, ZingoConfig},
-        wallet::WalletSettings,
-    };
+    use crate::config::{ChainType, ZingoConfig};
 
     #[tokio::test]
     async fn test_load_clientconfig() {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .expect("Ring to work as a default");
-        tracing_subscriber::fmt().init();
-
         let valid_uri = crate::config::construct_lightwalletd_uri(Some(
             crate::config::DEFAULT_INDEXER_URI.to_string(),
         ))
         .unwrap();
-        // let invalid_uri = construct_lightwalletd_uri(Some("Invalid URI".to_string()));
-        let temp_dir = tempfile::TempDir::new().unwrap();
 
+        let temp_dir = tempfile::TempDir::new().unwrap();
         let temp_path = temp_dir.path().to_path_buf();
-        // let temp_path_invalid = temp_dir.path().to_path_buf();
 
         let valid_config = ZingoConfig::builder()
             .set_indexer_uri(valid_uri.clone())
             .set_chain_type(ChainType::Mainnet)
             .set_wallet_dir(temp_path)
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(1).unwrap(),
-            })
-            .set_no_of_accounts(NonZeroU32::try_from(1).expect("hard-coded non-zero integer"))
-            .set_wallet_name("".to_string())
             .build();
 
         assert_eq!(valid_config.indexer_uri(), valid_uri);
-        assert_eq!(valid_config.chain_type, ChainType::Mainnet);
-
-        // let invalid_config = load_clientconfig_serverless(
-        //     invalid_uri.clone(),
-        //     Some(temp_path_invalid),
-        //     ChainType::Mainnet,
-        //     true,
-        // );
-        // assert_eq!(invalid_config.is_err(), true);
+        assert_eq!(valid_config.chain_type(), ChainType::Mainnet);
     }
 }

--- a/zingolib/src/config.rs
+++ b/zingolib/src/config.rs
@@ -120,13 +120,13 @@ pub enum WalletBase {
         no_of_accounts: NonZeroU32,
         chain_height: BlockHeight,
     },
-    /// Generate a wallet from a mnemonic (phrase or entropy) for a number of accounts.
+    /// Generate a wallet from a mnemonic phrase for a number of accounts.
     MnemonicPhrase {
         mnemonic_phrase: String,
         no_of_accounts: NonZeroU32,
         birthday: BlockHeight,
     },
-    /// Generate a wallet from a unified full viewing key.
+    /// Generate a wallet from an encoded unified full viewing key.
     // TODO: take concrete UFVK type
     Ufvk { ufvk: String, birthday: BlockHeight },
     /// Generate a wallet from a unified spending key.

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -23,7 +23,7 @@ include!(concat!(env!("OUT_DIR"), "/git_description.rs"));
 
 #[macro_use]
 extern crate rust_embed;
-/// Embedded zcash-params for mobile devices.
+/// Embedded zcash-params.
 #[derive(RustEmbed)]
 #[folder = "zcash-params/"]
 pub struct SaplingParams;

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -101,7 +101,7 @@ pub struct LightClient {
 }
 
 impl LightClient {
-    /// Creates a `LightClient` from [`crate::config::ZingoConfig`].
+    /// Creates a `LightClient` from [`crate::config::ClientConfig`].
     ///
     /// Will fail if a wallet file already exists in the given data directory unless `overwrite` is `true` or the
     /// [`crate::config::WalletConfig`] is of `Read` variant.

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -25,7 +25,7 @@ use pepper_sync::{
 use zingo_netutils::Indexer as _;
 
 use crate::{
-    config::{ChainType, WalletBase, ZingoConfig},
+    config::{ChainType, ClientConfig, WalletConfig},
     utils::now,
     wallet::{
         LightWallet,
@@ -104,12 +104,12 @@ impl LightClient {
     /// Creates a `LightClient` from [`crate::config::ZingoConfig`].
     ///
     /// Will fail if a wallet file already exists in the given data directory unless `overwrite` is `true` or the
-    /// [`crate::config::WalletBase`] is of `Read` variant.
-    /// `overwrite` has no effect if a wallet is read from file.
+    /// [`crate::config::WalletConfig`] is of `Read` variant.
+    /// `overwrite` has no effect if a wallet is being read from file.
     #[allow(clippy::result_large_err)]
-    pub fn new(config: ZingoConfig, overwrite: bool) -> Result<Self, LightClientError> {
-        let wallet = match config.wallet_base() {
-            WalletBase::Read => {
+    pub fn new(config: ClientConfig, overwrite: bool) -> Result<Self, LightClientError> {
+        let wallet = match config.wallet_config() {
+            WalletConfig::Read => {
                 let buffer = BufReader::new(
                     File::open(config.get_wallet_path()).map_err(LightClientError::FileError)?,
                 );
@@ -131,11 +131,7 @@ impl LightClient {
                     }
                 }
 
-                LightWallet::new(
-                    config.chain_type(),
-                    config.wallet_base(),
-                    config.wallet_settings(),
-                )?
+                LightWallet::new(config.chain_type(), config.wallet_config())?
             }
         };
 
@@ -384,8 +380,9 @@ impl std::fmt::Debug for LightClient {
 #[cfg(test)]
 mod tests {
     use crate::{
-        config::{ChainType, WalletBase, ZingoConfig},
+        config::{ChainType, ClientConfig, WalletConfig},
         lightclient::{LightClient, error::LightClientError},
+        testutils::default_test_wallet_settings,
     };
     use tempfile::TempDir;
     use zingo_common_components::protocol::ActivationHeights;
@@ -394,13 +391,14 @@ mod tests {
     #[tokio::test]
     async fn new_wallet_from_phrase() {
         let temp_dir = TempDir::new().unwrap();
-        let config = ZingoConfig::builder()
+        let config = ClientConfig::builder()
             .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
             .set_wallet_dir(temp_dir.path().to_path_buf())
-            .set_wallet_base(WalletBase::MnemonicPhrase {
+            .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: CHIMNEY_BETTER_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             })
             .build();
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -154,8 +154,8 @@ impl LightClient {
     }
 
     /// Returns the wallet birthday height for lock-free access.
-    pub fn birthday(&self) -> BlockHeight {
-        self.wallet.birthday
+    pub fn birthday(&self) -> u32 {
+        u32::from(self.wallet.birthday)
     }
 
     /// Returns the wallet's mnemonic phrase as a string.
@@ -397,7 +397,7 @@ mod tests {
             .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: CHIMNEY_BETTER_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             })
             .build();

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -3,7 +3,7 @@
 use std::{
     fs::File,
     io::BufReader,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU8},
@@ -26,6 +26,7 @@ use zingo_netutils::Indexer as _;
 
 use crate::{
     config::{ChainType, ZingoConfig},
+    utils::now,
     wallet::{
         LightWallet, WalletBase,
         balance::AccountBalance,
@@ -47,8 +48,9 @@ pub mod sync;
 
 /// Wallet struct owned by a [`crate::lightclient::LightClient`], with metadata and immutable wallet data stored outside
 /// the read/write lock.
-// TODO: add wallet specific metadata from zingo config such as wallet path
 struct WalletMeta {
+    /// Full path to wallet file.
+    wallet_path: PathBuf,
     /// The chain type, extracted at construction for lock-free access.
     chain_type: ChainType,
     /// The wallet birthday height.
@@ -59,13 +61,22 @@ struct WalletMeta {
     wallet_data: Arc<RwLock<LightWallet>>,
 }
 
+impl std::fmt::Debug for WalletMeta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WalletMeta")
+            .field("wallet_path", &self.wallet_path)
+            .field("chain_type", &self.chain_type)
+            .field("birthday", &self.birthday)
+            .field("mnemonic", &self.mnemonic)
+            .finish()
+    }
+}
+
 impl WalletMeta {
     /// Creates a new `WalletMeta` by wrapping a [`crate::wallet::LightWallet`] in a lock alongside it's metadata.
-    fn new(
-        // TODO: add wallet path etc. from zingo config
-        wallet: LightWallet,
-    ) -> Self {
+    fn new(wallet_path: PathBuf, wallet: LightWallet) -> Self {
         Self {
+            wallet_path,
             chain_type: wallet.chain_type(),
             birthday: wallet.birthday(),
             mnemonic: wallet.mnemonic().cloned(),
@@ -79,8 +90,6 @@ impl WalletMeta {
 ///
 /// `sync_mode` is an atomic representation of [`pepper_sync::wallet::SyncMode`].
 pub struct LightClient {
-    // TODO: split zingoconfig so data is not duplicated
-    pub config: ZingoConfig,
     indexer: zingo_netutils::GrpcIndexer,
     tor_client: Option<tor::Client>,
     wallet: WalletMeta,
@@ -140,10 +149,9 @@ impl LightClient {
 
         let indexer = zingo_netutils::GrpcIndexer::new(config.indexer_uri());
         Ok(LightClient {
-            config,
             indexer,
             tor_client: None,
-            wallet: WalletMeta::new(wallet),
+            wallet: WalletMeta::new(config.get_wallet_path().to_path_buf(), wallet),
             sync_mode: Arc::new(AtomicU8::new(SyncMode::NotRunning as u8)),
             sync_handle: None,
             save_active: Arc::new(AtomicBool::new(false)),
@@ -173,11 +181,6 @@ impl LightClient {
         Self::create_from_wallet(wallet, config, true)
     }
 
-    /// Returns config used to create lightclient.
-    pub fn config(&self) -> &ZingoConfig {
-        &self.config
-    }
-
     /// Returns the chain type for lock-free access.
     pub fn chain_type(&self) -> ChainType {
         self.wallet.chain_type
@@ -194,6 +197,22 @@ impl LightClient {
             .mnemonic
             .as_ref()
             .map(|m| m.phrase().to_string())
+    }
+
+    /// Returns full path to wallet file.
+    pub fn wallet_path(&self) -> PathBuf {
+        self.wallet.wallet_path.clone()
+    }
+
+    /// Returns path to the directory which holds the wallet file.
+    pub fn wallet_dir(&self) -> Result<PathBuf, LightClientError> {
+        self.wallet
+            .wallet_path
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| {
+                LightClientError::FileError(std::io::Error::other("wallet directory not found!"))
+            })
     }
 
     /// Returns a reference to the locked mutable wallet state.
@@ -219,12 +238,13 @@ impl LightClient {
 
     /// Creates a tor client for current price updates.
     ///
-    /// If `tor_dir` is `None` it will be set to the wallet's data directory.
+    /// If `tor_dir` is `None` it will be set to a directory named "tor" within the wallet's data directory.
     pub async fn create_tor_client(
         &mut self,
         tor_dir: Option<PathBuf>,
     ) -> Result<(), LightClientError> {
-        let tor_dir = tor_dir.unwrap_or_else(|| self.config.wallet_dir().join("tor"));
+        let wallet_dir = self.wallet_dir()?;
+        let tor_dir = tor_dir.unwrap_or_else(|| wallet_dir.join("tor"));
         tokio::fs::create_dir_all(tor_dir.as_path())
             .await
             .map_err(LightClientError::FileError)?;
@@ -358,12 +378,29 @@ impl LightClient {
     pub async fn do_total_value_to_address(&self) -> Result<TotalValueToAddress, SummaryError> {
         self.wallet().read().await.do_total_value_to_address().await
     }
+
+    /// Creates a backup file of the current wallet file in the wallet directory.
+    pub fn backup_wallet_file(&self) -> Result<(), LightClientError> {
+        let backup_time = now();
+        let backup_wallet_path = self.wallet_path().with_extension(
+            self.wallet_path()
+                .extension()
+                .map(|e| format!("backup.{}.{}", backup_time, e.to_string_lossy()))
+                .unwrap_or_else(|| format!("backup.{}.dat", backup_time)),
+        );
+
+        std::fs::copy(self.wallet_path(), backup_wallet_path)
+            .map_err(LightClientError::FileError)?;
+
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for LightClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LightClient")
-            .field("config", &self.config)
+            .field("indexer", &self.indexer)
+            .field("wallet_meta", &self.wallet)
             .field("sync_mode", &self.sync_mode())
             .field(
                 "save_active",
@@ -372,6 +409,7 @@ impl std::fmt::Debug for LightClient {
             .finish()
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -103,22 +103,10 @@ pub struct LightClient {
 impl LightClient {
     /// Creates a `LightClient` from [`crate::config::ZingoConfig`].
     ///
-    /// Will fail if a wallet file already exists in the given data directory unless `overwrite` is `true`.
+    /// Will fail if a wallet file already exists in the given data directory unless `overwrite` is `true` or the
+    /// [`crate::config::WalletBase`] is of `Read` variant.
     #[allow(clippy::result_large_err)]
     pub fn new(config: ZingoConfig, overwrite: bool) -> Result<Self, LightClientError> {
-        #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        {
-            if !overwrite && config.get_wallet_path().exists() {
-                return Err(LightClientError::FileError(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    format!(
-                        "Cannot save to given data directory as a wallet file already exists at:\n{}",
-                        config.get_wallet_path().display()
-                    ),
-                )));
-            }
-        }
-
         let wallet = match config.wallet_base() {
             WalletBase::Read => {
                 let buffer = BufReader::new(
@@ -128,11 +116,26 @@ impl LightClient {
                 LightWallet::read(buffer, config.chain_type())
                     .map_err(LightClientError::FileError)?
             }
-            _ => LightWallet::new(
-                config.chain_type(),
-                config.wallet_base(),
-                config.wallet_settings(),
-            )?,
+            _ => {
+                #[cfg(not(any(target_os = "ios", target_os = "android")))]
+                {
+                    if !overwrite && config.get_wallet_path().exists() {
+                        return Err(LightClientError::FileError(std::io::Error::new(
+                            std::io::ErrorKind::AlreadyExists,
+                            format!(
+                                "Cannot save to given data directory as a wallet file already exists at:\n{}",
+                                config.get_wallet_path().display()
+                            ),
+                        )));
+                    }
+                }
+
+                LightWallet::new(
+                    config.chain_type(),
+                    config.wallet_base(),
+                    config.wallet_settings(),
+                )?
+            }
         };
 
         let indexer = zingo_netutils::GrpcIndexer::new(config.indexer_uri());

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -105,6 +105,7 @@ impl LightClient {
     ///
     /// Will fail if a wallet file already exists in the given data directory unless `overwrite` is `true` or the
     /// [`crate::config::WalletBase`] is of `Read` variant.
+    /// `overwrite` has no effect if a wallet is read from file.
     #[allow(clippy::result_large_err)]
     pub fn new(config: ZingoConfig, overwrite: bool) -> Result<Self, LightClientError> {
         let wallet = match config.wallet_base() {

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -16,7 +16,7 @@ use tokio::{sync::RwLock, task::JoinHandle};
 use bip0039::Mnemonic;
 use zcash_client_backend::tor;
 use zcash_keys::address::UnifiedAddress;
-use zcash_protocol::consensus::{BlockHeight, Parameters};
+use zcash_protocol::consensus::BlockHeight;
 use zcash_transparent::address::TransparentAddress;
 
 use pepper_sync::{
@@ -25,10 +25,10 @@ use pepper_sync::{
 use zingo_netutils::Indexer as _;
 
 use crate::{
-    config::{ChainType, ZingoConfig},
+    config::{ChainType, WalletBase, ZingoConfig},
     utils::now,
     wallet::{
-        LightWallet, WalletBase,
+        LightWallet,
         balance::AccountBalance,
         error::{BalanceError, KeyError, SummaryError, WalletError},
         keys::unified::{ReceiverSelection, UnifiedAddressId},
@@ -73,7 +73,8 @@ impl std::fmt::Debug for WalletMeta {
 }
 
 impl WalletMeta {
-    /// Creates a new `WalletMeta` by wrapping a [`crate::wallet::LightWallet`] in a lock alongside it's metadata.
+    /// Creates a new `WalletMeta` by wrapping a [`crate::wallet::LightWallet`] in a lock alongside metadata and
+    /// immutable wallet data.
     fn new(wallet_path: PathBuf, wallet: LightWallet) -> Self {
         Self {
             wallet_path,
@@ -100,40 +101,11 @@ pub struct LightClient {
 }
 
 impl LightClient {
-    /// Creates a `LightClient` with a new wallet from fresh entropy and a birthday of the higher value between
-    /// [`chain_height` - 100] or sapling activation height.
+    /// Creates a `LightClient` from [`crate::config::ZingoConfig`].
+    ///
     /// Will fail if a wallet file already exists in the given data directory unless `overwrite` is `true`.
     #[allow(clippy::result_large_err)]
-    pub fn new(
-        config: ZingoConfig,
-        chain_height: BlockHeight,
-        overwrite: bool,
-    ) -> Result<Self, LightClientError> {
-        let sapling_activation_height = config
-            .chain_type()
-            .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
-            .expect("should have some sapling activation height");
-        let birthday = sapling_activation_height.max(chain_height - 100);
-
-        let wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::FreshEntropy {
-                no_of_accounts: config.no_of_accounts(),
-            },
-            birthday,
-            config.wallet_settings(),
-        )?;
-        Self::create_from_wallet(wallet, config, overwrite)
-    }
-
-    /// Creates a `LightClient` from a [`crate::wallet::LightWallet`] and [`crate::config::ZingoConfig`].
-    /// Will fail if a wallet file already exists in the given data directory unless `overwrite` is `true`.
-    #[allow(clippy::result_large_err)]
-    pub fn create_from_wallet(
-        wallet: LightWallet,
-        config: ZingoConfig,
-        overwrite: bool,
-    ) -> Result<Self, LightClientError> {
+    pub fn new(config: ZingoConfig, overwrite: bool) -> Result<Self, LightClientError> {
         #[cfg(not(any(target_os = "ios", target_os = "android")))]
         {
             if !overwrite && config.get_wallet_path().exists() {
@@ -147,7 +119,24 @@ impl LightClient {
             }
         }
 
+        let wallet = match config.wallet_base() {
+            WalletBase::Read => {
+                let buffer = BufReader::new(
+                    File::open(config.get_wallet_path()).map_err(LightClientError::FileError)?,
+                );
+
+                LightWallet::read(buffer, config.chain_type())
+                    .map_err(LightClientError::FileError)?
+            }
+            _ => LightWallet::new(
+                config.chain_type(),
+                config.wallet_base(),
+                config.wallet_settings(),
+            )?,
+        };
+
         let indexer = zingo_netutils::GrpcIndexer::new(config.indexer_uri());
+
         Ok(LightClient {
             indexer,
             tor_client: None,
@@ -157,28 +146,6 @@ impl LightClient {
             save_active: Arc::new(AtomicBool::new(false)),
             save_handle: None,
         })
-    }
-
-    /// Create a `LightClient` from an existing wallet file.
-    #[allow(clippy::result_large_err)]
-    pub fn create_from_wallet_path(config: ZingoConfig) -> Result<Self, LightClientError> {
-        let wallet_path = if config.get_wallet_path().exists() {
-            config.get_wallet_path()
-        } else {
-            return Err(LightClientError::FileError(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!(
-                    "Cannot read wallet. No file at {}",
-                    config.get_wallet_path().display()
-                ),
-            )));
-        };
-
-        let buffer = BufReader::new(File::open(wallet_path).map_err(LightClientError::FileError)?);
-        let wallet =
-            LightWallet::read(buffer, config.chain_type()).map_err(LightClientError::FileError)?;
-
-        Self::create_from_wallet(wallet, config, true)
     }
 
     /// Returns the chain type for lock-free access.
@@ -435,8 +402,8 @@ mod tests {
             WalletBase::Mnemonic {
                 mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
                 no_of_accounts: config.no_of_accounts(),
+                birthday: 1.into(),
             },
-            1.into(),
             config.wallet_settings(),
         )
         .unwrap();
@@ -450,8 +417,8 @@ mod tests {
             WalletBase::Mnemonic {
                 mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
                 no_of_accounts: config.no_of_accounts(),
+                birthday: 1.into(),
             },
-            1.into(),
             config.wallet_settings(),
         )
         .unwrap();

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -384,11 +384,9 @@ impl std::fmt::Debug for LightClient {
 #[cfg(test)]
 mod tests {
     use crate::{
-        config::{ChainType, ZingoConfig},
+        config::{ChainType, WalletBase, ZingoConfig},
         lightclient::{LightClient, error::LightClientError},
-        wallet::{LightWallet, WalletBase},
     };
-    use bip0039::Mnemonic;
     use tempfile::TempDir;
     use zingo_common_components::protocol::ActivationHeights;
     use zingo_test_vectors::seeds::CHIMNEY_BETTER_SEED;
@@ -399,35 +397,19 @@ mod tests {
         let config = ZingoConfig::builder()
             .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
             .set_wallet_dir(temp_dir.path().to_path_buf())
+            .set_wallet_base(WalletBase::MnemonicPhrase {
+                mnemonic_phrase: CHIMNEY_BETTER_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            })
             .build();
 
-        let wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::Mnemonic {
-                mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
-                no_of_accounts: config.no_of_accounts(),
-                birthday: 1.into(),
-            },
-            config.wallet_settings(),
-        )
-        .unwrap();
-        let mut lc = LightClient::create_from_wallet(wallet, config.clone(), false).unwrap();
+        let mut lc = LightClient::new(config.clone(), false).unwrap();
 
         lc.save_task().await;
         lc.wait_for_save().await;
 
-        let wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::Mnemonic {
-                mnemonic: Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap(),
-                no_of_accounts: config.no_of_accounts(),
-                birthday: 1.into(),
-            },
-            config.wallet_settings(),
-        )
-        .unwrap();
-        let lc_file_exists_error =
-            LightClient::create_from_wallet(wallet, config, false).unwrap_err();
+        let lc_file_exists_error = LightClient::new(config, false).unwrap_err();
 
         assert!(matches!(
             lc_file_exists_error,

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -183,7 +183,7 @@ mod shielding {
             .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 419200.into(),
+                birthday: 419200,
                 wallet_settings: default_test_wallet_settings(),
             })
             .build();

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -170,37 +170,33 @@ impl LightClient {
 mod shielding {
     use std::num::NonZeroU32;
 
-    use bip0039::Mnemonic;
     use pepper_sync::config::SyncConfig;
     use zcash_protocol::consensus::Parameters;
     use zingo_test_vectors::seeds;
 
     use crate::{
-        config::ZingoConfigBuilder,
+        config::{WalletBase, ZingoConfig},
         lightclient::LightClient,
-        wallet::{LightWallet, WalletBase, WalletSettings, error::ProposeShieldError},
+        wallet::{WalletSettings, error::ProposeShieldError},
     };
 
     fn create_basic_client() -> LightClient {
-        let config = ZingoConfigBuilder::default().build();
-        let wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::Mnemonic {
-                mnemonic: Mnemonic::from_phrase(seeds::HOSPITAL_MUSEUM_SEED.to_string()).unwrap(),
+        let config = ZingoConfig::builder()
+            .set_wallet_base(WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-            },
-            419200.into(),
-            WalletSettings {
+                birthday: 419200.into(),
+            })
+            .set_wallet_settings(WalletSettings {
                 sync_config: SyncConfig {
                     transparent_address_discovery:
                         pepper_sync::config::TransparentAddressDiscovery::minimal(),
                     performance_level: pepper_sync::config::PerformanceLevel::High,
                 },
                 min_confirmations: NonZeroU32::try_from(1).unwrap(),
-            },
-        )
-        .unwrap();
-        LightClient::create_from_wallet(wallet, config, true).unwrap()
+            })
+            .build();
+        LightClient::new(config, true).unwrap()
     }
 
     #[tokio::test]

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -168,32 +168,23 @@ impl LightClient {
 
 #[cfg(test)]
 mod shielding {
-    use std::num::NonZeroU32;
-
-    use pepper_sync::config::SyncConfig;
     use zcash_protocol::consensus::Parameters;
     use zingo_test_vectors::seeds;
 
     use crate::{
-        config::{WalletBase, ZingoConfig},
+        config::{ClientConfig, WalletConfig},
         lightclient::LightClient,
-        wallet::{WalletSettings, error::ProposeShieldError},
+        testutils::default_test_wallet_settings,
+        wallet::error::ProposeShieldError,
     };
 
     fn create_basic_client() -> LightClient {
-        let config = ZingoConfig::builder()
-            .set_wallet_base(WalletBase::MnemonicPhrase {
+        let config = ClientConfig::builder()
+            .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 419200.into(),
-            })
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery:
-                        pepper_sync::config::TransparentAddressDiscovery::minimal(),
-                    performance_level: pepper_sync::config::PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(1).unwrap(),
+                wallet_settings: default_test_wallet_settings(),
             })
             .build();
         LightClient::new(config, true).unwrap()

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -49,7 +49,7 @@ impl LightClient {
         self.save_active.store(true, atomic::Ordering::Release);
         let save_active = self.save_active.clone();
         let wallet = self.wallet().clone();
-        let wallet_path = self.config.get_wallet_path();
+        let wallet_path = self.wallet_path();
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let save_handle = tokio::spawn(async move {
@@ -119,8 +119,8 @@ impl LightClient {
     // TodO: can we shred it?
     pub async fn do_delete(&self) -> Result<(), String> {
         // Check if the file exists before attempting to delete
-        if self.config.get_wallet_path().exists() {
-            match remove_file(self.config.get_wallet_path()) {
+        if self.wallet_path().exists() {
+            match remove_file(self.wallet_path()) {
                 Ok(()) => {
                     log::debug!("File deleted successfully!");
                     Ok(())

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -224,42 +224,41 @@ mod test {
 
     use std::num::NonZeroU32;
 
-    use bip0039::Mnemonic;
-
     use pepper_sync::config::SyncConfig;
-    use zingo_test_vectors::seeds::ABANDON_ART_SEED;
+    use zingo_test_vectors::seeds;
 
     use crate::{
-        config::ZingoConfig,
+        config::{WalletBase, ZingoConfig},
         lightclient::{LightClient, sync::test::sync_example_wallet},
         mocks::proposal::ProposalBuilder,
         testutils::chain_generics::{
             conduct_chain::ConductChain as _, networked::NetworkedTestEnvironment, with_assertions,
         },
-        wallet::{LightWallet, WalletBase, WalletSettings, disk::testing::examples},
+        wallet::{WalletSettings, disk::testing::examples},
     };
 
-    #[tokio::test]
-    async fn complete_and_broadcast_unconnected_error() {
-        let config = ZingoConfig::builder().build();
-        let wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::Mnemonic {
-                mnemonic: Mnemonic::from_phrase(ABANDON_ART_SEED.to_string()).unwrap(),
+    fn create_basic_client() -> LightClient {
+        let config = ZingoConfig::builder()
+            .set_wallet_base(WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-            },
-            419_200.into(),
-            WalletSettings {
+                birthday: 419200.into(),
+            })
+            .set_wallet_settings(WalletSettings {
                 sync_config: SyncConfig {
                     transparent_address_discovery:
                         pepper_sync::config::TransparentAddressDiscovery::minimal(),
                     performance_level: pepper_sync::config::PerformanceLevel::High,
                 },
                 min_confirmations: NonZeroU32::try_from(1).unwrap(),
-            },
-        )
-        .unwrap();
-        let mut lc = LightClient::create_from_wallet(wallet, config, true).unwrap();
+            })
+            .build();
+        LightClient::new(config, true).unwrap()
+    }
+
+    #[tokio::test]
+    async fn complete_and_broadcast_unconnected_error() {
+        let mut lc = create_basic_client();
         let proposal = ProposalBuilder::default().build();
         lc.send(proposal, zip32::AccountId::ZERO).await.unwrap_err();
         // TODO: match on specific error

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -222,35 +222,29 @@ impl LightClient {
 mod test {
     //! all tests below (and in this mod) use example wallets, which describe real-world chains.
 
-    use std::num::NonZeroU32;
-
-    use pepper_sync::config::SyncConfig;
     use zingo_test_vectors::seeds;
 
     use crate::{
-        config::{WalletBase, ZingoConfig},
+        config::{ClientConfig, WalletConfig},
         lightclient::{LightClient, sync::test::sync_example_wallet},
         mocks::proposal::ProposalBuilder,
-        testutils::chain_generics::{
-            conduct_chain::ConductChain as _, networked::NetworkedTestEnvironment, with_assertions,
+        testutils::{
+            chain_generics::{
+                conduct_chain::ConductChain as _, networked::NetworkedTestEnvironment,
+                with_assertions,
+            },
+            default_test_wallet_settings,
         },
-        wallet::{WalletSettings, disk::testing::examples},
+        wallet::disk::testing::examples,
     };
 
     fn create_basic_client() -> LightClient {
-        let config = ZingoConfig::builder()
-            .set_wallet_base(WalletBase::MnemonicPhrase {
+        let config = ClientConfig::builder()
+            .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 419200.into(),
-            })
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery:
-                        pepper_sync::config::TransparentAddressDiscovery::minimal(),
-                    performance_level: pepper_sync::config::PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(1).unwrap(),
+                wallet_settings: default_test_wallet_settings(),
             })
             .build();
         LightClient::new(config, true).unwrap()

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -243,7 +243,7 @@ mod test {
             .set_wallet_config(WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 419200.into(),
+                birthday: 419200,
                 wallet_settings: default_test_wallet_settings(),
             })
             .build();

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -169,7 +169,7 @@ pub mod test {
             log::error!("Error installing crypto provider: {e:?}");
         }
 
-        let mut lc = wallet_case.load_example_wallet_with_client().await;
+        let mut lc = wallet_case.load_example_wallet().await;
 
         let sync_result = lc.sync_and_await().await.unwrap();
         tracing::info!("{sync_result}");

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -22,7 +22,7 @@ use crate::wallet::output::SpendStatus;
 use crate::wallet::summary::data::{
     BasicCoinSummary, BasicNoteSummary, OutgoingNoteSummary, TransactionSummary,
 };
-use crate::wallet::{LightWallet, WalletBase, WalletSettings};
+use crate::wallet::{LightWallet, WalletSettings};
 
 pub mod assertions;
 pub mod chain_generics;

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -3,8 +3,10 @@
 
 #![warn(missing_docs)]
 
+use std::num::NonZeroU32;
 use std::{io::Read, string::String, time::Duration};
 
+use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use pepper_sync::keys::decode_address;
 use zcash_address::unified::Fvk;
 use zcash_keys::address::UnifiedAddress;
@@ -14,6 +16,7 @@ use zcash_protocol::{PoolType, ShieldedProtocol, consensus};
 
 use crate::lightclient::LightClient;
 use crate::lightclient::error::LightClientError;
+use crate::wallet::WalletSettings;
 use crate::wallet::keys::unified::UnifiedKeyStore;
 use crate::wallet::output::SpendStatus;
 use crate::wallet::summary::data::{
@@ -30,6 +33,17 @@ pub mod paths;
 // Re-export test dependencies for convenience
 pub use portpicker;
 pub use tempfile;
+
+/// Default wallet settings for testing
+pub fn default_test_wallet_settings() -> WalletSettings {
+    WalletSettings {
+        sync_config: SyncConfig {
+            transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+            performance_level: PerformanceLevel::High,
+        },
+        min_confirmations: NonZeroU32::try_from(1).expect("hard-coded non-zero integer"),
+    }
+}
 
 /// TODO: Add Doc Comment Here!
 #[must_use]

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -3,10 +3,8 @@
 
 #![warn(missing_docs)]
 
-use std::num::NonZeroU32;
 use std::{io::Read, string::String, time::Duration};
 
-use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use pepper_sync::keys::decode_address;
 use zcash_address::unified::Fvk;
 use zcash_keys::address::UnifiedAddress;
@@ -14,7 +12,6 @@ use zcash_keys::encoding::AddressCodec;
 use zcash_protocol::consensus::NetworkConstants;
 use zcash_protocol::{PoolType, ShieldedProtocol, consensus};
 
-use crate::config::ZingoConfig;
 use crate::lightclient::LightClient;
 use crate::lightclient::error::LightClientError;
 use crate::wallet::keys::unified::UnifiedKeyStore;
@@ -22,7 +19,6 @@ use crate::wallet::output::SpendStatus;
 use crate::wallet::summary::data::{
     BasicCoinSummary, BasicNoteSummary, OutgoingNoteSummary, TransactionSummary,
 };
-use crate::wallet::{LightWallet, WalletSettings};
 
 pub mod assertions;
 pub mod chain_generics;

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -54,32 +54,6 @@ pub fn build_fvks_from_unified_keystore(unified_keystore: &UnifiedKeyStore) -> [
     ]
 }
 
-/// TODO: Add Doc Comment Here!
-#[must_use]
-pub fn build_fvk_client(fvks: &[&Fvk], config: ZingoConfig) -> LightClient {
-    let ufvk = zcash_address::unified::Encoding::encode(
-        &<zcash_address::unified::Ufvk as zcash_address::unified::Encoding>::try_from_items(
-            fvks.iter().copied().cloned().collect(),
-        )
-        .unwrap(),
-        &zcash_protocol::consensus::NetworkType::Regtest,
-    );
-    let wallet = LightWallet::new(
-        config.chain_type(),
-        WalletBase::Ufvk(ufvk),
-        1.into(),
-        WalletSettings {
-            sync_config: SyncConfig {
-                transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                performance_level: PerformanceLevel::High,
-            },
-            min_confirmations: NonZeroU32::try_from(1).unwrap(),
-        },
-    )
-    .unwrap();
-    LightClient::create_from_wallet(wallet, config, false).unwrap()
-}
-
 /// TODO: doc comment
 pub async fn assert_transaction_summary_exists(
     lightclient: &LightClient,

--- a/zingolib/src/testutils/chain_generics/conduct_chain.rs
+++ b/zingolib/src/testutils/chain_generics/conduct_chain.rs
@@ -3,7 +3,7 @@
 //! lib-to-node, which links a lightserver to a zcashd in regtest mode. see `impl ConductChain for LibtoNode
 //! darkside, a mode for the lightserver which mocks zcashd. search 'impl ConductChain for DarksideScenario
 
-use crate::config::{WalletBase, ZingoConfig};
+use crate::config::{ClientConfig, WalletConfig};
 use crate::get_base_address_macro;
 use crate::lightclient::LightClient;
 use crate::testutils::lightclient::from_inputs;
@@ -27,12 +27,12 @@ pub trait ConductChain {
     /// the server communicates some parameters (asyncronously)
     /// that are here compiled into an appropriate wallet configuration
     // super awful that this function has to exist, because the wallet should be able to communicate without 'test-only helpers'
-    async fn zingo_config(&mut self) -> crate::config::ZingoConfig;
+    async fn zingo_config(&mut self) -> crate::config::ClientConfig;
 
     /// builds an empty client
     async fn create_client(&mut self) -> LightClient {
         let config = self.zingo_config().await;
-        assert!(!matches!(config.wallet_base(), WalletBase::Read));
+        assert!(!matches!(config.wallet_config(), WalletConfig::Read));
         let mut lightclient = LightClient::new(config, false).unwrap();
         lightclient
             .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
@@ -43,8 +43,8 @@ pub trait ConductChain {
     }
 
     /// loads a client from bytes
-    fn load_client(&mut self, config: ZingoConfig) -> LightClient {
-        assert!(matches!(config.wallet_base(), WalletBase::Read));
+    fn load_client(&mut self, config: ClientConfig) -> LightClient {
+        assert!(matches!(config.wallet_config(), WalletConfig::Read));
         LightClient::new(config, false).unwrap()
     }
 

--- a/zingolib/src/testutils/chain_generics/conduct_chain.rs
+++ b/zingolib/src/testutils/chain_generics/conduct_chain.rs
@@ -3,11 +3,10 @@
 //! lib-to-node, which links a lightserver to a zcashd in regtest mode. see `impl ConductChain for LibtoNode
 //! darkside, a mode for the lightserver which mocks zcashd. search 'impl ConductChain for DarksideScenario
 
-use crate::config::ZingoConfig;
+use crate::config::{WalletBase, ZingoConfig};
 use crate::get_base_address_macro;
 use crate::lightclient::LightClient;
 use crate::testutils::lightclient::from_inputs;
-use crate::wallet::LightWallet;
 use crate::wallet::keys::unified::ReceiverSelection;
 
 #[allow(async_fn_in_trait)]
@@ -33,7 +32,8 @@ pub trait ConductChain {
     /// builds an empty client
     async fn create_client(&mut self) -> LightClient {
         let config = self.zingo_config().await;
-        let mut lightclient = LightClient::new(config, 1.into(), false).unwrap();
+        assert!(!matches!(config.wallet_base(), WalletBase::Read));
+        let mut lightclient = LightClient::new(config, false).unwrap();
         lightclient
             .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
             .await
@@ -43,9 +43,9 @@ pub trait ConductChain {
     }
 
     /// loads a client from bytes
-    fn load_client(&mut self, config: ZingoConfig, data: &[u8]) -> LightClient {
-        let wallet = LightWallet::read(data, config.chain_type()).unwrap();
-        LightClient::create_from_wallet(wallet, config, false).unwrap()
+    fn load_client(&mut self, config: ZingoConfig) -> LightClient {
+        assert!(matches!(config.wallet_base(), WalletBase::Read));
+        LightClient::new(config, false).unwrap()
     }
 
     /// moves the chain tip forward, creating 1 new block

--- a/zingolib/src/testutils/chain_generics/networked.rs
+++ b/zingolib/src/testutils/chain_generics/networked.rs
@@ -39,7 +39,7 @@ impl ConductChain for NetworkedTestEnvironment {
         unimplemented!()
     }
 
-    async fn zingo_config(&mut self) -> crate::config::ZingoConfig {
+    async fn zingo_config(&mut self) -> crate::config::ClientConfig {
         unimplemented!()
     }
 

--- a/zingolib/src/testutils/lightclient.rs
+++ b/zingolib/src/testutils/lightclient.rs
@@ -7,23 +7,6 @@ use zcash_protocol::{PoolType, ShieldedProtocol};
 use crate::lightclient::{LightClient, error::LightClientError};
 use crate::wallet::LightWallet;
 
-/// Create a lightclient from the buffer of another
-pub async fn new_client_from_save_buffer(
-    template_client: &mut LightClient,
-) -> Result<LightClient, LightClientError> {
-    let mut wallet_bytes: Vec<u8> = vec![];
-    template_client
-        .wallet()
-        .write()
-        .await
-        .write(&mut wallet_bytes, &template_client.chain_type())
-        .map_err(LightClientError::FileError)?; //TODO: improve read/write error variants
-
-    let wallet = LightWallet::read(wallet_bytes.as_slice(), template_client.chain_type())
-        .map_err(LightClientError::FileError)?;
-    LightClient::create_from_wallet(wallet, template_client.config.clone(), false)
-}
-
 /// gets the first address that will allow a sender to send to a specific pool, as a string
 pub async fn get_base_address(client: &LightClient, pooltype: PoolType) -> String {
     match pooltype {

--- a/zingolib/src/testutils/lightclient.rs
+++ b/zingolib/src/testutils/lightclient.rs
@@ -4,8 +4,7 @@
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::{PoolType, ShieldedProtocol};
 
-use crate::lightclient::{LightClient, error::LightClientError};
-use crate::wallet::LightWallet;
+use crate::lightclient::LightClient;
 
 /// gets the first address that will allow a sender to send to a specific pool, as a string
 pub async fn get_base_address(client: &LightClient, pooltype: PoolType) -> String {

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -54,6 +54,15 @@ pub struct WalletSettings {
     pub min_confirmations: NonZeroU32,
 }
 
+impl Default for WalletSettings {
+    fn default() -> Self {
+        Self {
+            sync_config: SyncConfig::default(),
+            min_confirmations: NonZeroU32::try_from(3).expect("hard-coded non-zero integer"),
+        }
+    }
+}
+
 /// Provides necessary information to recover the wallet without the wallet file.
 #[derive(Clone, Debug, PartialEq, serde::Serialize)]
 pub struct RecoveryInfo {

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -149,7 +149,13 @@ pub struct LightWallet {
 }
 
 impl LightWallet {
-    /// Create a new in-memory wallet.
+    /// Create a new in-memory wallet from [`crate::config::WalletConfig`].
+    ///
+    /// # Error
+    ///
+    /// An error will be returned if the wallet config is of `Read` variant as the wallet has already been created.
+    /// If is the responsbility of the struct that owns the [`crate::wallet::LightWallet`] to use the
+    /// `LightWallet::read` method instead.
     #[allow(clippy::result_large_err)]
     pub fn new(chain_type: ChainType, wallet_config: WalletConfig) -> Result<Self, WalletError> {
         let wallet_base = wallet_config.resolve(chain_type)?;

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -19,7 +19,7 @@ use pepper_sync::{
 };
 use zingo_price::PriceList;
 
-use crate::config::{ChainType, WalletBase};
+use crate::config::{ChainType, WalletConfig};
 use crate::data::proposal::ZingoProposal;
 use error::{KeyError, PriceError, WalletError};
 use keys::unified::{UnifiedAddressId, UnifiedKeyStore};
@@ -89,6 +89,14 @@ impl std::fmt::Display for RecoveryInfo {
     }
 }
 
+/// Base data required to construct a new [`crate::wallet::LightWallet`].
+pub(crate) struct WalletBase {
+    pub(crate) unified_key_store: BTreeMap<zip32::AccountId, UnifiedKeyStore>,
+    pub(crate) mnemonic: Option<Mnemonic>,
+    pub(crate) birthday: BlockHeight,
+    pub(crate) wallet_settings: WalletSettings,
+}
+
 /// In-memory wallet data struct
 ///
 /// The `mnemonic` can be `None` in the case of a wallet created directly from UFVKs or USKs.
@@ -143,30 +151,24 @@ pub struct LightWallet {
 impl LightWallet {
     /// Create a new in-memory wallet.
     #[allow(clippy::result_large_err)]
-    pub fn new(
+    pub fn new(chain_type: ChainType, wallet_config: WalletConfig) -> Result<Self, WalletError> {
+        let wallet_base = wallet_config.resolve(chain_type)?;
+        Self::from_base(chain_type, wallet_base)
+    }
+
+    /// Construct a wallet from [`crate::wallet::WalletBase`], resolved from a [`crate::config::WalletConfig`].
+    #[allow(clippy::result_large_err)]
+    pub(crate) fn from_base(
         chain_type: ChainType,
         wallet_base: WalletBase,
-        wallet_settings: WalletSettings,
     ) -> Result<Self, WalletError> {
-        let (unified_key_store, mnemonic, birthday) = wallet_base.resolve_keys(chain_type)?;
-        Self::from_keys(
-            chain_type,
+        let WalletBase {
             unified_key_store,
             mnemonic,
             birthday,
             wallet_settings,
-        )
-    }
+        } = wallet_base;
 
-    /// Construct a wallet from pre-resolved keys.
-    #[allow(clippy::result_large_err)]
-    pub(crate) fn from_keys(
-        chain_type: ChainType,
-        unified_key_store: BTreeMap<zip32::AccountId, UnifiedKeyStore>,
-        mnemonic: Option<Mnemonic>,
-        birthday: BlockHeight,
-        wallet_settings: WalletSettings,
-    ) -> Result<Self, WalletError> {
         let sapling_activation_height = chain_type
             .activation_height(zcash_protocol::consensus::NetworkUpgrade::Sapling)
             .expect("should have some sapling activation height");

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -19,7 +19,7 @@ use pepper_sync::{
 };
 use zingo_price::PriceList;
 
-use crate::config::ChainType;
+use crate::config::{ChainType, WalletBase};
 use crate::data::proposal::ZingoProposal;
 use error::{KeyError, PriceError, WalletError};
 use keys::unified::{UnifiedAddressId, UnifiedKeyStore};
@@ -80,80 +80,6 @@ impl std::fmt::Display for RecoveryInfo {
     }
 }
 
-/// Data used to initialize new instance of `LightWallet`
-pub enum WalletBase {
-    /// Generate a wallet with a new seed for a number of accounts.
-    FreshEntropy { no_of_accounts: NonZeroU32 },
-    /// Generate a wallet from a mnemonic (phrase or entropy) for a number of accounts.
-    Mnemonic {
-        mnemonic: Mnemonic,
-        no_of_accounts: NonZeroU32,
-    },
-    /// Generate a wallet from a unified full viewing key.
-    // TODO: take concrete UFVK type
-    Ufvk(String),
-    /// Generate a wallet from a unified spending key.
-    // TODO: take concrete USK type
-    Usk(Vec<u8>),
-}
-
-impl WalletBase {
-    /// Resolves the wallet base into a unified key store and optional mnemonic.
-    ///
-    /// `FreshEntropy` generates a new 24-word mnemonic and then resolves as `Mnemonic`.
-    #[allow(clippy::result_large_err)]
-    fn resolve_keys(
-        self,
-        chain_type: ChainType,
-    ) -> Result<
-        (
-            BTreeMap<zip32::AccountId, UnifiedKeyStore>,
-            Option<Mnemonic>,
-        ),
-        WalletError,
-    > {
-        match self {
-            WalletBase::FreshEntropy { no_of_accounts } => WalletBase::Mnemonic {
-                mnemonic: Mnemonic::generate(bip0039::Count::Words24),
-                no_of_accounts,
-            }
-            .resolve_keys(chain_type),
-            WalletBase::Mnemonic {
-                mnemonic,
-                no_of_accounts,
-            } => {
-                let no_of_accounts = u32::from(no_of_accounts);
-                let unified_key_store = (0..no_of_accounts)
-                    .map(|account_index| {
-                        let account_id = zip32::AccountId::try_from(account_index)?;
-                        Ok((
-                            account_id,
-                            UnifiedKeyStore::new_from_mnemonic(chain_type, &mnemonic, account_id)?,
-                        ))
-                    })
-                    .collect::<Result<BTreeMap<_, _>, KeyError>>()?;
-                Ok((unified_key_store, Some(mnemonic)))
-            }
-            WalletBase::Ufvk(ufvk_encoded) => {
-                let mut unified_key_store = BTreeMap::new();
-                unified_key_store.insert(
-                    zip32::AccountId::ZERO,
-                    UnifiedKeyStore::new_from_ufvk(chain_type, ufvk_encoded)?,
-                );
-                Ok((unified_key_store, None))
-            }
-            WalletBase::Usk(unified_spending_key) => {
-                let mut unified_key_store = BTreeMap::new();
-                unified_key_store.insert(
-                    zip32::AccountId::ZERO,
-                    UnifiedKeyStore::new_from_usk(unified_spending_key.as_slice())?,
-                );
-                Ok((unified_key_store, None))
-            }
-        }
-    }
-}
-
 /// In-memory wallet data struct
 ///
 /// The `mnemonic` can be `None` in the case of a wallet created directly from UFVKs or USKs.
@@ -207,17 +133,13 @@ pub struct LightWallet {
 
 impl LightWallet {
     /// Create a new in-memory wallet.
-    ///
-    /// For wallets from fresh entropy, it is worth considering setting `birthday` to 100 blocks below current height
-    /// of block chain to protect from re-orgs.
     #[allow(clippy::result_large_err)]
     pub fn new(
         chain_type: ChainType,
         wallet_base: WalletBase,
-        birthday: BlockHeight,
         wallet_settings: WalletSettings,
     ) -> Result<Self, WalletError> {
-        let (unified_key_store, mnemonic) = wallet_base.resolve_keys(chain_type)?;
+        let (unified_key_store, mnemonic, birthday) = wallet_base.resolve_keys(chain_type)?;
         Self::from_keys(
             chain_type,
             unified_key_store,

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -42,8 +42,8 @@ use pepper_sync::{
 };
 
 impl LightWallet {
-    /// Changes in version 39:
-    /// - sync state updated serialized version
+    /// Changes in version 40:
+    /// `ChainType` serialized as u8 instead of string to decouple from fmt::Display and reduce bytes stored.
     #[must_use]
     pub const fn serialized_version() -> u64 {
         40

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
+use std::path::PathBuf;
 
-use bytes::Buf;
 use http::Uri;
 
 use zcash_protocol::{PoolType, ShieldedProtocol};
@@ -9,9 +9,11 @@ use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscov
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds;
 
-use crate::config::{ChainType, DEFAULT_INDEXER_URI, WalletBase, ZingoConfig};
+use crate::config::{
+    ChainType, DEFAULT_INDEXER_URI, DEFAULT_INDEXER_URI_TESTNET, WalletBase, ZingoConfig,
+};
 use crate::lightclient::LightClient;
-use crate::wallet::{LightWallet, WalletSettings};
+use crate::wallet::WalletSettings;
 
 /// `ExampleWalletNetworkCase` sorts first by Network, then seed, then last saved version.
 /// It is public so that any consumer can select and load any example wallet.
@@ -129,152 +131,93 @@ impl NetworkSeedVersion {
     /// Loads wallet from test wallet files.
     // TODO: improve with macro
     #[must_use]
-    pub fn load_example_wallet(&self, network: ChainType) -> LightWallet {
+    pub fn example_wallet_path(&self) -> PathBuf {
         match self {
             NetworkSeedVersion::Regtest(seed) => match seed {
                 RegtestSeedVersion::HospitalMuseum(version) => match version {
-                    HospitalMuseumVersion::V27 => LightWallet::read(
-                        include_bytes!(
-                            "examples/regtest/hmvasmuvwmssvichcarbpoct/v27/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
+                    HospitalMuseumVersion::V27 => PathBuf::from(format!(
+                        "{}/examples/regtest/hmvasmuvwmssvichcarbpoct/v27/zingo-wallet.dat",
+                        module_path!()
+                    )),
                 },
                 RegtestSeedVersion::AbandonAbandon(version) => match version {
-                    AbandonAbandonVersion::V26 => LightWallet::read(
-                        include_bytes!(
-                            "examples/regtest/aaaaaaaaaaaaaaaaaaaaaaaa/v26/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
+                    AbandonAbandonVersion::V26 => PathBuf::from(format!(
+                        "{}/examples/regtest/aaaaaaaaaaaaaaaaaaaaaaaa/v26/zingo-wallet.dat",
+                        module_path!()
+                    )),
                 },
                 RegtestSeedVersion::AbsurdAmount(version) => match version {
-                    AbsurdAmountVersion::OrchAndSapl => LightWallet::read(
-                        include_bytes!(
-                        "examples/regtest/aadaalacaadaalacaadaalac/orch_and_sapl/zingo-wallet.dat"
-                    )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
-                    AbsurdAmountVersion::OrchOnly => LightWallet::read(
-                        include_bytes!(
-                            "examples/regtest/aadaalacaadaalacaadaalac/orch_only/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
+                    AbsurdAmountVersion::OrchAndSapl => PathBuf::from(format!(
+                        "{}/examples/regtest/aadaalacaadaalacaadaalac/orch_and_sapl/zingo-wallet.dat",
+                        module_path!()
+                    )),
+                    AbsurdAmountVersion::OrchOnly => PathBuf::from(format!(
+                        "{}/examples/regtest/aadaalacaadaalacaadaalac/orch_only/zingo-wallet.dat",
+                        module_path!()
+                    )),
                 },
             },
             NetworkSeedVersion::Testnet(seed) => match seed {
                 TestnetSeedVersion::ChimneyBetter(version) => match version {
-                    ChimneyBetterVersion::V26 => LightWallet::read(
-                        include_bytes!(
-                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/v26/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
-                    ChimneyBetterVersion::V27 => LightWallet::read(
-                        include_bytes!(
-                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/v27/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
-                    ChimneyBetterVersion::V28 => LightWallet::read(
-                        include_bytes!(
-                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/v28/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
-                    ChimneyBetterVersion::Latest => LightWallet::read(
-                        include_bytes!(
-                            "examples/testnet/cbbhrwiilgbrababsshsmtpr/latest/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
+                    ChimneyBetterVersion::V26 => PathBuf::from(format!(
+                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/v26/zingo-wallet.dat",
+                        module_path!()
+                    )),
+                    ChimneyBetterVersion::V27 => PathBuf::from(format!(
+                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/v27/zingo-wallet.dat",
+                        module_path!()
+                    )),
+                    ChimneyBetterVersion::V28 => PathBuf::from(format!(
+                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/v28/zingo-wallet.dat",
+                        module_path!()
+                    )),
+                    ChimneyBetterVersion::Latest => PathBuf::from(format!(
+                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/latest/zingo-wallet.dat",
+                        module_path!()
+                    )),
                 },
                 TestnetSeedVersion::MobileShuffle(version) => match version {
-                    MobileShuffleVersion::Gab72a38b => LightWallet::read(
-                        include_bytes!(
-                            "examples/testnet/mskmgdbhotbpetcjwcspgopp/Gab72a38b/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
-                    MobileShuffleVersion::G93738061a => LightWallet::read(
-                        include_bytes!(
-                            "examples/testnet/mskmgdbhotbpetcjwcspgopp/G93738061a/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
-                    MobileShuffleVersion::Latest => LightWallet::read(
-                        include_bytes!(
-                            "examples/testnet/mskmgdbhotbpetcjwcspgopp/latest/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
+                    MobileShuffleVersion::Gab72a38b => PathBuf::from(format!(
+                        "{}/examples/testnet/mskmgdbhotbpetcjwcspgopp/Gab72a38b/zingo-wallet.dat",
+                        module_path!()
+                    )),
+                    MobileShuffleVersion::G93738061a => PathBuf::from(format!(
+                        "{}/examples/testnet/mskmgdbhotbpetcjwcspgopp/G93738061a/zingo-wallet.dat",
+                        module_path!()
+                    )),
+                    MobileShuffleVersion::Latest => PathBuf::from(format!(
+                        "{}/examples/testnet/mskmgdbhotbpetcjwcspgopp/latest/zingo-wallet.dat",
+                        module_path!()
+                    )),
                 },
-                TestnetSeedVersion::GloryGoddess => LightWallet::read(
-                    include_bytes!("examples/testnet/glory_goddess/latest/zingo-wallet.dat")
-                        .reader(),
-                    network,
-                )
-                .unwrap(),
+                TestnetSeedVersion::GloryGoddess => PathBuf::from(format!(
+                    "{}/examples/testnet/glory_goddess/latest/zingo-wallet.dat",
+                    module_path!()
+                )),
             },
             NetworkSeedVersion::Mainnet(seed) => match seed {
                 MainnetSeedVersion::VillageTarget(version) => match version {
-                    VillageTargetVersion::V28 => LightWallet::read(
-                        include_bytes!(
-                            "examples/mainnet/vtfcorfbcbpctcfupmegmwbp/v28/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
+                    VillageTargetVersion::V28 => PathBuf::from(format!(
+                        "{}/examples/mainnet/vtfcorfbcbpctcfupmegmwbp/v28/zingo-wallet.dat",
+                        module_path!()
+                    )),
                 },
                 MainnetSeedVersion::HotelHumor(version) => match version {
-                    HotelHumorVersion::Gf0aaf9347 => LightWallet::read(
-                        include_bytes!(
-                            "examples/mainnet/hhcclaltpcckcsslpcnetblr/gf0aaf9347/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
-                    HotelHumorVersion::Latest => LightWallet::read(
-                        include_bytes!(
-                            "examples/mainnet/hhcclaltpcckcsslpcnetblr/latest/zingo-wallet.dat"
-                        )
-                        .reader(),
-                        network,
-                    )
-                    .unwrap(),
+                    HotelHumorVersion::Gf0aaf9347 => PathBuf::from(format!(
+                        "{}/examples/mainnet/hhcclaltpcckcsslpcnetblr/gf0aaf9347/zingo-wallet.dat",
+                        module_path!()
+                    )),
+                    HotelHumorVersion::Latest => PathBuf::from(format!(
+                        "{}/examples/mainnet/hhcclaltpcckcsslpcnetblr/latest/zingo-wallet.dat",
+                        module_path!()
+                    )),
                 },
             },
         }
     }
 
     /// Loads light client from test wallet files.
-    // TODO: improve with macro
-    pub async fn load_example_wallet_with_client(&self) -> LightClient {
+    pub async fn load_example_wallet(&self) -> LightClient {
         let config = match self {
             NetworkSeedVersion::Regtest(_) => {
                 // Probably should be undefined. For the purpose of these tests, I hope it doesnt matter.
@@ -283,7 +226,14 @@ impl NetworkSeedVersion {
                 ZingoConfig::builder()
                     .set_indexer_uri(lightwalletd_uri)
                     .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
-                    .set_wallet_name("".to_string())
+                    .set_wallet_name(
+                        self.example_wallet_path()
+                            .file_name()
+                            .unwrap()
+                            .to_string_lossy()
+                            .to_string(),
+                    )
+                    .set_wallet_dir(self.example_wallet_path().parent().unwrap().to_path_buf())
                     .set_wallet_base(WalletBase::Read)
                     .set_wallet_settings(WalletSettings {
                         sync_config: SyncConfig {
@@ -294,13 +244,49 @@ impl NetworkSeedVersion {
                     })
                     .build()
             }
-            NetworkSeedVersion::Testnet(_) => crate::config::ZingoConfig::create_testnet(),
-            NetworkSeedVersion::Mainnet(_) => crate::config::ZingoConfig::create_mainnet(),
+            NetworkSeedVersion::Testnet(_) => ZingoConfig::builder()
+                .set_indexer_uri(DEFAULT_INDEXER_URI_TESTNET.parse::<Uri>().unwrap())
+                .set_chain_type(ChainType::Testnet)
+                .set_wallet_name(
+                    self.example_wallet_path()
+                        .file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string(),
+                )
+                .set_wallet_dir(self.example_wallet_path().parent().unwrap().to_path_buf())
+                .set_wallet_base(WalletBase::Read)
+                .set_wallet_settings(WalletSettings {
+                    sync_config: SyncConfig {
+                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                        performance_level: PerformanceLevel::High,
+                    },
+                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
+                })
+                .build(),
+            NetworkSeedVersion::Mainnet(_) => ZingoConfig::builder()
+                .set_indexer_uri(DEFAULT_INDEXER_URI.parse::<Uri>().unwrap())
+                .set_chain_type(ChainType::Mainnet)
+                .set_wallet_name(
+                    self.example_wallet_path()
+                        .file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string(),
+                )
+                .set_wallet_dir(self.example_wallet_path().parent().unwrap().to_path_buf())
+                .set_wallet_base(WalletBase::Read)
+                .set_wallet_settings(WalletSettings {
+                    sync_config: SyncConfig {
+                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                        performance_level: PerformanceLevel::High,
+                    },
+                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
+                })
+                .build(),
         };
 
-        let wallet = self.load_example_wallet(config.chain_type());
-
-        LightClient::create_from_wallet(wallet, config, true).unwrap()
+        LightClient::new(config, false).unwrap()
     }
     /// picks the seed (or ufvk) string associated with an example wallet
     #[must_use]

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -1,31 +1,28 @@
-use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 use http::Uri;
 
 use zcash_protocol::{PoolType, ShieldedProtocol};
 
-use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds;
 
 use crate::config::{
-    ChainType, DEFAULT_INDEXER_URI, DEFAULT_INDEXER_URI_TESTNET, WalletBase, ZingoConfig,
+    ChainType, ClientConfig, DEFAULT_INDEXER_URI, DEFAULT_INDEXER_URI_TESTNET, WalletConfig,
 };
 use crate::lightclient::LightClient;
 use crate::testutils::paths::get_cargo_manifest_dir;
-use crate::wallet::WalletSettings;
 
 /// `ExampleWalletNetworkCase` sorts first by Network, then seed, then last saved version.
 /// It is public so that any consumer can select and load any example wallet.
 #[non_exhaustive]
 #[derive(Clone)]
 pub enum NetworkSeedVersion {
-    /// /
+    /// Regtest seed version
     Regtest(RegtestSeedVersion),
-    /// /
+    /// Testnet seed version
     Testnet(TestnetSeedVersion),
-    /// Mainnet is a live chain
+    /// Mainnet seed version
     Mainnet(MainnetSeedVersion),
 }
 
@@ -194,7 +191,7 @@ impl NetworkSeedVersion {
                 // Probably should be undefined. For the purpose of these tests, I hope it doesnt matter.
                 let lightwalletd_uri = DEFAULT_INDEXER_URI.parse::<Uri>().unwrap();
 
-                ZingoConfig::builder()
+                ClientConfig::builder()
                     .set_indexer_uri(lightwalletd_uri)
                     .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
                     .set_wallet_name(
@@ -205,17 +202,10 @@ impl NetworkSeedVersion {
                             .to_string(),
                     )
                     .set_wallet_dir(self.example_wallet_path().parent().unwrap().to_path_buf())
-                    .set_wallet_base(WalletBase::Read)
-                    .set_wallet_settings(WalletSettings {
-                        sync_config: SyncConfig {
-                            transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                            performance_level: PerformanceLevel::High,
-                        },
-                        min_confirmations: NonZeroU32::try_from(1).unwrap(),
-                    })
+                    .set_wallet_config(WalletConfig::Read)
                     .build()
             }
-            NetworkSeedVersion::Testnet(_) => ZingoConfig::builder()
+            NetworkSeedVersion::Testnet(_) => ClientConfig::builder()
                 .set_indexer_uri(DEFAULT_INDEXER_URI_TESTNET.parse::<Uri>().unwrap())
                 .set_chain_type(ChainType::Testnet)
                 .set_wallet_name(
@@ -226,16 +216,9 @@ impl NetworkSeedVersion {
                         .to_string(),
                 )
                 .set_wallet_dir(self.example_wallet_path().parent().unwrap().to_path_buf())
-                .set_wallet_base(WalletBase::Read)
-                .set_wallet_settings(WalletSettings {
-                    sync_config: SyncConfig {
-                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                        performance_level: PerformanceLevel::High,
-                    },
-                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
-                })
+                .set_wallet_config(WalletConfig::Read)
                 .build(),
-            NetworkSeedVersion::Mainnet(_) => ZingoConfig::builder()
+            NetworkSeedVersion::Mainnet(_) => ClientConfig::builder()
                 .set_indexer_uri(DEFAULT_INDEXER_URI.parse::<Uri>().unwrap())
                 .set_chain_type(ChainType::Mainnet)
                 .set_wallet_name(
@@ -246,14 +229,7 @@ impl NetworkSeedVersion {
                         .to_string(),
                 )
                 .set_wallet_dir(self.example_wallet_path().parent().unwrap().to_path_buf())
-                .set_wallet_base(WalletBase::Read)
-                .set_wallet_settings(WalletSettings {
-                    sync_config: SyncConfig {
-                        transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                        performance_level: PerformanceLevel::High,
-                    },
-                    min_confirmations: NonZeroU32::try_from(1).unwrap(),
-                })
+                .set_wallet_config(WalletConfig::Read)
                 .build(),
         };
 
@@ -261,7 +237,7 @@ impl NetworkSeedVersion {
     }
     /// picks the seed (or ufvk) string associated with an example wallet
     #[must_use]
-    pub fn example_wallet_base(&self) -> String {
+    pub fn example_wallet_seed(&self) -> String {
         match self {
             NetworkSeedVersion::Regtest(seed) => match seed {
                 RegtestSeedVersion::HospitalMuseum(_) => {

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -9,7 +9,7 @@ use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscov
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::seeds;
 
-use crate::config::{ChainType, DEFAULT_INDEXER_URI, ZingoConfig};
+use crate::config::{ChainType, DEFAULT_INDEXER_URI, WalletBase, ZingoConfig};
 use crate::lightclient::LightClient;
 use crate::wallet::{LightWallet, WalletSettings};
 
@@ -284,6 +284,7 @@ impl NetworkSeedVersion {
                     .set_indexer_uri(lightwalletd_uri)
                     .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
                     .set_wallet_name("".to_string())
+                    .set_wallet_base(WalletBase::Read)
                     .set_wallet_settings(WalletSettings {
                         sync_config: SyncConfig {
                             transparent_address_discovery: TransparentAddressDiscovery::minimal(),
@@ -291,7 +292,6 @@ impl NetworkSeedVersion {
                         },
                         min_confirmations: NonZeroU32::try_from(1).unwrap(),
                     })
-                    .set_no_of_accounts(NonZeroU32::try_from(1).unwrap())
                     .build()
             }
             NetworkSeedVersion::Testnet(_) => crate::config::ZingoConfig::create_testnet(),

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -13,6 +13,7 @@ use crate::config::{
     ChainType, DEFAULT_INDEXER_URI, DEFAULT_INDEXER_URI_TESTNET, WalletBase, ZingoConfig,
 };
 use crate::lightclient::LightClient;
+use crate::testutils::paths::get_cargo_manifest_dir;
 use crate::wallet::WalletSettings;
 
 /// `ExampleWalletNetworkCase` sorts first by Network, then seed, then last saved version.
@@ -135,82 +136,52 @@ impl NetworkSeedVersion {
         match self {
             NetworkSeedVersion::Regtest(seed) => match seed {
                 RegtestSeedVersion::HospitalMuseum(version) => match version {
-                    HospitalMuseumVersion::V27 => PathBuf::from(format!(
-                        "{}/examples/regtest/hmvasmuvwmssvichcarbpoct/v27/zingo-wallet.dat",
-                        module_path!()
-                    )),
+                    HospitalMuseumVersion::V27 => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/regtest/hmvasmuvwmssvichcarbpoct/v27/zingo-wallet.dat",
+                    ),
                 },
                 RegtestSeedVersion::AbandonAbandon(version) => match version {
-                    AbandonAbandonVersion::V26 => PathBuf::from(format!(
-                        "{}/examples/regtest/aaaaaaaaaaaaaaaaaaaaaaaa/v26/zingo-wallet.dat",
-                        module_path!()
-                    )),
+                    AbandonAbandonVersion::V26 =>  get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/regtest/aaaaaaaaaaaaaaaaaaaaaaaa/v26/zingo-wallet.dat"
+                    ),
                 },
                 RegtestSeedVersion::AbsurdAmount(version) => match version {
-                    AbsurdAmountVersion::OrchAndSapl => PathBuf::from(format!(
-                        "{}/examples/regtest/aadaalacaadaalacaadaalac/orch_and_sapl/zingo-wallet.dat",
-                        module_path!()
-                    )),
-                    AbsurdAmountVersion::OrchOnly => PathBuf::from(format!(
-                        "{}/examples/regtest/aadaalacaadaalacaadaalac/orch_only/zingo-wallet.dat",
-                        module_path!()
-                    )),
+                    AbsurdAmountVersion::OrchAndSapl => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/regtest/aadaalacaadaalacaadaalac/orch_and_sapl/zingo-wallet.dat",
+                    ),
+                    AbsurdAmountVersion::OrchOnly => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/regtest/aadaalacaadaalacaadaalac/orch_only/zingo-wallet.dat",
+                    ),
                 },
             },
             NetworkSeedVersion::Testnet(seed) => match seed {
                 TestnetSeedVersion::ChimneyBetter(version) => match version {
-                    ChimneyBetterVersion::V26 => PathBuf::from(format!(
-                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/v26/zingo-wallet.dat",
-                        module_path!()
-                    )),
-                    ChimneyBetterVersion::V27 => PathBuf::from(format!(
-                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/v27/zingo-wallet.dat",
-                        module_path!()
-                    )),
-                    ChimneyBetterVersion::V28 => PathBuf::from(format!(
-                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/v28/zingo-wallet.dat",
-                        module_path!()
-                    )),
-                    ChimneyBetterVersion::Latest => PathBuf::from(format!(
-                        "{}/examples/testnet/cbbhrwiilgbrababsshsmtpr/latest/zingo-wallet.dat",
-                        module_path!()
-                    )),
+                    ChimneyBetterVersion::V26 => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/cbbhrwiilgbrababsshsmtpr/v26/zingo-wallet.dat",
+                    ),
+                    ChimneyBetterVersion::V27 => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/cbbhrwiilgbrababsshsmtpr/v27/zingo-wallet.dat",
+                    ),
+                    ChimneyBetterVersion::V28 => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/cbbhrwiilgbrababsshsmtpr/v28/zingo-wallet.dat",
+                    ),
+                    ChimneyBetterVersion::Latest => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/cbbhrwiilgbrababsshsmtpr/latest/zingo-wallet.dat",
+                    ),
                 },
                 TestnetSeedVersion::MobileShuffle(version) => match version {
-                    MobileShuffleVersion::Gab72a38b => PathBuf::from(format!(
-                        "{}/examples/testnet/mskmgdbhotbpetcjwcspgopp/Gab72a38b/zingo-wallet.dat",
-                        module_path!()
-                    )),
-                    MobileShuffleVersion::G93738061a => PathBuf::from(format!(
-                        "{}/examples/testnet/mskmgdbhotbpetcjwcspgopp/G93738061a/zingo-wallet.dat",
-                        module_path!()
-                    )),
-                    MobileShuffleVersion::Latest => PathBuf::from(format!(
-                        "{}/examples/testnet/mskmgdbhotbpetcjwcspgopp/latest/zingo-wallet.dat",
-                        module_path!()
-                    )),
+                    MobileShuffleVersion::Gab72a38b => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/mskmgdbhotbpetcjwcspgopp/Gab72a38b/zingo-wallet.dat",
+                    ),
+                    MobileShuffleVersion::G93738061a => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/mskmgdbhotbpetcjwcspgopp/G93738061a/zingo-wallet.dat",
+                    ),
+                    MobileShuffleVersion::Latest => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/mskmgdbhotbpetcjwcspgopp/latest/zingo-wallet.dat",
+                    ),
                 },
-                TestnetSeedVersion::GloryGoddess => PathBuf::from(format!(
-                    "{}/examples/testnet/glory_goddess/latest/zingo-wallet.dat",
-                    module_path!()
-                )),
+                TestnetSeedVersion::GloryGoddess => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/testnet/glory_goddess/latest/zingo-wallet.dat",
+                    ),
             },
             NetworkSeedVersion::Mainnet(seed) => match seed {
                 MainnetSeedVersion::VillageTarget(version) => match version {
-                    VillageTargetVersion::V28 => PathBuf::from(format!(
-                        "{}/examples/mainnet/vtfcorfbcbpctcfupmegmwbp/v28/zingo-wallet.dat",
-                        module_path!()
-                    )),
+                    VillageTargetVersion::V28 => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/mainnet/vtfcorfbcbpctcfupmegmwbp/v28/zingo-wallet.dat",
+                    ),
                 },
                 MainnetSeedVersion::HotelHumor(version) => match version {
-                    HotelHumorVersion::Gf0aaf9347 => PathBuf::from(format!(
-                        "{}/examples/mainnet/hhcclaltpcckcsslpcnetblr/gf0aaf9347/zingo-wallet.dat",
-                        module_path!()
-                    )),
-                    HotelHumorVersion::Latest => PathBuf::from(format!(
-                        "{}/examples/mainnet/hhcclaltpcckcsslpcnetblr/latest/zingo-wallet.dat",
-                        module_path!()
-                    )),
+                    HotelHumorVersion::Gf0aaf9347 => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/mainnet/hhcclaltpcckcsslpcnetblr/gf0aaf9347/zingo-wallet.dat",
+                    ),
+                    HotelHumorVersion::Latest => get_cargo_manifest_dir().join("src/wallet/disk/testing/examples/mainnet/hhcclaltpcckcsslpcnetblr/latest/zingo-wallet.dat",
+                    ),
                 },
             },
         }
@@ -227,7 +198,7 @@ impl NetworkSeedVersion {
                     .set_indexer_uri(lightwalletd_uri)
                     .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
                     .set_wallet_name(
-                        self.example_wallet_path()
+                        dbg!(self.example_wallet_path())
                             .file_name()
                             .unwrap()
                             .to_string_lossy()

--- a/zingolib/src/wallet/disk/testing/examples.rs
+++ b/zingolib/src/wallet/disk/testing/examples.rs
@@ -195,7 +195,7 @@ impl NetworkSeedVersion {
                     .set_indexer_uri(lightwalletd_uri)
                     .set_chain_type(ChainType::Regtest(ActivationHeights::default()))
                     .set_wallet_name(
-                        dbg!(self.example_wallet_path())
+                        self.example_wallet_path()
                             .file_name()
                             .unwrap()
                             .to_string_lossy()

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -218,32 +218,28 @@ async fn loaded_wallet_assert(
 
 // todo: proptest enum
 #[tokio::test]
-async fn reload_wallet_from_buffer() {
+async fn reload_wallet_from_file() {
     use crate::wallet::{LightWallet, WalletBase};
     use zingo_test_vectors::seeds::CHIMNEY_BETTER_SEED;
 
-    let mid_client =
+    let mut mid_client =
         NetworkSeedVersion::Testnet(TestnetSeedVersion::ChimneyBetter(ChimneyBetterVersion::V28))
             .load_example_wallet_with_verification()
             .await;
     let mid_client_network = mid_client.chain_type();
 
-    let mut mid_buffer: Vec<u8> = vec![];
-    mid_client
-        .wallet()
-        .write()
-        .await
-        .write(&mut mid_buffer, &mid_client.chain_type())
-        .unwrap();
+    mid_client.save_task().await;
+    mid_client.wait_for_save().await;
+    mid_client.shutdown_save_task().await.unwrap();
 
-    let config = ZingoConfig::create_testnet();
-    let client = LightClient::create_from_wallet(
-        LightWallet::read(&mid_buffer[..], config.chain_type()).unwrap(),
-        config,
-        true,
-    )
-    .unwrap();
-    let wallet = client.wallet().read().await;
+    let config = ZingoConfig::builder()
+        .set_indexer_uri(mid_client.indexer_uri().cloned().unwrap())
+        .set_chain_type(mid_client_network)
+        .set_wallet_dir(mid_client.wallet_dir().unwrap())
+        .set_wallet_base(WalletBase::Read)
+        .build();
+    let loaded_client = LightClient::new(config, true).unwrap();
+    let loaded_wallet = loaded_client.wallet().read().await;
 
     let expected_mnemonic = Mnemonic::from_phrase(CHIMNEY_BETTER_SEED.to_string()).unwrap();
 
@@ -254,7 +250,7 @@ async fn reload_wallet_from_buffer() {
     )
     .unwrap();
 
-    let UnifiedKeyStore::Spend(usk) = &wallet
+    let UnifiedKeyStore::Spend(usk) = &loaded_wallet
         .unified_key_store
         .get(&zip32::AccountId::ZERO)
         .unwrap()
@@ -278,22 +274,22 @@ async fn reload_wallet_from_buffer() {
 
     // TODO: there were 3 UAs associated with this wallet, we reset to 1 to ensure index is upheld correctly and
     // should thoroughly test UA discovery when syncing which should find these UAs again
-    assert_eq!(wallet.unified_addresses.len(), 1);
-    for addr in wallet.unified_addresses.values() {
+    assert_eq!(loaded_wallet.unified_addresses.len(), 1);
+    for addr in loaded_wallet.unified_addresses.values() {
         assert!(addr.orchard().is_some());
         assert!(addr.sapling().is_none());
         assert!(addr.transparent().is_none());
     }
 
     let ufvk = usk.to_unified_full_viewing_key();
-    let chain_type = client.chain_type();
+    let chain_type = loaded_client.chain_type();
     let ufvk_string = ufvk.encode(&chain_type);
     let ufvk_base = WalletBase::Ufvk {
         ufvk: ufvk_string.clone(),
-        birthday: client.birthday(),
+        birthday: loaded_client.birthday(),
     };
     let view_wallet =
-        LightWallet::new(chain_type, ufvk_base, wallet.wallet_settings.clone()).unwrap();
+        LightWallet::new(chain_type, ufvk_base, loaded_wallet.wallet_settings.clone()).unwrap();
     let UnifiedKeyStore::View(v_ufvk) = &view_wallet
         .unified_key_store
         .get(&zip32::AccountId::ZERO)

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 impl NetworkSeedVersion {
     /// this is enough data to restore wallet from! thus, it is the bronze test for backward compatibility
     async fn load_example_wallet_with_verification(&self) -> LightClient {
-        let client = self.load_example_wallet_with_client().await;
+        let client = self.load_example_wallet().await;
         let wallet = client.wallet().read().await;
 
         assert_wallet_capability_matches_seed(&wallet, self.example_wallet_base()).await;
@@ -288,14 +288,12 @@ async fn reload_wallet_from_buffer() {
     let ufvk = usk.to_unified_full_viewing_key();
     let chain_type = client.chain_type();
     let ufvk_string = ufvk.encode(&chain_type);
-    let ufvk_base = WalletBase::Ufvk(ufvk_string.clone());
-    let view_wallet = LightWallet::new(
-        chain_type,
-        ufvk_base,
-        client.birthday(),
-        wallet.wallet_settings.clone(),
-    )
-    .unwrap();
+    let ufvk_base = WalletBase::Ufvk {
+        ufvk: ufvk_string.clone(),
+        birthday: client.birthday(),
+    };
+    let view_wallet =
+        LightWallet::new(chain_type, ufvk_base, wallet.wallet_settings.clone()).unwrap();
     let UnifiedKeyStore::View(v_ufvk) = &view_wallet
         .unified_key_store
         .get(&zip32::AccountId::ZERO)

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -4,7 +4,7 @@ use zcash_keys::keys::Era;
 use zcash_protocol::{PoolType, ShieldedProtocol};
 
 use crate::{
-    config::ZingoConfig,
+    config::ClientConfig,
     lightclient::LightClient,
     wallet::{
         disk::testing::{
@@ -27,7 +27,7 @@ impl NetworkSeedVersion {
         let client = self.load_example_wallet().await;
         let wallet = client.wallet().read().await;
 
-        assert_wallet_capability_matches_seed(&wallet, self.example_wallet_base()).await;
+        assert_wallet_capability_matches_seed(&wallet, self.example_wallet_seed()).await;
         for pool in [
             PoolType::Transparent,
             PoolType::Shielded(ShieldedProtocol::Orchard),
@@ -219,7 +219,7 @@ async fn loaded_wallet_assert(
 // todo: proptest enum
 #[tokio::test]
 async fn reload_wallet_from_file() {
-    use crate::wallet::{LightWallet, WalletBase};
+    use crate::wallet::{LightWallet, WalletConfig};
     use zingo_test_vectors::seeds::CHIMNEY_BETTER_SEED;
 
     let mut mid_client =
@@ -232,11 +232,11 @@ async fn reload_wallet_from_file() {
     mid_client.wait_for_save().await;
     mid_client.shutdown_save_task().await.unwrap();
 
-    let config = ZingoConfig::builder()
+    let config = ClientConfig::builder()
         .set_indexer_uri(mid_client.indexer_uri().cloned().unwrap())
         .set_chain_type(mid_client_network)
         .set_wallet_dir(mid_client.wallet_dir().unwrap())
-        .set_wallet_base(WalletBase::Read)
+        .set_wallet_config(WalletConfig::Read)
         .build();
     let loaded_client = LightClient::new(config, true).unwrap();
     let loaded_wallet = loaded_client.wallet().read().await;
@@ -284,12 +284,12 @@ async fn reload_wallet_from_file() {
     let ufvk = usk.to_unified_full_viewing_key();
     let chain_type = loaded_client.chain_type();
     let ufvk_string = ufvk.encode(&chain_type);
-    let ufvk_base = WalletBase::Ufvk {
+    let wallet_config = WalletConfig::Ufvk {
         ufvk: ufvk_string.clone(),
         birthday: loaded_client.birthday(),
+        wallet_settings: loaded_wallet.wallet_settings.clone(),
     };
-    let view_wallet =
-        LightWallet::new(chain_type, ufvk_base, loaded_wallet.wallet_settings.clone()).unwrap();
+    let view_wallet = LightWallet::new(chain_type, wallet_config).unwrap();
     let UnifiedKeyStore::View(v_ufvk) = &view_wallet
         .unified_key_store
         .get(&zip32::AccountId::ZERO)

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -76,9 +76,11 @@ pub enum WalletError {
         "birthday {0} below sapling activation height {1}. pre-sapling wallets are not supported!"
     )]
     BirthdayBelowSapling(u32, u32),
-    /// Cannot create a new wallet with a wallet base of `Read` variant.
-    #[error("Cannot create a new wallet with a wallet base of `Read` variant.")]
-    InvalidWalletBase,
+    /// Cannot create a new wallet with a wallet base of `Read` variant as the wallet is already created and stored as bytes.
+    #[error(
+        "Cannot create a new wallet with a wallet base of `Read` variant as the wallet is already created and stored as bytes."
+    )]
+    WalletAlreadyCreated,
 }
 
 /// Price error

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -11,7 +11,7 @@ use zcash_protocol::{PoolType, ShieldedProtocol};
 use super::output::OutputRef;
 
 /// Top level wallet errors
-// TODO: unify errors and error variants
+// TODO: remove external types from public API
 #[derive(Debug, thiserror::Error)]
 pub enum WalletError {
     /// Key error
@@ -76,6 +76,9 @@ pub enum WalletError {
         "birthday {0} below sapling activation height {1}. pre-sapling wallets are not supported!"
     )]
     BirthdayBelowSapling(u32, u32),
+    /// Cannot create a new wallet with a wallet base of `Read` variant.
+    #[error("Cannot create a new wallet with a wallet base of `Read` variant.")]
+    InvalidWalletBase,
 }
 
 /// Price error
@@ -166,6 +169,7 @@ pub enum BalanceError {
 }
 
 /// Errors associated with key and address derivation
+// TODO: make error private as contains external crate types. have public API safe higher level error type i.e. WalletError.
 #[derive(Debug, thiserror::Error)]
 pub enum KeyError {
     /// Error associated with standard IO
@@ -209,6 +213,9 @@ pub enum KeyError {
         "Transparent address generation failed. Latest transparent address has not received funds."
     )]
     GapError,
+    /// Invalid mnemonic phrase.
+    #[error("Invalid mnemonic phrase: {0}")]
+    InvalidMnemonicPhrase(#[from] bip0039::Error),
 }
 
 impl From<bip32::Error> for KeyError {

--- a/zingolib/src/wallet/keys/legacy/extended_transparent.rs
+++ b/zingolib/src/wallet/keys/legacy/extended_transparent.rs
@@ -2,7 +2,7 @@
 use std::io;
 use zcash_protocol::consensus::NetworkConstants;
 
-use crate::config::ZingoConfig;
+use crate::config::ClientConfig;
 use ring::hmac::{self, Context, Key};
 use secp256k1::{Error, PublicKey, Secp256k1, SecretKey, SignOnly};
 use std::sync::LazyLock;
@@ -101,7 +101,7 @@ impl ExtendedPrivKey {
     /// TODO: Add Doc Comment Here!
     #[must_use]
     pub fn get_ext_taddr_from_bip39seed(
-        config: &ZingoConfig,
+        config: &ClientConfig,
         bip39_seed: &[u8],
         position: u32,
     ) -> Self {

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -261,7 +261,7 @@ mod test {
         let client = examples::NetworkSeedVersion::Mainnet(
             examples::MainnetSeedVersion::HotelHumor(examples::HotelHumorVersion::Latest),
         )
-        .load_example_wallet_with_client()
+        .load_example_wallet()
         .await;
         let mut wallet = client.wallet().write().await;
 

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -175,7 +175,6 @@ impl LightWallet {
 
 #[cfg(test)]
 mod tests {
-
     use pepper_sync::wallet::WalletTransaction;
     use zcash_primitives::transaction::TxId;
     use zingo_status::confirmation_status::ConfirmationStatus;

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -192,7 +192,7 @@ mod tests {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 419_200.into(),
+                birthday: 419_200,
                 wallet_settings: default_test_wallet_settings(),
             },
         )

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -175,35 +175,26 @@ impl LightWallet {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU32;
 
-    use pepper_sync::{
-        config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery},
-        wallet::WalletTransaction,
-    };
+    use pepper_sync::wallet::WalletTransaction;
     use zcash_primitives::transaction::TxId;
     use zingo_status::confirmation_status::ConfirmationStatus;
+    use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
 
     use crate::{
-        config::ZingoConfig,
-        wallet::{LightWallet, WalletBase, WalletSettings, error::WalletError},
+        config::{ChainType, WalletBase},
+        wallet::{LightWallet, WalletSettings, error::WalletError},
     };
 
     fn test_wallet() -> LightWallet {
-        let config = ZingoConfig::builder().build();
         LightWallet::new(
-            config.chain_type(),
-            WalletBase::FreshEntropy {
+            ChainType::Mainnet,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
+                birthday: 419_200.into(),
             },
-            419_200.into(),
-            WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(1).unwrap(),
-            },
+            WalletSettings::default(),
         )
         .unwrap()
     }

--- a/zingolib/src/wallet/transaction.rs
+++ b/zingolib/src/wallet/transaction.rs
@@ -181,19 +181,20 @@ mod tests {
     use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
 
     use crate::{
-        config::{ChainType, WalletBase},
-        wallet::{LightWallet, WalletSettings, error::WalletError},
+        config::{ChainType, WalletConfig},
+        testutils::default_test_wallet_settings,
+        wallet::{LightWallet, error::WalletError},
     };
 
     fn test_wallet() -> LightWallet {
         LightWallet::new(
             ChainType::Mainnet,
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 419_200.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
-            WalletSettings::default(),
         )
         .unwrap()
     }

--- a/zingolib/src/wallet/utils.rs
+++ b/zingolib/src/wallet/utils.rs
@@ -1,6 +1,9 @@
 //! TODO: Add Mod Description Here!
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{self, Read, Write};
+use std::{
+    io::{self, Read, Write},
+    path::PathBuf,
+};
 use zcash_primitives::{memo::MemoBytes, transaction::TxId};
 
 /// TODO: Add Doc Comment Here!
@@ -58,6 +61,12 @@ pub(crate) fn read_sapling_params() -> Result<(Vec<u8>, Vec<u8>), String> {
             .as_ref(),
     );
     Ok((sapling_output, sapling_spend))
+}
+
+/// Returns the path to the default directory that the Zcash proving parameters are located in.
+pub fn get_zcash_params_path() -> std::io::Result<PathBuf> {
+    zcash_proofs::default_params_folder()
+        .ok_or_else(|| std::io::Error::other("could not load default params folder"))
 }
 
 #[cfg(test)]

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -151,9 +151,10 @@ impl ClientBuilder {
         }
     }
 
-    pub fn make_unique_data_dir_and_load_config(
+    pub fn make_unique_data_dir_and_create_config(
         &mut self,
         configured_activation_heights: ActivationHeights,
+        wallet_base: WalletBase,
     ) -> ZingoConfig {
         //! Each client requires a unique `data_dir`, we use the
         //! `client_number` counter for this.
@@ -163,7 +164,11 @@ impl ClientBuilder {
             self.zingo_datadir.path().to_string_lossy(),
             self.client_number
         );
-        self.create_clientconfig(PathBuf::from(conf_path), configured_activation_heights)
+        self.create_clientconfig(
+            PathBuf::from(conf_path),
+            configured_activation_heights,
+            wallet_base,
+        )
     }
 
     /// TODO: Add Doc Comment Here!
@@ -171,6 +176,7 @@ impl ClientBuilder {
         &self,
         conf_path: PathBuf,
         configured_activation_heights: ActivationHeights,
+        wallet_base: WalletBase,
     ) -> ZingoConfig {
         std::fs::create_dir(&conf_path).unwrap();
         ZingoConfig::builder()
@@ -178,6 +184,7 @@ impl ClientBuilder {
             .set_chain_type(ChainType::Regtest(configured_activation_heights))
             .set_wallet_dir(conf_path)
             .set_wallet_name("".to_string())
+            .set_wallet_base(wallet_base)
             .set_wallet_settings(WalletSettings {
                 sync_config: SyncConfig {
                     transparent_address_discovery: TransparentAddressDiscovery::minimal(),
@@ -205,30 +212,21 @@ impl ClientBuilder {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn build_client(
+    pub async fn build_client(
         &mut self,
-        mnemonic_phrase: String,
-        birthday: u64,
+        wallet_base: WalletBase,
         overwrite: bool,
         configured_activation_heights: ActivationHeights,
     ) -> LightClient {
-        let config = self.make_unique_data_dir_and_load_config(configured_activation_heights);
-        let mnemonic = Mnemonic::from_phrase(mnemonic_phrase).unwrap();
-        let birthday = (birthday as u32).into();
-        let mut wallet = LightWallet::new(
-            config.chain_type(),
-            WalletBase::Mnemonic {
-                mnemonic,
-                no_of_accounts: 1.try_into().unwrap(),
-            },
-            birthday,
-            config.wallet_settings(),
-        )
-        .unwrap();
-        wallet
+        let config =
+            self.make_unique_data_dir_and_create_config(configured_activation_heights, wallet_base);
+        let lightclient = LightClient::new(config, overwrite).unwrap();
+        lightclient
             .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
+            .await
             .unwrap();
-        LightClient::create_from_wallet(wallet, config, overwrite).unwrap()
+
+        lightclient
     }
 }
 

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -194,7 +194,7 @@ impl ClientBuilder {
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::ABANDON_ART_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             overwrite,
@@ -239,7 +239,7 @@ pub async fn unfunded_client(
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -314,7 +314,7 @@ pub async fn faucet_recipient(
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -508,7 +508,7 @@ pub async fn funded_orchard_mobileclient(value: u64) -> LocalNet<DefaultValidato
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -544,7 +544,7 @@ pub async fn funded_orchard_with_3_txs_mobileclient(
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -609,7 +609,7 @@ pub async fn funded_transparent_mobileclient(
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,
@@ -657,7 +657,7 @@ pub async fn funded_orchard_sapling_transparent_shielded_mobileclient(
             WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1.into(),
+                birthday: 1,
                 wallet_settings: default_test_wallet_settings(),
             },
             true,

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -13,7 +13,6 @@
 //! build the scenario with the most common settings. This simplifies test writing in
 //! most cases by removing the need for configuration.
 
-use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 use portpicker::Port;
@@ -29,19 +28,18 @@ use zcash_local_net::validator::{Validator, ValidatorConfig};
 
 use network_combo::DefaultIndexer;
 use network_combo::DefaultValidator;
-use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::{FUND_OFFLOAD_ORCHARD_ONLY, seeds};
-use zingolib::config::WalletBase;
-use zingolib::config::{ChainType, ZingoConfig};
+use zingolib::config::WalletConfig;
+use zingolib::config::{ChainType, ClientConfig};
 use zingolib::get_base_address_macro;
 use zingolib::lightclient::LightClient;
 use zingolib::lightclient::error::LightClientError;
+use zingolib::testutils::default_test_wallet_settings;
 use zingolib::testutils::lightclient::from_inputs::{self, quick_send};
 use zingolib::testutils::lightclient::get_base_address;
 use zingolib::testutils::port_to_localhost_uri;
 use zingolib::testutils::sync_to_target_height;
-use zingolib::wallet::WalletSettings;
 use zingolib::wallet::keys::unified::ReceiverSelection;
 
 /// Default regtest network processes for testing and zingo-cli regtest mode
@@ -152,8 +150,8 @@ impl ClientBuilder {
     pub fn make_unique_data_dir_and_create_config(
         &mut self,
         configured_activation_heights: ActivationHeights,
-        wallet_base: WalletBase,
-    ) -> ZingoConfig {
+        wallet_config: WalletConfig,
+    ) -> ClientConfig {
         //! Each client requires a unique `data_dir`, we use the
         //! `client_number` counter for this.
         self.client_number += 1;
@@ -165,7 +163,7 @@ impl ClientBuilder {
         self.create_clientconfig(
             PathBuf::from(conf_path),
             configured_activation_heights,
-            wallet_base,
+            wallet_config,
         )
     }
 
@@ -174,21 +172,14 @@ impl ClientBuilder {
         &self,
         conf_path: PathBuf,
         configured_activation_heights: ActivationHeights,
-        wallet_base: WalletBase,
-    ) -> ZingoConfig {
+        wallet_config: WalletConfig,
+    ) -> ClientConfig {
         std::fs::create_dir(&conf_path).unwrap();
-        ZingoConfig::builder()
+        ClientConfig::builder()
             .set_indexer_uri(self.server_id.clone())
             .set_chain_type(ChainType::Regtest(configured_activation_heights))
             .set_wallet_dir(conf_path)
-            .set_wallet_base(wallet_base)
-            .set_wallet_settings(WalletSettings {
-                sync_config: SyncConfig {
-                    transparent_address_discovery: TransparentAddressDiscovery::minimal(),
-                    performance_level: PerformanceLevel::High,
-                },
-                min_confirmations: NonZeroU32::try_from(1).unwrap(),
-            })
+            .set_wallet_config(wallet_config)
             .build()
     }
 
@@ -200,10 +191,11 @@ impl ClientBuilder {
     ) -> LightClient {
         //! A "faucet" is a lightclient that receives mining rewards
         self.build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::ABANDON_ART_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             overwrite,
             configured_activation_heights,
@@ -214,12 +206,12 @@ impl ClientBuilder {
     /// TODO: Add Doc Comment Here!
     pub async fn build_client(
         &mut self,
-        wallet_base: WalletBase,
+        wallet_config: WalletConfig,
         overwrite: bool,
         configured_activation_heights: ActivationHeights,
     ) -> LightClient {
-        let config =
-            self.make_unique_data_dir_and_create_config(configured_activation_heights, wallet_base);
+        let config = self
+            .make_unique_data_dir_and_create_config(configured_activation_heights, wallet_config);
         let mut lightclient = LightClient::new(config, overwrite).unwrap();
         lightclient
             .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
@@ -244,10 +236,11 @@ pub async fn unfunded_client(
 
     let mut lightclient = client_builder
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             configured_activation_heights,
@@ -318,10 +311,11 @@ pub async fn faucet_recipient(
         .await;
     let mut recipient = client_builder
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             configured_activation_heights,
@@ -511,10 +505,11 @@ pub async fn funded_orchard_mobileclient(value: u64) -> LocalNet<DefaultValidato
         .await;
     let recipient = client_builder
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             local_net.validator().get_activation_heights().await,
@@ -546,10 +541,11 @@ pub async fn funded_orchard_with_3_txs_mobileclient(
         .await;
     let mut recipient = client_builder
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             local_net.validator().get_activation_heights().await,
@@ -610,10 +606,11 @@ pub async fn funded_transparent_mobileclient(
         .await;
     let mut recipient = client_builder
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             local_net.validator().get_activation_heights().await,
@@ -657,10 +654,11 @@ pub async fn funded_orchard_sapling_transparent_shielded_mobileclient(
         .await;
     let mut recipient = client_builder
         .build_client(
-            WalletBase::MnemonicPhrase {
+            WalletConfig::MnemonicPhrase {
                 mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
                 no_of_accounts: 1.try_into().unwrap(),
                 birthday: 1.into(),
+                wallet_settings: default_test_wallet_settings(),
             },
             true,
             local_net.validator().get_activation_heights().await,

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -16,8 +16,6 @@
 use std::num::NonZeroU32;
 use std::path::PathBuf;
 
-use bip0039::Mnemonic;
-
 use portpicker::Port;
 use tempfile::TempDir;
 use zcash_protocol::PoolType;
@@ -34,6 +32,7 @@ use network_combo::DefaultValidator;
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_test_vectors::{FUND_OFFLOAD_ORCHARD_ONLY, seeds};
+use zingolib::config::WalletBase;
 use zingolib::config::{ChainType, ZingoConfig};
 use zingolib::get_base_address_macro;
 use zingolib::lightclient::LightClient;
@@ -42,9 +41,8 @@ use zingolib::testutils::lightclient::from_inputs::{self, quick_send};
 use zingolib::testutils::lightclient::get_base_address;
 use zingolib::testutils::port_to_localhost_uri;
 use zingolib::testutils::sync_to_target_height;
-use zingolib::wallet::WalletBase;
+use zingolib::wallet::WalletSettings;
 use zingolib::wallet::keys::unified::ReceiverSelection;
-use zingolib::wallet::{LightWallet, WalletSettings};
 
 /// Default regtest network processes for testing and zingo-cli regtest mode
 #[cfg(feature = "test_zainod_zcashd")]
@@ -195,18 +193,22 @@ impl ClientBuilder {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn build_faucet(
+    pub async fn build_faucet(
         &mut self,
         overwrite: bool,
         configured_activation_heights: ActivationHeights,
     ) -> LightClient {
         //! A "faucet" is a lightclient that receives mining rewards
         self.build_client(
-            seeds::ABANDON_ART_SEED.to_string(),
-            1,
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::ABANDON_ART_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
             overwrite,
             configured_activation_heights,
         )
+        .await
     }
 
     /// TODO: Add Doc Comment Here!
@@ -218,7 +220,7 @@ impl ClientBuilder {
     ) -> LightClient {
         let config =
             self.make_unique_data_dir_and_create_config(configured_activation_heights, wallet_base);
-        let lightclient = LightClient::new(config, overwrite).unwrap();
+        let mut lightclient = LightClient::new(config, overwrite).unwrap();
         lightclient
             .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
             .await
@@ -240,12 +242,17 @@ pub async fn unfunded_client(
     )
     .await;
 
-    let mut lightclient = client_builder.build_client(
-        seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-        1,
-        true,
-        configured_activation_heights,
-    );
+    let mut lightclient = client_builder
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            configured_activation_heights,
+        )
+        .await;
     lightclient.sync_and_await().await.unwrap();
 
     (local_net, lightclient)
@@ -275,7 +282,9 @@ pub async fn faucet(
     let (local_net, mut client_builder) =
         custom_clients(mine_to_pool, configured_activation_heights, chain_cache).await;
 
-    let mut faucet = client_builder.build_faucet(true, configured_activation_heights);
+    let mut faucet = client_builder
+        .build_faucet(true, configured_activation_heights)
+        .await;
 
     if matches!(DefaultValidator::PROCESS, ProcessId::Zebrad) {
         zebrad_shielded_funds(&local_net, mine_to_pool, &mut faucet).await;
@@ -304,13 +313,20 @@ pub async fn faucet_recipient(
     let (local_net, mut client_builder) =
         custom_clients(mine_to_pool, configured_activation_heights, chain_cache).await;
 
-    let mut faucet = client_builder.build_faucet(true, configured_activation_heights);
-    let mut recipient = client_builder.build_client(
-        seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-        1,
-        true,
-        configured_activation_heights,
-    );
+    let mut faucet = client_builder
+        .build_faucet(true, configured_activation_heights)
+        .await;
+    let mut recipient = client_builder
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            configured_activation_heights,
+        )
+        .await;
 
     if matches!(DefaultValidator::PROCESS, ProcessId::Zebrad) {
         zebrad_shielded_funds(&local_net, mine_to_pool, &mut faucet).await;
@@ -490,14 +506,20 @@ pub async fn funded_orchard_mobileclient(value: u64) -> LocalNet<DefaultValidato
         port_to_localhost_uri(local_net.indexer().port()),
         tempfile::tempdir().unwrap(),
     );
-    let mut faucet =
-        client_builder.build_faucet(true, local_net.validator().get_activation_heights().await);
-    let recipient = client_builder.build_client(
-        seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-        1,
-        true,
-        local_net.validator().get_activation_heights().await,
-    );
+    let mut faucet = client_builder
+        .build_faucet(true, local_net.validator().get_activation_heights().await)
+        .await;
+    let recipient = client_builder
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            local_net.validator().get_activation_heights().await,
+        )
+        .await;
     faucet.sync_and_await().await.unwrap();
     quick_send(
         &mut faucet,
@@ -519,14 +541,20 @@ pub async fn funded_orchard_with_3_txs_mobileclient(
         port_to_localhost_uri(local_net.indexer().port()),
         tempfile::tempdir().unwrap(),
     );
-    let mut faucet =
-        client_builder.build_faucet(true, local_net.validator().get_activation_heights().await);
-    let mut recipient = client_builder.build_client(
-        seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-        1,
-        true,
-        local_net.validator().get_activation_heights().await,
-    );
+    let mut faucet = client_builder
+        .build_faucet(true, local_net.validator().get_activation_heights().await)
+        .await;
+    let mut recipient = client_builder
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            local_net.validator().get_activation_heights().await,
+        )
+        .await;
     increase_height_and_wait_for_client(&local_net, &mut faucet, 1)
         .await
         .unwrap();
@@ -577,14 +605,20 @@ pub async fn funded_transparent_mobileclient(
         port_to_localhost_uri(local_net.indexer().port()),
         tempfile::tempdir().unwrap(),
     );
-    let mut faucet =
-        client_builder.build_faucet(true, local_net.validator().get_activation_heights().await);
-    let mut recipient = client_builder.build_client(
-        seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-        1,
-        true,
-        local_net.validator().get_activation_heights().await,
-    );
+    let mut faucet = client_builder
+        .build_faucet(true, local_net.validator().get_activation_heights().await)
+        .await;
+    let mut recipient = client_builder
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            local_net.validator().get_activation_heights().await,
+        )
+        .await;
     increase_height_and_wait_for_client(&local_net, &mut faucet, 1)
         .await
         .unwrap();
@@ -618,14 +652,20 @@ pub async fn funded_orchard_sapling_transparent_shielded_mobileclient(
         port_to_localhost_uri(local_net.indexer().port()),
         tempfile::tempdir().unwrap(),
     );
-    let mut faucet =
-        client_builder.build_faucet(true, local_net.validator().get_activation_heights().await);
-    let mut recipient = client_builder.build_client(
-        seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-        1,
-        true,
-        local_net.validator().get_activation_heights().await,
-    );
+    let mut faucet = client_builder
+        .build_faucet(true, local_net.validator().get_activation_heights().await)
+        .await;
+    let mut recipient = client_builder
+        .build_client(
+            WalletBase::MnemonicPhrase {
+                mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().unwrap(),
+                birthday: 1.into(),
+            },
+            true,
+            local_net.validator().get_activation_heights().await,
+        )
+        .await;
     increase_height_and_wait_for_client(&local_net, &mut faucet, 1)
         .await
         .unwrap();

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -183,7 +183,6 @@ impl ClientBuilder {
             .set_indexer_uri(self.server_id.clone())
             .set_chain_type(ChainType::Regtest(configured_activation_heights))
             .set_wallet_dir(conf_path)
-            .set_wallet_name("".to_string())
             .set_wallet_base(wallet_base)
             .set_wallet_settings(WalletSettings {
                 sync_config: SyncConfig {
@@ -192,7 +191,6 @@ impl ClientBuilder {
                 },
                 min_confirmations: NonZeroU32::try_from(1).unwrap(),
             })
-            .set_no_of_accounts(NonZeroU32::try_from(1).unwrap())
             .build()
     }
 


### PR DESCRIPTION
Fixes: #2269 
ontop of #2261

- renames `ZingoConfig` to `ClientConfig`
- new `WalletConfig` struct in config module replaced function of `WalletBase` which is no longer public and is resolved from the `WalletConfig`
- lightclient now has a single constructor `new` which only takes a `ClientConfig`. all data is encapsulated in the config about how the lightclient is to be constructed with no dead fields i.e. no data needs to be supplied that is not used.
- lightwallet now has a single constructor `new` except for the `read` impl for reading from file. `new` takes the new `WalletConfig` enum which encapsulates all variants of wallet creation with no dead fields.
- lightclient no longer holds the config. the config is used for lightclient construction and the data is stored in relevant fields in lightclient or lightwallet
- finishes stabilising the config modules public API with no external types except for `http::Uri` which appears to be a very stable type.
