### PR TITLE
Zebra v5 0 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,15 +1229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "corez"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,10 +1423,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "incrementalmerkletree",
- "orchard 0.14.0",
+ "orchard",
  "proptest",
  "prost",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "serde_json",
  "tokio",
  "tonic",
@@ -1445,12 +1436,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zcash_local_net",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
+ "zcash_primitives",
+ "zcash_protocol",
  "zebra-chain",
  "zingo-netutils",
  "zingo_common_components",
- "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=nu6_2_update_with_nuparams)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/idky137/infrastructure.git?branch=zebra_v5_0_0)",
  "zingolib",
  "zingolib_testutils",
  "zip32",
@@ -1585,7 +1576,7 @@ checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
  "indexmap 2.13.0",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1990,16 +1981,6 @@ dependencies = [
  "anstyle",
  "env_filter",
  "log",
-]
-
-[[package]]
-name = "equihash"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
-dependencies = [
- "blake2b_simd",
- "core2",
 ]
 
 [[package]]
@@ -2488,26 +2469,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "halo2_gadgets"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
-dependencies = [
- "arrayvec",
- "bitvec",
- "ff",
- "group",
- "halo2_poseidon",
- "halo2_proofs",
- "lazy_static",
- "pasta_curves",
- "rand 0.8.5",
- "sinsemilla",
- "subtle",
- "uint 0.9.5",
 ]
 
 [[package]]
@@ -3417,17 +3378,17 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
- "zcash_address 0.12.0",
- "zcash_client_backend 0.23.0",
+ "zcash_address",
+ "zcash_client_backend",
  "zcash_local_net",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
- "zcash_transparent 0.8.0",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_transparent",
  "zebra-chain",
  "zingo-netutils",
  "zingo-status 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zingo_common_components",
- "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=nu6_2_update_with_nuparams)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/idky137/infrastructure.git?branch=zebra_v5_0_0)",
  "zingolib",
  "zingolib_testutils",
  "zip32",
@@ -3974,41 +3935,6 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
-dependencies = [
- "aes",
- "bitvec",
- "blake2b_simd",
- "core2",
- "ff",
- "fpe",
- "getset",
- "group",
- "halo2_gadgets 0.3.1",
- "halo2_poseidon",
- "halo2_proofs",
- "hex",
- "incrementalmerkletree",
- "lazy_static",
- "memuse",
- "nonempty",
- "pasta_curves",
- "rand 0.8.5",
- "reddsa",
- "serde",
- "sinsemilla",
- "subtle",
- "tracing",
- "visibility",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "orchard"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
@@ -4021,7 +3947,7 @@ dependencies = [
  "fpe",
  "getset",
  "group",
- "halo2_gadgets 0.5.0",
+ "halo2_gadgets",
  "halo2_poseidon",
  "halo2_proofs",
  "hex",
@@ -4244,9 +4170,9 @@ dependencies = [
  "json",
  "jubjub",
  "memuse",
- "orchard 0.14.0",
+ "orchard",
  "rayon",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "shardtree",
  "simple-mermaid",
  "subtle",
@@ -4254,14 +4180,14 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "zcash_address 0.12.0",
- "zcash_client_backend 0.23.0",
- "zcash_encoding 0.4.0",
- "zcash_keys 0.14.0",
+ "zcash_address",
+ "zcash_client_backend",
+ "zcash_encoding",
+ "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
- "zcash_transparent 0.8.0",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_transparent",
  "zingo-memo 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zingo-netutils",
  "zingo-status 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4657,7 +4583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -4678,7 +4604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5604,39 +5530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
 dependencies = [
  "regex",
-]
-
-[[package]]
-name = "sapling-crypto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
-dependencies = [
- "aes",
- "bellman",
- "bitvec",
- "blake2b_simd",
- "blake2s_simd",
- "bls12_381",
- "core2",
- "document-features",
- "ff",
- "fpe",
- "getset",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "lazy_static",
- "memuse",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "redjubjub",
- "subtle",
- "tracing",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
 ]
 
 [[package]]
@@ -8911,20 +8804,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
-dependencies = [
- "bech32",
- "bs58",
- "core2",
- "f4jumble",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
-]
-
-[[package]]
-name = "zcash_address"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
@@ -8934,70 +8813,8 @@ dependencies = [
  "corez",
  "f4jumble",
  "proptest",
- "zcash_encoding 0.4.0",
- "zcash_protocol 0.9.0",
-]
-
-[[package]]
-name = "zcash_client_backend"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5eca509a516dbd9e4d13c1f5befd6d9fa25c7e62460444ef1b3f62122f323"
-dependencies = [
- "arti-client",
- "base64",
- "bech32",
- "bls12_381",
- "bs58",
- "crossbeam-channel",
- "document-features",
- "dynosaur",
- "fs-mistrust",
- "futures-util",
- "getset",
- "group",
- "hex",
- "http-body-util",
- "hyper",
- "hyper-util",
- "incrementalmerkletree",
- "memuse",
- "nonempty",
- "percent-encoding",
- "prost",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rayon",
- "rust_decimal",
- "sapling-crypto 0.5.0",
- "secrecy",
- "serde",
- "serde_json",
- "shardtree",
- "subtle",
- "time",
- "time-core",
- "tokio",
- "tokio-rustls",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tor-rtcompat",
- "tower 0.5.3",
- "tracing",
- "trait-variant",
- "webpki-roots 1.0.6",
- "which",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_keys 0.12.0",
- "zcash_note_encryption",
- "zcash_primitives 0.26.4",
- "zcash_protocol 0.7.2",
- "zcash_script",
- "zcash_transparent 0.6.3",
- "zip32",
- "zip321 0.6.0",
+ "zcash_encoding",
+ "zcash_protocol",
 ]
 
 [[package]]
@@ -9027,7 +8844,7 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard 0.14.0",
+ "orchard",
  "pasta_curves",
  "percent-encoding",
  "prost",
@@ -9035,7 +8852,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "rust_decimal",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "secp256k1 0.29.1",
  "secrecy",
  "serde",
@@ -9055,26 +8872,16 @@ dependencies = [
  "trait-variant",
  "webpki-roots 1.0.6",
  "which",
- "zcash_address 0.12.0",
- "zcash_encoding 0.4.0",
- "zcash_keys 0.14.0",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
+ "zcash_primitives",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.8.0",
+ "zcash_transparent",
  "zip32",
- "zip321 0.8.0",
-]
-
-[[package]]
-name = "zcash_encoding"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
-dependencies = [
- "core2",
- "nonempty",
+ "zip321",
 ]
 
 [[package]]
@@ -9101,33 +8908,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
-dependencies = [
- "bech32",
- "blake2b_simd",
- "bls12_381",
- "bs58",
- "core2",
- "document-features",
- "group",
- "memuse",
- "nonempty",
- "rand_core 0.6.4",
- "sapling-crypto 0.5.0",
- "secrecy",
- "subtle",
- "tracing",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
- "zcash_transparent 0.6.3",
- "zip32",
-]
-
-[[package]]
-name = "zcash_keys"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
@@ -9143,23 +8923,23 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard 0.14.0",
+ "orchard",
  "rand_core 0.6.4",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.12.0",
- "zcash_encoding 0.4.0",
- "zcash_protocol 0.9.0",
- "zcash_transparent 0.8.0",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
+ "zcash_transparent",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_local_net"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?tag=nu6_2_update_with_nuparams#1550e03208849271577be02c15e95a44d9052981"
+source = "git+https://github.com/idky137/infrastructure.git?branch=zebra_v5_0_0#bd251334828052c4d8f7525222286b795c70d021"
 dependencies = [
  "getset",
  "hex",
@@ -9171,12 +8951,12 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "zcash_protocol 0.9.0",
+ "zcash_protocol",
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",
  "zingo_common_components",
- "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?tag=nu6_2_update_with_nuparams)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/idky137/infrastructure.git?branch=zebra_v5_0_0)",
 ]
 
 [[package]]
@@ -9194,48 +8974,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9ff256fb298a7e94a73c1adad6c7e0b4b194b902e777ee9f5f2e12c4c4776"
-dependencies = [
- "bip32",
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "bs58",
- "core2",
- "crypto-common 0.2.0-rc.1",
- "document-features",
- "equihash 0.2.2",
- "ff",
- "fpe",
- "getset",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard 0.11.0",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "redjubjub",
- "ripemd 0.1.3",
- "sapling-crypto 0.5.0",
- "sha2 0.10.9",
- "subtle",
- "tracing",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_note_encryption",
- "zcash_protocol 0.7.2",
- "zcash_script",
- "zcash_spec",
- "zcash_transparent 0.6.3",
- "zip32",
-]
-
-[[package]]
-name = "zcash_primitives"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
@@ -9245,24 +8983,24 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.14.0",
+ "orchard",
  "rand_core 0.6.4",
  "redjubjub",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0",
+ "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.9.0",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.8.0",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -9282,23 +9020,11 @@ dependencies = [
  "minreq",
  "rand_core 0.6.4",
  "redjubjub",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "tracing",
  "wagyu-zcash-parameters",
  "xdg",
- "zcash_primitives 0.28.0",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b1a337bbc9a7d55ae35d31189f03507dbc7934e9a4bee5c1d5c47464860e48"
-dependencies = [
- "core2",
- "document-features",
- "hex",
- "memuse",
+ "zcash_primitives",
 ]
 
 [[package]]
@@ -9311,7 +9037,7 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
- "zcash_encoding 0.4.0",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -9342,32 +9068,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9b7b4bc11d8bb20833d1b8ab6807f4dca941b381f1129e5bbd72a84e391991"
-dependencies = [
- "bip32",
- "blake2b_simd",
- "bs58",
- "core2",
- "document-features",
- "getset",
- "hex",
- "nonempty",
- "ripemd 0.1.3",
- "secp256k1 0.29.1",
- "sha2 0.10.9",
- "subtle",
- "zcash_address 0.10.1",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.7.2",
- "zcash_script",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_transparent"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
@@ -9383,9 +9083,9 @@ dependencies = [
  "secp256k1 0.29.1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.12.0",
- "zcash_encoding 0.4.0",
- "zcash_protocol 0.9.0",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -9410,7 +9110,7 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash 0.3.0",
+ "equihash",
  "futures",
  "group",
  "halo2_proofs",
@@ -9421,14 +9121,14 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.14.0",
+ "orchard",
  "primitive-types",
  "rand_core 0.6.4",
  "rayon",
  "reddsa",
  "redjubjub",
  "ripemd 0.1.3",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "schemars 1.2.1",
  "secp256k1 0.29.1",
  "serde",
@@ -9445,14 +9145,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.12.0",
- "zcash_encoding 0.4.0",
+ "zcash_address",
+ "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
+ "zcash_primitives",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.8.0",
+ "zcash_transparent",
 ]
 
 [[package]]
@@ -9475,10 +9175,10 @@ dependencies = [
  "metrics",
  "mset",
  "once_cell",
- "orchard 0.14.0",
+ "orchard",
  "rand 0.8.5",
  "rayon",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -9487,11 +9187,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.28.0",
+ "zcash_primitives",
  "zcash_proofs",
- "zcash_protocol 0.9.0",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.8.0",
+ "zcash_transparent",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -9575,11 +9275,11 @@ dependencies = [
  "metrics",
  "nix 0.30.1",
  "openrpsee",
- "orchard 0.14.0",
+ "orchard",
  "phf 0.12.1",
  "prost",
  "rand 0.8.5",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "schemars 1.2.1",
  "semver",
  "serde",
@@ -9597,13 +9297,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which",
- "zcash_address 0.12.0",
- "zcash_keys 0.14.0",
- "zcash_primitives 0.28.0",
+ "zcash_address",
+ "zcash_keys",
+ "zcash_primitives",
  "zcash_proofs",
- "zcash_protocol 0.9.0",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.8.0",
+ "zcash_transparent",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -9621,7 +9321,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.5",
  "thiserror 2.0.18",
- "zcash_primitives 0.28.0",
+ "zcash_primitives",
  "zcash_script",
  "zebra-chain",
 ]
@@ -9652,7 +9352,7 @@ dependencies = [
  "regex",
  "rlimit",
  "rocksdb",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "semver",
  "serde",
  "tempfile",
@@ -9775,10 +9475,10 @@ dependencies = [
  "shellwords",
  "tokio",
  "tracing-subscriber",
- "zcash_address 0.12.0",
- "zcash_client_backend 0.23.0",
- "zcash_keys 0.14.0",
- "zcash_protocol 0.9.0",
+ "zcash_address",
+ "zcash_client_backend",
+ "zcash_keys",
+ "zcash_protocol",
  "zingo_common_components",
  "zingolib",
  "zip32",
@@ -9789,10 +9489,10 @@ name = "zingo-memo"
 version = "0.1.1"
 dependencies = [
  "rand 0.8.5",
- "zcash_address 0.12.0",
- "zcash_encoding 0.4.0",
- "zcash_keys 0.14.0",
- "zcash_protocol 0.9.0",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_keys",
+ "zcash_protocol",
 ]
 
 [[package]]
@@ -9801,26 +9501,28 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be89f74c1be1ac061f58921191c005fd2f9d83541e7ef6febfb5c51c0c3f539c"
 dependencies = [
- "zcash_address 0.12.0",
- "zcash_encoding 0.4.0",
- "zcash_keys 0.14.0",
- "zcash_protocol 0.9.0",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_keys",
+ "zcash_protocol",
 ]
 
 [[package]]
 name = "zingo-netutils"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2ca11c717feb94a0032da1e6cffb2928ce2c34aca3b430e85cac02fd0ab425"
+version = "1.1.0"
+source = "git+https://github.com/zingolabs/zingo-common.git?tag=v0_2_with_nu6_2_upgrade_v2#6b70ca07eb012150ad3fb0d2aa69260256fb30a4"
 dependencies = [
  "http",
+ "http-body",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "thiserror 1.0.69",
  "tokio-rustls",
  "tonic",
- "zcash_client_backend 0.21.2",
+ "tower 0.5.3",
+ "webpki-roots 0.25.4",
+ "zcash_client_backend",
 ]
 
 [[package]]
@@ -9833,8 +9535,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "zcash_client_backend 0.23.0",
- "zcash_encoding 0.4.0",
+ "zcash_client_backend",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -9842,8 +9544,8 @@ name = "zingo-status"
 version = "0.2.1"
 dependencies = [
  "byteorder",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
+ "zcash_primitives",
+ "zcash_protocol",
 ]
 
 [[package]]
@@ -9853,24 +9555,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa2f3e473a81f4b9fd3fb34d5e22a2c458ce0d8d3a73460e9aa0a2bbf71967f4"
 dependencies = [
  "byteorder",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
+ "zcash_primitives",
+ "zcash_protocol",
 ]
 
 [[package]]
 name = "zingo_common_components"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingo-common.git?tag=v0_2_with_nu6_2_upgrade#912a09c13a6987c2892db487ba9678fda53d9a15"
+source = "git+https://github.com/zingolabs/zingo-common.git?tag=v0_2_with_nu6_2_upgrade_v2#6b70ca07eb012150ad3fb0d2aa69260256fb30a4"
 dependencies = [
  "zebra-chain",
-]
-
-[[package]]
-name = "zingo_test_vectors"
-version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?tag=nu6_2_update_with_nuparams#1550e03208849271577be02c15e95a44d9052981"
-dependencies = [
- "bip0039 0.12.0",
 ]
 
 [[package]]
@@ -9884,7 +9578,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=nu6_2_update_with_nuparams#1550e03208849271577be02c15e95a44d9052981"
+source = "git+https://github.com/idky137/infrastructure.git?branch=zebra_v5_0_0#bd251334828052c4d8f7525222286b795c70d021"
 dependencies = [
  "bip0039 0.12.0",
 ]
@@ -9913,7 +9607,7 @@ dependencies = [
  "log",
  "log4rs",
  "nonempty",
- "orchard 0.14.0",
+ "orchard",
  "pepper-sync",
  "portpicker",
  "prost",
@@ -9922,7 +9616,7 @@ dependencies = [
  "rusqlite",
  "rust-embed",
  "rustls 0.23.37",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "secp256k1 0.31.1",
  "secrecy",
  "serde",
@@ -9937,14 +9631,14 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "webpki-roots 1.0.6",
- "zcash_address 0.12.0",
- "zcash_client_backend 0.23.0",
- "zcash_encoding 0.4.0",
- "zcash_keys 0.14.0",
- "zcash_primitives 0.28.0",
+ "zcash_address",
+ "zcash_client_backend",
+ "zcash_encoding",
+ "zcash_keys",
+ "zcash_primitives",
  "zcash_proofs",
- "zcash_protocol 0.9.0",
- "zcash_transparent 0.8.0",
+ "zcash_protocol",
+ "zcash_transparent",
  "zebra-chain",
  "zingo-memo 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zingo-netutils",
@@ -9966,10 +9660,10 @@ dependencies = [
  "portpicker",
  "tempfile",
  "zcash_local_net",
- "zcash_protocol 0.9.0",
+ "zcash_protocol",
  "zebra-chain",
  "zingo_common_components",
- "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=nu6_2_update_with_nuparams)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/idky137/infrastructure.git?branch=zebra_v5_0_0)",
  "zingolib",
  "zip32",
 ]
@@ -9989,19 +9683,6 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3090953750ce1d56aa213710765eb14997868f463c45dae115cf1ebe09fe39eb"
-dependencies = [
- "base64",
- "nom",
- "percent-encoding",
- "zcash_address 0.10.1",
- "zcash_protocol 0.7.2",
-]
-
-[[package]]
-name = "zip321"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
@@ -10009,8 +9690,8 @@ dependencies = [
  "base64",
  "nom",
  "percent-encoding",
- "zcash_address 0.12.0",
- "zcash_protocol 0.9.0",
+ "zcash_address",
+ "zcash_protocol",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ portpicker = "0.1"
 proptest = "1.6.0"
 tempfile = "3"
 test-log = "0.2"
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "nu6_2_update_with_nuparams" }
-zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "nu6_2_update_with_nuparams" }
+zcash_local_net = { git = "https://github.com/idky137/infrastructure.git", branch = "zebra_v5_0_0" }
+zingo_test_vectors = { git = "https://github.com/idky137/infrastructure.git", branch = "zebra_v5_0_0" }
 
 ### Documentation
 indoc = "2"
@@ -37,8 +37,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 # Zingo-common
-zingo-netutils = "2.0.1"
-zingo_common_components = { git = "https://github.com/zingolabs/zingo-common.git", tag = "v0_2_with_nu6_2_upgrade" }
+zingo-netutils = { git = "https://github.com/zingolabs/zingo-common.git",  tag = "v0_2_with_nu6_2_upgrade_v2"}
+zingo_common_components = { git = "https://github.com/zingolabs/zingo-common.git", tag = "v0_2_with_nu6_2_upgrade_v2" }
 
 ### Zcash
 incrementalmerkletree = "0.8.2"

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -178,15 +178,27 @@ async fn add_subtree_roots() {
         if scheme != "http" && scheme != "https" {
             return Err(GetClientError::InvalidScheme);
         }
+
         let _authority = uri.authority().ok_or(GetClientError::InvalidAuthority)?;
 
-        let endpoint = Endpoint::from_shared(uri.to_string())?.tcp_nodelay(true);
+        let endpoint = Endpoint::from_shared(uri.to_string())
+            .map_err(|_| GetClientError::InvalidAuthority)?
+            .tcp_nodelay(true);
 
         let channel = if scheme == "https" {
             let tls = ClientTlsConfig::new().with_webpki_roots();
-            endpoint.tls_config(tls)?.connect().await?
+
+            endpoint
+                .tls_config(tls)
+                .map_err(|_| GetClientError::InvalidScheme)?
+                .connect()
+                .await
+                .map_err(|_| GetClientError::InvalidAuthority)?
         } else {
-            endpoint.connect().await?
+            endpoint
+                .connect()
+                .await
+                .map_err(|_| GetClientError::InvalidAuthority)?
         };
 
         Ok(CompactTxStreamerClient::new(channel))

--- a/zingolib/src/grpc_connector.rs
+++ b/zingolib/src/grpc_connector.rs
@@ -27,15 +27,27 @@ pub(crate) async fn get_client(
     if scheme != "http" && scheme != "https" {
         return Err(GetClientError::InvalidScheme);
     }
+
     let _authority = uri.authority().ok_or(GetClientError::InvalidAuthority)?;
 
-    let endpoint = Endpoint::from_shared(uri.to_string())?.tcp_nodelay(true);
+    let endpoint = Endpoint::from_shared(uri.to_string())
+        .map_err(|_| GetClientError::InvalidAuthority)?
+        .tcp_nodelay(true);
 
     let channel = if scheme == "https" {
         let tls = ClientTlsConfig::new().with_webpki_roots();
-        endpoint.tls_config(tls)?.connect().await?
+
+        endpoint
+            .tls_config(tls)
+            .map_err(|_| GetClientError::InvalidScheme)?
+            .connect()
+            .await
+            .map_err(|_| GetClientError::InvalidAuthority)?
     } else {
-        endpoint.connect().await?
+        endpoint
+            .connect()
+            .await
+            .map_err(|_| GetClientError::InvalidAuthority)?
     };
 
     Ok(CompactTxStreamerClient::new(channel))


### PR DESCRIPTION
updates zcash_client_backend version in zingo_testutils (and connectd crates), required for zaino as this version pulls in the yanked orchard version