### PR TITLE
Fix darkside test reorg expires incoming tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ dependencies = [
  "zcash_protocol",
  "zebra-chain",
  "zingo-netutils",
+ "zingo-status 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zingo_common_components",
  "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=for_zingolib_v3_release)",
  "zingolib",

--- a/darkside-tests/Cargo.toml
+++ b/darkside-tests/Cargo.toml
@@ -9,6 +9,7 @@ chain_generic_tests = []
 
 [dependencies]
 zingolib = { workspace = true, features = ["darkside_tests", "testutils"] }
+zingo-status.workspace = true
 zingo-netutils = { workspace = true }
 zingo_common_components = { workspace = true, features = ["for_test"] }
 

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -374,7 +374,6 @@ async fn prepare_after_tx_index_change_reorg(uri: http::Uri) -> Result<(), Strin
     Ok(())
 }
 
-#[ignore = "darkside block continuity error, after re-org block 206's prev hash does not match 205's hash"]
 #[tokio::test]
 async fn reorg_expires_incoming_tx() {
     let lightwalletd = lightwalletd().await.unwrap();

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -7,7 +7,7 @@ use darkside_tests::{
         TREE_STATE_FOLDER_PATH,
     },
     darkside_connector::DarksideConnector,
-    darkside_types::{Empty, TreeState},
+    darkside_types::{Empty, RawTransaction, TreeState},
     utils::{lightwalletd, read_dataset, read_lines},
 };
 
@@ -610,7 +610,7 @@ async fn reorg_changes_outgoing_tx_height() {
         }
     );
 
-    let before_reorg_transactions = light_client.value_transfers(true).await.unwrap();
+    let before_reorg_transactions = light_client.transaction_summaries(true).await.unwrap().0;
 
     assert_eq!(before_reorg_transactions.len(), 1);
     assert_eq!(
@@ -667,9 +667,6 @@ async fn reorg_changes_outgoing_tx_height() {
 
     // check that the outgoing transaction has the correct height before
     // the reorg is triggered
-
-    tracing::info!("{:?}", light_client.value_transfers(true).await);
-
     assert_eq!(
         light_client
             .value_transfers(true)
@@ -699,24 +696,105 @@ async fn reorg_changes_outgoing_tx_height() {
     // Create reorg
     //
 
-    // stage empty blocks from height 205 to cause a Reorg
-    _ = connector.stage_blocks_create(sent_tx_height, 20, 1).await;
+    prepare_changes_outgoing_tx_height_after_reorg(server_id.clone(), tx.clone())
+        .await
+        .unwrap();
 
-    _ = connector
-        .stage_transactions_stream([(tx.clone().data, 210)].to_vec())
-        .await;
+    light_client.sync_and_await().await.unwrap();
 
-    _ = connector.apply_staged(211).await;
+    //
+    // due to a darkside bug where the returned txid of a transaction is different to the one requested we must mine
+    // beyond the expiry height to fail the duplicated tx. In production, this tx would be replaced immediately due to
+    // matching txids.
+    //
 
-    // temp hack as pepper sync needs tree state of latest block for sync status
-    connector.add_tree_state(TreeState { network: "regtest".to_string(), height: 211, hash: "015265800472a8aaf96c7891cf7bd63ee1468bb6f3747714a6bd76c40ec9298b".to_string(), time: 1694454562, sapling_tree: "000000".to_string(), orchard_tree: "01532c96c5d6a36ae79a9cad00ef7053e11b738c84c1022f80d8b0afcd2aedea23001f000001346fd8af3d66b14feaa60685fa189ca55cbd7f952fc25cdc971c310122b2402a01085516881012d2729492ba29b11522d3a45f0b70e2a7ab62a4243ec9a67c2a1100015fe60f3e71ba24797be5421c6c702e0a50c3a2178291a7d3dbd9543f5815cb0400000000000000000000000000000000000000000000000000".to_string() }).await.unwrap();
+    // verify that the reorged transaction is still there at the old height
+    assert_eq!(
+        light_client
+            .value_transfers(true)
+            .await
+            .unwrap()
+            .into_iter()
+            .find_map(|v| match v.kind {
+                ValueTransferKind::Sent(SentValueTransfer::Send) => {
+                    if v.recipient_address == Some(recipient_string.to_string())
+                        && v.value == 100000
+                        && v.status == ConfirmationStatus::Transmitted(205.into())
+                    {
+                        Some(v.blockheight)
+                    } else {
+                        None
+                    }
+                }
+                _ => {
+                    None
+                }
+            }),
+        Some(BlockHeight::from(205))
+    );
+    // mine 50 new blocks to expire tx
+    connector.stage_blocks_create(212, 50, 1).await.unwrap();
+    connector.apply_staged(261).await.unwrap();
 
-    let reorg_sync_result = light_client.sync_and_await().await;
+    // pepper sync needs tree state of latest block for sync status
+    connector.add_tree_state(TreeState { network: "regtest".to_string(), height: 261, hash: "015265800472a8aaf96c7891cf7bd63ee1468bb6f3747714a6bd76c40ec9298b".to_string(), time: 1694454562, sapling_tree: "000000".to_string(), orchard_tree: "01532c96c5d6a36ae79a9cad00ef7053e11b738c84c1022f80d8b0afcd2aedea23001f000001346fd8af3d66b14feaa60685fa189ca55cbd7f952fc25cdc971c310122b2402a01085516881012d2729492ba29b11522d3a45f0b70e2a7ab62a4243ec9a67c2a1100015fe60f3e71ba24797be5421c6c702e0a50c3a2178291a7d3dbd9543f5815cb0400000000000000000000000000000000000000000000000000".to_string() }).await.unwrap();
 
-    match reorg_sync_result {
-        Ok(value) => tracing::info!("{value}"),
-        Err(err_str) => tracing::info!("{err_str}"),
-    }
+    light_client.sync_and_await().await.unwrap();
+
+    let after_reorg_transactions = light_client.transaction_summaries(true).await.unwrap().0;
+
+    // the initial receive, the re-orged send and the failed tx (due to darkside bug)
+    assert_eq!(after_reorg_transactions.len(), 3);
+
+    // verify that the reorged transaction is in the new height
+    assert_eq!(
+        light_client
+            .value_transfers(true)
+            .await
+            .unwrap()
+            .into_iter()
+            .find_map(|v| match v.kind {
+                ValueTransferKind::Sent(SentValueTransfer::Send) => {
+                    if v.recipient_address == Some(recipient_string.to_string())
+                        && v.value == 100000
+                        && v.status == ConfirmationStatus::Confirmed(210.into())
+                    {
+                        Some(v.blockheight)
+                    } else {
+                        None
+                    }
+                }
+                _ => {
+                    None
+                }
+            }),
+        Some(BlockHeight::from(210))
+    );
+
+    // verify that the transaction that was stuck in transmitted due to darkside bug correctly expires
+    assert_eq!(
+        light_client
+            .value_transfers(true)
+            .await
+            .unwrap()
+            .into_iter()
+            .find_map(|v| match v.kind {
+                ValueTransferKind::Sent(SentValueTransfer::Send) => {
+                    if v.recipient_address == Some(recipient_string.to_string())
+                        && v.value == 100000
+                        && v.status == ConfirmationStatus::Failed(205.into())
+                    {
+                        Some(v.blockheight)
+                    } else {
+                        None
+                    }
+                }
+                _ => {
+                    None
+                }
+            }),
+        Some(BlockHeight::from(205))
+    );
 
     let expected_after_reorg_balance = AccountBalance {
         total_sapling_balance: Some(0.try_into().unwrap()),
@@ -738,35 +816,6 @@ async fn reorg_changes_outgoing_tx_height() {
             .unwrap(),
         expected_after_reorg_balance
     );
-
-    let after_reorg_transactions = light_client.value_transfers(true).await.unwrap();
-
-    assert_eq!(after_reorg_transactions.len(), 3);
-
-    tracing::info!("{:?}", light_client.value_transfers(true).await);
-
-    // FIXME: This test is broken because if this issue
-    // https://github.com/zingolabs/zingolib/issues/622
-    // verify that the reorged transaction is in the new height
-    // assert_eq!(
-    //     light_client
-    //         .list_value_transfers(true)
-    //         .await
-    //         .into_iter()
-    //         .find_map(|v| match v.kind {
-    //             ValueTransferKind::Sent { to_address, amount } => {
-    //                 if to_address.to_string() == recipient_string && amount == 100000 {
-    //                     Some(v.block_height)
-    //                 } else {
-    //                     None
-    //                 }
-    //             }
-    //             _ => {
-    //                 None
-    //             }
-    //         }),
-    //     Some(BlockHeight::from(211))
-    // );
 }
 
 async fn prepare_changes_outgoing_tx_height_before_reorg(uri: http::Uri) -> Result<(), String> {
@@ -807,6 +856,63 @@ async fn prepare_changes_outgoing_tx_height_before_reorg(uri: http::Uri) -> Resu
     }
 
     connector.apply_staged(204).await?;
+
+    sleep(std::time::Duration::new(1, 0)).await;
+
+    Ok(())
+}
+
+async fn prepare_changes_outgoing_tx_height_after_reorg(
+    uri: http::Uri,
+    tx: RawTransaction,
+) -> Result<(), String> {
+    let connector = DarksideConnector(uri.clone());
+
+    let mut client = connector.get_client().await.unwrap();
+    // Setup prodedures.  Up to this point there's no communication between the client and the dswd
+    client.clear_address_utxo(Empty {}).await.unwrap();
+
+    // reset with parameters
+    connector
+        .reset(202, String::from(BRANCH_ID), String::from("regtest"))
+        .await
+        .unwrap();
+
+    // this dataset works for this test since we only need funds to send a transaction.
+    let dataset_path = format!(
+        "{}/{}",
+        get_cargo_manifest_dir().to_string_lossy(),
+        REORG_EXPIRES_INCOMING_TX_HEIGHT_BEFORE
+    );
+
+    tracing::info!("dataset path: {dataset_path}");
+
+    connector
+        .stage_blocks_stream(read_dataset(dataset_path))
+        .await?;
+
+    for i in 201..211 {
+        let tree_state_path = format!(
+            "{}/{}/{}.json",
+            get_cargo_manifest_dir().to_string_lossy(),
+            TREE_STATE_FOLDER_PATH,
+            i
+        );
+        let tree_state = TreeState::from_file(tree_state_path).unwrap();
+        connector.add_tree_state(tree_state).await.unwrap();
+    }
+
+    // stage empty blocks from height 205 to cause a Reorg
+    _ = connector.stage_blocks_create(205, 20, 1).await;
+
+    _ = connector
+        .stage_transactions_stream([(tx.clone().data, 210)].to_vec())
+        .await;
+
+    _ = connector.apply_staged(211).await;
+
+    // temp hack as pepper sync needs tree state of latest block for sync status
+    connector.add_tree_state(TreeState { network: "regtest".to_string(), height: 211, hash: "015265800472a8aaf96c7891cf7bd63ee1468bb6f3747714a6bd76c40ec9298b".to_string(), time: 1694454562, sapling_tree: "000000".to_string(), orchard_tree: "01532c96c5d6a36ae79a9cad00ef7053e11b738c84c1022f80d8b0afcd2aedea23001f000001346fd8af3d66b14feaa60685fa189ca55cbd7f952fc25cdc971c310122b2402a01085516881012d2729492ba29b11522d3a45f0b70e2a7ab62a4243ec9a67c2a1100015fe60f3e71ba24797be5421c6c702e0a50c3a2178291a7d3dbd9543f5815cb0400000000000000000000000000000000000000000000000000".to_string() }).await.unwrap();
 
     sleep(std::time::Duration::new(1, 0)).await;
 

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -430,26 +430,28 @@ async fn reorg_expires_incoming_tx() {
         Err(err_str) => tracing::info!("{err_str}"),
     }
 
-    // Assert that balance holds
-    assert_eq!(
-        light_client
-            .account_balance(zip32::AccountId::ZERO)
-            .await
-            .unwrap(),
-        AccountBalance {
-            total_sapling_balance: Some(0.try_into().unwrap()),
-            confirmed_sapling_balance: Some(0.try_into().unwrap()),
-            unconfirmed_sapling_balance: Some(0.try_into().unwrap()),
-            total_orchard_balance: Some(0.try_into().unwrap()),
-            confirmed_orchard_balance: Some(0.try_into().unwrap()),
-            unconfirmed_orchard_balance: Some(0.try_into().unwrap()),
-            total_transparent_balance: Some(0.try_into().unwrap()),
-            confirmed_transparent_balance: Some(0.try_into().unwrap()),
-            unconfirmed_transparent_balance: Some(0.try_into().unwrap())
-        }
-    );
+    // // Assert that balance holds
+    // assert_eq!(
+    //     light_client
+    //         .account_balance(zip32::AccountId::ZERO)
+    //         .await
+    //         .unwrap(),
+    //     AccountBalance {
+    //         total_sapling_balance: Some(0.try_into().unwrap()),
+    //         confirmed_sapling_balance: Some(0.try_into().unwrap()),
+    //         unconfirmed_sapling_balance: Some(0.try_into().unwrap()),
+    //         total_orchard_balance: Some(0.try_into().unwrap()),
+    //         confirmed_orchard_balance: Some(0.try_into().unwrap()),
+    //         unconfirmed_orchard_balance: Some(0.try_into().unwrap()),
+    //         total_transparent_balance: Some(0.try_into().unwrap()),
+    //         confirmed_transparent_balance: Some(0.try_into().unwrap()),
+    //         unconfirmed_transparent_balance: Some(0.try_into().unwrap())
+    //     }
+    // );
 
     let after_reorg_transactions = light_client.value_transfers(true).await.unwrap();
+
+    dbg!(after_reorg_transactions.clone());
 
     assert_eq!(after_reorg_transactions.len(), 0);
 }
@@ -506,6 +508,12 @@ async fn prepare_expires_incoming_tx_after_reorg(uri: http::Uri) -> Result<(), S
     // Setup prodedures.  Up to this point there's no communication between the client and the dswd
     client.clear_address_utxo(Empty {}).await.unwrap();
 
+    // reset with parameters
+    connector
+        .reset(202, String::from(BRANCH_ID), String::from("regtest"))
+        .await
+        .unwrap();
+
     let dataset_path = format!(
         "{}/{}",
         get_cargo_manifest_dir().to_string_lossy(),
@@ -519,6 +527,17 @@ async fn prepare_expires_incoming_tx_after_reorg(uri: http::Uri) -> Result<(), S
                 .collect(),
         )
         .await?;
+
+    for i in 201..207 {
+        let tree_state_path = format!(
+            "{}/{}/{}.json",
+            get_cargo_manifest_dir().to_string_lossy(),
+            TREE_STATE_FOLDER_PATH,
+            i
+        );
+        let tree_state = TreeState::from_file(tree_state_path).unwrap();
+        connector.add_tree_state(tree_state).await.unwrap();
+    }
 
     connector.apply_staged(206).await?;
 
@@ -1218,6 +1237,7 @@ async fn reorg_changes_outgoing_tx_index() {
     //     Some(BlockHeight::from(205))
     // );
 }
+
 // UTILS TESTS
 #[tokio::test]
 async fn test_read_block_dataset() {

--- a/darkside-tests/tests/advanced_reorg_tests.rs
+++ b/darkside-tests/tests/advanced_reorg_tests.rs
@@ -16,6 +16,7 @@ use zcash_local_net::indexer::Indexer;
 use zcash_local_net::network::localhost_uri;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_common_components::protocol::activation_heights::for_test;
+use zingo_status::confirmation_status::ConfirmationStatus;
 use zingolib::testutils::tempfile::TempDir;
 use zingolib::wallet::summary::data::SentValueTransfer;
 use zingolib::wallet::summary::data::ValueTransferKind;
@@ -430,34 +431,35 @@ async fn reorg_expires_incoming_tx() {
         Err(err_str) => tracing::info!("{err_str}"),
     }
 
-    // // Assert that balance holds
-    // assert_eq!(
-    //     light_client
-    //         .account_balance(zip32::AccountId::ZERO)
-    //         .await
-    //         .unwrap(),
-    //     AccountBalance {
-    //         total_sapling_balance: Some(0.try_into().unwrap()),
-    //         confirmed_sapling_balance: Some(0.try_into().unwrap()),
-    //         unconfirmed_sapling_balance: Some(0.try_into().unwrap()),
-    //         total_orchard_balance: Some(0.try_into().unwrap()),
-    //         confirmed_orchard_balance: Some(0.try_into().unwrap()),
-    //         unconfirmed_orchard_balance: Some(0.try_into().unwrap()),
-    //         total_transparent_balance: Some(0.try_into().unwrap()),
-    //         confirmed_transparent_balance: Some(0.try_into().unwrap()),
-    //         unconfirmed_transparent_balance: Some(0.try_into().unwrap())
-    //     }
-    // );
+    // Assert that balance holds
+    assert_eq!(
+        light_client
+            .account_balance(zip32::AccountId::ZERO)
+            .await
+            .unwrap(),
+        AccountBalance {
+            total_sapling_balance: Some(0.try_into().unwrap()),
+            confirmed_sapling_balance: Some(0.try_into().unwrap()),
+            unconfirmed_sapling_balance: Some(0.try_into().unwrap()),
+            total_orchard_balance: Some(0.try_into().unwrap()),
+            confirmed_orchard_balance: Some(0.try_into().unwrap()),
+            unconfirmed_orchard_balance: Some(0.try_into().unwrap()),
+            total_transparent_balance: Some(0.try_into().unwrap()),
+            confirmed_transparent_balance: Some(0.try_into().unwrap()),
+            unconfirmed_transparent_balance: Some(0.try_into().unwrap())
+        }
+    );
 
     let after_reorg_transactions = light_client.value_transfers(true).await.unwrap();
 
-    dbg!(after_reorg_transactions.clone());
-
-    assert_eq!(after_reorg_transactions.len(), 0);
+    assert_eq!(after_reorg_transactions.len(), 1);
+    assert_eq!(
+        after_reorg_transactions.first().unwrap().status,
+        ConfirmationStatus::Failed(203.into())
+    );
 }
 
 async fn prepare_expires_incoming_tx_before_reorg(uri: http::Uri) -> Result<(), String> {
-    dbg!(&uri);
     let connector = DarksideConnector(uri.clone());
 
     let mut client = connector.get_client().await.unwrap();
@@ -501,7 +503,6 @@ async fn prepare_expires_incoming_tx_before_reorg(uri: http::Uri) -> Result<(), 
 }
 
 async fn prepare_expires_incoming_tx_after_reorg(uri: http::Uri) -> Result<(), String> {
-    dbg!(&uri);
     let connector = DarksideConnector(uri.clone());
 
     let mut client = connector.get_client().await.unwrap();

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -560,6 +560,17 @@ where
         .set_save_flag()
         .map_err(SyncError::WalletError)?;
 
+    dbg!("BLOCK DUMP");
+    wallet_guard
+        .get_wallet_blocks_mut()
+        .unwrap()
+        .iter()
+        .for_each(|(_height, block)| {
+            dbg!(block.block_height);
+            dbg!(block.block_hash);
+            dbg!(block.txids());
+        });
+
     drop(wallet_guard);
     drop(scanner);
     drop(fetch_request_sender);
@@ -1358,6 +1369,7 @@ fn truncate_wallet_data<W>(
 where
     W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints + SyncShardTrees,
 {
+    dbg!(truncate_height);
     let sync_state = wallet
         .get_sync_state_mut()
         .map_err(SyncError::WalletError)?;

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -560,17 +560,6 @@ where
         .set_save_flag()
         .map_err(SyncError::WalletError)?;
 
-    dbg!("BLOCK DUMP");
-    wallet_guard
-        .get_wallet_blocks_mut()
-        .unwrap()
-        .iter()
-        .for_each(|(_height, block)| {
-            dbg!(block.block_height);
-            dbg!(block.block_hash);
-            dbg!(block.txids());
-        });
-
     drop(wallet_guard);
     drop(scanner);
     drop(fetch_request_sender);
@@ -1369,7 +1358,6 @@ fn truncate_wallet_data<W>(
 where
     W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints + SyncShardTrees,
 {
-    dbg!(truncate_height);
     let sync_state = wallet
         .get_sync_state_mut()
         .map_err(SyncError::WalletError)?;

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -153,7 +153,7 @@ pub trait SyncTransactions: SyncWallet {
             .get_wallet_transactions()?
             .values()
             .filter(|tx| tx.status().is_confirmed_after(&truncate_height))
-            .map(|tx| tx.transaction().txid())
+            .map(|tx| tx.txid())
             .collect();
 
         set_transactions_failed(self.get_wallet_transactions_mut()?, invalid_txids);


### PR DESCRIPTION
Fixes: #2350

what was thought to be a possible re-org bug in the related issue turns out to be due to darkside issues where the internal zcash tx has an incorrect txid. this PR fixes this by setting failed txs by the wallet tx's txid instead.
