### PR TITLE
Upgrade cli interface more tests better sep of concerns

### DIFF
--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -72,15 +72,17 @@ impl Command for GetVersionCommand {
 struct ChangeServerCommand {}
 impl Command for ChangeServerCommand {
     fn help(&self) -> &'static str {
-        indoc! {r"
-            Change the lightwalletd server to receive blockchain data from
-
-            Usage:
-            change_server [server_uri]
-
-            Example:
-            change_server https://mainnet.lightwalletd.com:9067
-        "}
+        concat!(
+            "Change the lightwalletd server to receive blockchain data from\n",
+            "\n",
+            "Usage:\n",
+            "change_server [server_uri]\n",
+            "\n",
+            "Example:\n",
+            "change_server ",
+            crate::examples::server_uri!(),
+            "\n",
+        )
     }
 
     fn short_help(&self) -> &'static str {
@@ -194,14 +196,16 @@ impl Command for WalletKindCommand {
 struct ParseAddressCommand {}
 impl Command for ParseAddressCommand {
     fn help(&self) -> &'static str {
-        indoc! {r"
-            Parse an address
-            Usage:
-            parse_address <address>
-
-            Example
-            parse_address tmSwk8bjXdCgBvpS8Kybk5nUyE21QFcDqre
-        "}
+        concat!(
+            "Parse an address\n",
+            "Usage:\n",
+            "parse_address <address>\n",
+            "\n",
+            "Example\n",
+            "parse_address ",
+            crate::examples::transparent_address!(),
+            "\n",
+        )
     }
 
     fn short_help(&self) -> &'static str {
@@ -296,14 +300,16 @@ impl Command for ParseAddressCommand {
 struct ParseViewKeyCommand {}
 impl Command for ParseViewKeyCommand {
     fn help(&self) -> &'static str {
-        indoc! {r"
-            Parse a View Key
-            Usage:
-            parse_viewkey viewing_key
-
-            Example
-            parse_viewkey uviewregtest1l6s73mncrefycjhksvcp3zd6x2rpwddewv852ms8w0j828wu77h8v07fs6ph68kyp0ujwk4qmr3w4v9js4mr3ufqyasr0sddgumzyjamcgreda44kxtv4ar084szez337ld58avd9at4r5lptltgkn6uayzd055upf8cnlkarnxp69kz0vzelfww08xxhm0q0azdsplxff0mn2yyve88jyl8ujfau66pnc37skvl9528zazztf6xgk8aeewswjg4eeahpml77cxh57spgywdsc99h99twmp8sqhmp7g78l3g90equ2l4vh9vy0va6r8p568qr7nm5l5y96qgwmw9j2j788lalpeywy0af86krh4td69xqrrye6dvfx0uff84s3pm50kqx3tg3ktx88j2ujswe25s7pqvv3w4x382x07w0dp5gguqu757wlyf80f5nu9uw7wqttxmvrjhkl22x43de960c7kt97ge0dkt52j7uckht54eq768
-        "}
+        concat!(
+            "Parse a View Key\n",
+            "Usage:\n",
+            "parse_viewkey viewing_key\n",
+            "\n",
+            "Example\n",
+            "parse_viewkey ",
+            crate::examples::unified_viewing_key!(),
+            "\n",
+        )
     }
 
     fn short_help(&self) -> &'static str {
@@ -1045,20 +1051,25 @@ impl Command for ExportUfvkCommand {
 struct SendCommand {}
 impl Command for SendCommand {
     fn help(&self) -> &'static str {
-        indoc! {r#"
-            Propose a transfer of ZEC to the given address(es).
-            The fee required to send this transaction will be added to the proposal and displayed to the user.
-            The 'confirm' command must be called to complete and broadcast the proposed transaction(s).
-
-            Usage:
-                send <address> <amount in zatoshis> "<optional memo>"
-                OR
-                send '[{"address":"<address>", "amount":<amount in zatoshis>, "memo":"<optional memo>"}, ...]'
-            Example:
-                send ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d 200000 "Hello from the command line"
-                confirm
-
-        "#}
+        concat!(
+            "Propose a transfer of ZEC to the given address(es).\n",
+            "The fee required to send this transaction will be added to the proposal and displayed to the user.\n",
+            "The 'confirm' command must be called to complete and broadcast the proposed transaction(s).\n",
+            "\n",
+            "Usage:\n",
+            "    send <address> <amount in zatoshis> \"<optional memo>\"\n",
+            "    OR\n",
+            "    send '[{\"address\":\"<address>\", \"amount\":<amount in zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
+            "Example:\n",
+            "    send ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
+            "    confirm\n",
+        )
     }
 
     fn short_help(&self) -> &'static str {
@@ -1103,24 +1114,27 @@ impl Command for SendCommand {
 struct SendAllCommand {}
 impl Command for SendAllCommand {
     fn help(&self) -> &'static str {
-        indoc! {r#"
-            Propose to transfer all ZEC from shielded pools to a given address.
-            The fee required to send this transaction will be added to the proposal and displayed to the user.
-            The 'confirm' command must be called to complete and broadcast the proposed transaction(s).
-            If invoked with a JSON arg "zennies_for_zingo" must be specified, if set to 'true' 1_000_000 ZAT
-            will be sent to the zingolabs developer address with each transaction.
-
-            Warning:
-                Does not send transparent funds. These funds must be shielded first. Type `help shield` for more information.
-            Usage:
-                send_all <address> "<optional memo>"
-                OR
-                send_all '{ "address": "<address>", "memo": "<optional memo>", "zennies_for_zingo": <true|false> }'
-            Example:
-                send_all ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d "Sending all funds"
-                confirm
-
-        "#}
+        concat!(
+            "Propose to transfer all ZEC from shielded pools to a given address.\n",
+            "The fee required to send this transaction will be added to the proposal and displayed to the user.\n",
+            "The 'confirm' command must be called to complete and broadcast the proposed transaction(s).\n",
+            "If invoked with a JSON arg \"zennies_for_zingo\" must be specified, if set to 'true' 1_000_000 ZAT\n",
+            "will be sent to the zingolabs developer address with each transaction.\n",
+            "\n",
+            "Warning:\n",
+            "    Does not send transparent funds. These funds must be shielded first. Type `help shield` for more information.\n",
+            "Usage:\n",
+            "    send_all <address> \"<optional memo>\"\n",
+            "    OR\n",
+            "    send_all '{ \"address\": \"<address>\", \"memo\": \"<optional memo>\", \"zennies_for_zingo\": <true|false> }'\n",
+            "Example:\n",
+            "    send_all ",
+            crate::examples::sapling_address!(),
+            " \"",
+            crate::examples::send_all_memo!(),
+            "\"\n",
+            "    confirm\n",
+        )
     }
 
     fn short_help(&self) -> &'static str {
@@ -1165,19 +1179,24 @@ impl Command for SendAllCommand {
 struct QuickSendCommand {}
 impl Command for QuickSendCommand {
     fn help(&self) -> &'static str {
-        indoc! {r#"
-            Send ZEC to the given address(es). Combines `send` and `confirm` into a single command.
-            The fee required to send this transaction is additionally deducted from your balance.
-            Warning:
-                Transaction(s) will be sent without the user being aware of the fee amount.
-            Usage:
-                quicksend <address> <amount in zatoshis> "<optional memo>"
-                OR
-                quicksend '[{"address":"<address>", "amount":<amount in zatoshis>, "memo":"<optional memo>"}, ...]'
-            Example:
-                quicksend ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d 200000 "Hello from the command line"
-
-        "#}
+        concat!(
+            "Send ZEC to the given address(es). Combines `send` and `confirm` into a single command.\n",
+            "The fee required to send this transaction is additionally deducted from your balance.\n",
+            "Warning:\n",
+            "    Transaction(s) will be sent without the user being aware of the fee amount.\n",
+            "Usage:\n",
+            "    quicksend <address> <amount in zatoshis> \"<optional memo>\"\n",
+            "    OR\n",
+            "    quicksend '[{\"address\":\"<address>\", \"amount\":<amount in zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
+            "Example:\n",
+            "    quicksend ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
+        )
     }
 
     fn short_help(&self) -> &'static str {
@@ -1316,18 +1335,23 @@ impl Command for QuickShieldCommand {
 struct ConfirmCommand {}
 impl Command for ConfirmCommand {
     fn help(&self) -> &'static str {
-        indoc! {r#"
-            Confirms the latest proposal, constructing and transmitting the transaction(s) and resuming the sync task.
-            Fails if a proposal has not already been created with the 'send', 'send_all' or 'shield' commands.
-            Type 'help send', 'help sendall' or 'help shield' for more information on creating proposals.
-
-            Usage:
-                confirm
-            Example:
-                send ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d 200000 "Hello from the command line"
-                confirm
-
-        "#}
+        concat!(
+            "Confirms the latest proposal, constructing and transmitting the transaction(s) and resuming the sync task.\n",
+            "Fails if a proposal has not already been created with the 'send', 'send_all' or 'shield' commands.\n",
+            "Type 'help send', 'help sendall' or 'help shield' for more information on creating proposals.\n",
+            "\n",
+            "Usage:\n",
+            "    confirm\n",
+            "Example:\n",
+            "    send ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
+            "    confirm\n",
+        )
     }
 
     fn short_help(&self) -> &'static str {

--- a/zingo-cli/src/examples.rs
+++ b/zingo-cli/src/examples.rs
@@ -1,0 +1,80 @@
+//! Example data used as the single source of truth for help text and unit tests.
+//!
+//! Values are defined as macros so they can be used in `concat!` (which only
+//! accepts literals). Each macro has a corresponding `const` re-export for use
+//! in non-macro contexts (tests, runtime code).
+
+macro_rules! sapling_address {
+    () => {
+        "ztestsapling1x65nq4dgp0qfywgxcwk9n0fvm4fysmapgr2q00p85ju252h6l7mmxu2jg9cqqhtvzd69jwhgv8d"
+    };
+}
+pub(crate) use sapling_address;
+
+macro_rules! transparent_address {
+    () => {
+        "tmSwk8bjXdCgBvpS8Kybk5nUyE21QFcDqre"
+    };
+}
+pub(crate) use transparent_address;
+
+macro_rules! unified_viewing_key {
+    () => {
+        "uviewregtest1l6s73mncrefycjhksvcp3zd6x2rpwddewv852ms8w0j828wu77h8v07fs6ph68kyp0ujwk4qmr3w4v9js4mr3ufqyasr0sddgumzyjamcgreda44kxtv4ar084szez337ld58avd9at4r5lptltgkn6uayzd055upf8cnlkarnxp69kz0vzelfww08xxhm0q0azdsplxff0mn2yyve88jyl8ujfau66pnc37skvl9528zazztf6xgk8aeewswjg4eeahpml77cxh57spgywdsc99h99twmp8sqhmp7g78l3g90equ2l4vh9vy0va6r8p568qr7nm5l5y96qgwmw9j2j788lalpeywy0af86krh4td69xqrrye6dvfx0uff84s3pm50kqx3tg3ktx88j2ujswe25s7pqvv3w4x382x07w0dp5gguqu757wlyf80f5nu9uw7wqttxmvrjhkl22x43de960c7kt97ge0dkt52j7uckht54eq768"
+    };
+}
+pub(crate) use unified_viewing_key;
+
+macro_rules! amount_zatoshis {
+    () => {
+        "200000"
+    };
+}
+pub(crate) use amount_zatoshis;
+
+macro_rules! memo {
+    () => {
+        "Hello from the command line"
+    };
+}
+pub(crate) use memo;
+
+macro_rules! send_all_memo {
+    () => {
+        "Sending all funds"
+    };
+}
+pub(crate) use send_all_memo;
+
+macro_rules! server_uri {
+    () => {
+        "https://mainnet.lightwalletd.com:9067"
+    };
+}
+pub(crate) use server_uri;
+
+/// Const re-exports for use in non-macro contexts (e.g. tests, runtime code).
+/// Values that only appear in help text use the macro form above (for `concat!`).
+/// Values that only appear in tests are defined directly as consts here.
+#[cfg(test)]
+pub(crate) const BIN_NAME: &str = "zingo-cli";
+#[cfg(test)]
+pub(crate) const SAPLING_ADDRESS: &str = sapling_address!();
+#[cfg(test)]
+pub(crate) const TRANSPARENT_ADDRESS: &str = transparent_address!();
+#[cfg(test)]
+pub(crate) const UNIFIED_VIEWING_KEY: &str = unified_viewing_key!();
+#[cfg(test)]
+pub(crate) const AMOUNT_ZATOSHIS: &str = amount_zatoshis!();
+#[cfg(test)]
+pub(crate) const MEMO: &str = memo!();
+#[cfg(test)]
+pub(crate) const SEND_ALL_MEMO: &str = send_all_memo!();
+#[cfg(test)]
+pub(crate) const SERVER_URI: &str = server_uri!();
+#[cfg(test)]
+pub(crate) const SEED_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+#[cfg(test)]
+pub(crate) const BIRTHDAY: &str = "600000";
+#[cfg(test)]
+pub(crate) const DATA_DIR: &str = "/tmp/zingo-test-data";

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -5,6 +5,7 @@
 #![warn(missing_docs)]
 
 mod commands;
+mod examples;
 
 use std::num::NonZeroU32;
 use std::path::PathBuf;
@@ -24,10 +25,10 @@ use zingolib::wallet::{LightWallet, WalletBase, WalletSettings};
 
 use crate::commands::{RT, ShortCircuitedCommand};
 
-pub mod version;
+pub(crate) mod version;
 
-/// TODO: Add Doc Comment Here!
-pub fn build_clap_app() -> clap::ArgMatches {
+/// Builds the clap `Command` definition for the CLI.
+pub fn build_clap_app() -> clap::Command {
     clap::Command::new("Zingo CLI").version(version::VERSION)
             .arg(Arg::new("nosync")
                 .help("By default, zingo-cli will sync the wallet at startup. Pass --nosync to prevent the automatic sync at startup.")
@@ -84,7 +85,7 @@ pub fn build_clap_app() -> clap::ArgMatches {
                 .num_args(1..)
                 .index(2)
                 .action(clap::ArgAction::Append)
-        ).get_matches()
+        )
 }
 
 /// Custom function to parse a string into an `http::Uri`
@@ -191,18 +192,15 @@ fn sync_indicator_from_status(send_command: &impl Fn(String, Vec<String>) -> Str
 /// TODO: `start_interactive` does not explicitly reference a wallet, do we need
 /// to expose new/more/higher-layer abstractions to facilitate wallet reuse from
 /// the CLI?
-fn start_interactive(
-    command_transmitter: Sender<(String, Vec<String>)>,
-    resp_receiver: Receiver<String>,
-) {
+fn start_interactive(ch: CommandChannel) {
     // `()` can be used when no completer is required
     let mut rl = rustyline::DefaultEditor::new().expect("Default rustyline Editor not creatable!");
 
     log::debug!("Ready!");
 
     let send_command = |cmd: String, args: Vec<String>| -> String {
-        command_transmitter.send((cmd.clone(), args)).unwrap();
-        match resp_receiver.recv() {
+        ch.transmitter.send((cmd.clone(), args)).unwrap();
+        match ch.receiver.recv() {
             Ok(s) => s,
             Err(e) => {
                 let e = format!("Error executing command {cmd}: {e}");
@@ -287,10 +285,14 @@ fn start_interactive(
     }
 }
 
+/// A paired command/response channel for communicating with the background command loop.
+struct CommandChannel {
+    transmitter: Sender<(String, Vec<String>)>,
+    receiver: Receiver<String>,
+}
+
 /// TODO: Add Doc Comment Here!
-pub fn command_loop(
-    mut lightclient: LightClient,
-) -> (Sender<(String, Vec<String>)>, Receiver<String>) {
+pub(crate) fn command_loop(mut lightclient: LightClient) -> CommandChannel {
     let (command_transmitter, command_receiver) = channel::<(String, Vec<String>)>();
     let (resp_transmitter, resp_receiver) = channel::<String>();
 
@@ -308,12 +310,53 @@ pub fn command_loop(
         }
     });
 
-    (command_transmitter, resp_receiver)
+    CommandChannel {
+        transmitter: command_transmitter,
+        receiver: resp_receiver,
+    }
+}
+
+/// The CLI operates in one of two mutually exclusive modes,
+/// determined at the earliest possible moment from the parsed CLI arguments.
+#[derive(Debug, PartialEq)]
+enum ModeOfOperation {
+    /// Start the interactive REPL.
+    Interactive,
+    /// Execute a single command and exit.
+    Command {
+        /// The command name (e.g. "balance", "send").
+        name: String,
+        /// Additional positional arguments for the command.
+        args: Vec<String>,
+    },
+}
+
+/// Determines the mode of operation from parsed CLI arguments.
+///
+/// Returns [`ModeOfOperation::Command`] if a command is given, or
+/// [`ModeOfOperation::Interactive`] when no command is given.
+///
+/// The `help` command is handled separately before this function is called,
+/// so it will never appear as a [`ModeOfOperation::Command`].
+fn get_mode_of_operation(matches: &clap::ArgMatches) -> ModeOfOperation {
+    if let Some(cmd_name) = matches.get_one::<String>("COMMAND") {
+        let args = matches
+            .get_many::<String>("extra_args")
+            .map(|v| v.cloned().collect())
+            .unwrap_or_default();
+        ModeOfOperation::Command {
+            name: cmd_name.clone(),
+            args,
+        }
+    } else {
+        ModeOfOperation::Interactive
+    }
 }
 
 /// TODO: Add Doc Comment Here!
-pub struct ConfigTemplate {
-    params: Vec<String>,
+#[derive(Debug)]
+pub(crate) struct ConfigTemplate {
+    mode: ModeOfOperation,
     server: http::Uri,
     seed: Option<String>,
     ufvk: Option<String>,
@@ -321,27 +364,13 @@ pub struct ConfigTemplate {
     data_dir: PathBuf,
     sync: bool,
     waitsync: bool,
-    command: Option<String>,
     chaintype: ChainType,
     tor_enabled: bool,
 }
 
 impl ConfigTemplate {
-    fn fill(matches: clap::ArgMatches) -> Result<Self, String> {
+    fn fill(mode: ModeOfOperation, matches: clap::ArgMatches) -> Result<Self, String> {
         let tor_enabled = matches.get_flag("tor");
-        let params = if let Some(vals) = matches.get_many::<String>("extra_args") {
-            vals.cloned().collect()
-        } else {
-            vec![]
-        };
-        let command = if let Some(refstr) = matches.get_one::<String>("COMMAND") {
-            if refstr == &"help".to_string() {
-                short_circuit_on_help(params.clone());
-            }
-            Some(refstr.to_string())
-        } else {
-            None
-        };
         let seed = matches.get_one::<String>("seed").cloned();
         let ufvk = matches.get_one::<String>("viewkey").cloned();
         if seed.is_some() && ufvk.is_some() {
@@ -397,7 +426,7 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
         let sync = !matches.get_flag("nosync");
         let waitsync = matches.get_flag("waitsync");
         Ok(Self {
-            params,
+            mode,
             server,
             seed,
             ufvk,
@@ -405,26 +434,21 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
             data_dir,
             sync,
             waitsync,
-            command,
             chaintype,
             tor_enabled,
         })
     }
 }
 
-/// A (command, args) request
-pub type CommandRequest = (String, Vec<String>);
-
-/// Command responses are strings
-pub type CommandResponse = String;
-
 /// Used by the zingocli crate, and the zingo-mobile application:
 /// <https://github.com/zingolabs/zingolib/tree/dev/cli>
 /// <https://github.com/zingolabs/zingo-mobile>
-pub fn startup(
-    filled_template: &ConfigTemplate,
-) -> std::io::Result<(Sender<CommandRequest>, Receiver<CommandResponse>)> {
-    let config = ZingoConfig::builder()
+/// Builds a [`ZingoConfig`] from the filled config template.
+///
+/// This is a pure function — no I/O or side effects — and is the
+/// first testable seam inside the startup sequence.
+fn build_zingo_config(filled_template: &ConfigTemplate) -> ZingoConfig {
+    ZingoConfig::builder()
         .set_indexer_uri(filled_template.server.clone())
         .set_network_type(filled_template.chaintype)
         .set_wallet_dir(filled_template.data_dir.clone())
@@ -437,7 +461,11 @@ pub fn startup(
         })
         .set_no_of_accounts(NonZeroU32::try_from(1).expect("hard-coded non-zero integer"))
         .set_wallet_name("".to_string())
-        .build();
+        .build()
+}
+
+pub(crate) fn startup(filled_template: &ConfigTemplate) -> std::io::Result<CommandChannel> {
+    let config = build_zingo_config(filled_template);
 
     let mut lightclient = if let Some(seed_phrase) = filled_template.seed.clone() {
         let wallet = LightWallet::new(
@@ -493,7 +521,7 @@ pub fn startup(
             .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?
     };
 
-    if filled_template.command.is_none() {
+    if matches!(filled_template.mode, ModeOfOperation::Interactive) {
         // Print startup Messages
         info!(""); // Blank line
         info!("Starting Zingo-CLI");
@@ -529,15 +557,11 @@ pub fn startup(
     });
 
     // Start the command loop
-    let (command_transmitter, resp_receiver) = command_loop(lightclient);
-
-    Ok((command_transmitter, resp_receiver))
+    Ok(command_loop(lightclient))
 }
-fn start_cli_service(
-    cli_config: &ConfigTemplate,
-) -> (Sender<(String, Vec<String>)>, Receiver<String>) {
+fn start_cli_service(cli_config: &ConfigTemplate) -> CommandChannel {
     match startup(cli_config) {
-        Ok(c) => c,
+        Ok(ch) => ch,
         Err(e) => {
             let emsg = format!("Error during startup:\n{e}\n");
             eprintln!("{emsg}");
@@ -552,180 +576,60 @@ fn start_cli_service(
     }
 }
 fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) {
-    let (command_transmitter, resp_receiver) = start_cli_service(cli_config);
-    if cli_config.command.is_none() {
-        start_interactive(command_transmitter, resp_receiver);
-    } else {
-        command_transmitter
-            .send((
-                cli_config.command.clone().unwrap(),
-                cli_config
-                    .params
-                    .iter()
-                    .map(std::string::ToString::to_string)
-                    .collect::<Vec<String>>(),
-            ))
-            .unwrap();
-
-        match resp_receiver.recv() {
-            Ok(s) => println!("{s}"),
-            Err(e) => {
-                let e = format!(
-                    "Error executing command {}: {}",
-                    cli_config.command.clone().unwrap(),
-                    e
-                );
-                eprintln!("{e}");
-                error!("{e}");
-            }
+    let ch = start_cli_service(cli_config);
+    match &cli_config.mode {
+        ModeOfOperation::Interactive => {
+            start_interactive(ch);
         }
+        ModeOfOperation::Command { name, args } => {
+            ch.transmitter.send((name.clone(), args.clone())).unwrap();
 
-        command_transmitter
-            .send(("quit".to_string(), vec![]))
-            .unwrap();
-        match resp_receiver.recv() {
-            Ok(s) => println!("{s}"),
-            Err(e) => {
-                eprintln!("{e}");
+            match ch.receiver.recv() {
+                Ok(s) => println!("{s}"),
+                Err(e) => {
+                    let e = format!("Error executing command {name}: {e}");
+                    eprintln!("{e}");
+                    error!("{e}");
+                }
+            }
+
+            ch.transmitter.send(("quit".to_string(), vec![])).unwrap();
+            match ch.receiver.recv() {
+                Ok(s) => println!("{s}"),
+                Err(e) => {
+                    eprintln!("{e}");
+                }
             }
         }
     }
 }
 
-/// TODO: Add Doc Comment Here!
-pub fn run_cli() {
-    // Initialize logging
-    match ConfigTemplate::fill(build_clap_app()) {
+/// Returns help text if the parsed arguments indicate the `help` command,
+/// or `None` for all other modes. The caller is responsible for printing
+/// the text and exiting the process.
+pub fn help_output(matches: &clap::ArgMatches) -> Option<String> {
+    if matches.get_one::<String>("COMMAND").map(String::as_str) == Some("help") {
+        let args: Vec<String> = matches
+            .get_many::<String>("extra_args")
+            .map(|v| v.cloned().collect())
+            .unwrap_or_default();
+        Some(commands::HelpCommand::exec_without_lc(args))
+    } else {
+        None
+    }
+}
+
+/// Runs the CLI from pre-parsed arguments.
+///
+/// This function never calls `std::process::exit` or reads `std::env::args`.
+/// The caller (the binary entry point) is responsible for parsing arguments,
+/// handling the help short-circuit, and process-level setup.
+pub fn run_cli(matches: clap::ArgMatches) {
+    match ConfigTemplate::fill(get_mode_of_operation(&matches), matches) {
         Ok(cli_config) => dispatch_command_or_start_interactive(&cli_config),
         Err(e) => eprintln!("Error filling config template: {e:?}"),
     }
 }
 
-fn short_circuit_on_help(params: Vec<String>) {
-    for h in commands::HelpCommand::exec_without_lc(params).lines() {
-        println!("{h}");
-    }
-    std::process::exit(0x0100);
-}
-
 #[cfg(test)]
-mod tests {
-    use super::poll_sync_for_prompt_indicator;
-    use std::cell::RefCell;
-
-    #[test]
-    fn sync_poll_error() {
-        let send = |_cmd: String, _args: Vec<String>| "Error: connection lost".to_string();
-        assert_eq!(poll_sync_for_prompt_indicator(&send), " [Sync error]");
-    }
-
-    #[test]
-    fn sync_poll_completed() {
-        let send = |_cmd: String, _args: Vec<String>| {
-            "Sync completed succesfully: 1000 blocks".to_string()
-        };
-        assert_eq!(poll_sync_for_prompt_indicator(&send), " [Synced]");
-    }
-
-    #[test]
-    fn sync_in_progress_with_valid_status() {
-        let call_count = RefCell::new(0);
-        let send = |_cmd: String, args: Vec<String>| {
-            let n = {
-                let mut c = call_count.borrow_mut();
-                *c += 1;
-                *c
-            };
-            match n {
-                1 => {
-                    assert_eq!(args, vec!["poll"]);
-                    "Sync task is not complete.".to_string()
-                }
-                2 => {
-                    assert_eq!(args, vec!["status"]);
-                    r#"{"percentage_total_outputs_scanned": 45.2}"#.to_string()
-                }
-                _ => panic!("unexpected call"),
-            }
-        };
-        assert_eq!(
-            poll_sync_for_prompt_indicator(&send),
-            " [Syncing 45.2% complete]"
-        );
-    }
-
-    #[test]
-    fn sync_in_progress_with_unparseable_status() {
-        let call_count = RefCell::new(0);
-        let send = |_cmd: String, args: Vec<String>| {
-            let n = {
-                let mut c = call_count.borrow_mut();
-                *c += 1;
-                *c
-            };
-            match n {
-                1 => {
-                    assert_eq!(args, vec!["poll"]);
-                    "Sync task is not complete.".to_string()
-                }
-                2 => {
-                    assert_eq!(args, vec!["status"]);
-                    "not json".to_string()
-                }
-                _ => panic!("unexpected call"),
-            }
-        };
-        assert_eq!(poll_sync_for_prompt_indicator(&send), " [Syncing]");
-    }
-
-    #[test]
-    fn sync_not_launched_not_synced() {
-        let call_count = RefCell::new(0);
-        let send = |_cmd: String, args: Vec<String>| {
-            let n = {
-                let mut c = call_count.borrow_mut();
-                *c += 1;
-                *c
-            };
-            match n {
-                1 => {
-                    assert_eq!(args, vec!["poll"]);
-                    "Sync task has not been launched.".to_string()
-                }
-                2 => {
-                    assert_eq!(args, vec!["status"]);
-                    r#"{"percentage_total_outputs_scanned": 0.0}"#.to_string()
-                }
-                _ => panic!("unexpected call"),
-            }
-        };
-        assert_eq!(
-            poll_sync_for_prompt_indicator(&send),
-            " [Not syncing 0.0% complete]"
-        );
-    }
-
-    #[test]
-    fn sync_not_launched_fully_synced() {
-        let call_count = RefCell::new(0);
-        let send = |_cmd: String, args: Vec<String>| {
-            let n = {
-                let mut c = call_count.borrow_mut();
-                *c += 1;
-                *c
-            };
-            match n {
-                1 => {
-                    assert_eq!(args, vec!["poll"]);
-                    "Sync task has not been launched.".to_string()
-                }
-                2 => {
-                    assert_eq!(args, vec!["status"]);
-                    r#"{"percentage_total_outputs_scanned": 100.0}"#.to_string()
-                }
-                _ => panic!("unexpected call"),
-            }
-        };
-        assert_eq!(poll_sync_for_prompt_indicator(&send), " [Synced]");
-    }
-}
+mod tests;

--- a/zingo-cli/src/main.rs
+++ b/zingo-cli/src/main.rs
@@ -1,6 +1,22 @@
 #![forbid(unsafe_code)]
 
 use tracing_subscriber::EnvFilter;
+
+/// Parses CLI arguments and handles the help short-circuit.
+///
+/// The help check is tightly coupled with argument parsing so that the
+/// two cannot be accidentally reordered in `main`.
+fn parse_args_or_exit_for_help() -> clap::ArgMatches {
+    let matches = zingo_cli::build_clap_app().get_matches();
+    if let Some(help_text) = zingo_cli::help_output(&matches) {
+        for line in help_text.lines() {
+            println!("{line}");
+        }
+        std::process::exit(0x0100);
+    }
+    matches
+}
+
 pub fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -9,5 +25,6 @@ pub fn main() {
     if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
         eprintln!("Error installing crypto provider: {e:?}");
     }
-    zingo_cli::run_cli();
+    let matches = parse_args_or_exit_for_help();
+    zingo_cli::run_cli(matches);
 }

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -1,0 +1,554 @@
+use crate::build_clap_app;
+use crate::examples;
+
+/// Helper: parse the given args through the clap definition and return matches.
+fn parse(args: &[&str]) -> clap::ArgMatches {
+    build_clap_app()
+        .try_get_matches_from(args)
+        .expect("valid args")
+}
+
+mod mode_of_operation {
+    use super::*;
+    use crate::{ModeOfOperation, get_mode_of_operation};
+
+    fn assert_interactive(args: &[&str]) {
+        let matches = parse(args);
+        assert_eq!(
+            get_mode_of_operation(&matches),
+            ModeOfOperation::Interactive
+        );
+    }
+
+    fn assert_command(args: &[&str], expected_name: &str, expected_args: &[&str]) {
+        let matches = parse(args);
+        assert_eq!(
+            get_mode_of_operation(&matches),
+            ModeOfOperation::Command {
+                name: expected_name.to_string(),
+                args: expected_args.iter().map(|s| s.to_string()).collect(),
+            }
+        );
+    }
+
+    #[test]
+    fn no_command_yields_interactive() {
+        assert_interactive(&[examples::BIN_NAME]);
+    }
+
+    #[test]
+    fn command_without_extra_args() {
+        assert_command(&[examples::BIN_NAME, "balance"], "balance", &[]);
+    }
+
+    #[test]
+    fn command_with_extra_args() {
+        assert_command(
+            &[
+                examples::BIN_NAME,
+                "send",
+                examples::SAPLING_ADDRESS,
+                examples::AMOUNT_ZATOSHIS,
+            ],
+            "send",
+            &[examples::SAPLING_ADDRESS, examples::AMOUNT_ZATOSHIS],
+        );
+    }
+
+    #[test]
+    fn help_command_is_still_command_variant() {
+        // `help` is handled by `parse_args_or_exit_for_help` in main.rs before
+        // `get_mode_of_operation` is called, but if it were passed through
+        // it would produce a normal Command variant.
+        assert_command(&[examples::BIN_NAME, "help"], "help", &[]);
+    }
+
+    #[test]
+    fn flags_do_not_affect_mode_interactive() {
+        assert_interactive(&[examples::BIN_NAME, "--nosync", "--tor"]);
+    }
+
+    #[test]
+    fn flags_do_not_affect_mode_command() {
+        assert_command(&[examples::BIN_NAME, "--nosync", "balance"], "balance", &[]);
+    }
+
+    mod commands {
+        use super::*;
+
+        /// Assert that a command with no extra args parses correctly.
+        fn assert_no_arg_command(name: &str) {
+            assert_command(&[examples::BIN_NAME, name], name, &[]);
+        }
+
+        #[test]
+        fn send() {
+            assert_command(
+                &[
+                    examples::BIN_NAME,
+                    "send",
+                    examples::SAPLING_ADDRESS,
+                    examples::AMOUNT_ZATOSHIS,
+                    examples::MEMO,
+                ],
+                "send",
+                &[
+                    examples::SAPLING_ADDRESS,
+                    examples::AMOUNT_ZATOSHIS,
+                    examples::MEMO,
+                ],
+            );
+        }
+
+        #[test]
+        fn send_all() {
+            assert_command(
+                &[
+                    examples::BIN_NAME,
+                    "send_all",
+                    examples::SAPLING_ADDRESS,
+                    examples::SEND_ALL_MEMO,
+                ],
+                "send_all",
+                &[examples::SAPLING_ADDRESS, examples::SEND_ALL_MEMO],
+            );
+        }
+
+        #[test]
+        fn quicksend() {
+            assert_command(
+                &[
+                    examples::BIN_NAME,
+                    "quicksend",
+                    examples::SAPLING_ADDRESS,
+                    examples::AMOUNT_ZATOSHIS,
+                    examples::MEMO,
+                ],
+                "quicksend",
+                &[
+                    examples::SAPLING_ADDRESS,
+                    examples::AMOUNT_ZATOSHIS,
+                    examples::MEMO,
+                ],
+            );
+        }
+
+        #[test]
+        fn parse_address() {
+            assert_command(
+                &[
+                    examples::BIN_NAME,
+                    "parse_address",
+                    examples::TRANSPARENT_ADDRESS,
+                ],
+                "parse_address",
+                &[examples::TRANSPARENT_ADDRESS],
+            );
+        }
+
+        #[test]
+        fn parse_viewkey() {
+            assert_command(
+                &[
+                    examples::BIN_NAME,
+                    "parse_viewkey",
+                    examples::UNIFIED_VIEWING_KEY,
+                ],
+                "parse_viewkey",
+                &[examples::UNIFIED_VIEWING_KEY],
+            );
+        }
+
+        #[test]
+        fn change_server() {
+            assert_command(
+                &[examples::BIN_NAME, "change_server", examples::SERVER_URI],
+                "change_server",
+                &[examples::SERVER_URI],
+            );
+        }
+
+        #[test]
+        fn sync() {
+            assert_command(&[examples::BIN_NAME, "sync", "run"], "sync", &["run"]);
+        }
+
+        #[test]
+        fn new_address() {
+            assert_command(
+                &[examples::BIN_NAME, "new_address", "o"],
+                "new_address",
+                &["o"],
+            );
+        }
+
+        #[test]
+        fn balance() {
+            assert_no_arg_command("balance");
+        }
+
+        #[test]
+        fn confirm() {
+            assert_no_arg_command("confirm");
+        }
+
+        #[test]
+        fn shield() {
+            assert_no_arg_command("shield");
+        }
+
+        #[test]
+        fn height() {
+            assert_no_arg_command("height");
+        }
+
+        #[test]
+        fn info() {
+            assert_no_arg_command("info");
+        }
+
+        #[test]
+        fn addresses() {
+            assert_no_arg_command("addresses");
+        }
+
+        #[test]
+        fn save() {
+            assert_no_arg_command("save");
+        }
+
+        #[test]
+        fn quit() {
+            assert_no_arg_command("quit");
+        }
+
+        #[test]
+        fn notes() {
+            assert_no_arg_command("notes");
+        }
+
+        #[test]
+        fn version() {
+            assert_no_arg_command("version");
+        }
+
+        #[test]
+        fn rescan() {
+            assert_no_arg_command("rescan");
+        }
+
+        #[test]
+        fn export_ufvk() {
+            assert_no_arg_command("export_ufvk");
+        }
+
+        #[test]
+        fn settings() {
+            assert_no_arg_command("settings");
+        }
+
+        #[test]
+        fn value_transfers() {
+            assert_no_arg_command("value_transfers");
+        }
+
+        #[test]
+        fn transactions() {
+            assert_no_arg_command("transactions");
+        }
+
+        #[test]
+        fn quickshield() {
+            assert_no_arg_command("quickshield");
+        }
+
+        #[test]
+        fn wallet_kind() {
+            assert_no_arg_command("wallet_kind");
+        }
+
+        #[test]
+        fn birthday() {
+            assert_no_arg_command("birthday");
+        }
+
+        #[test]
+        fn delete() {
+            assert_no_arg_command("delete");
+        }
+    }
+}
+
+mod sync {
+    use crate::poll_sync_for_prompt_indicator;
+    use std::cell::RefCell;
+
+    /// Simulates a single-response sync poll and returns the prompt indicator.
+    fn poll_with(poll_response: &str) -> String {
+        let response = poll_response.to_string();
+        let send = move |_cmd: String, _args: Vec<String>| response.clone();
+        poll_sync_for_prompt_indicator(&send)
+    }
+
+    /// Simulates a two-step sync poll (poll then status) and returns the prompt indicator.
+    fn poll_then_status(poll_response: &str, status_response: &str) -> String {
+        let call_count = RefCell::new(0);
+        let poll = poll_response.to_string();
+        let status = status_response.to_string();
+        let send = move |_cmd: String, _args: Vec<String>| {
+            let mut c = call_count.borrow_mut();
+            *c += 1;
+            if *c == 1 {
+                poll.clone()
+            } else {
+                status.clone()
+            }
+        };
+        poll_sync_for_prompt_indicator(&send)
+    }
+
+    #[test]
+    fn poll_error() {
+        assert_eq!(poll_with("Error: connection lost"), " [Sync error]");
+    }
+
+    #[test]
+    fn poll_completed() {
+        assert_eq!(
+            poll_with("Sync completed succesfully: 1000 blocks"),
+            " [Synced]"
+        );
+    }
+
+    #[test]
+    fn in_progress_with_valid_status() {
+        assert_eq!(
+            poll_then_status(
+                "Sync task is not complete.",
+                r#"{"percentage_total_outputs_scanned": 45.2}"#,
+            ),
+            " [Syncing 45.2% complete]"
+        );
+    }
+
+    #[test]
+    fn in_progress_with_unparseable_status() {
+        assert_eq!(
+            poll_then_status("Sync task is not complete.", "not json"),
+            " [Syncing]"
+        );
+    }
+
+    #[test]
+    fn not_launched_not_synced() {
+        assert_eq!(
+            poll_then_status(
+                "Sync task has not been launched.",
+                r#"{"percentage_total_outputs_scanned": 0.0}"#,
+            ),
+            " [Not syncing 0.0% complete]"
+        );
+    }
+
+    #[test]
+    fn not_launched_fully_synced() {
+        assert_eq!(
+            poll_then_status(
+                "Sync task has not been launched.",
+                r#"{"percentage_total_outputs_scanned": 100.0}"#,
+            ),
+            " [Synced]"
+        );
+    }
+}
+
+mod config_template {
+    use super::*;
+    use crate::{ConfigTemplate, ModeOfOperation, build_zingo_config, get_mode_of_operation};
+    use std::path::PathBuf;
+    use zingolib::config::ChainType;
+
+    /// Helper: parse args, determine mode, and call fill.
+    fn fill(args: &[&str]) -> Result<ConfigTemplate, String> {
+        let matches = parse(args);
+        let mode = get_mode_of_operation(&matches);
+        ConfigTemplate::fill(mode, matches)
+    }
+
+    /// Helper: parse args, fill config, and build ZingoConfig in one step.
+    fn fill_and_build(args: &[&str]) -> zingolib::config::ZingoConfig {
+        build_zingo_config(&fill(args).unwrap())
+    }
+
+    mod happy_paths {
+        use super::*;
+
+        #[test]
+        fn defaults() {
+            let config = fill(&[examples::BIN_NAME]).unwrap();
+            assert_eq!(config.data_dir, PathBuf::from("wallets"));
+            assert_eq!(config.chaintype, ChainType::Mainnet);
+            assert!(config.sync);
+            assert!(!config.waitsync);
+            assert!(!config.tor_enabled);
+            assert!(config.seed.is_none());
+            assert!(config.ufvk.is_none());
+            assert_eq!(config.birthday, 0);
+            assert!(matches!(config.mode, ModeOfOperation::Interactive));
+        }
+
+        #[test]
+        fn nosync_flag() {
+            let config = fill(&[examples::BIN_NAME, "--nosync"]).unwrap();
+            assert!(!config.sync);
+        }
+
+        #[test]
+        fn waitsync_flag() {
+            let config = fill(&[examples::BIN_NAME, "--waitsync"]).unwrap();
+            assert!(config.waitsync);
+        }
+
+        #[test]
+        fn tor_flag() {
+            let config = fill(&[examples::BIN_NAME, "--tor"]).unwrap();
+            assert!(config.tor_enabled);
+        }
+
+        #[test]
+        fn custom_data_dir() {
+            let config = fill(&[examples::BIN_NAME, "--data-dir", examples::DATA_DIR]).unwrap();
+            assert_eq!(config.data_dir, PathBuf::from(examples::DATA_DIR));
+        }
+
+        #[test]
+        fn testnet_chain() {
+            let config = fill(&[examples::BIN_NAME, "--chain", "testnet"]).unwrap();
+            assert_eq!(config.chaintype, ChainType::Testnet);
+        }
+
+        #[test]
+        fn seed_with_birthday() {
+            let config = fill(&[
+                examples::BIN_NAME,
+                "--seed",
+                examples::SEED_PHRASE,
+                "--birthday",
+                examples::BIRTHDAY,
+            ])
+            .unwrap();
+            assert!(config.seed.is_some());
+            assert_eq!(config.birthday, examples::BIRTHDAY.parse::<u64>().unwrap());
+        }
+
+        #[test]
+        fn command_mode_preserved() {
+            let config = fill(&[examples::BIN_NAME, "balance"]).unwrap();
+            assert_eq!(
+                config.mode,
+                ModeOfOperation::Command {
+                    name: "balance".to_string(),
+                    args: vec![],
+                }
+            );
+        }
+    }
+
+    mod error_cases {
+        use super::*;
+
+        #[test]
+        fn seed_and_viewkey_both_provided() {
+            let err = fill(&[
+                examples::BIN_NAME,
+                "--seed",
+                examples::SEED_PHRASE,
+                "--viewkey",
+                examples::UNIFIED_VIEWING_KEY,
+                "--birthday",
+                examples::BIRTHDAY,
+            ])
+            .unwrap_err();
+            assert!(err.contains("Cannot load a wallet from both seed phrase and viewkey"));
+        }
+
+        #[test]
+        fn seed_without_birthday() {
+            let err = fill(&[examples::BIN_NAME, "--seed", examples::SEED_PHRASE]).unwrap_err();
+            assert!(err.contains("block height"));
+        }
+
+        #[test]
+        fn viewkey_without_birthday() {
+            let err = fill(&[
+                examples::BIN_NAME,
+                "--viewkey",
+                examples::UNIFIED_VIEWING_KEY,
+            ])
+            .unwrap_err();
+            assert!(err.contains("block height"));
+        }
+
+        #[test]
+        fn invalid_chain_type() {
+            let err = fill(&[examples::BIN_NAME, "--chain", "bogus"]).unwrap_err();
+            assert!(err.contains("bogus"));
+        }
+
+        #[test]
+        fn server_missing_port() {
+            let err = fill(&[examples::BIN_NAME, "--server", "https://example.com"]).unwrap_err();
+            assert!(err.contains("scheme"));
+        }
+    }
+
+    mod zingo_config {
+        use super::*;
+        use pepper_sync::config::PerformanceLevel;
+        use std::num::NonZeroU32;
+
+        #[test]
+        fn default_server_is_propagated() {
+            let zc = fill_and_build(&[examples::BIN_NAME]);
+            let uri = zc.indexer_uri().to_string();
+            assert!(
+                uri.starts_with(zingolib::config::DEFAULT_LIGHTWALLETD_SERVER),
+                "expected URI to start with default server, got: {uri}"
+            );
+        }
+
+        #[test]
+        fn custom_server_is_propagated() {
+            let zc = fill_and_build(&[examples::BIN_NAME, "--server", examples::SERVER_URI]);
+            let uri = zc.indexer_uri().to_string();
+            assert!(
+                uri.starts_with(examples::SERVER_URI),
+                "expected URI to start with {}, got: {uri}",
+                examples::SERVER_URI
+            );
+        }
+
+        #[test]
+        fn chain_type_is_propagated() {
+            let zc = fill_and_build(&[examples::BIN_NAME, "--chain", "testnet"]);
+            assert_eq!(zc.network_type(), ChainType::Testnet);
+        }
+
+        #[test]
+        fn data_dir_is_propagated() {
+            let zc = fill_and_build(&[examples::BIN_NAME, "--data-dir", examples::DATA_DIR]);
+            assert_eq!(zc.wallet_dir(), PathBuf::from(examples::DATA_DIR));
+        }
+
+        #[test]
+        fn default_wallet_settings() {
+            let zc = fill_and_build(&[examples::BIN_NAME]);
+            let ws = zc.wallet_settings();
+            assert!(matches!(
+                ws.sync_config.performance_level,
+                PerformanceLevel::High
+            ));
+            assert_eq!(ws.min_confirmations, NonZeroU32::new(3).unwrap());
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #2284
Fixes: #2282 

These changes make zingo-cli easier to work on by:

* making interactive mode and command mode enum variants
* helperizing extensively
* unit-testing helpers
* unifying example and test-vector data
* separating OS-process interacting logic from lib.rs by moving it to main.rs

I've been testing like this:

```bash
cargo check --all-features --tests --bin zingo-cli && cargo fmt && cargo clippy && cargo nextest run --package zingo-cli &&  cargo run -- help send