### PR TITLE
Persist the newest shard-tree checkpoint window

### DIFF
--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -999,7 +999,10 @@ impl ShardTrees {
         const SHARD_HEIGHT: u8,
     >(
         mut reader: R,
-    ) -> std::io::Result<ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>> {
+    ) -> std::io::Result<ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>>
+    where
+        u32: From<C>,
+    {
         let shards = Vector::read(&mut reader, |r| {
             let level = incrementalmerkletree::Level::from(r.read_u8()?);
             let index = r.read_u64::<LittleEndian>()?;
@@ -1044,7 +1047,6 @@ impl ShardTrees {
                 .expect("Infallible");
         }
         store.put_cap(read_shard(reader)?).expect("Infallible");
-
         Ok(shardtree::ShardTree::new(
             store,
             MAX_REORG_ALLOWANCE as usize,
@@ -1139,12 +1141,17 @@ impl ShardTrees {
 
         // Write checkpoints
         let mut checkpoints = Vec::new();
+        let checkpoint_count = store.checkpoint_count().expect("Infallible");
         store
-            .with_checkpoints(MAX_REORG_ALLOWANCE as usize, |checkpoint_id, checkpoint| {
+            .with_checkpoints(checkpoint_count, |checkpoint_id, checkpoint| {
                 checkpoints.push((*checkpoint_id, checkpoint.clone()));
                 Ok(())
             })
             .expect("Infallible");
+        if checkpoints.len() > MAX_REORG_ALLOWANCE as usize {
+            let keep_from = checkpoints.len() - MAX_REORG_ALLOWANCE as usize;
+            checkpoints.drain(..keep_from);
+        }
         write_with_error_handling!(write_checkpoints, checkpoints);
 
         // Write cap
@@ -1154,5 +1161,67 @@ impl ShardTrees {
         *shardtree = shardtree::ShardTree::new(store, MAX_REORG_ALLOWANCE as usize);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shardtree_roundtrip_keeps_newest_checkpoints() {
+        let mut shard_trees = ShardTrees::new();
+
+        for height in 1..=150 {
+            let height = BlockHeight::from_u32(height);
+            shard_trees
+                .sapling
+                .store_mut()
+                .add_checkpoint(height, Checkpoint::from_parts(TreeState::Empty, BTreeSet::new()))
+                .expect("infallible");
+            shard_trees
+                .orchard
+                .store_mut()
+                .add_checkpoint(height, Checkpoint::from_parts(TreeState::Empty, BTreeSet::new()))
+                .expect("infallible");
+        }
+
+        let mut bytes = Vec::new();
+        shard_trees.write(&mut bytes).expect("write should succeed");
+        let roundtripped = ShardTrees::read(bytes.as_slice()).expect("read should succeed");
+
+        let sapling_store = roundtripped.sapling.store();
+        let orchard_store = roundtripped.orchard.store();
+
+        assert_eq!(sapling_store.checkpoint_count().expect("infallible"), 100);
+        assert_eq!(orchard_store.checkpoint_count().expect("infallible"), 100);
+        assert_eq!(
+            sapling_store.min_checkpoint_id().expect("infallible"),
+            Some(BlockHeight::from_u32(51))
+        );
+        assert_eq!(
+            sapling_store.max_checkpoint_id().expect("infallible"),
+            Some(BlockHeight::from_u32(150))
+        );
+        assert_eq!(
+            orchard_store.min_checkpoint_id().expect("infallible"),
+            Some(BlockHeight::from_u32(51))
+        );
+        assert_eq!(
+            orchard_store.max_checkpoint_id().expect("infallible"),
+            Some(BlockHeight::from_u32(150))
+        );
+        assert!(
+            sapling_store
+                .get_checkpoint(&BlockHeight::from_u32(149))
+                .expect("infallible")
+                .is_some()
+        );
+        assert!(
+            sapling_store
+                .get_checkpoint(&BlockHeight::from_u32(50))
+                .expect("infallible")
+                .is_none()
+        );
     }
 }

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -999,10 +999,7 @@ impl ShardTrees {
         const SHARD_HEIGHT: u8,
     >(
         mut reader: R,
-    ) -> std::io::Result<ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>>
-    where
-        u32: From<C>,
-    {
+    ) -> std::io::Result<ShardTree<MemoryShardStore<H, C>, DEPTH, SHARD_HEIGHT>> {
         let shards = Vector::read(&mut reader, |r| {
             let level = incrementalmerkletree::Level::from(r.read_u8()?);
             let index = r.read_u64::<LittleEndian>()?;
@@ -1047,6 +1044,7 @@ impl ShardTrees {
                 .expect("Infallible");
         }
         store.put_cap(read_shard(reader)?).expect("Infallible");
+
         Ok(shardtree::ShardTree::new(
             store,
             MAX_REORG_ALLOWANCE as usize,
@@ -1177,12 +1175,18 @@ mod tests {
             shard_trees
                 .sapling
                 .store_mut()
-                .add_checkpoint(height, Checkpoint::from_parts(TreeState::Empty, BTreeSet::new()))
+                .add_checkpoint(
+                    height,
+                    Checkpoint::from_parts(TreeState::Empty, BTreeSet::new()),
+                )
                 .expect("infallible");
             shard_trees
                 .orchard
                 .store_mut()
-                .add_checkpoint(height, Checkpoint::from_parts(TreeState::Empty, BTreeSet::new()))
+                .add_checkpoint(
+                    height,
+                    Checkpoint::from_parts(TreeState::Empty, BTreeSet::new()),
+                )
                 .expect("infallible");
         }
 


### PR DESCRIPTION
## Summary

This fixes wallet shard-tree persistence so save/load keeps the newest reorg-safe checkpoint window instead of the oldest one.

## Root Cause

`write_shardtree()` was serializing checkpoints with:

```rust
store.with_checkpoints(MAX_REORG_ALLOWANCE as usize, ...)
```

`with_checkpoints()` iterates in ascending checkpoint ID order, so once a store had more than `MAX_REORG_ALLOWANCE` checkpoints, the wallet file kept the **oldest** 100 checkpoints instead of the **newest** 100.

That let recently rebuilt Sapling checkpoints disappear across save/load, which could cause consecutive sends from reopened wallets to fail with:

```text
Sapling shard store checkpoint not found at anchor height ...
```

## Fix

- collect all checkpoints during serialization
- trim to the newest `MAX_REORG_ALLOWANCE`
- keep the persisted checkpoint window aligned with current anchor/reorg needs

## Test

Added a round-trip regression test that creates 151 checkpoints and verifies the reloaded range is `51..150`, not `0..99`.

## Validation

- `cargo test -p pepper-sync shardtree_roundtrip_keeps_newest_checkpoints -- --nocapture`
- live testnet repro with instrumented `zingo-cli`
  - before fix: the second send after reopen failed with a missing Sapling checkpoint
  - after fix: the first, second, and third sends after reopen all succeeded

Closes #2267.
