### PR TITLE
fill todo doc comments in zingo-cli

### DIFF
--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1,5 +1,8 @@
-//! An interface that passes strings (e.g. from a cli, into zingolib)
-//! upgrade-or-replace
+//! Command definitions and dispatch for zingo-cli.
+//!
+//! Each command implements the [`Command`] trait (or [`ShortCircuitedCommand`]
+//! for commands that run without a wallet). All commands are registered in
+//! [`get_commands`] and dispatched by [`do_user_command`].
 
 mod error;
 mod utils;
@@ -37,7 +40,7 @@ pub trait Command {
     /// display command help (in cli)
     fn help(&self) -> &'static str;
 
-    /// TODO: Add Doc Comment for this!
+    /// A one-line summary shown in the two-column command listing.
     fn short_help(&self) -> &'static str;
 
     /// in zingocli, this string is printed to console
@@ -46,9 +49,14 @@ pub trait Command {
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String;
 }
 
-/// TODO: Add Doc Comment Here!
+/// A command that can execute without an active [`LightClient`].
+///
+/// This is used for commands like `help` that must run before the wallet
+/// is loaded — for example when the user passes `help` as the COMMAND
+/// argument on the command line.
 pub trait ShortCircuitedCommand {
-    /// TODO: Add Doc Comment Here!
+    /// Execute the command without a [`LightClient`], returning the
+    /// output string that will be printed to the console.
     fn exec_without_lc(args: Vec<String>) -> String;
 }
 
@@ -495,7 +503,7 @@ impl Command for ClearCommand {
     }
 }
 
-/// TODO: Add Doc Comment Here!
+/// Lists all available commands or shows detailed help for a specific command.
 pub struct HelpCommand {}
 impl Command for HelpCommand {
     fn help(&self) -> &'static str {
@@ -2011,7 +2019,10 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
     all
 }
 
-/// TODO: Add Doc Comment Here!
+/// Dispatches a user command by name to the appropriate [`Command`] implementation.
+///
+/// Returns the command's output string, or an "Unknown command" message
+/// if no command with the given name exists.
 pub fn do_user_command(cmd: &str, args: &[&str], lightclient: &mut LightClient) -> String {
     match get_commands().get(cmd.to_ascii_lowercase().as_str()) {
         Some(cmd) => cmd.exec(args, lightclient),

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -1,5 +1,12 @@
-//! `ZingoCli`
-//! TODO: Add Crate Description Here!
+//! `ZingoCli` — a command-line interface for the Zingo Zcash light wallet.
+//!
+//! This crate provides the library half of `zingo-cli`. It owns argument
+//! parsing ([`build_clap_app`]), configuration assembly, wallet startup,
+//! the interactive REPL, and single-command dispatch.
+//!
+//! The binary entry point (`main.rs`) is intentionally thin: it handles
+//! process-level concerns (tracing, crypto-provider installation, error
+//! reporting) and delegates all wallet logic here via [`run_cli`].
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
@@ -307,7 +314,11 @@ struct CommandChannel {
     receiver: Receiver<String>,
 }
 
-/// TODO: Add Doc Comment Here!
+/// Spawns a background thread that listens for `(command, args)` messages,
+/// executes each command against the [`LightClient`], and sends the
+/// string response back through the returned [`CommandChannel`].
+///
+/// The loop exits when it receives a `"quit"` or `"exit"` command.
 pub(crate) fn command_loop(mut lightclient: LightClient) -> CommandChannel {
     let (command_transmitter, command_receiver) = channel::<(String, Vec<String>)>();
     let (resp_transmitter, resp_receiver) = channel::<String>();
@@ -392,7 +403,11 @@ fn get_communication_mode(_matches: &clap::ArgMatches) -> CommunicationMode {
     CommunicationMode::Online
 }
 
-/// TODO: Add Doc Comment Here!
+/// All CLI-derived configuration needed to start a wallet session.
+///
+/// Built by [`ConfigTemplate::fill`] from parsed [`clap::ArgMatches`],
+/// then consumed by [`build_zingo_config`] and [`dispatch_command_or_start_interactive`]
+/// to create the [`LightClient`] and command channel.
 #[derive(Debug)]
 pub(crate) struct ConfigTemplate {
     mode: ModeOfOperation,

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -6,7 +6,9 @@
 //!
 //! The binary entry point (`main.rs`) is intentionally thin: it handles
 //! process-level concerns (tracing, crypto-provider installation, error
-//! reporting) and delegates all wallet logic here via [`run_cli`].
+//! reporting) and delegates to [`run_cli`], which builds a
+//! [`LightClient`](zingolib::lightclient::LightClient) and runs the
+//! command loop.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
@@ -403,11 +405,11 @@ fn get_communication_mode(_matches: &clap::ArgMatches) -> CommunicationMode {
     CommunicationMode::Online
 }
 
-/// All CLI-derived configuration needed to start a wallet session.
+/// All CLI-derived configuration needed to create a [`LightClient`] and
+/// start the command loop.
 ///
 /// Built by [`ConfigTemplate::fill`] from parsed [`clap::ArgMatches`],
-/// then consumed by [`build_zingo_config`] and [`dispatch_command_or_start_interactive`]
-/// to create the [`LightClient`] and command channel.
+/// then consumed by [`build_zingo_config`] and [`dispatch_command_or_start_interactive`].
 #[derive(Debug)]
 pub(crate) struct ConfigTemplate {
     mode: ModeOfOperation,

--- a/zingo-cli/src/version.rs
+++ b/zingo-cli/src/version.rs
@@ -1,5 +1,5 @@
-//! Version
-//! TODO: Add Mod Description Here!
+//! Crate version constant for `zingo-cli`.
 
-/// TODO: Add Doc Comment Here!
+/// The current version of the `zingo-cli` crate, used in `--version` output
+/// and the clap `Command` definition.
 pub const VERSION: &str = "0.1.1";


### PR DESCRIPTION
Fixes: #2301

Retargeted against `dev` per @zancas feedback on #2301.

Fill all TODO placeholder doc comments across `zingo-cli/src/`:

- **lib.rs**: crate-level docs, `command_loop()`, `ConfigTemplate`
- **commands.rs**: module docs, `short_help()`, `ShortCircuitedCommand`, `HelpCommand`, `get_commands()`, `do_user_command()`
- **version.rs**: module and `VERSION` const docs

Note: `commands.rs` line 1-2 originally read "An interface that passes strings (e.g. from a cli, into zingolib) / upgrade-or-replace" — replaced with clearer module docs. The "upgrade-or-replace" note may have been intentional @zancas; happy to restore if needed.

**AI disclosure**: Doc comments drafted with Claude Code (Anthropic), reviewed and verified against source by human contributor.