### PR TITLE
redirect tracing to log file in interactive mode

### DIFF
--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -603,6 +603,12 @@ pub fn help_output(matches: &clap::ArgMatches) -> Option<String> {
     }
 }
 
+/// Returns `true` if the CLI will start the interactive REPL
+/// (i.e. no COMMAND was given).
+pub fn is_interactive(matches: &clap::ArgMatches) -> bool {
+    matches!(get_mode_of_operation(matches), ModeOfOperation::Interactive)
+}
+
 /// Runs the CLI from pre-parsed arguments.
 ///
 /// This function never calls `std::process::exit` or reads `std::env::args`.

--- a/zingo-cli/src/main.rs
+++ b/zingo-cli/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use std::sync::Mutex;
 use tracing_subscriber::EnvFilter;
 
 /// Parses CLI arguments and handles the help short-circuit.
@@ -17,14 +18,56 @@ fn parse_args_or_exit_for_help() -> clap::ArgMatches {
     matches
 }
 
+/// Default log file directory.
+const LOG_DIR: &str = ".zingo-cli";
+/// Default log file name within the log directory.
+const LOG_FILE: &str = "cli.log";
+
+/// Initializes tracing based on the mode of operation.
+///
+/// In interactive mode, logs are written to a file so error-level tracing
+/// output (e.g. from pepper_sync) does not pollute the REPL. In command
+/// mode, logs go to stderr as before.
+fn init_tracing(matches: &clap::ArgMatches) {
+    let env_filter = EnvFilter::from_default_env();
+
+    if zingo_cli::is_interactive(matches) {
+        let log_path = std::path::PathBuf::from(LOG_DIR).join(LOG_FILE);
+        if let Some(parent) = log_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+        {
+            Ok(file) => {
+                tracing_subscriber::fmt()
+                    .with_env_filter(env_filter)
+                    .with_writer(Mutex::new(file))
+                    .with_ansi(false)
+                    .init();
+                return;
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: could not open log file {}: {e}. Logging to stderr.",
+                    log_path.display()
+                );
+            }
+        }
+    }
+
+    // Command mode or file-creation fallback: log to stderr
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
+}
+
 pub fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
     // install default crypto provider (ring)
     if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
         eprintln!("Error installing crypto provider: {e:?}");
     }
     let matches = parse_args_or_exit_for_help();
+    init_tracing(&matches);
     zingo_cli::run_cli(matches);
 }


### PR DESCRIPTION
Fixes: #2278

In interactive mode, `pepper_sync` ERROR-level logs (memo decode failures, server timeouts) are written directly to stderr, polluting the REPL output:

```
(main) Block:3284135 [Syncing 26.7%] >> 2026-03-24T23:13:36.216018Z ERROR pepper_sync::scan::transactions: Failed to decode memo data...
```

### Changes

- Add `init_tracing()` in `main.rs` that routes tracing output to `.zingo-cli/cli.log` in interactive mode. Command mode continues logging to stderr.
- Add `is_interactive()` public helper in `lib.rs` so `main.rs` can query the mode without exposing `ModeOfOperation`.
- If the log file can't be created, falls back to stderr with a warning.
- All 70 existing tests pass.

Note: this is a subset of the tracing improvements in PR #2294 (`divide_commands`), backported independently to `dev` so the fix can land without depending on the full CLI refactor.

**AI disclosure**: Fix implemented with Claude Code (Anthropic), reviewed and verified by human contributor.