### PR TITLE
Fix append subtree roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,6 +3325,7 @@ version = "0.2.0"
 dependencies = [
  "bip0039 0.13.4",
  "http",
+ "incrementalmerkletree",
  "itertools 0.14.0",
  "json",
  "pepper-sync",
@@ -3333,6 +3334,7 @@ dependencies = [
  "shardtree",
  "test-log",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "zcash_address",
@@ -3342,6 +3344,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_transparent",
  "zebra-chain",
+ "zingo-netutils",
  "zingo-status 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zingo_common_components",
  "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=for_zingolib_v3_release)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,6 +3405,7 @@ version = "0.2.0"
 dependencies = [
  "bip0039 0.13.4",
  "http",
+ "incrementalmerkletree",
  "itertools 0.14.0",
  "json",
  "pepper-sync",
@@ -3413,6 +3414,7 @@ dependencies = [
  "shardtree",
  "test-log",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "zcash_address 0.12.0",
@@ -3422,6 +3424,7 @@ dependencies = [
  "zcash_protocol 0.9.0",
  "zcash_transparent 0.8.0",
  "zebra-chain",
+ "zingo-netutils",
  "zingo-status",
  "zingo_common_components",
  "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=nu6_2_update_with_nuparams)",

--- a/libtonode-tests/Cargo.toml
+++ b/libtonode-tests/Cargo.toml
@@ -12,14 +12,15 @@ ci = ["zingolib/ci"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-zingolib = { workspace = true, features = ["darkside_tests", "testutils"] }
-zingo_common_components = { workspace = true, features = ["for_test"] }
+zingolib = { workspace = true, features = ["testutils"] }
 pepper-sync = { workspace = true }
 zingo-status = { workspace = true }
-
 zingolib_testutils = { version = "0.1.0", path = "../zingolib_testutils", features = ["test_lwd_zcashd"]}
+
 zcash_local_net.workspace = true
 zingo_test_vectors.workspace = true
+zingo_common_components = { workspace = true, features = ["for_test"] }
+zingo-netutils = { workspace = true }
 
 zip32 = { workspace = true }
 zcash_address = { workspace = true, features = ["test-dependencies"] }
@@ -30,6 +31,7 @@ zcash_transparent = { workspace = true }
 shardtree.workspace = true
 bip0039.workspace = true
 zebra-chain = { workspace = true }
+incrementalmerkletree.workspace = true
 
 tokio = { workspace = true, features = ["full"] }
 json = { workspace = true }
@@ -39,6 +41,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 http = { workspace = true }
+tonic.workspace = true
 
 [dev-dependencies]
 rustls.workspace = true

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -4,6 +4,7 @@ use bip0039::Mnemonic;
 use incrementalmerkletree::Position;
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
 use pepper_sync::sync::ScanPriority;
+use pepper_sync::wallet::ShardTrees;
 use shardtree::store::ShardStore;
 use zcash_local_net::validator::Validator;
 use zcash_protocol::consensus::BlockHeight;
@@ -94,6 +95,78 @@ async fn sync_mainnet_test() {
 
 #[tokio::test]
 async fn add_subtree_roots() {
+    fn assert_subtree_roots_match_server(
+        shard_trees: &mut ShardTrees,
+        sapling_subtree_roots_server: Vec<Vec<u8>>,
+        orchard_subtree_roots_server: Vec<Vec<u8>>,
+    ) {
+        let mut sapling_shard_addrs = shard_trees.sapling.store().get_shard_roots().unwrap();
+        if sapling_shard_addrs.len() > sapling_subtree_roots_server.len() {
+            sapling_shard_addrs.pop();
+        }
+        assert!(
+            sapling_shard_addrs.len() == sapling_subtree_roots_server.len(),
+            "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
+            sapling_shard_addrs.len(),
+            sapling_subtree_roots_server.len()
+        );
+        let mut sapling_subtree_roots_wallet = Vec::new();
+        for addr in sapling_shard_addrs {
+            let root = shard_trees
+                .sapling
+                .root(addr, Position::from(u64::MAX))
+                .unwrap();
+            sapling_subtree_roots_wallet.push(root.to_bytes().to_vec());
+        }
+
+        assert!(!sapling_subtree_roots_server.is_empty());
+        assert!(
+            sapling_subtree_roots_wallet.len() == sapling_subtree_roots_server.len(),
+            "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
+            sapling_subtree_roots_wallet.len(),
+            sapling_subtree_roots_server.len()
+        );
+        sapling_subtree_roots_wallet
+            .iter()
+            .zip(sapling_subtree_roots_server.clone())
+            .for_each(|(wallet_root, server_root)| {
+                assert!(wallet_root.as_slice() == server_root.as_slice());
+            });
+
+        let mut orchard_shard_addrs = shard_trees.orchard.store().get_shard_roots().unwrap();
+        if orchard_shard_addrs.len() > orchard_subtree_roots_server.len() {
+            orchard_shard_addrs.pop();
+        }
+        assert!(
+            orchard_shard_addrs.len() == orchard_subtree_roots_server.len(),
+            "no of orchard shard roots wallet: {}, no of orchard shard roots server: {}",
+            orchard_shard_addrs.len(),
+            orchard_subtree_roots_server.len()
+        );
+        let mut orchard_subtree_roots_wallet = Vec::new();
+        for addr in orchard_shard_addrs {
+            let root = shard_trees
+                .orchard
+                .root(addr, Position::from(u64::MAX))
+                .unwrap();
+            orchard_subtree_roots_wallet.push(root.to_bytes().to_vec());
+        }
+
+        assert!(!orchard_subtree_roots_server.is_empty());
+        assert!(
+            orchard_subtree_roots_wallet.len() == orchard_subtree_roots_server.len(),
+            "no of orchard shard roots wallet: {}, no of orchard shard roots server: {}",
+            orchard_subtree_roots_wallet.len(),
+            orchard_subtree_roots_server.len()
+        );
+        orchard_subtree_roots_wallet
+            .iter()
+            .zip(orchard_subtree_roots_server)
+            .for_each(|(wallet_root, server_root)| {
+                assert!(wallet_root.as_slice() == server_root.as_slice());
+            });
+    }
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Ring to work as a default");
@@ -185,77 +258,27 @@ async fn add_subtree_roots() {
     {
         let shard_trees = &mut lightclient.wallet.write().await.shard_trees;
 
-        let mut sapling_shard_addrs = shard_trees.sapling.store().get_shard_roots().unwrap();
-        if sapling_shard_addrs.len() > sapling_subtree_roots_server.len() {
-            sapling_shard_addrs.pop();
-        }
-        assert!(
-            sapling_shard_addrs.len() == sapling_subtree_roots_server.len(),
-            "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
-            sapling_shard_addrs.len(),
-            sapling_subtree_roots_server.len()
+        assert_subtree_roots_match_server(
+            shard_trees,
+            sapling_subtree_roots_server.clone(),
+            orchard_subtree_roots_server.clone(),
         );
-        let mut sapling_subtree_roots_wallet = Vec::new();
-        for addr in sapling_shard_addrs {
-            let root = shard_trees
-                .sapling
-                .root(addr, Position::from(u64::MAX))
-                .unwrap();
-            sapling_subtree_roots_wallet.push(root.to_bytes().to_vec());
-        }
-
-        assert!(!sapling_subtree_roots_server.is_empty());
-        assert!(
-            sapling_subtree_roots_wallet.len() == sapling_subtree_roots_server.len(),
-            "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
-            sapling_subtree_roots_wallet.len(),
-            sapling_subtree_roots_server.len()
-        );
-        sapling_subtree_roots_wallet
-            .iter()
-            .zip(sapling_subtree_roots_server.clone())
-            .for_each(|(wallet_root, server_root)| {
-                assert!(wallet_root.as_slice() == server_root.as_slice());
-            });
-
-        let mut orchard_shard_addrs = shard_trees.orchard.store().get_shard_roots().unwrap();
-        if orchard_shard_addrs.len() > orchard_subtree_roots_server.len() {
-            orchard_shard_addrs.pop();
-        }
-        assert!(
-            orchard_shard_addrs.len() == orchard_subtree_roots_server.len(),
-            "no of orchard shard roots wallet: {}, no of orchard shard roots server: {}",
-            orchard_shard_addrs.len(),
-            orchard_subtree_roots_server.len()
-        );
-        let mut orchard_subtree_roots_wallet = Vec::new();
-        for addr in orchard_shard_addrs {
-            let root = shard_trees
-                .orchard
-                .root(addr, Position::from(u64::MAX))
-                .unwrap();
-            orchard_subtree_roots_wallet.push(root.to_bytes().to_vec());
-        }
-
-        assert!(!orchard_subtree_roots_server.is_empty());
-        assert!(
-            orchard_subtree_roots_wallet.len() == orchard_subtree_roots_server.len(),
-            "no of orchard shard roots wallet: {}, no of orchard shard roots server: {}",
-            orchard_subtree_roots_wallet.len(),
-            orchard_subtree_roots_server.len()
-        );
-        orchard_subtree_roots_wallet
-            .iter()
-            .zip(orchard_subtree_roots_server)
-            .for_each(|(wallet_root, server_root)| {
-                assert!(wallet_root.as_slice() == server_root.as_slice());
-            });
 
         shard_trees
             .sapling
             .store_mut()
             .truncate_shards(500)
             .unwrap();
+        let sapling_shard_addrs = shard_trees.sapling.store().get_shard_roots().unwrap();
+        assert!(sapling_shard_addrs.len() != sapling_subtree_roots_server.len());
+
+        shard_trees
+            .orchard
+            .store_mut()
+            .truncate_shards(500)
+            .unwrap();
+        let orchard_shard_addrs = shard_trees.orchard.store().get_shard_roots().unwrap();
+        assert!(orchard_shard_addrs.len() != orchard_subtree_roots_server.len());
     }
 
     lightclient.sync().await.unwrap();
@@ -274,43 +297,15 @@ async fn add_subtree_roots() {
     let _ = lightclient.stop_sync();
     let _ = lightclient.await_sync().await;
 
-    // tokio::time::sleep(Duration::from_secs(10)).await;
+    {
+        let shard_trees = &mut lightclient.wallet.write().await.shard_trees;
 
-    // {
-    //     let shard_trees = &mut lightclient.wallet.write().await.shard_trees;
-
-    //     let mut sapling_shard_addrs = shard_trees.sapling.store().get_shard_roots().unwrap();
-    //     if sapling_shard_addrs.len() > sapling_subtree_roots_server.len() {
-    //         sapling_shard_addrs.pop();
-    //     }
-    //     assert!(
-    //         sapling_shard_addrs.len() == sapling_subtree_roots_server.len(),
-    //         "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
-    //         sapling_shard_addrs.len(),
-    //         sapling_subtree_roots_server.len()
-    //     );
-    //     let mut sapling_subtree_roots_wallet = Vec::new();
-    //     for addr in sapling_shard_addrs {
-    //         let root = shard_trees
-    //             .sapling
-    //             .root(addr, Position::from(u64::MAX))
-    //             .unwrap();
-    //         sapling_subtree_roots_wallet.push(root.to_bytes().to_vec());
-    //     }
-
-    //     assert!(
-    //         sapling_subtree_roots_wallet.len() == sapling_subtree_roots_server.len(),
-    //         "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
-    //         sapling_subtree_roots_wallet.len(),
-    //         sapling_subtree_roots_server.len()
-    //     );
-    //     sapling_subtree_roots_wallet
-    //         .iter()
-    //         .zip(sapling_subtree_roots_server)
-    //         .for_each(|(wallet_root, server_root)| {
-    //             assert!(wallet_root.as_slice() == server_root.as_slice());
-    //         });
-    // }
+        assert_subtree_roots_match_server(
+            shard_trees,
+            sapling_subtree_roots_server.clone(),
+            orchard_subtree_roots_server.clone(),
+        );
+    }
 }
 
 // temporary test for sync development

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -166,11 +166,7 @@ async fn add_subtree_roots() {
         orchard_subtree_roots_server.push(root.root_hash);
     }
 
-    dbg!("1");
-    dbg!(lightclient.sync_mode());
     lightclient.sync().await.unwrap();
-    dbg!("post-sync");
-    dbg!(&lightclient.sync_handle);
     while !(lightclient
         .wallet
         .read()
@@ -181,16 +177,10 @@ async fn add_subtree_roots() {
         .any(|range| range.priority() == ScanPriority::Scanning)
         || matches!(lightclient.poll_sync(), PollReport::Ready(_)))
     {
-        dbg!("2");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    dbg!("3");
-    dbg!(lightclient.sync_mode());
     let _ = lightclient.stop_sync();
-    dbg!(lightclient.sync_mode());
-    dbg!("4");
     let _ = lightclient.await_sync().await;
-    dbg!("5");
 
     {
         let shard_trees = &mut lightclient.wallet.write().await.shard_trees;
@@ -268,12 +258,7 @@ async fn add_subtree_roots() {
             .unwrap();
     }
 
-    dbg!("6");
-    dbg!(lightclient.sync_mode());
     lightclient.sync().await.unwrap();
-    tokio::time::sleep(Duration::from_secs(10)).await;
-    dbg!("post-sync");
-    dbg!(&lightclient.sync_handle);
     while !(lightclient
         .wallet
         .read()
@@ -284,17 +269,10 @@ async fn add_subtree_roots() {
         .any(|range| range.priority() == ScanPriority::Scanning)
         || matches!(lightclient.poll_sync(), PollReport::Ready(_)))
     {
-        dbg!("7");
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    dbg!("8");
-    dbg!(lightclient.sync_mode());
     let _ = lightclient.stop_sync();
-    dbg!(lightclient.sync_mode());
-    dbg!("9");
     let _ = lightclient.await_sync().await;
-    dbg!(&lightclient.sync_handle);
-    dbg!("10");
 
     // tokio::time::sleep(Duration::from_secs(10)).await;
 

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -6,9 +6,12 @@ use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscov
 use pepper_sync::sync::ScanPriority;
 use pepper_sync::wallet::ShardTrees;
 use shardtree::store::ShardStore;
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
 use zcash_local_net::validator::Validator;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_common_components::protocol::activation_heights::for_test::all_height_one_nus;
+use zingo_netutils::GetClientError;
 use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
 use zingolib::data::PollReport;
 use zingolib::testutils::lightclient::from_inputs::quick_send;
@@ -167,6 +170,28 @@ async fn add_subtree_roots() {
             });
     }
 
+    // temporary client creation until zingolib v5 lands with new netutils update (imminent!)
+    async fn get_client(
+        uri: http::Uri,
+    ) -> Result<CompactTxStreamerClient<Channel>, GetClientError> {
+        let scheme = uri.scheme_str().ok_or(GetClientError::InvalidScheme)?;
+        if scheme != "http" && scheme != "https" {
+            return Err(GetClientError::InvalidScheme);
+        }
+        let _authority = uri.authority().ok_or(GetClientError::InvalidAuthority)?;
+
+        let endpoint = Endpoint::from_shared(uri.to_string())?.tcp_nodelay(true);
+
+        let channel = if scheme == "https" {
+            let tls = ClientTlsConfig::new().with_webpki_roots();
+            endpoint.tls_config(tls)?.connect().await?
+        } else {
+            endpoint.connect().await?
+        };
+
+        Ok(CompactTxStreamerClient::new(channel))
+    }
+
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Ring to work as a default");
@@ -205,7 +230,7 @@ async fn add_subtree_roots() {
     )
     .unwrap();
 
-    let mut grpc_client = zingo_netutils::get_client(lightclient.config.get_lightwalletd_uri())
+    let mut grpc_client = get_client(lightclient.config.get_lightwalletd_uri())
         .await
         .unwrap();
 

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -1,12 +1,15 @@
 use std::{num::NonZeroU32, time::Duration};
 
 use bip0039::Mnemonic;
+use incrementalmerkletree::Position;
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
+use pepper_sync::sync::ScanPriority;
 use shardtree::store::ShardStore;
 use zcash_local_net::validator::Validator;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_common_components::protocol::activation_heights::for_test::all_height_one_nus;
 use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
+use zingolib::data::PollReport;
 use zingolib::testutils::lightclient::from_inputs::quick_send;
 use zingolib::testutils::paths::get_cargo_manifest_dir;
 use zingolib::testutils::tempfile::TempDir;
@@ -89,13 +92,11 @@ async fn sync_mainnet_test() {
     // dbg!(&wallet.sync_state);
 }
 
-#[ignore = "mainnet test for large chain"]
 #[tokio::test]
-async fn sync_status() {
+async fn add_subtree_roots() {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("Ring to work as a default");
-    tracing_subscriber::fmt().init();
 
     let uri = construct_lightwalletd_uri(Some(DEFAULT_LIGHTWALLETD_SERVER.to_string()));
     let temp_dir = TempDir::new().unwrap();
@@ -106,7 +107,7 @@ async fn sync_status() {
         zingolib::config::ChainType::Mainnet,
         WalletSettings {
             sync_config: SyncConfig {
-                transparent_address_discovery: TransparentAddressDiscovery::minimal(),
+                transparent_address_discovery: TransparentAddressDiscovery::disabled(),
                 performance_level: PerformanceLevel::High,
             },
             min_confirmations: NonZeroU32::try_from(1).unwrap(),
@@ -122,7 +123,7 @@ async fn sync_status() {
                 mnemonic: Mnemonic::from_phrase(HOSPITAL_MUSEUM_SEED.to_string()).unwrap(),
                 no_of_accounts: NonZeroU32::try_from(1).expect("hard-coded integer"),
             },
-            2_496_152.into(),
+            2_000_000.into(),
             config.wallet_settings.clone(),
         )
         .unwrap(),
@@ -131,7 +132,207 @@ async fn sync_status() {
     )
     .unwrap();
 
-    lightclient.sync_and_await().await.unwrap();
+    let mut grpc_client = zingo_netutils::get_client(lightclient.config.get_lightwalletd_uri())
+        .await
+        .unwrap();
+
+    let request = tonic::Request::new(zcash_client_backend::proto::service::GetSubtreeRootsArg {
+        start_index: 0,
+        shielded_protocol: 0,
+        max_entries: 0,
+    });
+    let mut sapling_subtree_roots_server = Vec::new();
+    let mut sapling_subtree_roots_stream = grpc_client
+        .get_subtree_roots(request)
+        .await
+        .unwrap()
+        .into_inner();
+    while let Some(root) = sapling_subtree_roots_stream.message().await.unwrap() {
+        sapling_subtree_roots_server.push(root.root_hash);
+    }
+
+    let request = tonic::Request::new(zcash_client_backend::proto::service::GetSubtreeRootsArg {
+        start_index: 0,
+        shielded_protocol: 1,
+        max_entries: 0,
+    });
+    let mut orchard_subtree_roots_server = Vec::new();
+    let mut orchard_subtree_roots_stream = grpc_client
+        .get_subtree_roots(request)
+        .await
+        .unwrap()
+        .into_inner();
+    while let Some(root) = orchard_subtree_roots_stream.message().await.unwrap() {
+        orchard_subtree_roots_server.push(root.root_hash);
+    }
+
+    dbg!("1");
+    dbg!(lightclient.sync_mode());
+    lightclient.sync().await.unwrap();
+    dbg!("post-sync");
+    dbg!(&lightclient.sync_handle);
+    while !(lightclient
+        .wallet
+        .read()
+        .await
+        .sync_state
+        .scan_ranges()
+        .iter()
+        .any(|range| range.priority() == ScanPriority::Scanning)
+        || matches!(lightclient.poll_sync(), PollReport::Ready(_)))
+    {
+        dbg!("2");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    dbg!("3");
+    dbg!(lightclient.sync_mode());
+    let _ = lightclient.stop_sync();
+    dbg!(lightclient.sync_mode());
+    dbg!("4");
+    let _ = lightclient.await_sync().await;
+    dbg!("5");
+
+    {
+        let shard_trees = &mut lightclient.wallet.write().await.shard_trees;
+
+        let mut sapling_shard_addrs = shard_trees.sapling.store().get_shard_roots().unwrap();
+        if sapling_shard_addrs.len() > sapling_subtree_roots_server.len() {
+            sapling_shard_addrs.pop();
+        }
+        assert!(
+            sapling_shard_addrs.len() == sapling_subtree_roots_server.len(),
+            "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
+            sapling_shard_addrs.len(),
+            sapling_subtree_roots_server.len()
+        );
+        let mut sapling_subtree_roots_wallet = Vec::new();
+        for addr in sapling_shard_addrs {
+            let root = shard_trees
+                .sapling
+                .root(addr, Position::from(u64::MAX))
+                .unwrap();
+            sapling_subtree_roots_wallet.push(root.to_bytes().to_vec());
+        }
+
+        assert!(!sapling_subtree_roots_server.is_empty());
+        assert!(
+            sapling_subtree_roots_wallet.len() == sapling_subtree_roots_server.len(),
+            "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
+            sapling_subtree_roots_wallet.len(),
+            sapling_subtree_roots_server.len()
+        );
+        sapling_subtree_roots_wallet
+            .iter()
+            .zip(sapling_subtree_roots_server.clone())
+            .for_each(|(wallet_root, server_root)| {
+                assert!(wallet_root.as_slice() == server_root.as_slice());
+            });
+
+        let mut orchard_shard_addrs = shard_trees.orchard.store().get_shard_roots().unwrap();
+        if orchard_shard_addrs.len() > orchard_subtree_roots_server.len() {
+            orchard_shard_addrs.pop();
+        }
+        assert!(
+            orchard_shard_addrs.len() == orchard_subtree_roots_server.len(),
+            "no of orchard shard roots wallet: {}, no of orchard shard roots server: {}",
+            orchard_shard_addrs.len(),
+            orchard_subtree_roots_server.len()
+        );
+        let mut orchard_subtree_roots_wallet = Vec::new();
+        for addr in orchard_shard_addrs {
+            let root = shard_trees
+                .orchard
+                .root(addr, Position::from(u64::MAX))
+                .unwrap();
+            orchard_subtree_roots_wallet.push(root.to_bytes().to_vec());
+        }
+
+        assert!(!orchard_subtree_roots_server.is_empty());
+        assert!(
+            orchard_subtree_roots_wallet.len() == orchard_subtree_roots_server.len(),
+            "no of orchard shard roots wallet: {}, no of orchard shard roots server: {}",
+            orchard_subtree_roots_wallet.len(),
+            orchard_subtree_roots_server.len()
+        );
+        orchard_subtree_roots_wallet
+            .iter()
+            .zip(orchard_subtree_roots_server)
+            .for_each(|(wallet_root, server_root)| {
+                assert!(wallet_root.as_slice() == server_root.as_slice());
+            });
+
+        shard_trees
+            .sapling
+            .store_mut()
+            .truncate_shards(500)
+            .unwrap();
+    }
+
+    dbg!("6");
+    dbg!(lightclient.sync_mode());
+    lightclient.sync().await.unwrap();
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    dbg!("post-sync");
+    dbg!(&lightclient.sync_handle);
+    while !(lightclient
+        .wallet
+        .read()
+        .await
+        .sync_state
+        .scan_ranges()
+        .iter()
+        .any(|range| range.priority() == ScanPriority::Scanning)
+        || matches!(lightclient.poll_sync(), PollReport::Ready(_)))
+    {
+        dbg!("7");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    dbg!("8");
+    dbg!(lightclient.sync_mode());
+    let _ = lightclient.stop_sync();
+    dbg!(lightclient.sync_mode());
+    dbg!("9");
+    let _ = lightclient.await_sync().await;
+    dbg!(&lightclient.sync_handle);
+    dbg!("10");
+
+    // tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // {
+    //     let shard_trees = &mut lightclient.wallet.write().await.shard_trees;
+
+    //     let mut sapling_shard_addrs = shard_trees.sapling.store().get_shard_roots().unwrap();
+    //     if sapling_shard_addrs.len() > sapling_subtree_roots_server.len() {
+    //         sapling_shard_addrs.pop();
+    //     }
+    //     assert!(
+    //         sapling_shard_addrs.len() == sapling_subtree_roots_server.len(),
+    //         "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
+    //         sapling_shard_addrs.len(),
+    //         sapling_subtree_roots_server.len()
+    //     );
+    //     let mut sapling_subtree_roots_wallet = Vec::new();
+    //     for addr in sapling_shard_addrs {
+    //         let root = shard_trees
+    //             .sapling
+    //             .root(addr, Position::from(u64::MAX))
+    //             .unwrap();
+    //         sapling_subtree_roots_wallet.push(root.to_bytes().to_vec());
+    //     }
+
+    //     assert!(
+    //         sapling_subtree_roots_wallet.len() == sapling_subtree_roots_server.len(),
+    //         "no of sapling shard roots wallet: {}, no of sapling shard roots server: {}",
+    //         sapling_subtree_roots_wallet.len(),
+    //         sapling_subtree_roots_server.len()
+    //     );
+    //     sapling_subtree_roots_wallet
+    //         .iter()
+    //         .zip(sapling_subtree_roots_server)
+    //         .for_each(|(wallet_root, server_root)| {
+    //             assert!(wallet_root.as_slice() == server_root.as_slice());
+    //         });
+    // }
 }
 
 // temporary test for sync development

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -216,19 +216,23 @@ where
                 self.update_workers();
 
                 let sync_state = wallet.get_sync_state().map_err(SyncError::WalletError)?;
+                dbg!("a");
                 if !sync_state
                     .scan_ranges()
                     .iter()
                     .any(|scan_range| scan_range.priority() == ScanPriority::Verify)
                 {
+                    dbg!("b");
                     if sync_state
                         .scan_ranges()
                         .iter()
                         .any(|scan_range| scan_range.priority() == ScanPriority::Scanning)
                     {
+                        dbg!("c");
                         // the last scan ranges with `Verify` priority are currently being scanned.
                         return Ok(());
                     }
+                    dbg!("d");
                     // verification complete
                     self.state.verified();
                     return Ok(());
@@ -239,6 +243,7 @@ where
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Scan => {
+                dbg!("scan");
                 self.batcher
                     .as_mut()
                     .expect("batcher should be running")
@@ -248,6 +253,7 @@ where
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Shutdown => {
+                dbg!("shutdown");
                 shutdown_mempool.store(true, atomic::Ordering::Release);
                 while let Some(worker) = self.idle_worker() {
                     self.shutdown_worker(worker.id).await;
@@ -284,15 +290,19 @@ where
     where
         W: SyncWallet + SyncBlocks + SyncNullifiers,
     {
+        dbg!("update batcher");
         let batcher = self.batcher.as_ref().expect("batcher should be running");
         if !batcher.is_batching() {
+            dbg!("create scan task");
             if let Some(scan_task) = sync::state::create_scan_task(
                 &self.consensus_parameters,
                 wallet,
                 nullifier_map_limit_exceeded,
             )? {
+                dbg!("add task");
                 batcher.add_scan_task(scan_task);
             } else if wallet.get_sync_state()?.scan_complete() {
+                dbg!("set shutdown");
                 self.state.shutdown();
             }
         }
@@ -349,6 +359,7 @@ where
             let mut previous_task_last_block: Option<WalletBlock> = None;
 
             while let Some(mut scan_task) = scan_task_receiver.recv().await {
+                dbg!("batcher main loop");
                 let fetch_nullifiers_only =
                     scan_task.scan_range.priority() == ScanPriority::ScannedWithoutMapping;
 
@@ -360,7 +371,7 @@ where
                 let mut first_batch = true;
 
                 let mut block_stream = {
-                    let range = scan_task.scan_range.block_range().clone();
+                    let range = dbg!(scan_task.scan_range.block_range().clone());
                     let frs = fetch_request_sender.clone();
 
                     let open_fut = async move {
@@ -532,8 +543,12 @@ where
 
                 let _ignore_error = batch_sender.send(scan_task).await;
 
+                dbg!("batcher set false");
                 is_batching.store(false, atomic::Ordering::Release);
             }
+
+            dbg!("batcher return ok");
+            is_batching.store(false, atomic::Ordering::Release);
             Ok(())
         });
 

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -216,23 +216,19 @@ where
                 self.update_workers();
 
                 let sync_state = wallet.get_sync_state().map_err(SyncError::WalletError)?;
-                dbg!("a");
                 if !sync_state
                     .scan_ranges()
                     .iter()
                     .any(|scan_range| scan_range.priority() == ScanPriority::Verify)
                 {
-                    dbg!("b");
                     if sync_state
                         .scan_ranges()
                         .iter()
                         .any(|scan_range| scan_range.priority() == ScanPriority::Scanning)
                     {
-                        dbg!("c");
                         // the last scan ranges with `Verify` priority are currently being scanned.
                         return Ok(());
                     }
-                    dbg!("d");
                     // verification complete
                     self.state.verified();
                     return Ok(());
@@ -243,7 +239,6 @@ where
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Scan => {
-                dbg!("scan");
                 self.batcher
                     .as_mut()
                     .expect("batcher should be running")
@@ -253,7 +248,6 @@ where
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Shutdown => {
-                dbg!("shutdown");
                 shutdown_mempool.store(true, atomic::Ordering::Release);
                 while let Some(worker) = self.idle_worker() {
                     self.shutdown_worker(worker.id).await;
@@ -290,19 +284,15 @@ where
     where
         W: SyncWallet + SyncBlocks + SyncNullifiers,
     {
-        dbg!("update batcher");
         let batcher = self.batcher.as_ref().expect("batcher should be running");
         if !batcher.is_batching() {
-            dbg!("create scan task");
             if let Some(scan_task) = sync::state::create_scan_task(
                 &self.consensus_parameters,
                 wallet,
                 nullifier_map_limit_exceeded,
             )? {
-                dbg!("add task");
                 batcher.add_scan_task(scan_task);
             } else if wallet.get_sync_state()?.scan_complete() {
-                dbg!("set shutdown");
                 self.state.shutdown();
             }
         }
@@ -359,7 +349,6 @@ where
             let mut previous_task_last_block: Option<WalletBlock> = None;
 
             while let Some(mut scan_task) = scan_task_receiver.recv().await {
-                dbg!("batcher main loop");
                 let fetch_nullifiers_only =
                     scan_task.scan_range.priority() == ScanPriority::ScannedWithoutMapping;
 
@@ -371,7 +360,7 @@ where
                 let mut first_batch = true;
 
                 let mut block_stream = {
-                    let range = dbg!(scan_task.scan_range.block_range().clone());
+                    let range = scan_task.scan_range.block_range().clone();
                     let frs = fetch_request_sender.clone();
 
                     let open_fut = async move {
@@ -543,11 +532,9 @@ where
 
                 let _ignore_error = batch_sender.send(scan_task).await;
 
-                dbg!("batcher set false");
                 is_batching.store(false, atomic::Ordering::Release);
             }
 
-            dbg!("batcher return ok");
             is_batching.store(false, atomic::Ordering::Release);
             Ok(())
         });

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -536,6 +536,7 @@ where
             }
 
             is_batching.store(false, atomic::Ordering::Release);
+
             Ok(())
         });
 
@@ -687,6 +688,8 @@ where
 
                 is_scanning.store(false, atomic::Ordering::Release);
             }
+
+            is_scanning.store(false, atomic::Ordering::Release);
         });
 
         self.handle = Some(handle);

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -323,14 +323,12 @@ where
         + Send,
 {
     let mut sync_mode_enum = SyncMode::from_atomic_u8(sync_mode.clone())?;
-    dbg!(sync_mode_enum);
     if sync_mode_enum == SyncMode::NotRunning {
         sync_mode_enum = SyncMode::Running;
         sync_mode.store(sync_mode_enum as u8, atomic::Ordering::Release);
     } else {
         return Err(SyncModeError::SyncAlreadyRunning.into());
     }
-    dbg!(sync_mode.load(atomic::Ordering::Acquire));
 
     tracing::info!("Starting sync...");
 
@@ -469,7 +467,6 @@ where
             }
 
             _update_scanner = interval.tick() => {
-                dbg!("update scanner");
                 sync_mode_enum = SyncMode::from_atomic_u8(sync_mode.clone())?;
                 match sync_mode_enum {
                     SyncMode::Paused => {
@@ -481,7 +478,6 @@ where
                         }
                     },
                     SyncMode::Shutdown => {
-                        dbg!("sd tick");
                         let mut wallet_guard = wallet.write().await;
                         let sync_status = match sync_status(&*wallet_guard).await {
                             Ok(status) => status,
@@ -523,10 +519,8 @@ where
 
                 scanner.update(&mut *wallet.write().await, shutdown_mempool.clone(), nullifier_map_limit_exceeded).await?;
 
-                dbg!("sd check");
                 if matches!(scanner.state, ScannerState::Shutdown) {
                     // wait for mempool monitor to receive mempool transactions
-                dbg!("sd check inner");
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     if is_shutdown(&scanner, unprocessed_mempool_transactions_count.clone())
                     {
@@ -538,7 +532,6 @@ where
         }
     }
 
-    dbg!("exited loop");
     let mut wallet_guard = wallet.write().await;
     let sync_status = match sync_status(&*wallet_guard).await {
         Ok(status) => status,

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1723,8 +1723,16 @@ where
     let shard_trees = wallet
         .get_shard_trees_mut()
         .map_err(SyncError::WalletError)?;
-    witness::add_subtree_roots(sapling_subtree_roots, &mut shard_trees.sapling)?;
-    witness::add_subtree_roots(orchard_subtree_roots, &mut shard_trees.orchard)?;
+    witness::add_subtree_roots(
+        sapling_start_index,
+        sapling_subtree_roots,
+        &mut shard_trees.sapling,
+    )?;
+    witness::add_subtree_roots(
+        orchard_start_index,
+        orchard_subtree_roots,
+        &mut shard_trees.orchard,
+    )?;
 
     Ok(())
 }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -323,12 +323,14 @@ where
         + Send,
 {
     let mut sync_mode_enum = SyncMode::from_atomic_u8(sync_mode.clone())?;
+    dbg!(sync_mode_enum);
     if sync_mode_enum == SyncMode::NotRunning {
         sync_mode_enum = SyncMode::Running;
         sync_mode.store(sync_mode_enum as u8, atomic::Ordering::Release);
     } else {
         return Err(SyncModeError::SyncAlreadyRunning.into());
     }
+    dbg!(sync_mode.load(atomic::Ordering::Acquire));
 
     tracing::info!("Starting sync...");
 
@@ -467,6 +469,7 @@ where
             }
 
             _update_scanner = interval.tick() => {
+                dbg!("update scanner");
                 sync_mode_enum = SyncMode::from_atomic_u8(sync_mode.clone())?;
                 match sync_mode_enum {
                     SyncMode::Paused => {
@@ -478,6 +481,7 @@ where
                         }
                     },
                     SyncMode::Shutdown => {
+                        dbg!("sd tick");
                         let mut wallet_guard = wallet.write().await;
                         let sync_status = match sync_status(&*wallet_guard).await {
                             Ok(status) => status,
@@ -492,6 +496,8 @@ where
                             .set_save_flag()
                             .map_err(SyncError::WalletError)?;
                         drop(wallet_guard);
+                        mempool_handle.abort();
+                        fetcher_handle.abort();
                         tracing::info!("Sync successfully shutdown.");
 
                         return Ok(SyncResult {
@@ -517,8 +523,10 @@ where
 
                 scanner.update(&mut *wallet.write().await, shutdown_mempool.clone(), nullifier_map_limit_exceeded).await?;
 
+                dbg!("sd check");
                 if matches!(scanner.state, ScannerState::Shutdown) {
                     // wait for mempool monitor to receive mempool transactions
+                dbg!("sd check inner");
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                     if is_shutdown(&scanner, unprocessed_mempool_transactions_count.clone())
                     {
@@ -530,6 +538,7 @@ where
         }
     }
 
+    dbg!("exited loop");
     let mut wallet_guard = wallet.write().await;
     let sync_status = match sync_status(&*wallet_guard).await {
         Ok(status) => status,
@@ -1724,12 +1733,12 @@ where
         .get_shard_trees_mut()
         .map_err(SyncError::WalletError)?;
     witness::add_subtree_roots(
-        sapling_start_index,
+        sapling_start_index as usize,
         sapling_subtree_roots,
         &mut shard_trees.sapling,
     )?;
     witness::add_subtree_roots(
-        orchard_start_index,
+        orchard_start_index as usize,
         orchard_subtree_roots,
         &mut shard_trees.orchard,
     )?;

--- a/pepper-sync/src/witness.rs
+++ b/pepper-sync/src/witness.rs
@@ -86,6 +86,7 @@ where
 
 #[cfg(not(feature = "darkside_test"))]
 pub(crate) fn add_subtree_roots<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
+    subtree_root_start_index: usize,
     subtree_roots: Vec<SubtreeRoot>,
     shard_tree: &mut shardtree::ShardTree<S, DEPTH, SHARD_HEIGHT>,
 ) -> Result<(), ServerError>
@@ -108,7 +109,7 @@ where
         let shard = LocatedPrunableTree::with_root_value(
             incrementalmerkletree::Address::from_parts(
                 incrementalmerkletree::Level::new(SHARD_HEIGHT),
-                index as u64,
+                (subtree_root_start_index + index) as u64,
             ),
             (node, shardtree::RetentionFlags::EPHEMERAL),
         );

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `lightclient::error::LightClientError`: added `SyncLaunchErrror` variant.
 
 ### Removed
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -55,7 +55,7 @@ pub struct LightClient {
     /// Wallet data
     pub wallet: Arc<RwLock<LightWallet>>,
     sync_mode: Arc<AtomicU8>,
-    sync_handle: Option<JoinHandle<Result<SyncResult, SyncError<WalletError>>>>,
+    pub sync_handle: Option<JoinHandle<Result<SyncResult, SyncError<WalletError>>>>,
     save_active: Arc<AtomicBool>,
     save_handle: Option<JoinHandle<std::io::Result<()>>>,
 }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -55,7 +55,7 @@ pub struct LightClient {
     /// Wallet data
     pub wallet: Arc<RwLock<LightWallet>>,
     sync_mode: Arc<AtomicU8>,
-    pub sync_handle: Option<JoinHandle<Result<SyncResult, SyncError<WalletError>>>>,
+    sync_handle: Option<JoinHandle<Result<SyncResult, SyncError<WalletError>>>>,
     save_active: Arc<AtomicBool>,
     save_handle: Option<JoinHandle<std::io::Result<()>>>,
 }

--- a/zingolib/src/lightclient/error.rs
+++ b/zingolib/src/lightclient/error.rs
@@ -12,6 +12,9 @@ use crate::wallet::{
 
 #[derive(Debug, thiserror::Error)]
 pub enum LightClientError {
+    /// Sync failed to launch..
+    #[error("Sync failed to launch.")]
+    SyncLaunchError,
     /// Sync not running.
     #[error("No sync handle. Sync is not running.")]
     SyncNotRunning,

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -21,7 +21,6 @@ impl LightClient {
     /// `sync_handle` field.
     // TODO: add realtime sync updates to zingo-cli when it can handle printing during user input
     pub async fn sync(&mut self) -> Result<(), LightClientError> {
-        dbg!("sync 1");
         if self.sync_mode() != SyncMode::NotRunning {
             return Err(LightClientError::SyncModeError(
                 SyncModeError::SyncAlreadyRunning,
@@ -36,7 +35,6 @@ impl LightClient {
         let wallet = self.wallet.clone();
         let sync_mode = self.sync_mode.clone();
         let sync_handle = tokio::spawn(async move {
-            dbg!("sync 2");
             pepper_sync::sync(client, &network, wallet, sync_mode, sync_config).await
         });
 
@@ -47,7 +45,6 @@ impl LightClient {
             interval.tick().await;
         }
 
-        dbg!("sync 3");
         self.sync_handle = Some(sync_handle);
 
         Ok(())
@@ -118,20 +115,16 @@ impl LightClient {
 
     /// Polls the sync task, returning [`self::PollReport`].
     pub fn poll_sync(&mut self) -> PollReport<SyncResult, SyncError<WalletError>> {
-        dbg!("poll sync");
         if let Some(mut sync_handle) = self.sync_handle.take() {
             if let Some(sync_result) = sync_handle.borrow_mut().now_or_never() {
-                dbg!("poll ready");
                 self.sync_mode
                     .store(SyncMode::NotRunning as u8, atomic::Ordering::Release);
                 PollReport::Ready(sync_result.expect("task panicked"))
             } else {
-                dbg!("poll not ready");
                 self.sync_handle = Some(sync_handle);
                 PollReport::NotReady
             }
         } else {
-            dbg!("poll no handle");
             self.sync_mode
                 .store(SyncMode::NotRunning as u8, atomic::Ordering::Release);
             PollReport::NoHandle

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -21,6 +21,7 @@ impl LightClient {
     /// `sync_handle` field.
     // TODO: add realtime sync updates to zingo-cli when it can handle printing during user input
     pub async fn sync(&mut self) -> Result<(), LightClientError> {
+        dbg!("sync 1");
         if self.sync_mode() != SyncMode::NotRunning {
             return Err(LightClientError::SyncModeError(
                 SyncModeError::SyncAlreadyRunning,
@@ -35,8 +36,18 @@ impl LightClient {
         let wallet = self.wallet.clone();
         let sync_mode = self.sync_mode.clone();
         let sync_handle = tokio::spawn(async move {
+            dbg!("sync 2");
             pepper_sync::sync(client, &network, wallet, sync_mode, sync_config).await
         });
+
+        let mut interval = tokio::time::interval(Duration::from_millis(50));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        interval.tick().await;
+        while self.sync_mode() == SyncMode::NotRunning {
+            interval.tick().await;
+        }
+
+        dbg!("sync 3");
         self.sync_handle = Some(sync_handle);
 
         Ok(())
@@ -107,16 +118,22 @@ impl LightClient {
 
     /// Polls the sync task, returning [`self::PollReport`].
     pub fn poll_sync(&mut self) -> PollReport<SyncResult, SyncError<WalletError>> {
+        dbg!("poll sync");
         if let Some(mut sync_handle) = self.sync_handle.take() {
             if let Some(sync_result) = sync_handle.borrow_mut().now_or_never() {
+                dbg!("poll ready");
                 self.sync_mode
                     .store(SyncMode::NotRunning as u8, atomic::Ordering::Release);
                 PollReport::Ready(sync_result.expect("task panicked"))
             } else {
+                dbg!("poll not ready");
                 self.sync_handle = Some(sync_handle);
                 PollReport::NotReady
             }
         } else {
+            dbg!("poll no handle");
+            self.sync_mode
+                .store(SyncMode::NotRunning as u8, atomic::Ordering::Release);
             PollReport::NoHandle
         }
     }

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -8,6 +8,9 @@ use futures::FutureExt;
 use pepper_sync::error::SyncError;
 use pepper_sync::error::SyncModeError;
 use pepper_sync::wallet::SyncMode;
+use tokio::time::MissedTickBehavior;
+use tokio::time::interval;
+use tokio::time::timeout;
 
 use crate::data::PollReport;
 use crate::wallet::error::WalletError;
@@ -15,6 +18,8 @@ use crate::wallet::error::WalletError;
 use super::LightClient;
 use super::SyncResult;
 use super::error::LightClientError;
+
+const SYNC_START_TIMEOUT: Duration = Duration::from_secs(3);
 
 impl LightClient {
     /// Launches a task for syncing the wallet to the latest state of the block chain, storing the handle in the
@@ -37,15 +42,43 @@ impl LightClient {
         let sync_handle = tokio::spawn(async move {
             pepper_sync::sync(client, &network, wallet, sync_mode, sync_config).await
         });
-
-        let mut interval = tokio::time::interval(Duration::from_millis(50));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        interval.tick().await;
-        while self.sync_mode() == SyncMode::NotRunning {
-            interval.tick().await;
-        }
-
         self.sync_handle = Some(sync_handle);
+
+        if timeout(SYNC_START_TIMEOUT, async {
+            let mut interval = interval(Duration::from_millis(50));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            interval.tick().await;
+            while self.sync_mode() == SyncMode::NotRunning {
+                interval.tick().await;
+            }
+        })
+        .await
+        .is_err()
+        {
+            match self.poll_sync() {
+                PollReport::Ready(sync_result) => {
+                    // sync can only return an error in this context so ignore success and return errror.
+                    let _ignore_sync_success = sync_result?;
+                }
+                PollReport::NotReady => {
+                    // this error should never be reached.
+                    // timeout only occurs when sync has returned an error so handle will always be ready.
+                    // cleans up sync handle and sets sync mode back to 'not running'.
+                    if let Some(sync_handle) = self.sync_handle.take() {
+                        sync_handle.abort();
+                        let _ignore_cancelled = sync_handle.await;
+                    }
+                    self.sync_mode
+                        .store(SyncMode::NotRunning as u8, atomic::Ordering::Release);
+                    return Err(LightClientError::SyncLaunchError);
+                }
+                PollReport::NoHandle => {
+                    // this error should never be reached.
+                    // sync handle must exist in this scope.
+                    return Err(LightClientError::SyncLaunchError);
+                }
+            }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Fixes: #2357 

added test "add_subtree_roots". failed on without the subtree root index bugfix in the following way:

```
$ cargo nextest run -p libtonode-tests add_subtree_roots --no-capture
   Compiling pepper-sync v0.3.0 (/home/oscar/src/zingolib/pepper-sync)
   Compiling zingolib v3.0.1 (/home/oscar/src/zingolib/zingolib)
   Compiling zingolib_testutils v0.1.0 (/home/oscar/src/zingolib/zingolib_testutils)
   Compiling libtonode-tests v0.2.0 (/home/oscar/src/zingolib/libtonode-tests)
    Finished `test` profile [optimized + debuginfo] target(s) in 47.89s
────────────
 Nextest run ID 134ed0c1-82fb-417c-a91a-56cb6e84f7d6 with nextest profile: default
    Starting 1 test across 6 binaries (83 tests skipped)
       START (1/1) libtonode-tests::sync add_subtree_roots

running 1 test

thread 'add_subtree_roots' panicked at libtonode-tests/tests/sync.rs:107:9:
no of sapling shard roots wallet: 1096, no of sapling shard roots server: 1127
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test add_subtree_roots ... FAILED

failures:

failures:
    add_subtree_roots

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 8.62s

        FAIL [   8.624s] (1/1) libtonode-tests::sync add_subtree_roots
```

test passes on this branch.

- also fixes an issue where sync polling states sync is running but sync mode states sync is not running.
- correctly builds libtonode-tests without "darkside-tests" feature which disables necessary RPC calls to test pepper-sync

#2348 will need to merge first to fix ci test failure
