### PR TITLE
validate --data-dir is not a file before startup

### DIFF
--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -26,3 +26,6 @@ shellwords = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
 zip32 = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -404,7 +404,9 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
                     "--data-dir must be a directory, not a file.\n\
                      You provided: {dir}\n\
                      Hint: use the parent directory instead, e.g. --data-dir {}",
-                    path.parent().map(|p| p.display().to_string()).unwrap_or_else(|| ".".into())
+                    path.parent()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|| ".".into())
                 ));
             }
             path
@@ -620,7 +622,7 @@ pub fn help_output(matches: &clap::ArgMatches) -> Option<String> {
 pub fn run_cli(matches: clap::ArgMatches) {
     match ConfigTemplate::fill(get_mode_of_operation(&matches), matches) {
         Ok(cli_config) => dispatch_command_or_start_interactive(&cli_config),
-        Err(e) => eprintln!("Error filling config template: {e:?}"),
+        Err(e) => eprintln!("Error filling config template: {e}"),
     }
 }
 

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -398,7 +398,16 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
         };
 
         let data_dir = if let Some(dir) = matches.get_one::<String>("data-dir") {
-            PathBuf::from(dir.clone())
+            let path = PathBuf::from(dir.clone());
+            if path.is_file() {
+                return Err(format!(
+                    "--data-dir must be a directory, not a file.\n\
+                     You provided: {dir}\n\
+                     Hint: use the parent directory instead, e.g. --data-dir {}",
+                    path.parent().map(|p| p.display().to_string()).unwrap_or_else(|| ".".into())
+                ));
+            }
+            path
         } else {
             PathBuf::from("wallets")
         };

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -500,6 +500,14 @@ mod config_template {
             let err = fill(&[examples::BIN_NAME, "--server", "https://example.com"]).unwrap_err();
             assert!(err.contains("scheme"));
         }
+
+        #[test]
+        fn data_dir_is_a_file() {
+            let tmp = tempfile::NamedTempFile::new().unwrap();
+            let file_path = tmp.path().to_str().unwrap();
+            let err = fill(&[examples::BIN_NAME, "--data-dir", file_path]).unwrap_err();
+            assert!(err.contains("must be a directory, not a file"));
+        }
     }
 
     mod zingo_config {


### PR DESCRIPTION
Fixes: #2272

When `--data-dir` points to a wallet file (e.g. `--data-dir /path/to/zingo-wallet.dat`) instead of its parent directory, zingolib panics with:

```
panic!("Couldn't create zcash directory!")
```

This gives no indication that the path should be a directory, not a file.

### Changes

- Add early validation in `ConfigTemplate::fill()` that checks if the provided `--data-dir` path is an existing file
- Return a clear error message with the correct parent directory as a hint:
  ```
  --data-dir must be a directory, not a file.
  You provided: /path/to/zingo-wallet.dat
  Hint: use the parent directory instead, e.g. --data-dir /path/to
  ```
- Add test `data_dir_is_a_file` in the `error_cases` module
- All 71 existing tests pass

**AI disclosure**: Fix implemented with Claude Code (Anthropic), reviewed and verified by human contributor.