### PR TITLE
Update workspace to corez dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1220,13 +1220,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.3.3"
+name = "corez"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
-]
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
 
 [[package]]
 name = "cpufeatures"
@@ -1574,7 +1571,7 @@ checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
  "indexmap 2.13.0",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1710,7 +1707,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1956,12 +1953,12 @@ dependencies = [
 
 [[package]]
 name = "equihash"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
- "core2",
+ "corez",
  "document-features",
 ]
 
@@ -1978,7 +1975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2441,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
+checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -3202,7 +3199,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3347,7 +3344,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zcash_transparent",
- "zingo-status 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zingo-status",
  "zingo_common_components",
  "zingo_test_vectors",
  "zingolib",
@@ -3575,6 +3572,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -3648,7 +3657,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3840,14 +3849,14 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.11.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
+checksum = "497e74492624a1d1cc8c9675a7afb17b430d32fd9efc171513d0840140b5f0c7"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2",
+ "corez",
  "ff",
  "fpe",
  "getset",
@@ -3862,6 +3871,7 @@ dependencies = [
  "nonempty",
  "pasta_curves",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -4092,8 +4102,8 @@ dependencies = [
  "zcash_primitives",
  "zcash_protocol",
  "zcash_transparent",
- "zingo-memo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zingo-status 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zingo-memo",
+ "zingo-status",
  "zip32",
 ]
 
@@ -4486,7 +4496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -4507,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4671,7 +4681,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5276,7 +5286,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5371,7 +5381,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.30.1",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -5418,9 +5428,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
+checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
 dependencies = [
  "aes",
  "bellman",
@@ -5428,7 +5438,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2",
+ "corez",
  "document-features",
  "ff",
  "fpe",
@@ -6108,7 +6118,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8095,7 +8105,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8552,9 +8562,9 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yoke"
@@ -8594,13 +8604,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
+checksum = "355f3db1087875052b5ad0f9e7179a7e7794f0ae9cb1d6ab2b7db29f7b9a9b0b"
 dependencies = [
  "bech32",
  "bs58",
- "core2",
+ "corez",
  "f4jumble",
  "proptest",
  "zcash_encoding",
@@ -8609,9 +8619,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5eca509a516dbd9e4d13c1f5befd6d9fa25c7e62460444ef1b3f62122f323"
+checksum = "7d052d002ffd18bf4f129ab161e0a584c96b3578d9b9e88cd2dafef7df7db408"
 dependencies = [
  "arti-client",
  "base64",
@@ -8676,11 +8686,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_encoding"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
- "core2",
+ "corez",
+ "hex",
  "nonempty",
 ]
 
@@ -8697,9 +8708,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
+checksum = "b340e2bc20698c4d784d920dcda1f270d076bef2b0726b732ca9ca7574d61241"
 dependencies = [
  "bech32",
  "bip32",
@@ -8707,7 +8718,7 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "core2",
+ "corez",
  "document-features",
  "group",
  "memuse",
@@ -8727,13 +8738,14 @@ dependencies = [
 
 [[package]]
 name = "zcash_local_net"
-version = "0.4.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=5bcbf53d680542c247d01585c12085c1be831adc#5bcbf53d680542c247d01585c12085c1be831adc"
+version = "0.5.0"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=fix-corez-deps#8546a0c652982b20edf1fe3090e9a26f5a2cc0c6"
 dependencies = [
  "getset",
  "hex",
  "json",
- "portpicker",
+ "nix 0.29.0",
+ "reqwest",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
@@ -8762,52 +8774,40 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9ff256fb298a7e94a73c1adad6c7e0b4b194b902e777ee9f5f2e12c4c4776"
+checksum = "a59f418f8b1274a526d57dfa3b1a7b3724f04926c84712a27c1602e4b44bfacd"
 dependencies = [
- "bip32",
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "bs58",
- "core2",
+ "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
  "ff",
- "fpe",
- "getset",
- "group",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
  "orchard",
- "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
- "ripemd 0.1.3",
  "sapling-crypto",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
- "subtle",
- "tracing",
- "zcash_address",
  "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
- "zcash_spec",
  "zcash_transparent",
- "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2c13bb673d542608a0e6502ac5494136e7ce4ce97e92dd239489b2523eed9"
+checksum = "95c6749aeaf49a56874d915482bc03e4afb9f6e561ed476b7c906e6d9de3ef74"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8817,7 +8817,6 @@ dependencies = [
  "home",
  "jubjub",
  "known-folders",
- "lazy_static",
  "minreq",
  "rand_core 0.6.4",
  "redjubjub",
@@ -8830,21 +8829,22 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b1a337bbc9a7d55ae35d31189f03507dbc7934e9a4bee5c1d5c47464860e48"
+checksum = "79ef3de16a4464a574591aa3e4ea875116372638307d7ae04415279ec187ba88"
 dependencies = [
- "core2",
+ "corez",
  "document-features",
  "hex",
  "memuse",
+ "zcash_encoding",
 ]
 
 [[package]]
 name = "zcash_script"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ef9d04e0434a80b62ad06c5a610557be358ef60a98afa5dbc8ecaf19ad72e7"
+checksum = "774d808ab619b0f1887d7b90cd815c356101698d16aa681f3d2d9dea063de475"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -8868,14 +8868,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9b7b4bc11d8bb20833d1b8ab6807f4dca941b381f1129e5bbd72a84e391991"
+checksum = "9e9ad72051b49432acd56d44ab301bb6467bd70eb23faab3f35539e4ecf2733d"
 dependencies = [
  "bip32",
- "blake2b_simd",
  "bs58",
- "core2",
+ "corez",
  "document-features",
  "getset",
  "hex",
@@ -8894,9 +8893,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "6.0.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eebcd0ad0160d7bbc7f8ed26e6d00e257adf17c6d136628ea8ae979c027eced"
+checksum = "99160b5cb49188c44bcba2ae56d0a85d2ba592243247451458bdf50ac3fd596d"
 dependencies = [
  "bech32",
  "bitflags 2.11.0",
@@ -8958,9 +8957,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f9fb46b7fb3d7065fdf6d36f11cd48aa0fd7c0efc5294311dc756d06275348"
+checksum = "c8e7835e49a2056b262cd4adc4b9b1f85f11821dad6b9353742d4bf088cef3fb"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8997,9 +8996,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c7afee9c651c8db90970db9ab86d42a313016457271fdf3340ae0b6bc4b2d"
+checksum = "c072b418e2858eb1963116356c5093033ca3c6f62426ea7acf2a22e0d031bcaf"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -9035,9 +9034,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608b55b6cd9ddecc73a7a20d801847e0461ea5178e17cac5734b1b0e6d21aa5f"
+checksum = "dfa5570277295b66b33fb6aa4a1d8ceed5e33925d3928be7afc18e8af157ec7b"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -9051,9 +9050,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "6.0.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5465db3b35a3c894567f32036c84d6ff1aacdfa300f87ddfa237d29ac9f120df"
+checksum = "b4e44dc2ca75c5ab16a2ce489f9919da2f6b2141ea5bff1f84addf96e871b5b5"
 dependencies = [
  "base64",
  "chrono",
@@ -9069,7 +9068,7 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
  "metrics",
- "nix",
+ "nix 0.30.1",
  "openrpsee",
  "phf 0.12.1",
  "prost",
@@ -9105,11 +9104,12 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86811347886796806663c5e66cfef8085ba5bbc04bb9f94adf5fcb54e3ef76c6"
+checksum = "45be1c2696543c5ba1282c4d65cba52f8bf79db4b7879d90b26664fb01f00c32"
 dependencies = [
  "libzcash_script",
+ "rand 0.8.5",
  "thiserror 2.0.18",
  "zcash_primitives",
  "zcash_script",
@@ -9118,9 +9118,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd379520336d750a75d22e0aaaf9f48d16f03b31db86fe2629993ce219071fe0"
+checksum = "81fecd536ba6131e3560995b42590dbe08bd767003dfac102995140a00ad2ab3"
 dependencies = [
  "bincode 1.3.3",
  "chrono",
@@ -9291,22 +9291,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "zingo-memo"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4152c6c9ac701ef82b82deca2b5db7bbf70583c04031f97423bf9f850d74e4a"
-dependencies = [
- "zcash_address",
- "zcash_client_backend",
- "zcash_encoding",
- "zcash_keys",
- "zcash_primitives",
-]
-
-[[package]]
 name = "zingo-netutils"
 version = "4.0.0"
-source = "git+https://github.com/zingolabs/zingo-common?branch=indexer_trait#7c580435f301518dfb26cf004e9f583c1f6ac82d"
+source = "git+https://github.com/zingolabs/zingo-common?branch=fix-corez-deps#793e8bade56fcdf122188d5d48068c9ae2c10cda"
 dependencies = [
  "http",
  "lightwallet-protocol",
@@ -9341,17 +9328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zingo-status"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b345e3911479cf21dddf6027c8fb78010b787044d42461d6864dcc42620f159"
-dependencies = [
- "byteorder",
- "zcash_primitives",
- "zcash_protocol",
-]
-
-[[package]]
 name = "zingo_common_components"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9368,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=5bcbf53d680542c247d01585c12085c1be831adc#5bcbf53d680542c247d01585c12085c1be831adc"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=fix-corez-deps#8546a0c652982b20edf1fe3090e9a26f5a2cc0c6"
 dependencies = [
  "bip0039 0.12.0",
 ]
@@ -9420,10 +9396,10 @@ dependencies = [
  "zcash_proofs",
  "zcash_protocol",
  "zcash_transparent",
- "zingo-memo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zingo-memo",
  "zingo-netutils",
  "zingo-price",
- "zingo-status 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zingo-status",
  "zingo_common_components",
  "zingo_test_vectors",
  "zip32",
@@ -9461,9 +9437,9 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3090953750ce1d56aa213710765eb14997868f463c45dae115cf1ebe09fe39eb"
+checksum = "a2159ebf6e48565b2fc74a4beae8d906f06657ca61c0db21a0361f15a075feee"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,18 +3572,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -5381,7 +5369,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.30.1",
+ "nix",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -8739,12 +8727,11 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.5.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=fix-corez-deps#8546a0c652982b20edf1fe3090e9a26f5a2cc0c6"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=434653b2e807062d22be11692d16d5abf4957b48#434653b2e807062d22be11692d16d5abf4957b48"
 dependencies = [
  "getset",
  "hex",
  "json",
- "nix 0.29.0",
  "reqwest",
  "serde_json",
  "tempfile",
@@ -9068,7 +9055,7 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
  "metrics",
- "nix 0.30.1",
+ "nix",
  "openrpsee",
  "phf 0.12.1",
  "prost",
@@ -9293,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "zingo-netutils"
 version = "4.0.0"
-source = "git+https://github.com/zingolabs/zingo-common?branch=fix-corez-deps#793e8bade56fcdf122188d5d48068c9ae2c10cda"
+source = "git+https://github.com/zingolabs/zingo-common?branch=indexer_trait#1f434a7a03918357b2e9e4c078bbe0d8375ec265"
 dependencies = [
  "http",
  "lightwallet-protocol",
@@ -9344,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=fix-corez-deps#8546a0c652982b20edf1fe3090e9a26f5a2cc0c6"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=434653b2e807062d22be11692d16d5abf4957b48#434653b2e807062d22be11692d16d5abf4957b48"
 dependencies = [
  "bip0039 0.12.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,9 @@ resolver = "2"
 ### Workspace
 # pepper-sync = "0.2.0"
 pepper-sync = { path = "pepper-sync" } # NOTE: for development between releases
-# zingo-memo = { path = "zingo-memo" } # NOTE: for development between releases
-zingo-memo = "0.1.0"
+zingo-memo = { path = "zingo-memo" } # NOTE: for development between releases
 zingo-price = { path = "zingo-price" }
-# zingo-status = { path = "zingo-status" } # NOTE: for development between releases
-zingo-status = "0.2.0"
+zingo-status = { path = "zingo-status" } # NOTE: for development between releases
 zingolib = { path = "zingolib" }
 
 ### Tests and Integration Tests
@@ -30,8 +28,8 @@ portpicker = "0.1"
 proptest = "1.6.0"
 tempfile = "3"
 test-log = "0.2"
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "5bcbf53d680542c247d01585c12085c1be831adc" }
-zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "5bcbf53d680542c247d01585c12085c1be831adc" }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", branch = "fix-corez-deps" }
+zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", branch = "fix-corez-deps" }
 
 ### Documentation
 indoc = "2"
@@ -43,32 +41,32 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 ### Zingo-common
-zingo-netutils = { git = "https://github.com/zingolabs/zingo-common", branch = "indexer_trait", features = ["back_compatible", "globally-public-transparent"] }
+zingo-netutils = { git = "https://github.com/zingolabs/zingo-common", branch = "fix-corez-deps", features = ["back_compatible", "globally-public-transparent"] }
 zingo_common_components = "0.3.0"
 
 ### Zcash
 incrementalmerkletree = "0.8.2"
-orchard = "0.11.0"
-sapling-crypto = "0.5.0"
+orchard = "0.13.1"
+sapling-crypto = "0.7.0"
 shardtree = "0.6.1"
-zcash_address = "0.10"
-zcash_client_backend = { version = "0.21", features = [
+zcash_address = "0.11"
+zcash_client_backend = { version = "0.22", features = [
     "lightwalletd-tonic",
     "orchard",
     "transparent-inputs",
     "tor",
 ] }
-zcash_encoding = "0.3"
-zcash_keys = { version = "0.12", features = [
+zcash_encoding = "0.4"
+zcash_keys = { version = "0.13", features = [
     "transparent-inputs",
     "sapling",
     "orchard",
 ] }
 zcash_note_encryption = "0.4"
-zcash_primitives = "0.26"
-zcash_proofs = "0.26"
-zcash_protocol = "0.7" # public API (TODO: remove from public API)
-zcash_transparent = "0.6"
+zcash_primitives = "0.27"
+zcash_proofs = "0.27"
+zcash_protocol = "0.8" # public API (TODO: remove from public API)
+zcash_transparent = "0.7"
 
 ### Blockchain Protocol
 bip0039 = { version = "0.14", features = ["rand"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ portpicker = "0.1"
 proptest = "1.6.0"
 tempfile = "3"
 test-log = "0.2"
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", branch = "fix-corez-deps" }
-zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", branch = "fix-corez-deps" }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "434653b2e807062d22be11692d16d5abf4957b48" }
+zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "434653b2e807062d22be11692d16d5abf4957b48" }
 
 ### Documentation
 indoc = "2"
@@ -41,7 +41,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 ### Zingo-common
-zingo-netutils = { git = "https://github.com/zingolabs/zingo-common", branch = "fix-corez-deps", features = ["back_compatible", "globally-public-transparent"] }
+zingo-netutils = { git = "https://github.com/zingolabs/zingo-common", branch = "indexer_trait", features = ["back_compatible", "globally-public-transparent"] }
 zingo_common_components = "0.3.0"
 
 ### Zcash

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -810,7 +810,7 @@ mod fast {
         let alice_to_bob = TransactionRequest::new(vec![
             Payment::new(
                 ZcashAddress::from_str(&bob.encode(&faucet.chain_type())).unwrap(),
-                Zatoshis::from_u64(1_000).unwrap(),
+                Some(Zatoshis::from_u64(1_000).unwrap()),
                 Some(Memo::encode(
                     &Memo::from_str(&("Alice->Bob #1\nReply to\n".to_string() + &alice)).unwrap(),
                 )),
@@ -824,7 +824,7 @@ mod fast {
         let alice_to_bob_2 = TransactionRequest::new(vec![
             Payment::new(
                 ZcashAddress::from_str(&bob.encode(&faucet.chain_type())).unwrap(),
-                Zatoshis::from_u64(1_000).unwrap(),
+                Some(Zatoshis::from_u64(1_000).unwrap()),
                 Some(Memo::encode(
                     &Memo::from_str(&("Alice->Bob #2\nReply to\n".to_string() + &alice)).unwrap(),
                 )),
@@ -838,7 +838,7 @@ mod fast {
         let alice_to_charlie = TransactionRequest::new(vec![
             Payment::new(
                 ZcashAddress::from_str(&charlie.encode(&faucet.chain_type())).unwrap(),
-                Zatoshis::from_u64(1_000).unwrap(),
+                Some(Zatoshis::from_u64(1_000).unwrap()),
                 Some(Memo::encode(
                     &Memo::from_str(&("Alice->Charlie #2\nReply to\n".to_string() + &alice))
                         .unwrap(),
@@ -853,7 +853,7 @@ mod fast {
         let charlie_to_alice = TransactionRequest::new(vec![
             Payment::new(
                 ZcashAddress::from_str(&alice).unwrap(),
-                Zatoshis::from_u64(1_000).unwrap(),
+                Some(Zatoshis::from_u64(1_000).unwrap()),
                 Some(Memo::encode(
                     &Memo::from_str(
                         &("Charlie->Alice #2\nReply to\n".to_string()
@@ -871,7 +871,7 @@ mod fast {
         let bob_to_alice = TransactionRequest::new(vec![
             Payment::new(
                 ZcashAddress::from_str(&alice).unwrap(),
-                Zatoshis::from_u64(1_000).unwrap(),
+                Some(Zatoshis::from_u64(1_000).unwrap()),
                 Some(Memo::encode(
                     &Memo::from_str(
                         &("Bob->Alice #2\nReply to\n".to_string()

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -2170,15 +2170,7 @@ mod slow {
             )],
             sapling_notes: vec![],
             transparent_coins: vec![],
-            outgoing_orchard_notes:vec![OutgoingNoteSummary {
-                 value: 99_960_000,
-                 memo: None,
-                 recipient: "uregtest1sj5ym8x03ya948f8558qa3t0cvc75x8jygxv7fzyjmgunuhegu2r39dy2zskf8cgq2dqcl8x0wxjc8p6k2kjf2jpl0m7zttrzqhm9kmf".to_string(),
-                 recipient_unified_address: None,
-                 output_index: 0,
-                 account_id: AccountId::ZERO,
-                 scope: summary::data::Scope::from(zip32::Scope::Internal),
-             }],
+            outgoing_orchard_notes: vec![],
             outgoing_sapling_notes: vec![OutgoingNoteSummary {
                  output_index: 0,
                  value: first_send_to_sapling,
@@ -2210,15 +2202,7 @@ mod slow {
             )],
             sapling_notes: vec![],
             transparent_coins: vec![],
-            outgoing_orchard_notes: vec![OutgoingNoteSummary {
-                 output_index: 0,
-                 value: 99_925_000,
-                 memo: None,
-                 recipient: "uregtest1sj5ym8x03ya948f8558qa3t0cvc75x8jygxv7fzyjmgunuhegu2r39dy2zskf8cgq2dqcl8x0wxjc8p6k2kjf2jpl0m7zttrzqhm9kmf".to_string(),
-                 recipient_unified_address: None,
-                 account_id: AccountId::ZERO,
-                 scope: summary::data::Scope::from(zip32::Scope::Internal),
-             }],
+            outgoing_orchard_notes: vec![],
             outgoing_sapling_notes: vec![],
             outgoing_transparent_coins: vec![],
         };
@@ -2336,15 +2320,7 @@ mod slow {
             )],
             sapling_notes: vec![],
             transparent_coins: vec![],
-            outgoing_orchard_notes: vec![OutgoingNoteSummary {
-                 output_index: 0,
-                 value: 965_000,
-                 memo: None,
-                 recipient: "uregtest1sj5ym8x03ya948f8558qa3t0cvc75x8jygxv7fzyjmgunuhegu2r39dy2zskf8cgq2dqcl8x0wxjc8p6k2kjf2jpl0m7zttrzqhm9kmf".to_string(),
-                 recipient_unified_address: None,
-                 account_id: AccountId::ZERO,
-                 scope: summary::data::Scope::from(zip32::Scope::Internal),
-             }],
+            outgoing_orchard_notes: vec![],
             outgoing_sapling_notes: vec![],
             outgoing_transparent_coins: vec![],
         };
@@ -2380,15 +2356,7 @@ TransactionSummary {
             )],
             sapling_notes: vec![],
             transparent_coins: vec![],
-            outgoing_orchard_notes: vec![OutgoingNoteSummary {
-                 output_index: 0,
-                 value: 99_885_000,
-                 memo: None,
-                 recipient: "uregtest1sj5ym8x03ya948f8558qa3t0cvc75x8jygxv7fzyjmgunuhegu2r39dy2zskf8cgq2dqcl8x0wxjc8p6k2kjf2jpl0m7zttrzqhm9kmf".to_string(),
-                 recipient_unified_address: None,
-                 account_id: AccountId::ZERO,
-                 scope: summary::data::Scope::from(zip32::Scope::Internal),
-             }],
+            outgoing_orchard_notes: vec![],
             outgoing_sapling_notes: vec![OutgoingNoteSummary {
                 output_index: 0,
                  value: second_send_to_sapling,
@@ -2416,9 +2384,7 @@ TransactionSummary {
 
         // Third external transparent
         let external_transparent_3 = 20_000;
-        let summary_external_transparent_3 =
-
-TransactionSummary {
+        let summary_external_transparent_3 = TransactionSummary {
             txid: utils::conversion::txid_from_hex_encoded_str(TEST_TXID).unwrap(),
             datetime: 0,
             status: ConfirmationStatus::Confirmed(BlockHeight::from_u32(10)),
@@ -2435,15 +2401,7 @@ TransactionSummary {
             )],
             sapling_notes: vec![],
             transparent_coins: vec![],
-            outgoing_orchard_notes: vec![OutgoingNoteSummary {
-                 output_index: 0,
-                 value: 930_000,
-                 memo: None,
-                 recipient: "uregtest1sj5ym8x03ya948f8558qa3t0cvc75x8jygxv7fzyjmgunuhegu2r39dy2zskf8cgq2dqcl8x0wxjc8p6k2kjf2jpl0m7zttrzqhm9kmf".to_string(),
-                 recipient_unified_address: None,
-                 account_id: AccountId::ZERO,
-                 scope: summary::data::Scope::from(zip32::Scope::Internal),
-             }],
+            outgoing_orchard_notes: vec![],
             outgoing_sapling_notes: vec![],
             outgoing_transparent_coins: vec![],
         };

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -183,7 +183,9 @@ async fn store_all_checkpoints_in_verification_window_chain_cache() {
 
     local_net
         .validator_mut()
-        .cache_chain(get_cargo_manifest_dir().join("store_all_checkpoints_test"));
+        .cache_chain(get_cargo_manifest_dir().join("store_all_checkpoints_test"))
+        .await
+        .unwrap();
 }
 
 #[ignore = "ignored until we add framework for chain caches as we don't want to check these into the zingolib repo"]

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -184,8 +184,7 @@ async fn store_all_checkpoints_in_verification_window_chain_cache() {
     local_net
         .validator_mut()
         .cache_chain(get_cargo_manifest_dir().join("store_all_checkpoints_test"))
-        .await
-        .unwrap();
+        .await;
 }
 
 #[ignore = "ignored until we add framework for chain caches as we don't want to check these into the zingolib repo"]

--- a/pepper-sync/src/client/fetch.rs
+++ b/pepper-sync/src/client/fetch.rs
@@ -14,7 +14,8 @@ use zcash_client_backend::proto::{
         compact_tx_streamer_client::CompactTxStreamerClient,
     },
 };
-use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
+use zcash_primitives::transaction::TxId;
+use zcash_protocol::consensus::BlockHeight;
 
 use crate::client::FetchRequest;
 
@@ -224,6 +225,7 @@ async fn get_block_range(
             height: u64::from(block_range.end) - 1,
             hash: vec![],
         }),
+        pool_types: vec![],
     });
 
     request.set_timeout(HEAVY_UNARY_TIMEOUT);
@@ -251,6 +253,7 @@ async fn get_block_range_nullifiers(
             height: u64::from(block_range.end) - 1,
             hash: vec![],
         }),
+        pool_types: vec![],
     });
 
     request.set_timeout(HEAVY_UNARY_TIMEOUT);
@@ -371,6 +374,7 @@ async fn get_taddress_txs(
             height: u64::from(block_range.end) - 1,
             hash: vec![],
         }),
+        pool_types: vec![],
     });
 
     let mut request = tonic::Request::new(TransparentAddressBlockFilter { address, range });

--- a/pepper-sync/src/client/fetch.rs
+++ b/pepper-sync/src/client/fetch.rs
@@ -258,10 +258,13 @@ async fn get_block_range_nullifiers(
 
     request.set_timeout(HEAVY_UNARY_TIMEOUT);
 
+    #[allow(deprecated)]
+    let nullifier_range = client.get_block_range_nullifiers(request);
+
     let resp = call_with_timeout(
         "get_block_range_nullifiers (open)",
         STREAM_OPEN_TIMEOUT,
-        client.get_block_range_nullifiers(request),
+        nullifier_range,
     )
     .await?;
 

--- a/pepper-sync/src/error.rs
+++ b/pepper-sync/src/error.rs
@@ -3,8 +3,9 @@
 use std::{array::TryFromSliceError, convert::Infallible};
 
 use shardtree::error::ShardTreeError;
-use zcash_primitives::{block::BlockHash, consensus::BlockHeight, transaction::TxId};
+use zcash_primitives::{block::BlockHash, transaction::TxId};
 use zcash_protocol::PoolType;
+use zcash_protocol::consensus::BlockHeight;
 
 use crate::wallet::OutputId;
 

--- a/pepper-sync/src/scan.rs
+++ b/pepper-sync/src/scan.rs
@@ -10,8 +10,9 @@ use tokio::sync::mpsc;
 use incrementalmerkletree::Position;
 use zcash_client_backend::proto::compact_formats::{CompactBlock, CompactTx};
 use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::{transaction::TxId, zip32::AccountId};
+use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::{self, BlockHeight};
+use zip32::AccountId;
 
 use crate::{
     client::FetchRequest,

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -12,8 +12,9 @@ use zcash_client_backend::proto::compact_formats::{
 };
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_note_encryption::Domain;
-use zcash_primitives::{block::BlockHash, zip32::AccountId};
+use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{self, BlockHeight};
+use zip32::AccountId;
 
 use crate::{
     client::{self, FetchRequest},
@@ -359,7 +360,7 @@ fn calculate_sapling_leaves_and_retentions<D: Domain>(
             .enumerate()
             .map(|(output_index, output)| {
                 let note_commitment = CompactOutputDescription::try_from(output)
-                    .map_err(|()| ScanError::InvalidSaplingOutput)?
+                    .map_err(|_| ScanError::InvalidSaplingOutput)?
                     .cmu;
                 let leaf = sapling_crypto::Node::from_cmu(&note_commitment);
                 let decrypted: bool = incoming_output_indexes.contains(&(output_index as u16));
@@ -396,7 +397,7 @@ fn calculate_orchard_leaves_and_retentions<D: Domain>(
             .enumerate()
             .map(|(output_index, output)| {
                 let note_commitment = CompactAction::try_from(output)
-                    .map_err(|()| ScanError::InvalidOrchardAction)?
+                    .map_err(|_| ScanError::InvalidOrchardAction)?
                     .cmx();
                 let leaf = MerkleHashOrchard::from_cmx(&note_commitment);
                 let decrypted: bool = incoming_output_indexes.contains(&(output_index as u16));

--- a/pepper-sync/src/scan/compact_blocks/runners.rs
+++ b/pepper-sync/src/scan/compact_blocks/runners.rs
@@ -104,7 +104,7 @@ where
                     .iter()
                     .enumerate()
                     .map(|(i, output)| {
-                        CompactOutputDescription::try_from(output).map_err(|()| {
+                        CompactOutputDescription::try_from(output).map_err(|_| {
                             zcash_client_backend::scanning::ScanError::EncodingInvalid {
                                 at_height: block_height,
                                 txid,
@@ -124,7 +124,7 @@ where
                     .iter()
                     .enumerate()
                     .map(|(i, action)| {
-                        CompactAction::try_from(action).map_err(|()| {
+                        CompactAction::try_from(action).map_err(|_| {
                             zcash_client_backend::scanning::ScanError::EncodingInvalid {
                                 at_height: block_height,
                                 txid,

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -16,8 +16,9 @@ use tokio::{
 
 use zcash_client_backend::proto::compact_formats::CompactBlock;
 use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::{transaction::TxId, zip32::AccountId};
+use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::{self, BlockHeight};
+use zip32::AccountId;
 
 use crate::{
     client::{self, FetchRequest},

--- a/pepper-sync/src/scan/transactions.rs
+++ b/pepper-sync/src/scan/transactions.rs
@@ -13,7 +13,10 @@ use sapling_crypto::{
     bundle::{GrothProofBytes, OutputDescription},
     note_encryption::SaplingDomain,
 };
-use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
+use zcash_keys::{
+    address::UnifiedAddress,
+    keys::{OutgoingViewingKey, UnifiedFullViewingKey},
+};
 use zcash_note_encryption::{BatchDomain, Domain, ENC_CIPHERTEXT_SIZE, ShieldedOutput};
 use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::{
@@ -187,7 +190,12 @@ pub(crate) fn scan_transaction(
                         &dfvk.to_ivk(scope),
                     ),
                 ));
-                sapling_ovks.push((key_id, dfvk.to_ovk(scope)));
+                add_unified_ovk(
+                    &mut sapling_ovks,
+                    &mut orchard_ovks,
+                    key_id,
+                    dfvk.to_ovk(scope).into(),
+                );
             }
         }
 
@@ -198,8 +206,28 @@ pub(crate) fn scan_transaction(
                     key_id,
                     orchard::keys::PreparedIncomingViewingKey::new(&fvk.to_ivk(scope)),
                 ));
-                orchard_ovks.push((key_id, fvk.to_ovk(scope)));
+                add_unified_ovk(
+                    &mut sapling_ovks,
+                    &mut orchard_ovks,
+                    key_id,
+                    fvk.to_ovk(scope).into(),
+                );
             }
+        }
+
+        if let Some(tkeys) = ufvk.transparent() {
+            add_unified_ovk(
+                &mut sapling_ovks,
+                &mut orchard_ovks,
+                KeyId::from_parts(*account_id, Scope::External),
+                OutgoingViewingKey::from(tkeys.external_ovk().as_bytes()),
+            );
+            add_unified_ovk(
+                &mut sapling_ovks,
+                &mut orchard_ovks,
+                KeyId::from_parts(*account_id, Scope::Internal),
+                OutgoingViewingKey::from(tkeys.internal_ovk().as_bytes()),
+            );
         }
     }
 
@@ -327,6 +355,16 @@ pub(crate) fn scan_transaction(
         outgoing_sapling_notes,
         outgoing_orchard_notes,
     })
+}
+
+fn add_unified_ovk(
+    sapling_ovks: &mut Vec<(KeyId, sapling_crypto::keys::OutgoingViewingKey)>,
+    orchard_ovks: &mut Vec<(KeyId, orchard::keys::OutgoingViewingKey)>,
+    key_id: KeyId,
+    ovk: OutgoingViewingKey,
+) {
+    sapling_ovks.push((key_id, ovk.into()));
+    orchard_ovks.push((key_id, ovk.into()));
 }
 
 fn scan_incoming_coins<P: consensus::Parameters>(

--- a/pepper-sync/src/scan/transactions.rs
+++ b/pepper-sync/src/scan/transactions.rs
@@ -15,19 +15,19 @@ use sapling_crypto::{
 };
 use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
 use zcash_note_encryption::{BatchDomain, Domain, ENC_CIPHERTEXT_SIZE, ShieldedOutput};
-use zcash_primitives::{
-    memo::Memo,
-    transaction::{Transaction, TxId},
-    zip32::AccountId,
-};
+use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::{
     ShieldedProtocol,
     consensus::{self, BlockHeight, NetworkConstants},
+    memo::Memo,
 };
 
-use zcash_transparent::bundle::TxIn;
+use zcash_transparent::bundle::{
+    Authorization as TransparentAuthorization, Bundle as TransparentBundle, TxIn,
+};
 use zingo_memo::ParsedMemo;
 use zingo_status::confirmation_status::ConfirmationStatus;
+use zip32::AccountId;
 
 use crate::{
     client::{self, FetchRequest},
@@ -555,11 +555,11 @@ fn collect_nullifiers(
 }
 
 /// Adds the outpoints from a transparent bundle to the outpoint map.
-fn collect_outpoints<A: zcash_primitives::transaction::components::transparent::Authorization>(
+fn collect_outpoints<A: TransparentAuthorization>(
     outpoint_map: &mut BTreeMap<OutputId, ScanTarget>,
     txid: TxId,
     block_height: BlockHeight,
-    transparent_bundle: &zcash_primitives::transaction::components::transparent::Bundle<A>,
+    transparent_bundle: &TransparentBundle<A>,
 ) {
     transparent_bundle
         .vin

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -662,14 +662,10 @@ impl WalletTransaction {
             })
             .saturating_sub(self.total_output_value::<TransparentCoin>());
 
-        // TODO: it is not intended behaviour to create outgoing change notes. the logic must be changed to be resilient
-        // to this fix to zcash client backend
-        let sapling_value_sent = self
-            .total_outgoing_note_value::<OutgoingSaplingNote>()
-            .saturating_sub(self.total_output_value::<SaplingNote>());
-        let orchard_value_sent = self
-            .total_outgoing_note_value::<OutgoingOrchardNote>()
-            .saturating_sub(self.total_output_value::<OrchardNote>());
+        let sapling_value_sent =
+            self.total_external_outgoing_note_value::<OutgoingSaplingNote, SaplingNote>();
+        let orchard_value_sent =
+            self.total_external_outgoing_note_value::<OutgoingOrchardNote, OrchardNote>();
 
         transparent_value_sent + sapling_value_sent + orchard_value_sent
     }
@@ -696,6 +692,24 @@ impl WalletTransaction {
     pub fn total_outgoing_note_value<Op: OutgoingNoteInterface>(&self) -> u64 {
         Op::transaction_outgoing_notes(self)
             .iter()
+            .map(OutgoingNoteInterface::value)
+            .sum()
+    }
+
+    /// Returns total sum of outgoing note values for outputs that are not wallet-owned.
+    #[must_use]
+    pub fn total_external_outgoing_note_value<Outgoing, Incoming>(&self) -> u64
+    where
+        Outgoing: OutgoingNoteInterface,
+        Incoming: OutputInterface,
+    {
+        Outgoing::transaction_outgoing_notes(self)
+            .iter()
+            .filter(|outgoing_note| {
+                !Incoming::transaction_outputs(self)
+                    .iter()
+                    .any(|wallet_note| wallet_note.output_id() == outgoing_note.output_id())
+            })
             .map(OutgoingNoteInterface::value)
             .sum()
     }

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -21,17 +21,15 @@ use tokio::sync::mpsc;
 use zcash_address::unified::ParseError;
 use zcash_client_backend::proto::compact_formats::CompactBlock;
 use zcash_keys::{address::UnifiedAddress, encoding::encode_payment_address};
-use zcash_primitives::{
-    block::BlockHash,
-    memo::Memo,
-    transaction::{TxId, components::transparent::OutPoint},
-};
+use zcash_primitives::{block::BlockHash, transaction::TxId};
 use zcash_protocol::{
     PoolType, ShieldedProtocol,
     consensus::{self, BlockHeight},
+    memo::Memo,
     value::Zatoshis,
 };
 use zcash_transparent::address::Script;
+use zcash_transparent::bundle::OutPoint;
 
 use zingo_status::confirmation_status::ConfirmationStatus;
 

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -17,12 +17,12 @@ use zcash_client_backend::serialization::shardtree::{read_shard, write_shard};
 use zcash_encoding::{Optional, Vector};
 use zcash_primitives::{
     block::BlockHash,
-    memo::Memo,
     merkle_tree::HashSer,
     transaction::{Transaction, TxId},
 };
 use zcash_protocol::{
     consensus::{self, BlockHeight},
+    memo::Memo,
     value::Zatoshis,
 };
 use zcash_transparent::address::Script;

--- a/zingo-status/src/confirmation_status.rs
+++ b/zingo-status/src/confirmation_status.rs
@@ -185,7 +185,7 @@ impl ConfirmationStatus {
     ///
     /// ```
     /// use zingo_status::confirmation_status::ConfirmationStatus;
-    /// use zcash_primitives::consensus::BlockHeight;
+    /// use zcash_protocol::consensus::BlockHeight;
     ///
     /// assert!(ConfirmationStatus::Calculated(1.into()).is_pending());
     /// assert!(ConfirmationStatus::Transmitted(1.into()).is_pending());
@@ -206,7 +206,7 @@ impl ConfirmationStatus {
     ///
     /// ```
     /// use zingo_status::confirmation_status::ConfirmationStatus;
-    /// use zcash_primitives::consensus::BlockHeight;
+    /// use zcash_protocol::consensus::BlockHeight;
     ///
     /// assert!(!ConfirmationStatus::Calculated(1.into()).is_failed());
     /// assert!(!ConfirmationStatus::Transmitted(1.into()).is_failed());

--- a/zingolib/src/data.rs
+++ b/zingolib/src/data.rs
@@ -49,7 +49,7 @@ pub mod receivers {
         fn from(receiver: Receiver) -> Self {
             Payment::new(
                 receiver.recipient_address,
-                receiver.amount,
+                Some(receiver.amount),
                 receiver.memo,
                 None,
                 None,

--- a/zingolib/src/data/proposal.rs
+++ b/zingolib/src/data/proposal.rs
@@ -45,7 +45,8 @@ pub fn total_payment_amount(proposal: &ProportionalFeeProposal) -> Result<Zatosh
         .iter()
         .map(zcash_client_backend::proposal::Step::transaction_request)
         .try_fold(Zatoshis::ZERO, |acc, request| {
-            (acc + request.total()?).ok_or(BalanceError::Overflow)
+            let total = request.total()?.ok_or(BalanceError::Overflow)?;
+            (acc + total).ok_or(BalanceError::Overflow)
         })
 }
 

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -7,8 +7,8 @@ use bip0039::Mnemonic;
 
 use zcash_client_backend::tor;
 use zcash_keys::address::UnifiedAddress;
-use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-use zcash_protocol::consensus::Parameters;
+use zcash_primitives::transaction::TxId;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zcash_transparent::keys::NonHardenedChildIndex;
 
 use pepper_sync::keys::transparent::{self, TransparentScope};

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -5,8 +5,8 @@ use std::convert::Infallible;
 use pepper_sync::{error::ScanError, wallet::OutputId};
 use shardtree::error::ShardTreeError;
 use zcash_keys::keys::DerivationError;
-use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
-use zcash_protocol::{PoolType, ShieldedProtocol};
+use zcash_primitives::transaction::TxId;
+use zcash_protocol::{PoolType, ShieldedProtocol, consensus::BlockHeight};
 
 use super::output::OutputRef;
 

--- a/zingolib/src/wallet/legacy.rs
+++ b/zingolib/src/wallet/legacy.rs
@@ -17,10 +17,12 @@ use zcash_client_backend::{
 };
 use zcash_encoding::{CompactSize, Optional, Vector};
 use zcash_primitives::{
-    consensus::BlockHeight,
-    memo::{Memo, MemoBytes},
     merkle_tree::{HashSer, read_commitment_tree, read_incremental_witness},
     transaction::TxId,
+};
+use zcash_protocol::{
+    consensus::BlockHeight,
+    memo::{Memo, MemoBytes},
 };
 use zingo_status::confirmation_status::ConfirmationStatus;
 

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -57,6 +57,7 @@ impl LightWallet {
             request,
             // TODO: replace wallet min_confirmations field with confirmation policy to unify for all proposals
             ConfirmationsPolicy::new_symmetrical(self.wallet_settings.min_confirmations, false),
+            None,
         )
         .map_err(ProposeSendError::Proposal)
     }
@@ -114,6 +115,7 @@ impl LightWallet {
             account_id,
             // TODO: replace wallet min_confirmations field with confirmation policy to unify for all proposals
             ConfirmationsPolicy::new_symmetrical(self.wallet_settings.min_confirmations, false),
+            zcash_client_backend::data_api::TransparentOutputFilter::All,
         )
         .map_err(ProposeShieldError::Component)?;
 

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -81,6 +81,7 @@ impl LightWallet {
             &SpendingKeys::new(usk),
             zcash_client_backend::wallet::OvkPolicy::Sender,
             &proposal,
+            None,
         )
         .map_err(CalculateTransactionError::Calculation)
     }
@@ -225,7 +226,7 @@ mod tests {
             transaction_request_from_receivers(rec).expect("rec can requestify");
 
         assert_eq!(
-            request.total().expect("total"),
+            request.total().expect("total").expect("amounts present"),
             (amount_1 + amount_2).expect("add")
         );
     }

--- a/zingolib/src/wallet/utils.rs
+++ b/zingolib/src/wallet/utils.rs
@@ -4,7 +4,8 @@ use std::{
     io::{self, Read, Write},
     path::PathBuf,
 };
-use zcash_primitives::{memo::MemoBytes, transaction::TxId};
+use zcash_primitives::transaction::TxId;
+use zcash_protocol::memo::MemoBytes;
 
 /// TODO: Add Doc Comment Here!
 pub fn read_string<R: Read>(mut reader: R) -> io::Result<String> {

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -6,10 +6,12 @@ use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
         Account, AccountBirthday, AccountPurpose, Balance, BlockMetadata, InputSource,
-        NullifierQuery, ORCHARD_SHARD_HEIGHT, ReceivedNotes, SAPLING_SHARD_HEIGHT, TargetValue,
-        TransactionDataRequest, WalletCommitmentTrees, WalletRead, WalletSummary, WalletUtxo,
+        NullifierQuery, ORCHARD_SHARD_HEIGHT, ReceivedNotes, ReceivedTransactionOutput,
+        SAPLING_SHARD_HEIGHT, TargetValue, TransactionDataRequest, TransparentKeyOrigin,
+        TransparentOutputFilter, WalletCommitmentTrees, WalletRead, WalletSummary, WalletUtxo,
         WalletWrite, Zip32Derivation,
-        chain::CommitmentTreeRoot,
+        chain::{ChainState, CommitmentTreeRoot},
+        error::FindAccountForAddressError,
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     wallet::{Exposure, NoteId, ReceivedNote, TransparentAddressMetadata, WalletTransparentOutput},
@@ -17,12 +19,12 @@ use zcash_client_backend::{
 use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
 use zcash_primitives::{
     block::BlockHash,
-    memo::Memo,
     transaction::{Transaction, TxId},
 };
 use zcash_protocol::{
     PoolType, ShieldedProtocol,
     consensus::{self, BlockHeight, Parameters},
+    memo::Memo,
 };
 use zcash_transparent::address::TransparentAddress;
 use zcash_transparent::bundle::{OutPoint, TxOut};
@@ -62,6 +64,10 @@ impl Account for ZingoAccount {
     }
 
     fn uivk(&self) -> zcash_keys::keys::UnifiedIncomingViewingKey {
+        unimplemented!()
+    }
+
+    fn birthday_height(&self) -> BlockHeight {
         unimplemented!()
     }
 }
@@ -305,7 +311,7 @@ impl WalletRead for LightWallet {
         _account: Self::AccountId,
         _max_height: TargetHeight,
         _confirmations_policy: ConfirmationsPolicy,
-    ) -> Result<HashMap<TransparentAddress, (TransparentKeyScope, Balance)>, Self::Error> {
+    ) -> Result<HashMap<TransparentAddress, (TransparentKeyOrigin, Balance)>, Self::Error> {
         unimplemented!()
     }
 
@@ -336,6 +342,23 @@ impl WalletRead for LightWallet {
     }
 
     fn transaction_data_requests(&self) -> Result<Vec<TransactionDataRequest>, Self::Error> {
+        unimplemented!()
+    }
+
+    fn find_account_for_address<P: Parameters>(
+        &self,
+        _params: &P,
+        _address: &zcash_keys::address::Address,
+    ) -> Result<Option<Self::AccountId>, FindAccountForAddressError<Self::Error>> {
+        unimplemented!()
+    }
+
+    fn get_received_outputs(
+        &self,
+        _txid: TxId,
+        _target_height: TargetHeight,
+        _confirmations_policy: ConfirmationsPolicy,
+    ) -> Result<Vec<ReceivedTransactionOutput>, Self::Error> {
         unimplemented!()
     }
 }
@@ -417,7 +440,10 @@ impl WalletWrite for LightWallet {
 
     fn store_decrypted_tx(
         &mut self,
-        _received_tx: zcash_client_backend::data_api::DecryptedTransaction<Self::AccountId>,
+        _received_tx: zcash_client_backend::data_api::DecryptedTransaction<
+            Transaction,
+            Self::AccountId,
+        >,
     ) -> Result<(), Self::Error> {
         unimplemented!()
     }
@@ -469,6 +495,14 @@ impl WalletWrite for LightWallet {
     }
 
     fn truncate_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+        unimplemented!()
+    }
+
+    fn truncate_to_chain_state(&mut self, _chain_state: ChainState) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    fn rewind_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
         unimplemented!()
     }
 
@@ -831,6 +865,7 @@ impl InputSource for LightWallet {
         address: &TransparentAddress,
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
+        _output_filter: TransparentOutputFilter,
     ) -> Result<Vec<WalletUtxo>, Self::Error> {
         let address = transparent::encode_address(&self.chain_type, *address);
 


### PR DESCRIPTION
## Summary
- update librustzcash dependencies to the released corez-based line
- point zingo-netutils and infrastructure test dependencies at the companion corez migration branches
- use workspace zingo-memo and zingo-status so they inherit the updated dependency graph
- apply initial pepper-sync import and lightwallet protocol updates for the new crate layout

## Companion PRs
- zingolabs/zingo-common#69
- zingolabs/infrastructure#261

## Verification
- cargo tree -i core2 --locked --offline exits with no matching package

## Current status
This is a draft because the dependency graph is core2-free, but the full workspace check still needs the zcash_client_backend 0.22 wallet API migration. Current remaining failures are in zingolib wallet/data-api implementations: missing new WalletRead/WalletWrite trait methods, TransparentKeyOrigin/TransparentOutputFilter updates, TxVersion parameters, and ZIP-321 amount API changes.