### PR TITLE
Add reproducible containerized test runs

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -9,3 +9,6 @@ ZCASH_VERSION=6.12.1
 
 # Zaino image tag used to provide zainod (https://hub.docker.com/r/zingodevops/zaino)
 ZAINO_IMAGE_TAG=0.3.0-rc.1
+
+# cargo-nextest version compatible with the pinned Rust toolchain.
+NEXTEST_VERSION=0.9.128

--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -1,0 +1,11 @@
+# Rust is intentionally not set here. The canonical source is
+# rust-toolchain.toml's `channel`; Makefile.toml derives RUST_VERSION from it.
+
+# lightwalletd Git tag (https://github.com/zcash/lightwalletd/releases)
+LIGHTWALLETD_VERSION=0.4.18
+
+# zcashd Git tag without the leading "v" (https://github.com/zcash/zcash/releases)
+ZCASH_VERSION=6.12.1
+
+# Zaino image tag used to provide zainod (https://hub.docker.com/r/zingodevops/zaino)
+ZAINO_IMAGE_TAG=0.3.0-rc.1

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,319 @@
+env_files = [".env.testing-artifacts"]
+
+[config]
+default_to_workspace = false
+
+[env]
+NEXTEST_EXPERIMENTAL_LIBTEST_JSON = "1"
+ZINGOLIB_NEXTEST_PROFILE = "ci"
+ZINGOLIB_NEXTEST_RETRIES = "2"
+ZINGOLIB_NEXTEST_FILTER = "not test(slow)"
+IMAGE_NAME = "zingodevops/ci-build"
+RUST_VERSION = { script = ["sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*\"\\([0-9.]*\\)\".*/\\1/p' rust-toolchain.toml | head -n1"] }
+
+[tasks.default]
+alias = "help"
+
+[tasks.help]
+description = "List Zingolib cargo-make tasks"
+script_runner = "bash"
+script = '''
+set -euo pipefail
+
+cat <<'HELP'
+Zingolib test tasks
+-------------------
+
+Common usage:
+  makers run
+  cargo make run
+
+The run task runs tests inside a reproducible container image:
+  cargo nextest run --verbose --workspace --profile ci --retries 2 -E 'not test(slow)'
+
+Build or refresh the local image:
+  makers build-image
+
+Run the same nextest command on the host:
+  makers local-run
+
+The local-run task mirrors the PR test defaults:
+  cargo nextest run --verbose --workspace --profile ci --retries 2 -E 'not test(slow)'
+
+Forward extra nextest flags after the task name:
+  makers run -p zingo-memo
+
+Override the default nextest filter:
+  ZINGOLIB_NEXTEST_FILTER='package(zingolib) & not test(slow)' makers run
+
+Reproduce the latest failing or incomplete nextest run:
+  makers rerun
+
+Run ignored tests explicitly:
+  makers run-ignored
+
+Install cargo-make if these commands are unavailable:
+  cargo install cargo-make
+HELP
+'''
+
+[tasks.base-script]
+script_runner = "bash"
+script.pre = '''
+set -euo pipefail
+
+container_runtime() {
+  if [[ -n "${CONTAINER_RUNTIME:-}" ]]; then
+    printf '%s\n' "${CONTAINER_RUNTIME}"
+  elif command -v podman >/dev/null 2>&1; then
+    printf '%s\n' "podman"
+  elif command -v docker >/dev/null 2>&1; then
+    printf '%s\n' "docker"
+  else
+    echo "Neither podman nor docker was found. Install one or set CONTAINER_RUNTIME." >&2
+    exit 1
+  fi
+}
+
+container_mount_suffix() {
+  case "$(container_runtime)" in
+    podman) printf '%s\n' ":U" ;;
+    *) printf '%s\n' "" ;;
+  esac
+}
+
+container_dir_hash() {
+  {
+    for path in .env.testing-artifacts rust-toolchain.toml; do
+      printf '%s %s\n' "${path}" "$(git hash-object "${path}")"
+    done
+    find docker-ci -type f | LC_ALL=C sort | while IFS= read -r path; do
+      printf '%s %s\n' "${path}" "$(git hash-object "${path}")"
+    done
+  } | git hash-object --stdin | cut -c1-14
+}
+
+container_image_tag() {
+  printf 'RUST_%s-LIGHTWALLETD_%s-ZCASH_%s-ZAINO_%s-CONTAINER_%s' \
+    "${RUST_VERSION}" \
+    "${LIGHTWALLETD_VERSION}" \
+    "${ZCASH_VERSION}" \
+    "${ZAINO_IMAGE_TAG}" \
+    "$(container_dir_hash)" \
+    | git hash-object --stdin \
+    | cut -c1-14
+}
+
+append_workspace_default() {
+  local use_default_workspace=1
+  for arg in "$@"; do
+    case "${arg}" in
+      -p|--package|--package=*|--workspace|--all|--exclude|--exclude=*|--manifest-path|--manifest-path=*)
+        use_default_workspace=0
+        ;;
+    esac
+  done
+
+  if [[ "${use_default_workspace}" -eq 1 ]]; then
+    printf '%s\n' "--workspace"
+  fi
+}
+'''
+script.main = "true"
+
+[tasks.prepare-test-binaries-dir]
+description = "Ensure the local test binary directory exists"
+script_runner = "bash"
+script = '''
+set -euo pipefail
+mkdir -p test_binaries/bins
+'''
+
+[tasks.compute-image-tag]
+description = "Print the reproducible local test image tag"
+extend = "base-script"
+script.main = '''
+echo "$(container_image_tag)"
+'''
+
+[tasks.init-container-volumes]
+description = "Initialize named volumes used by containerized tests"
+extend = "base-script"
+script.main = '''
+runtime="$(container_runtime)"
+for volume in zingolib-container-target zingolib-cargo-git zingolib-cargo-registry; do
+  "${runtime}" volume inspect "${volume}" >/dev/null 2>&1 || "${runtime}" volume create "${volume}" >/dev/null
+done
+mkdir -p target test_binaries/bins
+'''
+
+[tasks.build-image]
+description = "Build the reproducible local test image from .env.testing-artifacts"
+extend = "base-script"
+dependencies = ["init-container-volumes"]
+script.main = '''
+runtime="$(container_runtime)"
+tag="$(container_image_tag)"
+
+echo "Building ${IMAGE_NAME}:${tag}"
+echo "  RUST_VERSION=${RUST_VERSION}"
+echo "  LIGHTWALLETD_VERSION=${LIGHTWALLETD_VERSION}"
+echo "  ZCASH_VERSION=${ZCASH_VERSION}"
+echo "  ZAINO_IMAGE_TAG=${ZAINO_IMAGE_TAG}"
+
+"${runtime}" build \
+  -f docker-ci/Dockerfile \
+  --build-arg "RUST_VERSION=${RUST_VERSION}" \
+  --build-arg "LIGHTWALLETD_VERSION=${LIGHTWALLETD_VERSION}" \
+  --build-arg "ZCASH_VERSION=${ZCASH_VERSION}" \
+  --build-arg "ZAINO_IMAGE_TAG=${ZAINO_IMAGE_TAG}" \
+  -t "${IMAGE_NAME}:${tag}" \
+  docker-ci
+'''
+
+[tasks.ensure-image-exists]
+description = "Build the reproducible test image if it is not present locally"
+extend = "base-script"
+dependencies = ["init-container-volumes"]
+script.main = '''
+runtime="$(container_runtime)"
+tag="$(container_image_tag)"
+
+echo "Checking for ${IMAGE_NAME}:${tag} with ${runtime}..."
+
+if "${runtime}" image inspect "${IMAGE_NAME}:${tag}" >/dev/null 2>&1; then
+  echo "Image ${IMAGE_NAME}:${tag} already exists."
+else
+  echo "Image ${IMAGE_NAME}:${tag} not found; building it now."
+  export CONTAINER_RUNTIME="${runtime}"
+  makers build-image
+fi
+'''
+
+[tasks.local-run]
+clear = true
+description = "Run reproducible workspace tests on the host with the same defaults used by PR CI"
+dependencies = ["prepare-test-binaries-dir"]
+script_runner = "bash"
+extend = "base-script"
+script.main = '''
+args=(
+  --verbose
+  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
+  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
+)
+
+workspace_arg="$(append_workspace_default "$@")"
+if [[ -n "${workspace_arg}" ]]; then
+  args+=("${workspace_arg}")
+fi
+
+if [[ -n "${ZINGOLIB_NEXTEST_FILTER:-}" ]]; then
+  args+=(-E "${ZINGOLIB_NEXTEST_FILTER}")
+fi
+
+cargo nextest run "${args[@]}" "${@}"
+'''
+
+[tasks.run]
+clear = true
+description = "Run reproducible workspace tests inside the local test container"
+dependencies = ["ensure-image-exists"]
+script_runner = "bash"
+extend = "base-script"
+script.main = '''
+runtime="$(container_runtime)"
+mount_suffix="$(container_mount_suffix)"
+tag="$(container_image_tag)"
+
+args=(
+  --verbose
+  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
+  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
+)
+
+workspace_arg="$(append_workspace_default "$@")"
+if [[ -n "${workspace_arg}" ]]; then
+  args+=("${workspace_arg}")
+fi
+
+if [[ -n "${ZINGOLIB_NEXTEST_FILTER:-}" ]]; then
+  args+=(-E "${ZINGOLIB_NEXTEST_FILTER}")
+fi
+
+"${runtime}" run --rm --init \
+  -v "${PWD}:/workspace" \
+  -v "zingolib-container-target:/workspace/target${mount_suffix}" \
+  -v "zingolib-cargo-git:/root/.cargo/git${mount_suffix}" \
+  -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
+  -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
+  -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
+  -w /workspace \
+  "${IMAGE_NAME}:${tag}" \
+  bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli /usr/bin/zainod test_binaries/bins/ && exec "$@"' \
+  bash \
+  cargo nextest run "${args[@]}" "${@}"
+'''
+
+[tasks.rerun]
+clear = true
+description = "Rerun tests that failed or did not complete in the latest recorded nextest run"
+dependencies = ["ensure-image-exists"]
+script_runner = "bash"
+extend = "base-script"
+script.main = '''
+runtime="$(container_runtime)"
+mount_suffix="$(container_mount_suffix)"
+tag="$(container_image_tag)"
+
+args=(
+  --verbose
+  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
+  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
+  --rerun latest
+)
+
+workspace_arg="$(append_workspace_default "$@")"
+if [[ -n "${workspace_arg}" ]]; then
+  args+=("${workspace_arg}")
+fi
+
+if [[ -n "${ZINGOLIB_NEXTEST_FILTER:-}" ]]; then
+  args+=(-E "${ZINGOLIB_NEXTEST_FILTER}")
+fi
+
+"${runtime}" run --rm --init \
+  -v "${PWD}:/workspace" \
+  -v "zingolib-container-target:/workspace/target${mount_suffix}" \
+  -v "zingolib-cargo-git:/root/.cargo/git${mount_suffix}" \
+  -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
+  -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
+  -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
+  -w /workspace \
+  "${IMAGE_NAME}:${tag}" \
+  bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli /usr/bin/zainod test_binaries/bins/ && exec "$@"' \
+  bash \
+  cargo nextest run "${args[@]}" "${@}"
+'''
+
+[tasks.run-ignored]
+clear = true
+description = "Run ignored tests with the reproducible nextest profile"
+dependencies = ["prepare-test-binaries-dir"]
+script_runner = "bash"
+extend = "base-script"
+script.main = '''
+args=(
+  --verbose
+  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
+  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
+  --run-ignored all
+)
+
+workspace_arg="$(append_workspace_default "$@")"
+if [[ -n "${workspace_arg}" ]]; then
+  args+=("${workspace_arg}")
+fi
+
+cargo nextest run "${args[@]}" "${@}"
+'''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -94,11 +94,12 @@ container_dir_hash() {
 }
 
 container_image_tag() {
-  printf 'RUST_%s-LIGHTWALLETD_%s-ZCASH_%s-ZAINO_%s-CONTAINER_%s' \
+  printf 'RUST_%s-LIGHTWALLETD_%s-ZCASH_%s-ZAINO_%s-NEXTEST_%s-CONTAINER_%s' \
     "${RUST_VERSION}" \
     "${LIGHTWALLETD_VERSION}" \
     "${ZCASH_VERSION}" \
     "${ZAINO_IMAGE_TAG}" \
+    "${NEXTEST_VERSION}" \
     "$(container_dir_hash)" \
     | git hash-object --stdin \
     | cut -c1-14
@@ -160,6 +161,7 @@ echo "  RUST_VERSION=${RUST_VERSION}"
 echo "  LIGHTWALLETD_VERSION=${LIGHTWALLETD_VERSION}"
 echo "  ZCASH_VERSION=${ZCASH_VERSION}"
 echo "  ZAINO_IMAGE_TAG=${ZAINO_IMAGE_TAG}"
+echo "  NEXTEST_VERSION=${NEXTEST_VERSION}"
 
 "${runtime}" build \
   -f docker-ci/Dockerfile \
@@ -167,6 +169,7 @@ echo "  ZAINO_IMAGE_TAG=${ZAINO_IMAGE_TAG}"
   --build-arg "LIGHTWALLETD_VERSION=${LIGHTWALLETD_VERSION}" \
   --build-arg "ZCASH_VERSION=${ZCASH_VERSION}" \
   --build-arg "ZAINO_IMAGE_TAG=${ZAINO_IMAGE_TAG}" \
+  --build-arg "NEXTEST_VERSION=${NEXTEST_VERSION}" \
   -t "${IMAGE_NAME}:${tag}" \
   docker-ci
 '''

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Zingo-CLI does automatic note and utxo management, which means it doesn't allow 
     * Please install the build tools for your platform. On Ubuntu `sudo apt install build-essential gcc libsqlite3-dev`
 * Protobuf Compiler
     * Please install the protobuf compiler for your platform. On Ubuntu `sudo apt install protobuf-compiler`
+* cargo-make and cargo-nextest for reproducible local test runs
+    * Run `cargo install cargo-make cargo-nextest`
 ```
 git clone https://github.com/zingolabs/zingolib.git
 cd zingolib
@@ -44,6 +46,26 @@ cargo build --release --package zingo-cli
 ```
 
 This will launch the interactive prompt. Type `help` to get a list of commands.
+
+## Testing
+
+Use `makers run` or `cargo make run` to run the same default nextest shape used by PR CI inside a reproducible local container image:
+
+```
+makers run
+```
+
+The task builds the image if needed, symlinks the image-provided `lightwalletd`, `zcashd`, `zcash-cli`, and `zainod` into `test_binaries/bins`, then runs the workspace with the `ci` nextest profile, two retries, and the default filter `not test(slow)`. The image tag is derived from `.env.testing-artifacts`, `rust-toolchain.toml`, and `docker-ci`.
+
+Extra nextest flags can be forwarded after the task name, and the default filter can be changed with `ZINGOLIB_NEXTEST_FILTER`.
+
+```
+makers run -p zingo-memo
+ZINGOLIB_NEXTEST_FILTER='package(zingolib) & not test(slow)' makers run
+makers rerun
+```
+
+Use `makers local-run` to run the same nextest command on the host.
 
 ## Notes:
 * If you want to run your own server, please see [zingo lightwalletd](https://github.com/zingolabs/lightwalletd), and then run `./zingo-cli --server http://127.0.0.1:9067`

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ ZINGOLIB_NEXTEST_FILTER='package(zingolib) & not test(slow)' makers run
 makers rerun
 ```
 
+To run the containerized test suite with all features enabled, pass `--all-features` through to nextest:
+
+```
+makers run --all-features
+```
+
+This still applies the default `not test(slow)` filter. To match `cargo nextest run --all-features` more closely, clear the default filter:
+
+```
+ZINGOLIB_NEXTEST_FILTER= makers run --all-features
+```
+
 Use `makers local-run` to run the same nextest command on the host.
 
 ## Notes:

--- a/docker-ci/Dockerfile
+++ b/docker-ci/Dockerfile
@@ -1,4 +1,14 @@
+ARG RUST_VERSION=1.90
+ARG LIGHTWALLETD_VERSION=0.4.18
+ARG ZCASH_VERSION=6.12.1
+ARG ZAINO_IMAGE_TAG=0.3.0-rc.1
+
+FROM docker.io/zodlinc/zcash:v${ZCASH_VERSION} AS zcashd-downloader
+FROM docker.io/zingodevops/zaino:${ZAINO_IMAGE_TAG} AS zainod-downloader
+
 FROM debian:trixie-slim AS builder
+
+ARG LIGHTWALLETD_VERSION
 
 WORKDIR /usr/src
 
@@ -9,7 +19,6 @@ RUN apt update \
     pkg-config \
     libc6-dev \
     m4 \
-    g++-multilib \
     autoconf \
     libtool \
     ncurses-dev \
@@ -28,21 +37,26 @@ RUN apt update \
 # Build lightwalletd
 RUN git clone https://github.com/zcash/lightwalletd \
     && cd lightwalletd \
-    && git checkout v0.4.18 \
+    && git checkout "v${LIGHTWALLETD_VERSION}" \
     && make
-
-# Build zcashd and fetch params
-RUN git clone https://github.com/zcash/zcash.git \
-    && cd zcash/ \
-    && git checkout v6.3.0 \
-    && ./zcutil/build.sh -j$(nproc)
 
 FROM debian:trixie-slim AS runner
 
+ARG RUST_VERSION
+ARG LIGHTWALLETD_VERSION
+ARG ZCASH_VERSION
+ARG ZAINO_IMAGE_TAG
+
+LABEL org.zingolib.test-artifacts.versions.rust="${RUST_VERSION}"
+LABEL org.zingolib.test-artifacts.versions.lightwalletd="${LIGHTWALLETD_VERSION}"
+LABEL org.zingolib.test-artifacts.versions.zcashd="${ZCASH_VERSION}"
+LABEL org.zingolib.test-artifacts.versions.zaino="${ZAINO_IMAGE_TAG}"
+
 # Copy regtest binaries and zcash params from builder
 COPY --from=builder /usr/src/lightwalletd/lightwalletd /usr/bin/
-COPY --from=builder /usr/src/zcash/src/zcashd /usr/bin/
-COPY --from=builder /usr/src/zcash/src/zcash-cli /usr/bin/
+COPY --from=zcashd-downloader /usr/local/bin/zcashd /usr/bin/
+COPY --from=zcashd-downloader /usr/local/bin/zcash-cli /usr/bin/
+COPY --from=zainod-downloader /usr/local/bin/zainod /usr/bin/
 
 # Install dependencies and update ca certificates
 RUN apt update \
@@ -59,15 +73,14 @@ RUN apt update \
     ca-certificates \
     && update-ca-certificates
 
-# Install rust and cargo tarpaulin
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# Install pinned Rust tooling and test helpers
 ENV HOME=/root
 ENV CARGO_HOME=$HOME/.cargo
 ENV RUSTUP_HOME=$HOME/.rustup
 ENV PATH=$PATH:$CARGO_HOME/bin
-RUN rustup toolchain install stable --profile minimal --component clippy \
-    && rustup update \
-    && rustup default stable
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain "${RUST_VERSION}" --profile minimal \
+    && rustup component add clippy rustfmt
 RUN cargo install cargo-nextest --locked
 RUN cargo install cargo-tarpaulin
 
@@ -75,4 +88,3 @@ RUN cargo install cargo-tarpaulin
 RUN apt autoremove -y \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
-

--- a/docker-ci/Dockerfile
+++ b/docker-ci/Dockerfile
@@ -2,6 +2,7 @@ ARG RUST_VERSION=1.90
 ARG LIGHTWALLETD_VERSION=0.4.18
 ARG ZCASH_VERSION=6.12.1
 ARG ZAINO_IMAGE_TAG=0.3.0-rc.1
+ARG NEXTEST_VERSION=0.9.128
 
 FROM docker.io/zodlinc/zcash:v${ZCASH_VERSION} AS zcashd-downloader
 FROM docker.io/zingodevops/zaino:${ZAINO_IMAGE_TAG} AS zainod-downloader
@@ -46,11 +47,13 @@ ARG RUST_VERSION
 ARG LIGHTWALLETD_VERSION
 ARG ZCASH_VERSION
 ARG ZAINO_IMAGE_TAG
+ARG NEXTEST_VERSION
 
 LABEL org.zingolib.test-artifacts.versions.rust="${RUST_VERSION}"
 LABEL org.zingolib.test-artifacts.versions.lightwalletd="${LIGHTWALLETD_VERSION}"
 LABEL org.zingolib.test-artifacts.versions.zcashd="${ZCASH_VERSION}"
 LABEL org.zingolib.test-artifacts.versions.zaino="${ZAINO_IMAGE_TAG}"
+LABEL org.zingolib.test-artifacts.versions.nextest="${NEXTEST_VERSION}"
 
 # Copy regtest binaries and zcash params from builder
 COPY --from=builder /usr/src/lightwalletd/lightwalletd /usr/bin/
@@ -81,8 +84,7 @@ ENV PATH=$PATH:$CARGO_HOME/bin
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain "${RUST_VERSION}" --profile minimal \
     && rustup component add clippy rustfmt
-RUN cargo install cargo-nextest --locked
-RUN cargo install cargo-tarpaulin
+RUN cargo install cargo-nextest --version "${NEXTEST_VERSION}" --locked
 
 # Apt clean up
 RUN apt autoremove -y \

--- a/docker-ci/Dockerfile
+++ b/docker-ci/Dockerfile
@@ -70,6 +70,7 @@ RUN apt update \
     curl \
     pkg-config \
     libssl-dev \
+    libsqlite3-dev \
     build-essential \
     protobuf-compiler \
     libclang-dev \

--- a/docker-ci/README.txt
+++ b/docker-ci/README.txt
@@ -1,9 +1,15 @@
-The following is required to successfully update the docker container for Github CI workflows:
- - update the lightwalletd and zcash git tags to the latest versions in 'docker-ci/Dockerfile' 
- - change to the `docker-ci` directory
- - run 'docker build -t zingodevops/ci-build:<new image version number> .' to build the image locally 
- - run 'docker login' and fill in the credentials for DockerHub
- - run 'docker push zingodevops/ci-build:<new image version number>' to push to DockerHub
- - update github workflow files to the new image version number
+The container test image is versioned from `.env.testing-artifacts`,
+`rust-toolchain.toml`, and this `docker-ci` directory.
+
+For local reproducible test runs:
+ - update `.env.testing-artifacts` if lightwalletd, zcashd, or the Zaino image tag changes
+ - run `makers build-image` to build the local image
+ - run `makers run` to execute tests inside the image
+
+For Github CI workflow images:
+ - run `makers compute-image-tag` to get the reproducible image tag
+ - run `docker login` and fill in the credentials for DockerHub
+ - run `docker push zingodevops/ci-build:<computed image tag>` to push to DockerHub
+ - update github workflow files to the new image tag
 
  NOTE: if `sudo` is necessary use `sudo` with all commands including login.


### PR DESCRIPTION
## Summary
- add cargo-make tasks for reproducible containerized nextest runs
- pin test artifact versions in .env.testing-artifacts
- build a local test image that provides lightwalletd, zcashd, zcash-cli, and zainod
- document makers run, local-run, rerun, and all-features usage

Closes #2339

## Testing
- makers compute-image-tag
- makers local-run --no-run -p zingo-memo
- makers run --no-run -p zingo-memo
