### PR TITLE
change output id type from u16 to u32

### DIFF
--- a/pepper-sync/CHANGELOG.md
+++ b/pepper-sync/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `wallet::TransparentCoin`: serialized version incremented to 1 to serialize output indexes as u32
+- `wallet::WalletNote`: serialized version incremented to 2 to serialize output indexes as u32
+- `wallet::OutgoingNote`: serialized version incremented to 1 to serialize output indexes as u32
+- `wallet::OutputId`:
+  - `output_index` field is now u32.
+  - `new` constructor `output_index` parameter is now u32.
+  - `output_index` method's return type is now u32.
 
 ### Removed
 

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -328,7 +328,7 @@ fn calculate_nullifiers_and_positions<D, K, Nf>(
     K: ScanningKeyOps<D, Nf>,
 {
     for (output_id, incoming_output) in incoming_decrypted_outputs {
-        let position = Position::from(u64::from(tree_size + u32::from(output_id.output_index())));
+        let position = Position::from(u64::from(tree_size + output_id.output_index()));
         let key = keys
             .get(&incoming_output.ivk_tag)
             .expect("key should be available as it was used to decrypt output");
@@ -362,7 +362,11 @@ fn calculate_sapling_leaves_and_retentions<D: Domain>(
                     .map_err(|()| ScanError::InvalidSaplingOutput)?
                     .cmu;
                 let leaf = sapling_crypto::Node::from_cmu(&note_commitment);
-                let decrypted: bool = incoming_output_indexes.contains(&(output_index as u16));
+                let decrypted: bool = incoming_output_indexes.contains(
+                    &output_index
+                        .try_into()
+                        .expect("output indexes should be valid u32"),
+                );
                 let retention = if decrypted {
                     Retention::Marked
                 } else {
@@ -399,7 +403,11 @@ fn calculate_orchard_leaves_and_retentions<D: Domain>(
                     .map_err(|()| ScanError::InvalidOrchardAction)?
                     .cmx();
                 let leaf = MerkleHashOrchard::from_cmx(&note_commitment);
-                let decrypted: bool = incoming_output_indexes.contains(&(output_index as u16));
+                let decrypted: bool = incoming_output_indexes.contains(
+                    &output_index
+                        .try_into()
+                        .expect("output indexes should be valid u32"),
+                );
                 let retention = if decrypted {
                     Retention::Marked
                 } else {

--- a/pepper-sync/src/scan/compact_blocks/runners.rs
+++ b/pepper-sync/src/scan/compact_blocks/runners.rs
@@ -598,7 +598,15 @@ where
                              output_index,
                              value,
                          }| {
-                            (OutputId::new(txid, output_index as u16), value)
+                            (
+                                OutputId::new(
+                                    txid,
+                                    output_index
+                                        .try_into()
+                                        .expect("output indexes should be valid u32"),
+                                ),
+                                value,
+                            )
                         },
                     )
                     .collect()

--- a/pepper-sync/src/scan/transactions.rs
+++ b/pepper-sync/src/scan/transactions.rs
@@ -340,7 +340,12 @@ fn scan_incoming_coins<P: consensus::Parameters>(
         if let Some(address) = output.recipient_address() {
             let encoded_address = keys::transparent::encode_address(consensus_parameters, address);
             if let Some((address, key_id)) = transparent_addresses.get_key_value(&encoded_address) {
-                let output_id = OutputId::new(txid, output_index as u16);
+                let output_id = OutputId::new(
+                    txid,
+                    output_index
+                        .try_into()
+                        .expect("output indexes should be valid u32"),
+                );
 
                 transparent_coins.push(TransparentCoin {
                     output_id,
@@ -375,7 +380,12 @@ where
         .enumerate()
     {
         if let Some(((note, _, memo_bytes), key_index)) = output {
-            let output_id = OutputId::new(txid, output_index as u16);
+            let output_id = OutputId::new(
+                txid,
+                output_index
+                    .try_into()
+                    .expect("output indexes should be valid u32"),
+            );
             let (nullifier, position) = nullifiers_and_positions.map_or(Ok((None, None)), |m| {
                 m.get(&output_id)
                     .map(|(nf, pos)| (Some(*nf), Some(*pos)))
@@ -419,7 +429,12 @@ where
             &output.out_ciphertext(),
         ) {
             outgoing_notes.push(OutgoingNote {
-                output_id: OutputId::new(txid, output_index as u16),
+                output_id: OutputId::new(
+                    txid,
+                    output_index
+                        .try_into()
+                        .expect("output indexes should be valid u32"),
+                ),
                 key_id: key_ids[key_index],
                 note,
                 memo: Memo::from_bytes(memo_bytes.as_ref())?,

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -290,13 +290,13 @@ pub struct OutputId {
     /// ID of associated transaction.
     txid: TxId,
     /// Index of output within the transactions bundle of the given pool type.
-    output_index: u16,
+    output_index: u32,
 }
 
 impl OutputId {
     /// Creates new `OutputId` from parts.
     #[must_use]
-    pub fn new(txid: TxId, output_index: u16) -> Self {
+    pub fn new(txid: TxId, output_index: u32) -> Self {
         OutputId { txid, output_index }
     }
 
@@ -308,7 +308,7 @@ impl OutputId {
 
     /// Index of output within the transactions bundle of the given pool type.
     #[must_use]
-    pub fn output_index(&self) -> u16 {
+    pub fn output_index(&self) -> u32 {
         self.output_index
     }
 }
@@ -328,13 +328,13 @@ impl std::fmt::Display for OutputId {
 
 impl From<&OutPoint> for OutputId {
     fn from(value: &OutPoint) -> Self {
-        OutputId::new(*value.txid(), value.n() as u16)
+        OutputId::new(*value.txid(), value.n())
     }
 }
 
 impl From<OutputId> for OutPoint {
     fn from(value: OutputId) -> Self {
-        OutPoint::new(value.txid.into(), u32::from(value.output_index))
+        OutPoint::new(value.txid.into(), value.output_index)
     }
 }
 

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -434,15 +434,19 @@ impl WalletTransaction {
 
 impl TransparentCoin {
     fn serialized_version() -> u8 {
-        0
+        1
     }
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
+        let version = reader.read_u8()?;
 
         let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
+        let output_index = if version >= 1 {
+            reader.read_u32::<LittleEndian>()?
+        } else {
+            u32::from(reader.read_u16::<LittleEndian>()?)
+        };
 
         let account_id = zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?)
             .expect("only valid account ids written");
@@ -475,7 +479,7 @@ impl TransparentCoin {
         writer.write_u8(Self::serialized_version())?;
 
         self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+        writer.write_u32::<LittleEndian>(self.output_id.output_index())?;
 
         writer.write_u32::<LittleEndian>(self.key_id.account_id().into())?;
         writer.write_u8(self.key_id.scope() as u8)?;
@@ -494,7 +498,7 @@ impl TransparentCoin {
 
 impl<N, Nf: Copy> WalletNote<N, Nf> {
     fn serialized_version() -> u8 {
-        1
+        2
     }
 }
 
@@ -529,7 +533,11 @@ impl SaplingNote {
         let version = reader.read_u8()?;
 
         let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
+        let output_index = if version >= 2 {
+            reader.read_u32::<LittleEndian>()?
+        } else {
+            u32::from(reader.read_u16::<LittleEndian>()?)
+        };
 
         let account_id =
             zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
@@ -616,7 +624,7 @@ impl SaplingNote {
         writer.write_u8(Self::serialized_version())?;
 
         self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+        writer.write_u32::<LittleEndian>(self.output_id.output_index())?;
 
         writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
         writer.write_u8(self.key_id.scope as u8)?;
@@ -656,7 +664,11 @@ impl OrchardNote {
         let version = reader.read_u8()?;
 
         let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
+        let output_index = if version >= 2 {
+            reader.read_u32::<LittleEndian>()?
+        } else {
+            u32::from(reader.read_u16::<LittleEndian>()?)
+        };
 
         let account_id =
             zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
@@ -727,7 +739,7 @@ impl OrchardNote {
         writer.write_u8(Self::serialized_version())?;
 
         self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+        writer.write_u32::<LittleEndian>(self.output_id.output_index())?;
 
         writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
         writer.write_u8(self.key_id.scope as u8)?;
@@ -754,7 +766,7 @@ impl OrchardNote {
 
 impl<N> OutgoingNote<N> {
     fn serialized_version() -> u8 {
-        0
+        1
     }
 }
 
@@ -764,10 +776,14 @@ impl OutgoingSaplingNote {
         mut reader: R,
         consensus_parameters: &impl consensus::Parameters,
     ) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
+        let version = reader.read_u8()?;
 
         let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
+        let output_index = if version >= 1 {
+            reader.read_u32::<LittleEndian>()?
+        } else {
+            u32::from(reader.read_u16::<LittleEndian>()?)
+        };
 
         let account_id =
             zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
@@ -844,7 +860,7 @@ impl OutgoingSaplingNote {
         writer.write_u8(Self::serialized_version())?;
 
         self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+        writer.write_u32::<LittleEndian>(self.output_id.output_index())?;
 
         writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
         writer.write_u8(self.key_id.scope as u8)?;
@@ -879,10 +895,14 @@ impl OutgoingOrchardNote {
         mut reader: R,
         consensus_parameters: &impl consensus::Parameters,
     ) -> std::io::Result<Self> {
-        let _version = reader.read_u8()?;
+        let version = reader.read_u8()?;
 
         let txid = TxId::read(&mut reader)?;
-        let output_index = reader.read_u16::<LittleEndian>()?;
+        let output_index = if version >= 1 {
+            reader.read_u32::<LittleEndian>()?
+        } else {
+            u32::from(reader.read_u16::<LittleEndian>()?)
+        };
 
         let account_id =
             zip32::AccountId::try_from(reader.read_u32::<LittleEndian>()?).map_err(|e| {
@@ -947,7 +967,7 @@ impl OutgoingOrchardNote {
         writer.write_u8(Self::serialized_version())?;
 
         self.output_id.txid().write(&mut writer)?;
-        writer.write_u16::<LittleEndian>(self.output_id.output_index())?;
+        writer.write_u32::<LittleEndian>(self.output_id.output_index())?;
 
         writer.write_u32::<LittleEndian>(self.key_id.account_id.into())?;
         writer.write_u8(self.key_id.scope as u8)?;

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `wallet::summary::data`:
+  - `NoteSummary`: `output_index` field is now u32.
+  - `OutgoingNoteSummary`: `output_index` field is now u32.
+  - `CoinSummary`: `output_index` field is now u32.
+  - `OutgoingCoinSummary`: `output_index` field is now u32.
+- `wallet::disk`: serialized version incremented to 40 for serializing output indexes as u32.
+- `wallet::output::OutputRef`: `output_index` method now returns u32.
 
 ### Removed
 

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -41,11 +41,11 @@ use pepper_sync::{
 };
 
 impl LightWallet {
-    /// Changes in version 39:
-    /// - sync state updated serialized version
+    /// Changes in version 40:
+    /// - output id type changed from u16 to u32
     #[must_use]
     pub const fn serialized_version() -> u64 {
-        39
+        40
     }
 
     /// Serialize into `writer`
@@ -109,7 +109,7 @@ impl LightWallet {
             &self.outpoint_map.iter().collect::<Vec<_>>(),
             |w, &(&output_id, &scan_target)| {
                 output_id.txid().write(&mut *w)?;
-                w.write_u16::<LittleEndian>(output_id.output_index())?;
+                w.write_u32::<LittleEndian>(output_id.output_index())?;
                 scan_target.write(w)
             },
         )?;
@@ -127,7 +127,7 @@ impl LightWallet {
         info!("Reading wallet version {version}");
         match version {
             ..32 => Self::read_v0(reader, network, version),
-            32..=39 => Self::read_v32(reader, network, version),
+            32..=40 => Self::read_v32(reader, network, version),
             _ => Err(io::Error::new(
                 ErrorKind::InvalidData,
                 format!(
@@ -495,7 +495,11 @@ impl LightWallet {
         let nullifier_map = NullifierMap::read(&mut reader)?;
         let outpoint_map = Vector::read(&mut reader, |mut r| {
             let outpoint_txid = TxId::read(&mut r)?;
-            let output_index = r.read_u16::<LittleEndian>()?;
+            let output_index = if version >= 40 {
+                r.read_u32::<LittleEndian>()?
+            } else {
+                u32::from(r.read_u16::<LittleEndian>()?)
+            };
             let scan_target = if version >= 37 {
                 ScanTarget::read(r)?
             } else {

--- a/zingolib/src/wallet/output.rs
+++ b/zingolib/src/wallet/output.rs
@@ -55,7 +55,7 @@ impl OutputRef {
 
     /// Output identifier.
     #[must_use]
-    pub fn output_index(&self) -> u16 {
+    pub fn output_index(&self) -> u32 {
         self.output_id.output_index()
     }
 

--- a/zingolib/src/wallet/summary.rs
+++ b/zingolib/src/wallet/summary.rs
@@ -171,7 +171,9 @@ impl LightWallet {
                                                 &self.network,
                                                 address,
                                             ),
-                                            output_index: output_index as u16,
+                                            output_index: output_index
+                                                .try_into()
+                                                .expect("output index should be valid u32"),
                                         }
                                     })
                                 })

--- a/zingolib/src/wallet/summary.rs
+++ b/zingolib/src/wallet/summary.rs
@@ -67,7 +67,7 @@ impl LightWallet {
                         BasicNoteSummary::from_parts(
                             output.value(),
                             spend_status,
-                            u32::from(output.output_id().output_index()),
+                            output.output_id().output_index(),
                             memo,
                         )
                     })
@@ -87,7 +87,7 @@ impl LightWallet {
                         BasicNoteSummary::from_parts(
                             output.value(),
                             spend_status,
-                            u32::from(output.output_id().output_index()),
+                            output.output_id().output_index(),
                             memo,
                         )
                     })
@@ -101,7 +101,7 @@ impl LightWallet {
                         BasicCoinSummary::from_parts(
                             output.value(),
                             spend_status,
-                            u32::from(output.output_id().output_index()),
+                            output.output_id().output_index(),
                         )
                     })
                     .collect::<Vec<_>>();

--- a/zingolib/src/wallet/summary/data.rs
+++ b/zingolib/src/wallet/summary/data.rs
@@ -909,7 +909,7 @@ impl std::fmt::Display for OutgoingNoteSummaries {
 pub struct OutgoingCoinSummary {
     pub value: u64,
     pub recipient: String,
-    pub output_index: u16,
+    pub output_index: u32,
 }
 
 impl std::fmt::Display for OutgoingCoinSummary {

--- a/zingolib/src/wallet/summary/data.rs
+++ b/zingolib/src/wallet/summary/data.rs
@@ -518,7 +518,7 @@ pub struct NoteSummary {
     pub memo: Option<String>,
     pub time: u32,
     pub txid: TxId,
-    pub output_index: u16,
+    pub output_index: u32,
     pub account_id: zip32::AccountId,
     pub scope: Scope,
 }
@@ -723,7 +723,7 @@ pub struct CoinSummary {
     pub spend_status: SpendStatus,
     pub time: u32,
     pub txid: TxId,
-    pub output_index: u16,
+    pub output_index: u32,
     pub account_id: zip32::AccountId,
     pub scope: TransparentScope,
     pub address_index: u32,
@@ -843,7 +843,7 @@ pub struct OutgoingNoteSummary {
     pub memo: Option<String>,
     pub recipient: String,
     pub recipient_unified_address: Option<String>,
-    pub output_index: u16,
+    pub output_index: u32,
     pub account_id: zip32::AccountId,
     pub scope: Scope,
 }

--- a/zingolib/src/wallet/sync.rs
+++ b/zingolib/src/wallet/sync.rs
@@ -270,12 +270,8 @@ mod tests {
         .unwrap();
         let (first_valid_diversifier, _) = fvk.find_address(DiversifierIndex::new()).unwrap();
 
-        let result = SyncWallet::add_sapling_address(
-            &mut wallet,
-            account_id,
-            addr.clone(),
-            first_valid_diversifier,
-        );
+        let result =
+            SyncWallet::add_sapling_address(&mut wallet, account_id, addr, first_valid_diversifier);
         assert!(result.is_ok());
         assert!(
             wallet

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -772,7 +772,10 @@ impl InputSource for LightWallet {
                         PoolType::SAPLING,
                     ),
                     note.output_id().txid(),
-                    note.output_id().output_index(),
+                    note.output_id()
+                        .output_index()
+                        .try_into()
+                        .expect("shielded notes are always valid u16"),
                     note.note().clone(),
                     note.key_id().scope,
                     note.position()
@@ -791,7 +794,10 @@ impl InputSource for LightWallet {
                         PoolType::ORCHARD,
                     ),
                     note.output_id().txid(),
-                    note.output_id().output_index(),
+                    note.output_id()
+                        .output_index()
+                        .try_into()
+                        .expect("shielded notes are always valid u16"),
                     *note.note(),
                     note.key_id().scope,
                     note.position()


### PR DESCRIPTION
Fixes:  #2359 

due to shared trait methods for all outputs via OutputInterface it was most appropriate to change all output ids to u32 rather than separate transparent and shielded output id types and interfaces