### PR TITLE
upgrade test harness

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -5,10 +5,10 @@
 LIGHTWALLETD_VERSION=0.4.18
 
 # zcashd Git tag without the leading "v" (https://github.com/zcash/zcash/releases)
-ZCASH_VERSION=6.12.1
+ZCASH_VERSION=6.12.3
 
 # Zaino image tag used to provide zainod (https://hub.docker.com/r/zingodevops/zaino)
-ZAINO_IMAGE_TAG=0.3.0-rc.1
+ZAINO_IMAGE_TAG=0.3.1
 
 # cargo-nextest version compatible with the pinned Rust toolchain.
 NEXTEST_VERSION=0.9.128

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8729,7 +8729,7 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.5.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=434653b2e807062d22be11692d16d5abf4957b48#434653b2e807062d22be11692d16d5abf4957b48"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=b8929c4821c18ec7a059fbd6b57bd39795568fa1#b8929c4821c18ec7a059fbd6b57bd39795568fa1"
 dependencies = [
  "getset",
  "hex",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=434653b2e807062d22be11692d16d5abf4957b48#434653b2e807062d22be11692d16d5abf4957b48"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=b8929c4821c18ec7a059fbd6b57bd39795568fa1#b8929c4821c18ec7a059fbd6b57bd39795568fa1"
 dependencies = [
  "bip0039 0.12.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ portpicker = "0.1"
 proptest = "1.6.0"
 tempfile = "3"
 test-log = "0.2"
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "434653b2e807062d22be11692d16d5abf4957b48" }
-zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "434653b2e807062d22be11692d16d5abf4957b48" }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "b8929c4821c18ec7a059fbd6b57bd39795568fa1" }
+zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "b8929c4821c18ec7a059fbd6b57bd39795568fa1" }
 
 ### Documentation
 indoc = "2"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -119,6 +119,53 @@ append_workspace_default() {
     printf '%s\n' "--workspace"
   fi
 }
+
+nextest_args() {
+  local -a extra_args=("$@")
+  local -a args=(
+    --verbose
+    --profile "${ZINGOLIB_NEXTEST_PROFILE}"
+    --retries "${ZINGOLIB_NEXTEST_RETRIES}"
+  )
+
+  args+=("${extra_args[@]}")
+
+  local workspace_arg
+  workspace_arg="$(append_workspace_default "$@")"
+  if [[ -n "${workspace_arg}" ]]; then
+    args+=("${workspace_arg}")
+  fi
+
+  if [[ -n "${ZINGOLIB_NEXTEST_FILTER:-}" ]]; then
+    args+=(-E "${ZINGOLIB_NEXTEST_FILTER}")
+  fi
+
+  printf '%s\n' "${args[@]}"
+}
+
+container_nextest_run() {
+  local runtime mount_suffix tag
+  runtime="$(container_runtime)"
+  mount_suffix="$(container_mount_suffix)"
+  tag="$(container_image_tag)"
+
+  local -a args
+  mapfile -t args < <(nextest_args "$@")
+
+  "${runtime}" run --rm --init \
+    --pids-limit -1 \
+    -v "${PWD}:/workspace" \
+    -v "zingolib-container-target:/workspace/target${mount_suffix}" \
+    -v "zingolib-cargo-git:/root/.cargo/git${mount_suffix}" \
+    -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
+    -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
+    -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
+    -w /workspace \
+    "${IMAGE_NAME}:${tag}" \
+    bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli /usr/bin/zainod test_binaries/bins/ && exec "$@"' \
+    bash \
+    cargo nextest run "${args[@]}"
+}
 '''
 script.main = "true"
 
@@ -200,22 +247,8 @@ dependencies = ["prepare-test-binaries-dir"]
 script_runner = "bash"
 extend = "base-script"
 script.main = '''
-args=(
-  --verbose
-  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
-  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
-)
-
-workspace_arg="$(append_workspace_default "$@")"
-if [[ -n "${workspace_arg}" ]]; then
-  args+=("${workspace_arg}")
-fi
-
-if [[ -n "${ZINGOLIB_NEXTEST_FILTER:-}" ]]; then
-  args+=(-E "${ZINGOLIB_NEXTEST_FILTER}")
-fi
-
-cargo nextest run "${args[@]}" "${@}"
+mapfile -t args < <(nextest_args "$@")
+cargo nextest run "${args[@]}"
 '''
 
 [tasks.container-test]
@@ -225,37 +258,7 @@ dependencies = ["ensure-image-exists"]
 script_runner = "bash"
 extend = "base-script"
 script.main = '''
-runtime="$(container_runtime)"
-mount_suffix="$(container_mount_suffix)"
-tag="$(container_image_tag)"
-
-args=(
-  --verbose
-  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
-  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
-)
-
-workspace_arg="$(append_workspace_default "$@")"
-if [[ -n "${workspace_arg}" ]]; then
-  args+=("${workspace_arg}")
-fi
-
-if [[ -n "${ZINGOLIB_NEXTEST_FILTER:-}" ]]; then
-  args+=(-E "${ZINGOLIB_NEXTEST_FILTER}")
-fi
-
-"${runtime}" run --rm --init \
-  -v "${PWD}:/workspace" \
-  -v "zingolib-container-target:/workspace/target${mount_suffix}" \
-  -v "zingolib-cargo-git:/root/.cargo/git${mount_suffix}" \
-  -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
-  -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
-  -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
-  -w /workspace \
-  "${IMAGE_NAME}:${tag}" \
-  bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli /usr/bin/zainod test_binaries/bins/ && exec "$@"' \
-  bash \
-  cargo nextest run "${args[@]}" "${@}"
+container_nextest_run "$@"
 '''
 
 [tasks.rerun]
@@ -265,38 +268,7 @@ dependencies = ["ensure-image-exists"]
 script_runner = "bash"
 extend = "base-script"
 script.main = '''
-runtime="$(container_runtime)"
-mount_suffix="$(container_mount_suffix)"
-tag="$(container_image_tag)"
-
-args=(
-  --verbose
-  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
-  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
-  --rerun latest
-)
-
-workspace_arg="$(append_workspace_default "$@")"
-if [[ -n "${workspace_arg}" ]]; then
-  args+=("${workspace_arg}")
-fi
-
-if [[ -n "${ZINGOLIB_NEXTEST_FILTER:-}" ]]; then
-  args+=(-E "${ZINGOLIB_NEXTEST_FILTER}")
-fi
-
-"${runtime}" run --rm --init \
-  -v "${PWD}:/workspace" \
-  -v "zingolib-container-target:/workspace/target${mount_suffix}" \
-  -v "zingolib-cargo-git:/root/.cargo/git${mount_suffix}" \
-  -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
-  -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
-  -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
-  -w /workspace \
-  "${IMAGE_NAME}:${tag}" \
-  bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/lightwalletd /usr/bin/zcashd /usr/bin/zcash-cli /usr/bin/zainod test_binaries/bins/ && exec "$@"' \
-  bash \
-  cargo nextest run "${args[@]}" "${@}"
+container_nextest_run --rerun latest "$@"
 '''
 
 [tasks.run-ignored]
@@ -306,17 +278,6 @@ dependencies = ["prepare-test-binaries-dir"]
 script_runner = "bash"
 extend = "base-script"
 script.main = '''
-args=(
-  --verbose
-  --profile "${ZINGOLIB_NEXTEST_PROFILE}"
-  --retries "${ZINGOLIB_NEXTEST_RETRIES}"
-  --run-ignored all
-)
-
-workspace_arg="$(append_workspace_default "$@")"
-if [[ -n "${workspace_arg}" ]]; then
-  args+=("${workspace_arg}")
-fi
-
-cargo nextest run "${args[@]}" "${@}"
+mapfile -t args < <(nextest_args --run-ignored all "$@")
+cargo nextest run "${args[@]}"
 '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -25,10 +25,10 @@ Zingolib test tasks
 -------------------
 
 Common usage:
-  makers run
-  cargo make run
+  makers container-test
+  cargo make container-test
 
-The run task runs tests inside a reproducible container image:
+The container-test task runs tests inside a reproducible container image:
   cargo nextest run --verbose --workspace --profile ci --retries 2 -E 'not test(slow)'
 
 Build or refresh the local image:
@@ -41,10 +41,10 @@ The local-run task mirrors the PR test defaults:
   cargo nextest run --verbose --workspace --profile ci --retries 2 -E 'not test(slow)'
 
 Forward extra nextest flags after the task name:
-  makers run -p zingo-memo
+  makers container-test -p zingo-memo
 
 Override the default nextest filter:
-  ZINGOLIB_NEXTEST_FILTER='package(zingolib) & not test(slow)' makers run
+  ZINGOLIB_NEXTEST_FILTER='package(zingolib) & not test(slow)' makers container-test
 
 Reproduce the latest failing or incomplete nextest run:
   makers rerun
@@ -218,7 +218,7 @@ fi
 cargo nextest run "${args[@]}" "${@}"
 '''
 
-[tasks.run]
+[tasks.container-test]
 clear = true
 description = "Run reproducible workspace tests inside the local test container"
 dependencies = ["ensure-image-exists"]

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ This will launch the interactive prompt. Type `help` to get a list of commands.
 
 ## Testing
 
-Use `makers run` or `cargo make run` to run the same default nextest shape used by PR CI inside a reproducible local container image:
+Use `makers container-test` or `cargo make container-test` to run the same default nextest shape used by PR CI inside a reproducible local container image:
 
 ```
-makers run
+makers container-test
 ```
 
 The task builds the image if needed, symlinks the image-provided `lightwalletd`, `zcashd`, `zcash-cli`, and `zainod` into `test_binaries/bins`, then runs the workspace with the `ci` nextest profile, two retries, and the default filter `not test(slow)`. The image tag is derived from `.env.testing-artifacts`, `rust-toolchain.toml`, and `docker-ci`.
@@ -60,21 +60,21 @@ The task builds the image if needed, symlinks the image-provided `lightwalletd`,
 Extra nextest flags can be forwarded after the task name, and the default filter can be changed with `ZINGOLIB_NEXTEST_FILTER`.
 
 ```
-makers run -p zingo-memo
-ZINGOLIB_NEXTEST_FILTER='package(zingolib) & not test(slow)' makers run
+makers container-test -p zingo-memo
+ZINGOLIB_NEXTEST_FILTER='package(zingolib) & not test(slow)' makers container-test
 makers rerun
 ```
 
 To run the containerized test suite with all features enabled, pass `--all-features` through to nextest:
 
 ```
-makers run --all-features
+makers container-test --all-features
 ```
 
 This still applies the default `not test(slow)` filter. To match `cargo nextest run --all-features` more closely, clear the default filter:
 
 ```
-ZINGOLIB_NEXTEST_FILTER= makers run --all-features
+ZINGOLIB_NEXTEST_FILTER= makers container-test --all-features
 ```
 
 Use `makers local-run` to run the same nextest command on the host.

--- a/docker-ci/Dockerfile
+++ b/docker-ci/Dockerfile
@@ -57,8 +57,8 @@ LABEL org.zingolib.test-artifacts.versions.nextest="${NEXTEST_VERSION}"
 
 # Copy regtest binaries and zcash params from builder
 COPY --from=builder /usr/src/lightwalletd/lightwalletd /usr/bin/
-COPY --from=zcashd-downloader /usr/local/bin/zcashd /usr/bin/
-COPY --from=zcashd-downloader /usr/local/bin/zcash-cli /usr/bin/
+COPY --from=zcashd-downloader /usr/bin/zcashd /usr/bin/
+COPY --from=zcashd-downloader /usr/bin/zcash-cli /usr/bin/
 COPY --from=zainod-downloader /usr/local/bin/zainod /usr/bin/
 
 # Install dependencies and update ca certificates


### PR DESCRIPTION
This:

#### Refactors podman based testing to:

  - work with larger numbers of parallel tests.
  - DRY code
  - match zaino naming conventions for podman tests

To test run:

**makers container-test**

#### Points at latest infrastructure:

b8929c4821c18ec7a059fbd6b57bd39795568fa1

#### Points container test at latest

zcashd 6.12.3
zainod 0.3.1
