### PR TITLE
copy sapling params to OUT_DIR instead of source directory

### DIFF
--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -38,7 +38,7 @@ portpicker = { workspace = true, optional = true }
 prost = { workspace = true }
 rand = { workspace = true }
 ring = { workspace = true }
-rust-embed = { workspace = true, features = ["debug-embed"] }
+rust-embed = { workspace = true, features = ["debug-embed", "interpolate-folder-path"] }
 rustls.workspace = true
 sapling-crypto.workspace = true
 secp256k1 = { workspace = true }

--- a/zingolib/build.rs
+++ b/zingolib/build.rs
@@ -52,9 +52,11 @@ fn get_zcash_params() {
         }
     };
 
-    // Copy the params to the internal location.
-    let internal_params_path = Path::new("zcash-params");
-    std::fs::create_dir_all(internal_params_path).unwrap();
+    // Copy the params to OUT_DIR so they can be embedded by rust_embed
+    // without writing to the source directory.
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let internal_params_path = Path::new(&out_dir).join("zcash-params");
+    std::fs::create_dir_all(&internal_params_path).unwrap();
     std::fs::copy(
         params_path.spend,
         internal_params_path.join("sapling-spend.params"),

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -25,7 +25,7 @@ include!(concat!(env!("OUT_DIR"), "/git_description.rs"));
 extern crate rust_embed;
 /// Embedded zcash-params.
 #[derive(RustEmbed)]
-#[folder = "zcash-params/"]
+#[folder = "$OUT_DIR/zcash-params/"]
 pub struct SaplingParams;
 
 /// Developer donation address


### PR DESCRIPTION
## Summary

- Build script now copies sapling params to `$OUT_DIR/zcash-params/` instead of `zingolib/zcash-params/` in the source tree
- Uses `rust_embed`'s `interpolate-folder-path` feature to resolve `$OUT_DIR` at compile time
- Eliminates ~50MB of duplicated param files in the source directory

## Problem

The build script wrote sapling params to `zingolib/zcash-params/` (in the source tree), violating Cargo's convention of only writing to `target/` and `~/.cargo`. This broke reproducible builds, caused unnecessary duplication, and panicked if the source directory was read-only.

## Changes

| File | Change |
|------|--------|
| `zingolib/build.rs` | Copy params to `$OUT_DIR/zcash-params/` instead of `./zcash-params/` |
| `zingolib/src/lib.rs` | `#[folder = "$OUT_DIR/zcash-params/"]` (was `"zcash-params/"`) |
| `zingolib/Cargo.toml` | Add `interpolate-folder-path` feature to `rust-embed` |

## Test plan

- [x] `cargo check -p zingolib` passes
- [x] `cargo check -p zingo-cli` passes
- [x] `cargo clippy -p zingolib -- -D warnings` passes
- [x] `cargo doc --no-deps -p zingolib` passes (with `-D warnings`)
- [x] `cargo fmt` clean
- [x] Params appear in `target/debug/build/zingolib-*/out/zcash-params/`

**Note:** The existing `zingolib/zcash-params/` directory (gitignored) can now be deleted. New builds will not write to it.

Fixes #2315

## AI Disclosure

Claude (Anthropic) assisted with codebase analysis and patch authoring. All code was reviewed and understood by the committer.