### PR TITLE
fix scan range truncation bug

### DIFF
--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -12,7 +12,7 @@ jobs:
         phase: [build, check, clippy, doc, format]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -57,7 +57,7 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,7 +19,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   NEXTEST-FLAGS: ${{ inputs.nextest-flags }}
+  DARKSIDE_PACKAGE: darkside-tests
 
 jobs:
   build-test-artifacts:
@@ -32,20 +33,37 @@ jobs:
 
       - name: Install system deps
         run: |
-         apt-get update
-         apt-get install -y libsqlite3-dev pkg-config
+          apt-get update
+          apt-get install -y libsqlite3-dev pkg-config
 
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Build and archive tests
-        run: cargo nextest archive --verbose --workspace --archive-file nextest-archive.tar.zst
+      - name: Build and archive non-darkside tests
+        run: |
+          cargo nextest archive --verbose \
+            --workspace \
+            --exclude "$DARKSIDE_PACKAGE" \
+            --archive-file nextest-archive-normal.tar.zst
 
-      - name: Upload archive
+      - name: Build and archive darkside tests
+        run: |
+          cargo nextest archive --verbose \
+            -p "$DARKSIDE_PACKAGE" \
+            --archive-file nextest-archive-darkside.tar.zst
+
+      - name: Upload normal archive
         uses: actions/upload-artifact@v4
         with:
-          name: nextest-archive
-          path: nextest-archive.tar.zst
+          name: nextest-archive-normal
+          path: nextest-archive-normal.tar.zst
+          overwrite: true
+
+      - name: Upload darkside archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-archive-darkside
+          path: nextest-archive-darkside.tar.zst
           overwrite: true
 
   run-tests:
@@ -59,7 +77,15 @@ jobs:
       image: zingodevops/ci-build:009
       options: --security-opt seccomp=unconfined
     strategy:
+      fail-fast: false
       matrix:
+        suite:
+          - name: normal
+            artifact: nextest-archive-normal
+            archive: nextest-archive-normal.tar.zst
+          - name: darkside
+            artifact: nextest-archive-darkside
+            archive: nextest-archive-darkside.tar.zst
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout repository
@@ -74,9 +100,12 @@ jobs:
       - name: Download archive
         uses: actions/download-artifact@v4
         with:
-          name: nextest-archive
+          name: ${{ matrix.suite.artifact }}
 
-      - name: Run tests
+      - name: Run ${{ matrix.suite.name }} tests
         run: |
-          cargo nextest run --verbose --profile ci --retries 2 --archive-file nextest-archive.tar.zst \
-            --workspace-remap ./ --partition count:${{ matrix.partition }}/8 ${{ env.NEXTEST-FLAGS }}
+          cargo nextest run --verbose --profile ci --retries 2 \
+            --archive-file ${{ matrix.suite.archive }} \
+            --workspace-remap ./ \
+            --partition count:${{ matrix.partition }}/8 \
+            ${{ env.NEXTEST-FLAGS }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -67,7 +67,7 @@ jobs:
           overwrite: true
 
   run-tests:
-    name: Run tests
+    name: Run normal tests
     runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     needs: build-test-artifacts
@@ -79,13 +79,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite:
-          - name: normal
-            artifact: nextest-archive-normal
-            archive: nextest-archive-normal.tar.zst
-          - name: darkside
-            artifact: nextest-archive-darkside
-            archive: nextest-archive-darkside.tar.zst
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout repository
@@ -97,15 +90,47 @@ jobs:
       - name: Symlink lightwalletd and zcash binaries
         run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./test_binaries/bins/
 
-      - name: Download archive
+      - name: Download normal archive
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.suite.artifact }}
+          name: nextest-archive-normal
 
-      - name: Run ${{ matrix.suite.name }} tests
+      - name: Run normal tests
         run: |
           cargo nextest run --verbose --profile ci --retries 2 \
-            --archive-file ${{ matrix.suite.archive }} \
+            --archive-file nextest-archive-normal.tar.zst \
             --workspace-remap ./ \
             --partition count:${{ matrix.partition }}/8 \
+            ${{ env.NEXTEST-FLAGS }}
+
+  run-darkside-tests:
+    name: Run darkside tests
+    runs-on: ubuntu-24.04
+    if: github.event.pull_request.draft == false
+    needs: build-test-artifacts
+    env:
+      RUSTFLAGS: -D warnings
+    container:
+      image: zingodevops/ci-build:009
+      options: --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: create binaries dir
+        run: mkdir -p ./test_binaries/bins
+
+      - name: Symlink lightwalletd and zcash binaries
+        run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./test_binaries/bins/
+
+      - name: Download darkside archive
+        uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive-darkside
+
+      - name: Run darkside tests
+        run: |
+          cargo nextest run --verbose --profile ci --retries 2 \
+            --archive-file nextest-archive-darkside.tar.zst \
+            --workspace-remap ./ \
             ${{ env.NEXTEST-FLAGS }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,14 +53,14 @@ jobs:
             --archive-file nextest-archive-darkside.tar.zst
 
       - name: Upload normal archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextest-archive-normal
           path: nextest-archive-normal.tar.zst
           overwrite: true
 
       - name: Upload darkside archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nextest-archive-darkside
           path: nextest-archive-darkside.tar.zst
@@ -91,7 +91,7 @@ jobs:
         run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./test_binaries/bins/
 
       - name: Download normal archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nextest-archive-normal
 
@@ -124,7 +124,7 @@ jobs:
         run: ln -s /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli ./test_binaries/bins/
 
       - name: Download darkside archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nextest-archive-darkside
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,7 @@ jobs:
         partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: create binaries dir
         run: mkdir -p ./test_binaries/bins
@@ -115,7 +115,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: create binaries dir
         run: mkdir -p ./test_binaries/bins

--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ Here are some CLI arguments you can pass to `zingo-cli`. Please run `zingo-cli -
 
 ## Regtest
 Please see `zingo-cli/README.md` for details of running zingo-cli in regtest mode with a local network.
+
+## Testing
+Darkside tests must be run seprately to the tests in the rest of the workspace to avoid zingolib being built with the "darkside_tests" feature in non-darkside testing.
+
+`run_workspace_tests.sh` script may be used as a helper to run all tests in one invocation.

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -162,6 +162,12 @@ async fn prepare_after_tx_height_change_reorg(uri: http::Uri) -> Result<(), Stri
     // Setup prodedures.  Up to this point there's no communication between the client and the dswd
     client.clear_address_utxo(Empty {}).await.unwrap();
 
+    // reset with parameters
+    connector
+        .reset(202, String::from(BRANCH_ID), String::from("regtest"))
+        .await
+        .unwrap();
+
     let dataset_path = format!(
         "{}/{}",
         get_cargo_manifest_dir().to_string_lossy(),
@@ -175,6 +181,17 @@ async fn prepare_after_tx_height_change_reorg(uri: http::Uri) -> Result<(), Stri
                 .collect(),
         )
         .await?;
+
+    for i in 201..207 {
+        let tree_state_path = format!(
+            "{}/{}/{}.json",
+            get_cargo_manifest_dir().to_string_lossy(),
+            TREE_STATE_FOLDER_PATH,
+            i
+        );
+        let tree_state = TreeState::from_file(tree_state_path).unwrap();
+        connector.add_tree_state(tree_state).await.unwrap();
+    }
 
     connector.apply_staged(206).await?;
 

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -25,7 +25,6 @@ use zingolib::{
 };
 use zingolib_testutils::scenarios::ClientBuilder;
 
-#[ignore]
 #[tokio::test]
 async fn reorg_changes_incoming_tx_height() {
     let lightwalletd = lightwalletd().await.unwrap();

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -199,7 +199,6 @@ async fn prepare_after_tx_height_change_reorg(uri: http::Uri) -> Result<(), Stri
     Ok(())
 }
 
-#[ignore]
 #[tokio::test]
 async fn reorg_changes_incoming_tx_index() {
     let lightwalletd = lightwalletd().await.unwrap();
@@ -336,6 +335,12 @@ async fn prepare_after_tx_index_change_reorg(uri: http::Uri) -> Result<(), Strin
     // Setup prodedures.  Up to this point there's no communication between the client and the dswd
     client.clear_address_utxo(Empty {}).await.unwrap();
 
+    // reset with parameters
+    connector
+        .reset(202, String::from(BRANCH_ID), String::from("regtest"))
+        .await
+        .unwrap();
+
     let dataset_path = format!(
         "{}/{}",
         get_cargo_manifest_dir().to_string_lossy(),
@@ -349,6 +354,17 @@ async fn prepare_after_tx_index_change_reorg(uri: http::Uri) -> Result<(), Strin
                 .collect(),
         )
         .await?;
+
+    for i in 201..207 {
+        let tree_state_path = format!(
+            "{}/{}/{}.json",
+            get_cargo_manifest_dir().to_string_lossy(),
+            TREE_STATE_FOLDER_PATH,
+            i
+        );
+        let tree_state = TreeState::from_file(tree_state_path).unwrap();
+        connector.add_tree_state(tree_state).await.unwrap();
+    }
 
     connector.apply_staged(206).await?;
 

--- a/libtonode-tests/Cargo.toml
+++ b/libtonode-tests/Cargo.toml
@@ -12,7 +12,7 @@ ci = ["zingolib/ci"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-zingolib = { workspace = true, features = ["darkside_tests", "testutils"] }
+zingolib = { workspace = true, features = ["testutils"] }
 zingo_common_components = { workspace = true, features = ["for_test"] }
 pepper-sync = { workspace = true }
 zingo-status = { workspace = true }

--- a/pepper-sync/src/client.rs
+++ b/pepper-sync/src/client.rs
@@ -31,9 +31,11 @@ use crate::error::{MempoolError, ServerError};
 
 pub(crate) mod fetch;
 
+#[cfg(not(feature = "darkside_test"))]
 const MAX_RETRIES: u8 = 3;
 
 const FETCH_REPLY_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(not(feature = "darkside_test"))]
 const STREAM_MSG_TIMEOUT: Duration = Duration::from_secs(15);
 
 async fn recv_fetch_reply<T>(
@@ -51,6 +53,7 @@ async fn recv_fetch_reply<T>(
     }
 }
 
+#[cfg(not(feature = "darkside_test"))]
 async fn next_stream_item<T>(
     stream: &mut tonic::Streaming<T>,
     what: &'static str,
@@ -334,6 +337,7 @@ pub(crate) async fn get_utxo_metadata(
 /// Gets transactions relevant to a given `transparent address` in the specified `block_range`.
 ///
 /// Requires [`crate::client::fetch::fetch`] to be running concurrently, connected via the `fetch_request` channel.
+#[cfg(not(feature = "darkside_test"))]
 pub(crate) async fn get_transparent_address_transactions(
     fetch_request_sender: UnboundedSender<FetchRequest>,
     consensus_parameters: &impl consensus::Parameters,

--- a/pepper-sync/src/keys/transparent.rs
+++ b/pepper-sync/src/keys/transparent.rs
@@ -3,10 +3,11 @@
 use zcash_address::{ToAddress as _, ZcashAddress};
 use zcash_protocol::consensus;
 use zcash_transparent::address::TransparentAddress;
-use zcash_transparent::keys::{
-    AccountPubKey, IncomingViewingKey as _, NonHardenedChildIndex, TransparentKeyScope,
-};
+use zcash_transparent::keys::{NonHardenedChildIndex, TransparentKeyScope};
 use zip32::AccountId;
+
+#[cfg(not(feature = "darkside_test"))]
+use zcash_transparent::keys::{AccountPubKey, IncomingViewingKey as _};
 
 use crate::wallet::KeyIdInterface;
 
@@ -103,6 +104,7 @@ impl TryFrom<u8> for TransparentScope {
     }
 }
 
+#[cfg(not(feature = "darkside_test"))]
 pub(crate) fn derive_address(
     consensus_parameters: &impl consensus::Parameters,
     account_pubkey: &AccountPubKey,
@@ -123,6 +125,7 @@ pub(crate) fn derive_address(
     Ok(encode_address(consensus_parameters, address))
 }
 
+#[cfg(not(feature = "darkside_test"))]
 fn derive_external_address(
     account_pubkey: &AccountPubKey,
     address_index: NonHardenedChildIndex,
@@ -132,6 +135,7 @@ fn derive_external_address(
         .derive_address(address_index)
 }
 
+#[cfg(not(feature = "darkside_test"))]
 fn derive_internal_address(
     account_pubkey: &AccountPubKey,
     address_index: NonHardenedChildIndex,
@@ -141,6 +145,7 @@ fn derive_internal_address(
         .derive_address(address_index)
 }
 
+#[cfg(not(feature = "darkside_test"))]
 fn derive_refund_address(
     account_pubkey: &AccountPubKey,
     address_index: NonHardenedChildIndex,

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -45,9 +45,11 @@ use crate::witness::LocatedTreeData;
 #[cfg(not(feature = "darkside_test"))]
 use crate::witness;
 
+#[cfg(not(feature = "darkside_test"))]
+pub(crate) mod transparent;
+
 pub(crate) mod spend;
 pub(crate) mod state;
-pub(crate) mod transparent;
 
 const UNCONFIRMED_SPEND_INVALIDATION_THRESHOLD: u32 = 3;
 pub(crate) const MAX_REORG_ALLOWANCE: u32 = 100;

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -624,6 +624,12 @@ where
             // The wallet reported height is above the current proxy height
             // reset to the proxy height.
             truncate_wallet_data(wallet, chain_height)?;
+            truncate_scan_ranges(
+                chain_height,
+                wallet
+                    .get_sync_state_mut()
+                    .map_err(SyncError::WalletError)?,
+            );
             return Ok(chain_height);
         }
         // The last wallet reported height is equal or below the proxy height.
@@ -1362,7 +1368,6 @@ where
         std::cmp::Ordering::Greater | std::cmp::Ordering::Equal => truncate_height,
         std::cmp::Ordering::Less => consensus::H0,
     };
-    truncate_scan_ranges(checked_truncate_height, sync_state);
 
     if checked_truncate_height > highest_scanned_height {
         return Ok(());
@@ -1413,6 +1418,12 @@ where
         })
         .collect::<Vec<_>>();
     truncate_wallet_data(wallet, consensus::H0)?;
+    truncate_scan_ranges(
+        consensus::H0,
+        wallet
+            .get_sync_state_mut()
+            .map_err(SyncError::WalletError)?,
+    );
     wallet
         .get_wallet_transactions_mut()
         .map_err(SyncError::WalletError)?

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -371,6 +371,7 @@ where
         .get_unified_full_viewing_keys()
         .map_err(SyncError::WalletError)?;
 
+    #[cfg(not(feature = "darkside_test"))]
     transparent::update_addresses_and_scan_targets(
         consensus_parameters,
         &mut *wallet_guard,

--- a/run_workspace_tests.sh
+++ b/run_workspace_tests.sh
@@ -1,0 +1,2 @@
+cargo nextest run --workspace --exclude darkside-tests
+cargo nextest run -p darkside-tests


### PR DESCRIPTION
fixes issue where scan range is truncated during re-org when chain height is higher than wallet's last known chain height.

this PR also fixes a re-org test "reorg_changes_incoming_tx_height" and feature gates out the part of sync which calls a broken RPC in darkside to verify this bug has been fixed. this test is now no longer ignored and passes where as when this test is run on current stable branch without the broken RPC call it returns this failure:

        FAIL [   7.630s] darkside-tests::advanced_reorg_tests reorg_changes_incoming_tx_height
  stdout ───

    running 1 test
    test reorg_changes_incoming_tx_height ... FAILED

    failures:

    failures:
        reorg_changes_incoming_tx_height

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 7 filtered out; finished in 7.62s

  stderr ───
    [darkside-tests/tests/advanced_reorg_tests.rs:114:5] &uri = http://127.0.0.1:22003/
    [darkside-tests/tests/advanced_reorg_tests.rs:158:5] &uri = http://127.0.0.1:22003/

    thread 'reorg_changes_incoming_tx_height' panicked at /home/oscar/tmp/zingolib/zingolib/pepper-sync/src/sync/state.rs:829:10:
    scan ranges must be non-empty
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

    thread 'reorg_changes_incoming_tx_height' panicked at zingolib/src/lightclient/sync.rs:114:47:
    task panicked: JoinError::Panic(Id(135), "scan ranges must be non-empty", ...)

────────────
     Summary [   7.631s] 1 test run: 0 passed, 1 failed, 183 skipped
        FAIL [   7.630s] darkside-tests::advanced_reorg_tests reorg_changes_incoming_tx_height

Fixes: #2347 
