### PR TITLE
remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9251,7 +9251,6 @@ dependencies = [
 name = "zingo-cli"
 version = "0.2.0"
 dependencies = [
- "bip0039 0.14.0",
  "clap",
  "http",
  "indoc",
@@ -9334,7 +9333,6 @@ name = "zingo-status"
 version = "0.2.0"
 dependencies = [
  "byteorder",
- "zcash_primitives",
  "zcash_protocol",
 ]
 
@@ -9381,7 +9379,6 @@ dependencies = [
  "bip32",
  "bs58",
  "byteorder",
- "bytes",
  "chrono",
  "dirs",
  "futures",
@@ -9409,7 +9406,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "zcash_address",
  "zcash_client_backend",
  "zcash_encoding",
@@ -9431,9 +9427,7 @@ dependencies = [
 name = "zingolib_testutils"
 version = "0.1.0"
 dependencies = [
- "bip0039 0.14.0",
  "http",
- "pepper-sync",
  "portpicker",
  "tempfile",
  "zcash_local_net",

--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -14,7 +14,6 @@ zcash_client_backend = { workspace = true }
 zcash_keys = { workspace = true }
 zcash_protocol = { workspace = true }
 
-bip0039 = { workspace = true }
 clap = { workspace = true }
 http = { workspace = true }
 indoc = { workspace = true }

--- a/zingo-status/Cargo.toml
+++ b/zingo-status/Cargo.toml
@@ -14,6 +14,3 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 zcash_protocol = { workspace = true }
 byteorder = { workspace = true }
-
-[dev-dependencies]
-zcash_primitives = { workspace = true }

--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -185,7 +185,7 @@ impl ConfirmationStatus {
     ///
     /// ```
     /// use zingo_status::confirmation_status::ConfirmationStatus;
-    /// use zcash_primitives::consensus::BlockHeight;
+
     ///
     /// assert!(ConfirmationStatus::Calculated(1.into()).is_pending());
     /// assert!(ConfirmationStatus::Transmitted(1.into()).is_pending());
@@ -206,7 +206,7 @@ impl ConfirmationStatus {
     ///
     /// ```
     /// use zingo_status::confirmation_status::ConfirmationStatus;
-    /// use zcash_primitives::consensus::BlockHeight;
+
     ///
     /// assert!(!ConfirmationStatus::Calculated(1.into()).is_failed());
     /// assert!(!ConfirmationStatus::Transmitted(1.into()).is_failed());

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -21,7 +21,6 @@ bip0039.workspace = true
 bip32 = { workspace = true, features = ["secp256k1-ffi"] }
 bs58 = { workspace = true, features = ["check"] }
 byteorder = { workspace = true }
-bytes = { workspace = true }
 chrono = { workspace = true }
 dirs.workspace = true
 futures = { workspace = true }
@@ -49,7 +48,6 @@ tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
-tracing-subscriber = { workspace = true }
 zcash_address = { workspace = true }
 zcash_client_backend = { workspace = true, features = [
     "unstable",

--- a/zingolib_testutils/Cargo.toml
+++ b/zingolib_testutils/Cargo.toml
@@ -12,7 +12,6 @@ test_lwd_zcashd = []
 
 # zingolib
 zingolib = { workspace = true, features = ["testutils"] }
-pepper-sync.workspace = true
 zingo_common_components.workspace = true
 
 # zingo infrastructure
@@ -21,10 +20,6 @@ zingo_test_vectors.workspace = true
 
 # zcash
 zcash_protocol.workspace = true
-
-# bitcoin
-
-bip0039.workspace = true
 
 # utilties
 


### PR DESCRIPTION
## Summary

Remove 6 unused dependencies flagged by `cargo shear`:

| Crate | Package | Reason |
|-------|---------|--------|
| `bip0039` | zingo-cli | No references in source |
| `tracing-subscriber` | zingolib | No references in source |
| `bytes` | zingolib | No references in source |
| `pepper-sync` | zingolib_testutils | No references in source |
| `bip0039` | zingolib_testutils | No references in source |
| `zcash_primitives` | zingo-status (dev) | Only dead imports in doc test examples |

Also removed the unused `use zcash_primitives::consensus::BlockHeight` lines from two doc test examples in `zingo-status/src/confirmation_status.rs` — `BlockHeight` was imported but never used.

Three workspace-level deps (`futures-util`, `tonic-prost`, `bytes`) remain flagged but are used by `darkside-tests` and already in its `cargo-shear` ignore list.

## Test plan

- [x] `cargo check` (full workspace) passes
- [x] `cargo test --doc -p zingo-status` — all 10 doc tests pass
- [x] `cargo fmt` clean
- [x] `cargo shear` confirms per-crate deps are clean

Contributes to #2067

## AI Disclosure

Claude (Anthropic) assisted with codebase analysis and patch authoring. All code was reviewed and understood by the committer.