### PR TITLE
Use lightwallet-protocol in pepper-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,6 +4073,7 @@ dependencies = [
  "incrementalmerkletree",
  "json",
  "jubjub",
+ "lightwallet-protocol",
  "memuse",
  "orchard",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4070,6 +4070,7 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "futures",
+ "hex",
  "incrementalmerkletree",
  "json",
  "jubjub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4087,14 +4087,13 @@ dependencies = [
  "tonic",
  "tracing",
  "zcash_address",
- "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_transparent",
- "zingo-memo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zingo-memo",
  "zingo-status 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip32",
 ]
@@ -9293,19 +9292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zingo-memo"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4152c6c9ac701ef82b82deca2b5db7bbf70583c04031f97423bf9f850d74e4a"
-dependencies = [
- "zcash_address",
- "zcash_client_backend",
- "zcash_encoding",
- "zcash_keys",
- "zcash_primitives",
-]
-
-[[package]]
 name = "zingo-netutils"
 version = "4.0.0"
 source = "git+https://github.com/zingolabs/zingo-common?branch=indexer_trait#7c580435f301518dfb26cf004e9f583c1f6ac82d"
@@ -9422,7 +9408,7 @@ dependencies = [
  "zcash_proofs",
  "zcash_protocol",
  "zcash_transparent",
- "zingo-memo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zingo-memo",
  "zingo-netutils",
  "zingo-price",
  "zingo-status 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ resolver = "2"
 ### Workspace
 # pepper-sync = "0.2.0"
 pepper-sync = { path = "pepper-sync" } # NOTE: for development between releases
-# zingo-memo = { path = "zingo-memo" } # NOTE: for development between releases
-zingo-memo = "0.1.0"
+zingo-memo = { path = "zingo-memo" }
 zingo-price = { path = "zingo-price" }
 # zingo-status = { path = "zingo-status" } # NOTE: for development between releases
 zingo-status = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tracing-subscriber = "0.3"
 ### Zingo-common
 zingo-netutils = { git = "https://github.com/zingolabs/zingo-common", branch = "indexer_trait", features = ["back_compatible", "globally-public-transparent"] }
 zingo_common_components = "0.3.0"
+lightwallet-protocol = "0.3.0"
 
 ### Zcash
 incrementalmerkletree = "0.8.2"

--- a/pepper-sync/CHANGELOG.md
+++ b/pepper-sync/CHANGELOG.md
@@ -19,8 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `error::ServerError::recovery_recommendation()` — server-level recovery classification.
 
 ### Changed
+- Proto-generated lightwallet types and `CompactTxStreamerClient` now come from
+  `lightwallet-protocol` instead of `zcash_client_backend`.
+- Local compatibility helpers now provide compact block, compact transaction,
+  tree state, and shard serialization behavior previously imported from
+  `zcash_client_backend`.
 
 ### Removed
+- Direct and transitive `zcash_client_backend` dependency from `pepper-sync`.
 
 ## [0.3.0]
 

--- a/pepper-sync/Cargo.toml
+++ b/pepper-sync/Cargo.toml
@@ -22,6 +22,7 @@ test-features = []
 
 [dependencies]
 # Zingo
+lightwallet-protocol.workspace = true
 zingo-memo.workspace = true
 zingo-status.workspace = true
 

--- a/pepper-sync/Cargo.toml
+++ b/pepper-sync/Cargo.toml
@@ -32,9 +32,6 @@ orchard.workspace = true
 sapling-crypto.workspace = true
 shardtree.workspace = true
 zcash_address.workspace = true
-zcash_client_backend = { workspace = true, features = [
-    "unstable-serialization",
-] }
 zcash_encoding = { workspace = true, optional = true }
 zcash_keys.workspace = true
 zcash_note_encryption.workspace = true

--- a/pepper-sync/Cargo.toml
+++ b/pepper-sync/Cargo.toml
@@ -75,6 +75,7 @@ json.workspace = true
 
 # Serialization
 byteorder = { workspace = true, optional = true }
+hex.workspace = true
 
 # Documentation
 simple-mermaid.workspace = true

--- a/pepper-sync/src/client.rs
+++ b/pepper-sync/src/client.rs
@@ -11,15 +11,14 @@ use std::{
 
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
-use zcash_client_backend::data_api::chain::ChainState;
 use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::consensus::{self, BlockHeight};
 
 use crate::{
     error::{MempoolError, ServerError},
     lightwallet::{
-        BlockId, CompactBlock, CompactTxStreamerClient, GetAddressUtxosReply, RawTransaction,
-        TreeState, TreeStateExt,
+        BlockId, ChainState, CompactBlock, CompactTxStreamerClient, GetAddressUtxosReply,
+        RawTransaction, TreeState, TreeStateExt,
     },
 };
 

--- a/pepper-sync/src/client.rs
+++ b/pepper-sync/src/client.rs
@@ -11,23 +11,20 @@ use std::{
 
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
-use zcash_client_backend::{
-    data_api::chain::ChainState,
-    proto::{
-        compact_formats::CompactBlock,
-        service::{
-            BlockId, GetAddressUtxosReply, RawTransaction, TreeState,
-            compact_tx_streamer_client::CompactTxStreamerClient,
-        },
-    },
-};
+use zcash_client_backend::data_api::chain::ChainState;
 use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::consensus::{self, BlockHeight};
 
-#[cfg(not(feature = "darkside_test"))]
-use zcash_client_backend::proto::service::SubtreeRoot;
+use crate::{
+    error::{MempoolError, ServerError},
+    lightwallet::{
+        BlockId, CompactBlock, CompactTxStreamerClient, GetAddressUtxosReply, RawTransaction,
+        TreeState, TreeStateExt,
+    },
+};
 
-use crate::error::{MempoolError, ServerError};
+#[cfg(not(feature = "darkside_test"))]
+use crate::lightwallet::SubtreeRoot;
 
 pub(crate) mod fetch;
 

--- a/pepper-sync/src/client/fetch.rs
+++ b/pepper-sync/src/client/fetch.rs
@@ -6,24 +6,22 @@ use tokio::sync::mpsc::UnboundedReceiver;
 
 use tonic::transport::Channel;
 use tracing::instrument;
-use zcash_client_backend::proto::{
-    compact_formats::CompactBlock,
-    service::{
-        BlockId, BlockRange, ChainSpec, GetAddressUtxosArg, GetAddressUtxosReply, RawTransaction,
-        TransparentAddressBlockFilter, TreeState, TxFilter,
-        compact_tx_streamer_client::CompactTxStreamerClient,
-    },
-};
 use zcash_primitives::{consensus::BlockHeight, transaction::TxId};
 
-use crate::client::FetchRequest;
+use crate::{
+    client::FetchRequest,
+    lightwallet::{
+        BlockId, BlockRange, ChainSpec, CompactBlock, CompactTxStreamerClient, GetAddressUtxosArg,
+        GetAddressUtxosReply, RawTransaction, TransparentAddressBlockFilter, TreeState, TxFilter,
+    },
+};
 
 const UNARY_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 const STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 const HEAVY_UNARY_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[cfg(not(feature = "darkside_test"))]
-use zcash_client_backend::proto::service::{GetSubtreeRootsArg, SubtreeRoot};
+use crate::lightwallet::{GetSubtreeRootsArg, SubtreeRoot};
 
 async fn call_with_timeout<T, F>(
     what: &'static str,
@@ -224,6 +222,7 @@ async fn get_block_range(
             height: u64::from(block_range.end) - 1,
             hash: vec![],
         }),
+        pool_types: vec![],
     });
 
     request.set_timeout(HEAVY_UNARY_TIMEOUT);
@@ -251,6 +250,7 @@ async fn get_block_range_nullifiers(
             height: u64::from(block_range.end) - 1,
             hash: vec![],
         }),
+        pool_types: vec![],
     });
 
     request.set_timeout(HEAVY_UNARY_TIMEOUT);
@@ -371,6 +371,7 @@ async fn get_taddress_txs(
             height: u64::from(block_range.end) - 1,
             hash: vec![],
         }),
+        pool_types: vec![],
     });
 
     let mut request = tonic::Request::new(TransparentAddressBlockFilter { address, range });
@@ -392,7 +393,7 @@ async fn get_taddress_txs(
 pub(crate) async fn get_mempool_stream(
     client: &mut CompactTxStreamerClient<Channel>,
 ) -> Result<tonic::Streaming<RawTransaction>, tonic::Status> {
-    let mut request = tonic::Request::new(zcash_client_backend::proto::service::Empty {});
+    let mut request = tonic::Request::new(crate::lightwallet::Empty {});
     request.set_timeout(HEAVY_UNARY_TIMEOUT);
 
     let resp = call_with_timeout(

--- a/pepper-sync/src/client/fetch.rs
+++ b/pepper-sync/src/client/fetch.rs
@@ -255,6 +255,7 @@ async fn get_block_range_nullifiers(
 
     request.set_timeout(HEAVY_UNARY_TIMEOUT);
 
+    #[allow(deprecated)]
     let resp = call_with_timeout(
         "get_block_range_nullifiers (open)",
         STREAM_OPEN_TIMEOUT,

--- a/pepper-sync/src/error.rs
+++ b/pepper-sync/src/error.rs
@@ -4,7 +4,7 @@ use std::{array::TryFromSliceError, convert::Infallible};
 
 use shardtree::error::ShardTreeError;
 use zcash_primitives::{block::BlockHash, consensus::BlockHeight, transaction::TxId};
-use zcash_protocol::PoolType;
+use zcash_protocol::{PoolType, ShieldedProtocol};
 
 use crate::wallet::OutputId;
 
@@ -197,9 +197,20 @@ pub enum ScanError {
     /// Continuity error.
     #[error("continuity error. {0}")]
     ContinuityError(#[from] ContinuityError),
-    /// Zcash client backend scan error
-    #[error("{0}")]
-    ZcbScanError(zcash_client_backend::scanning::ScanError),
+    /// Invalid compact output encoding.
+    #[error(
+        "invalid {pool_type:?} compact output encoding at height {at_height}, txid {txid}, output index {index}"
+    )]
+    EncodingInvalid {
+        /// Block height.
+        at_height: BlockHeight,
+        /// Transaction ID.
+        txid: TxId,
+        /// Shielded pool.
+        pool_type: ShieldedProtocol,
+        /// Output index.
+        index: usize,
+    },
     /// Invalid sapling nullifier
     #[error("invalid sapling nullifier. {0}")]
     InvalidSaplingNullifier(#[from] TryFromSliceError),

--- a/pepper-sync/src/lib.rs
+++ b/pepper-sync/src/lib.rs
@@ -108,6 +108,7 @@ pub(crate) mod client;
 pub mod config;
 pub mod error;
 pub mod keys;
+pub(crate) mod lightwallet;
 pub(crate) mod scan;
 pub mod sync;
 pub mod wallet;

--- a/pepper-sync/src/lightwallet.rs
+++ b/pepper-sync/src/lightwallet.rs
@@ -1,4 +1,7 @@
-use zcash_primitives::{block::BlockHash, transaction::TxId};
+use incrementalmerkletree::frontier::CommitmentTree;
+use zcash_client_backend::data_api::chain::ChainState;
+use zcash_note_encryption::EphemeralKeyBytes;
+use zcash_primitives::{block::BlockHash, merkle_tree::read_commitment_tree, transaction::TxId};
 use zcash_protocol::consensus::BlockHeight;
 
 pub(crate) use lightwallet_protocol::*;
@@ -6,6 +9,7 @@ pub(crate) use lightwallet_protocol::*;
 pub(crate) trait CompactBlockExt {
     fn hash(&self) -> BlockHash;
     fn height(&self) -> BlockHeight;
+    fn prev_hash(&self) -> BlockHash;
 }
 
 impl CompactBlockExt for CompactBlock {
@@ -17,6 +21,10 @@ impl CompactBlockExt for CompactBlock {
         self.height
             .try_into()
             .expect("block height must fit in u32")
+    }
+
+    fn prev_hash(&self) -> BlockHash {
+        BlockHash::from_slice(&self.prev_hash)
     }
 }
 
@@ -33,4 +41,125 @@ impl CompactTxExt for CompactTx {
             .expect("txid must be 32 bytes");
         TxId::from_bytes(txid)
     }
+}
+
+pub(crate) trait TreeStateExt {
+    fn to_chain_state(&self) -> std::io::Result<ChainState>;
+}
+
+impl TreeStateExt for TreeState {
+    fn to_chain_state(&self) -> std::io::Result<ChainState> {
+        let mut hash_bytes = hex::decode(&self.hash).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Block hash is not valid hex: {e:?}"),
+            )
+        })?;
+        hash_bytes.reverse();
+
+        Ok(ChainState::new(
+            self.height.try_into().map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid block height")
+            })?,
+            BlockHash::try_from_slice(&hash_bytes).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid block hash length.",
+                )
+            })?,
+            sapling_tree(self)?.to_frontier(),
+            orchard_tree(self)?.to_frontier(),
+        ))
+    }
+}
+
+fn sapling_tree(
+    tree_state: &TreeState,
+) -> std::io::Result<
+    CommitmentTree<sapling_crypto::Node, { sapling_crypto::NOTE_COMMITMENT_TREE_DEPTH }>,
+> {
+    if tree_state.sapling_tree.is_empty() {
+        Ok(CommitmentTree::empty())
+    } else {
+        let tree_bytes = hex::decode(&tree_state.sapling_tree).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Hex decoding of Sapling tree bytes failed: {e:?}"),
+            )
+        })?;
+        read_commitment_tree::<
+            sapling_crypto::Node,
+            _,
+            { sapling_crypto::NOTE_COMMITMENT_TREE_DEPTH },
+        >(&tree_bytes[..])
+    }
+}
+
+fn orchard_tree(
+    tree_state: &TreeState,
+) -> std::io::Result<
+    CommitmentTree<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>,
+> {
+    if tree_state.orchard_tree.is_empty() {
+        Ok(CommitmentTree::empty())
+    } else {
+        let tree_bytes = hex::decode(&tree_state.orchard_tree).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Hex decoding of Orchard tree bytes failed: {e:?}"),
+            )
+        })?;
+        read_commitment_tree::<
+            orchard::tree::MerkleHashOrchard,
+            _,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >(&tree_bytes[..])
+    }
+}
+
+pub(crate) fn sapling_output_description(
+    output: &CompactSaplingOutput,
+) -> Result<sapling_crypto::note_encryption::CompactOutputDescription, ()> {
+    Ok(sapling_crypto::note_encryption::CompactOutputDescription {
+        cmu: sapling_cmu(output)?,
+        ephemeral_key: ephemeral_key(&output.ephemeral_key)?,
+        enc_ciphertext: output.ciphertext[..].try_into().map_err(|_| ())?,
+    })
+}
+
+fn sapling_cmu(
+    output: &CompactSaplingOutput,
+) -> Result<sapling_crypto::note::ExtractedNoteCommitment, ()> {
+    let repr: [u8; 32] = output.cmu[..].try_into().map_err(|_| ())?;
+    Option::from(sapling_crypto::note::ExtractedNoteCommitment::from_bytes(
+        &repr,
+    ))
+    .ok_or(())
+}
+
+pub(crate) fn orchard_compact_action(
+    action: &CompactOrchardAction,
+) -> Result<orchard::note_encryption::CompactAction, ()> {
+    Ok(orchard::note_encryption::CompactAction::from_parts(
+        orchard_nf(action)?,
+        orchard_cmx(action)?,
+        ephemeral_key(&action.ephemeral_key)?,
+        action.ciphertext[..].try_into().map_err(|_| ())?,
+    ))
+}
+
+fn orchard_cmx(
+    action: &CompactOrchardAction,
+) -> Result<orchard::note::ExtractedNoteCommitment, ()> {
+    let cmx: [u8; 32] = action.cmx[..].try_into().map_err(|_| ())?;
+    Option::from(orchard::note::ExtractedNoteCommitment::from_bytes(&cmx)).ok_or(())
+}
+
+fn orchard_nf(action: &CompactOrchardAction) -> Result<orchard::note::Nullifier, ()> {
+    let nf: [u8; 32] = action.nullifier[..].try_into().map_err(|_| ())?;
+    Option::from(orchard::note::Nullifier::from_bytes(&nf)).ok_or(())
+}
+
+fn ephemeral_key(bytes: &[u8]) -> Result<EphemeralKeyBytes, ()> {
+    bytes.try_into().map(EphemeralKeyBytes).map_err(|_| ())
 }

--- a/pepper-sync/src/lightwallet.rs
+++ b/pepper-sync/src/lightwallet.rs
@@ -1,10 +1,46 @@
-use incrementalmerkletree::frontier::CommitmentTree;
-use zcash_client_backend::data_api::chain::ChainState;
+use incrementalmerkletree::frontier::{CommitmentTree, Frontier};
 use zcash_note_encryption::EphemeralKeyBytes;
 use zcash_primitives::{block::BlockHash, merkle_tree::read_commitment_tree, transaction::TxId};
 use zcash_protocol::consensus::BlockHeight;
 
 pub(crate) use lightwallet_protocol::*;
+
+pub(crate) struct ChainState {
+    sapling_tree: Frontier<sapling_crypto::Node, { sapling_crypto::NOTE_COMMITMENT_TREE_DEPTH }>,
+    orchard_tree:
+        Frontier<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>,
+}
+
+impl ChainState {
+    fn new(
+        sapling_tree: Frontier<
+            sapling_crypto::Node,
+            { sapling_crypto::NOTE_COMMITMENT_TREE_DEPTH },
+        >,
+        orchard_tree: Frontier<
+            orchard::tree::MerkleHashOrchard,
+            { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
+        >,
+    ) -> Self {
+        Self {
+            sapling_tree,
+            orchard_tree,
+        }
+    }
+
+    pub(crate) fn final_sapling_tree(
+        &self,
+    ) -> &Frontier<sapling_crypto::Node, { sapling_crypto::NOTE_COMMITMENT_TREE_DEPTH }> {
+        &self.sapling_tree
+    }
+
+    pub(crate) fn final_orchard_tree(
+        &self,
+    ) -> &Frontier<orchard::tree::MerkleHashOrchard, { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 }>
+    {
+        &self.orchard_tree
+    }
+}
 
 pub(crate) trait CompactBlockExt {
     fn hash(&self) -> BlockHash;
@@ -49,24 +85,14 @@ pub(crate) trait TreeStateExt {
 
 impl TreeStateExt for TreeState {
     fn to_chain_state(&self) -> std::io::Result<ChainState> {
-        let mut hash_bytes = hex::decode(&self.hash).map_err(|e| {
+        hex::decode(&self.hash).map_err(|e| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("Block hash is not valid hex: {e:?}"),
             )
         })?;
-        hash_bytes.reverse();
 
         Ok(ChainState::new(
-            self.height.try_into().map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid block height")
-            })?,
-            BlockHash::try_from_slice(&hash_bytes).ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "Invalid block hash length.",
-                )
-            })?,
             sapling_tree(self)?.to_frontier(),
             orchard_tree(self)?.to_frontier(),
         ))

--- a/pepper-sync/src/lightwallet.rs
+++ b/pepper-sync/src/lightwallet.rs
@@ -1,0 +1,36 @@
+use zcash_primitives::{block::BlockHash, transaction::TxId};
+use zcash_protocol::consensus::BlockHeight;
+
+pub(crate) use lightwallet_protocol::*;
+
+pub(crate) trait CompactBlockExt {
+    fn hash(&self) -> BlockHash;
+    fn height(&self) -> BlockHeight;
+}
+
+impl CompactBlockExt for CompactBlock {
+    fn hash(&self) -> BlockHash {
+        BlockHash::from_slice(&self.hash)
+    }
+
+    fn height(&self) -> BlockHeight {
+        self.height
+            .try_into()
+            .expect("block height must fit in u32")
+    }
+}
+
+pub(crate) trait CompactTxExt {
+    fn txid(&self) -> TxId;
+}
+
+impl CompactTxExt for CompactTx {
+    fn txid(&self) -> TxId {
+        let txid: [u8; 32] = self
+            .txid
+            .as_slice()
+            .try_into()
+            .expect("txid must be 32 bytes");
+        TxId::from_bytes(txid)
+    }
+}

--- a/pepper-sync/src/scan.rs
+++ b/pepper-sync/src/scan.rs
@@ -8,7 +8,6 @@ use task::ScanTask;
 use tokio::sync::mpsc;
 
 use incrementalmerkletree::Position;
-use zcash_client_backend::proto::compact_formats::{CompactBlock, CompactTx};
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::{transaction::TxId, zip32::AccountId};
 use zcash_protocol::consensus::{self, BlockHeight};
@@ -16,6 +15,7 @@ use zcash_protocol::consensus::{self, BlockHeight};
 use crate::{
     client::FetchRequest,
     error::{ScanError, ServerError},
+    lightwallet::{CompactBlock, CompactBlockExt, CompactTx, CompactTxExt},
     sync::ScanPriority,
     wallet::{NullifierMap, OutputId, ScanTarget, WalletBlock, WalletTransaction},
     witness::{self, LocatedTreeData, WitnessData},

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -4,12 +4,9 @@ use std::{
 };
 
 use incrementalmerkletree::{Marking, Position, Retention};
-use orchard::{note_encryption::CompactAction, tree::MerkleHashOrchard};
-use sapling_crypto::{Node, note_encryption::CompactOutputDescription};
+use orchard::tree::MerkleHashOrchard;
+use sapling_crypto::Node;
 use tokio::sync::mpsc;
-use zcash_client_backend::proto::compact_formats::{
-    CompactBlock, CompactOrchardAction, CompactSaplingOutput,
-};
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_note_encryption::Domain;
 use zcash_primitives::{block::BlockHash, zip32::AccountId};
@@ -19,6 +16,10 @@ use crate::{
     client::{self, FetchRequest},
     error::{ContinuityError, ScanError, ServerError},
     keys::{KeyId, ScanningKeyOps, ScanningKeys},
+    lightwallet::{
+        CompactBlock, CompactBlockExt, CompactOrchardAction, CompactSaplingOutput, CompactTxExt,
+        orchard_compact_action, sapling_output_description,
+    },
     wallet::{NullifierMap, OutputId, ScanTarget, TreeBounds, WalletBlock},
     witness::WitnessData,
 };
@@ -149,11 +150,7 @@ where
             block_hash: block.hash(),
             prev_hash: block.prev_hash(),
             time: block.time,
-            txids: block
-                .vtx
-                .iter()
-                .map(zcash_client_backend::proto::compact_formats::CompactTx::txid)
-                .collect(),
+            txids: block.vtx.iter().map(CompactTxExt::txid).collect(),
             tree_bounds: TreeBounds {
                 sapling_initial_tree_size,
                 sapling_final_tree_size,
@@ -358,7 +355,7 @@ fn calculate_sapling_leaves_and_retentions<D: Domain>(
             .iter()
             .enumerate()
             .map(|(output_index, output)| {
-                let note_commitment = CompactOutputDescription::try_from(output)
+                let note_commitment = sapling_output_description(output)
                     .map_err(|()| ScanError::InvalidSaplingOutput)?
                     .cmu;
                 let leaf = sapling_crypto::Node::from_cmu(&note_commitment);
@@ -395,7 +392,7 @@ fn calculate_orchard_leaves_and_retentions<D: Domain>(
             .iter()
             .enumerate()
             .map(|(output_index, output)| {
-                let note_commitment = CompactAction::try_from(output)
+                let note_commitment = orchard_compact_action(output)
                     .map_err(|()| ScanError::InvalidOrchardAction)?
                     .cmx();
                 let leaf = MerkleHashOrchard::from_cmx(&note_commitment);

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -184,9 +184,7 @@ where
 {
     let mut runners = BatchRunners::<(), ()>::for_keys(trial_decrypt_task_size, scanning_keys);
     for block in compact_blocks {
-        runners
-            .add_block(consensus_parameters, block.clone())
-            .map_err(ScanError::ZcbScanError)?;
+        runners.add_block(consensus_parameters, block.clone())?;
     }
     runners.flush();
 

--- a/pepper-sync/src/scan/compact_blocks/runners.rs
+++ b/pepper-sync/src/scan/compact_blocks/runners.rs
@@ -17,6 +17,7 @@ use zcash_protocol::{ShieldedProtocol, consensus};
 
 use memuse::DynamicUsage;
 
+use crate::error::ScanError;
 use crate::keys::KeyId;
 use crate::keys::ScanningKeyOps as _;
 use crate::keys::ScanningKeys;
@@ -83,11 +84,7 @@ where
     }
 
     #[tracing::instrument(skip_all, fields(height = block.height))]
-    pub(crate) fn add_block<P>(
-        &mut self,
-        params: &P,
-        block: CompactBlock,
-    ) -> Result<(), zcash_client_backend::scanning::ScanError>
+    pub(crate) fn add_block<P>(&mut self, params: &P, block: CompactBlock) -> Result<(), ScanError>
     where
         P: consensus::Parameters + Send + 'static,
     {
@@ -107,7 +104,7 @@ where
                     .enumerate()
                     .map(|(i, output)| {
                         sapling_output_description(output).map_err(|()| {
-                            zcash_client_backend::scanning::ScanError::EncodingInvalid {
+                            ScanError::EncodingInvalid {
                                 at_height: block_height,
                                 txid,
                                 pool_type: ShieldedProtocol::Sapling,
@@ -126,13 +123,11 @@ where
                     .iter()
                     .enumerate()
                     .map(|(i, action)| {
-                        orchard_compact_action(action).map_err(|()| {
-                            zcash_client_backend::scanning::ScanError::EncodingInvalid {
-                                at_height: block_height,
-                                txid,
-                                pool_type: ShieldedProtocol::Orchard,
-                                index: i,
-                            }
+                        orchard_compact_action(action).map_err(|()| ScanError::EncodingInvalid {
+                            at_height: block_height,
+                            txid,
+                            pool_type: ShieldedProtocol::Orchard,
+                            index: i,
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?,

--- a/pepper-sync/src/scan/compact_blocks/runners.rs
+++ b/pepper-sync/src/scan/compact_blocks/runners.rs
@@ -7,9 +7,8 @@ use std::sync::atomic::AtomicUsize;
 
 use crossbeam_channel as channel;
 
-use orchard::note_encryption::{CompactAction, OrchardDomain};
-use sapling_crypto::note_encryption::{CompactOutputDescription, SaplingDomain};
-use zcash_client_backend::proto::compact_formats::CompactBlock;
+use orchard::note_encryption::OrchardDomain;
+use sapling_crypto::note_encryption::SaplingDomain;
 use zcash_note_encryption::{BatchDomain, COMPACT_NOTE_SIZE, Domain, ShieldedOutput, batch};
 use zcash_primitives::{
     block::BlockHash, transaction::TxId, transaction::components::sapling::zip212_enforcement,
@@ -21,6 +20,9 @@ use memuse::DynamicUsage;
 use crate::keys::KeyId;
 use crate::keys::ScanningKeyOps as _;
 use crate::keys::ScanningKeys;
+use crate::lightwallet::{
+    CompactBlock, CompactBlockExt, CompactTxExt, orchard_compact_action, sapling_output_description,
+};
 use crate::wallet::OutputId;
 
 type TaggedSaplingBatch = Batch<
@@ -104,7 +106,7 @@ where
                     .iter()
                     .enumerate()
                     .map(|(i, output)| {
-                        CompactOutputDescription::try_from(output).map_err(|()| {
+                        sapling_output_description(output).map_err(|()| {
                             zcash_client_backend::scanning::ScanError::EncodingInvalid {
                                 at_height: block_height,
                                 txid,
@@ -124,7 +126,7 @@ where
                     .iter()
                     .enumerate()
                     .map(|(i, action)| {
-                        CompactAction::try_from(action).map_err(|()| {
+                        orchard_compact_action(action).map_err(|()| {
                             zcash_client_backend::scanning::ScanError::EncodingInvalid {
                                 at_height: block_height,
                                 txid,

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -14,7 +14,6 @@ use tokio::{
     task::{JoinError, JoinHandle},
 };
 
-use zcash_client_backend::proto::compact_formats::CompactBlock;
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::{transaction::TxId, zip32::AccountId};
 use zcash_protocol::consensus::{self, BlockHeight};
@@ -24,6 +23,7 @@ use crate::{
     config::PerformanceLevel,
     error::{ScanError, ServerError, SyncError},
     keys::transparent::TransparentAddressId,
+    lightwallet::{CompactBlock, CompactBlockExt},
     sync::{self, ScanPriority, ScanRange},
     wallet::{
         ScanTarget, WalletBlock,

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -12,8 +12,6 @@ use incrementalmerkletree::{Marking, Retention};
 use orchard::tree::MerkleHashOrchard;
 use shardtree::store::ShardStore;
 use tonic::transport::Channel;
-use zcash_client_backend::proto::service::RawTransaction;
-use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::ShieldedProtocol;
@@ -29,6 +27,7 @@ use crate::error::{
     SyncStatusError,
 };
 use crate::keys::transparent::TransparentAddressId;
+use crate::lightwallet::{CompactTxStreamerClient, RawTransaction};
 use crate::scan::ScanResults;
 use crate::scan::task::{Scanner, ScannerState};
 use crate::scan::transactions::scan_transaction;

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -31,7 +31,7 @@ use super::{ScanPriority, VERIFY_BLOCK_RANGE_SIZE};
 const NARROW_SCAN_AREA: u32 = 10_000;
 
 #[cfg(not(feature = "darkside_test"))]
-use zcash_client_backend::proto::service::SubtreeRoot;
+use crate::lightwallet::SubtreeRoot;
 
 /// Used to determine which end of the scan range is verified.
 pub(super) enum VerifyEnd {

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -19,7 +19,6 @@ use orchard::tree::MerkleHashOrchard;
 use shardtree::{ShardTree, store::memory::MemoryShardStore};
 use tokio::sync::mpsc;
 use zcash_address::unified::ParseError;
-use zcash_client_backend::proto::compact_formats::CompactBlock;
 use zcash_keys::{address::UnifiedAddress, encoding::encode_payment_address};
 use zcash_primitives::{
     block::BlockHash,
@@ -39,6 +38,7 @@ use crate::{
     client::FetchRequest,
     error::{ServerError, SyncModeError},
     keys::{self, KeyId, transparent::TransparentAddressId},
+    lightwallet::{CompactBlock, CompactBlockExt, CompactTxExt},
     scan::compact_blocks::calculate_block_tree_bounds,
     sync::{MAX_REORG_ALLOWANCE, ScanPriority, ScanRange},
     witness,
@@ -395,11 +395,7 @@ impl WalletBlock {
             block_hash: block.hash(),
             prev_hash: block.prev_hash(),
             time: block.time,
-            txids: block
-                .vtx
-                .iter()
-                .map(zcash_client_backend::proto::compact_formats::CompactTx::txid)
-                .collect(),
+            txids: block.vtx.iter().map(CompactTxExt::txid).collect(),
             tree_bounds,
         })
     }

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -3,17 +3,17 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::{Read, Write},
-    ops::Range,
+    ops::{Deref, Range},
+    sync::Arc,
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use incrementalmerkletree::{Hashable, Position};
 use shardtree::{
-    LocatedPrunableTree, ShardTree,
+    LocatedPrunableTree, Node, PrunableTree, RetentionFlags, ShardTree, Tree,
     store::{Checkpoint, ShardStore, TreeState, memory::MemoryShardStore},
 };
-use zcash_client_backend::serialization::shardtree::{read_shard, write_shard};
 use zcash_encoding::{Optional, Vector};
 use zcash_primitives::{
     block::BlockHash,
@@ -45,6 +45,86 @@ use super::{
     SaplingNote, ShardTrees, SyncState, TransparentCoin, TreeBounds, WalletBlock, WalletNote,
     WalletTransaction,
 };
+
+const SHARD_SER_V1: u8 = 1;
+const SHARD_NIL_TAG: u8 = 0;
+const SHARD_LEAF_TAG: u8 = 1;
+const SHARD_PARENT_TAG: u8 = 2;
+
+fn write_shard<H: HashSer, W: Write>(
+    writer: &mut W,
+    tree: &PrunableTree<H>,
+) -> std::io::Result<()> {
+    fn write_inner<H: HashSer, W: Write>(
+        mut writer: &mut W,
+        tree: &PrunableTree<H>,
+    ) -> std::io::Result<()> {
+        match tree.deref() {
+            Node::Parent { ann, left, right } => {
+                writer.write_u8(SHARD_PARENT_TAG)?;
+                Optional::write(&mut writer, ann.as_ref(), |w, h| {
+                    <H as HashSer>::write(h, w)
+                })?;
+                write_inner(writer, left)?;
+                write_inner(writer, right)?;
+                Ok(())
+            }
+            Node::Leaf { value } => {
+                writer.write_u8(SHARD_LEAF_TAG)?;
+                value.0.write(&mut writer)?;
+                writer.write_u8(value.1.bits())?;
+                Ok(())
+            }
+            Node::Nil => {
+                writer.write_u8(SHARD_NIL_TAG)?;
+                Ok(())
+            }
+        }
+    }
+
+    writer.write_u8(SHARD_SER_V1)?;
+    write_inner(writer, tree)
+}
+
+fn read_shard<H: HashSer, R: Read>(mut reader: R) -> std::io::Result<PrunableTree<H>> {
+    fn read_shard_v1<H: HashSer, R: Read>(mut reader: &mut R) -> std::io::Result<PrunableTree<H>> {
+        match reader.read_u8()? {
+            SHARD_PARENT_TAG => {
+                let ann = Optional::read(&mut reader, <H as HashSer>::read)?.map(Arc::new);
+                let left = read_shard_v1(reader)?;
+                let right = read_shard_v1(reader)?;
+                Ok(Tree::parent(ann, left, right))
+            }
+            SHARD_LEAF_TAG => {
+                let value = <H as HashSer>::read(&mut reader)?;
+                let flags = reader.read_u8().and_then(|bits| {
+                    RetentionFlags::from_bits(bits).ok_or_else(|| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!(
+                                "Byte value {bits} does not correspond to a valid set of retention flags"
+                            ),
+                        )
+                    })
+                })?;
+                Ok(Tree::leaf((value, flags)))
+            }
+            SHARD_NIL_TAG => Ok(Tree::empty()),
+            other => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Node tag not recognized: {other}"),
+            )),
+        }
+    }
+
+    match reader.read_u8()? {
+        SHARD_SER_V1 => read_shard_v1(&mut reader),
+        other => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Shard serialization version not recognized: {other}"),
+        )),
+    }
+}
 
 fn read_string<R: Read>(mut reader: R) -> std::io::Result<String> {
     let str_len = reader.read_u64::<LittleEndian>()?;

--- a/pepper-sync/src/witness.rs
+++ b/pepper-sync/src/witness.rs
@@ -9,8 +9,9 @@ use zcash_protocol::consensus::BlockHeight;
 
 #[cfg(not(feature = "darkside_test"))]
 use {
-    crate::error::ServerError, shardtree::store::ShardStore, subtle::CtOption,
-    zcash_client_backend::proto::service::SubtreeRoot,
+    crate::{error::ServerError, lightwallet::SubtreeRoot},
+    shardtree::store::ShardStore,
+    subtle::CtOption,
 };
 
 pub(crate) const SHARD_HEIGHT: u8 = 16;


### PR DESCRIPTION
## Summary
- switch pepper-sync proto types and CompactTxStreamerClient to lightwallet-protocol
- add local compatibility helpers for compact block/tx, tree state, compact output/action decoding, and shard serialization
- remove zcash_client_backend from pepper-sync's dependency graph
- document the migration in pepper-sync changelog

## Verification
- cargo check -p pepper-sync
- cargo test -p pepper-sync
- cargo tree -p pepper-sync -i zcash_client_backend