### PR TITLE
fix: treat duplicate-in-mempool rejection as transmission success

### DIFF
--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -830,6 +830,7 @@ async fn from_t_z_o_tz_to_zo_tzo_to_orchard() {
 /// arithmetic.
 #[tokio::test]
 async fn send_survives_lost_response_and_duplicate_rejection() {
+    use crate::testutils::mock_indexer::LostSendDestination;
     use zingo_status::confirmation_status::ConfirmationStatus;
 
     let mut net = MockNet::launch().await;
@@ -844,7 +845,7 @@ async fn send_survives_lost_response_and_duplicate_rejection() {
     recipient.sync_and_await().await.unwrap();
     check_client_balances!(recipient, o: 100_000 s: 0 t: 0);
 
-    net.chain.write().await.lose_next_send_response = true;
+    net.chain.write().await.lose_next_send_response = Some(LostSendDestination::Mempool);
 
     let txids = from_inputs::quick_send(
         &mut recipient,
@@ -873,5 +874,72 @@ async fn send_survives_lost_response_and_duplicate_rejection() {
     recipient.sync_and_await().await.unwrap();
     // Identical arithmetic to `funded_send_confirms_on_the_mock_chain`:
     // the lost response and duplicate rejection must not perturb it.
+    check_client_balances!(recipient, o: 70_000 s: 0 t: 0);
+}
+
+/// Twin of [`send_survives_lost_response_and_duplicate_rejection`] for
+/// the validator's earlier phase: the lost-response submission is
+/// still in the download/verification queue when the retry arrives, so
+/// the rejection reads "transaction dropped because it is already
+/// queued for download" (zebra's pre-acceptance duplicate check) —
+/// observed live in the 2026-07-11 container runs, where verification
+/// lagged the send by seconds under load. That rejection proves
+/// delivery but not minability, so the wallet must hold success until
+/// its probes see the storage-backed mempool rejection — and only then
+/// return Ok, keeping send-Ok ⇒ minable-now. The mock answers two
+/// queued rejections before promoting, so the probe loop is exercised
+/// deterministically; mining immediately after the send must therefore
+/// confirm the transaction.
+#[tokio::test]
+async fn send_survives_lost_response_and_queued_duplicate_rejection() {
+    use crate::testutils::mock_indexer::LostSendDestination;
+    use zingo_status::confirmation_status::ConfirmationStatus;
+
+    let mut net = MockNet::launch().await;
+    let mut recipient = net
+        .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+        .await;
+    let recipient_ua =
+        get_base_address(&recipient, PoolType::Shielded(ShieldedProtocol::Orchard)).await;
+
+    net.chain.write().await.mine_empty_blocks(1);
+    fund(&net, vec![(&recipient_ua, 100_000, None)], 1).await;
+    recipient.sync_and_await().await.unwrap();
+    check_client_balances!(recipient, o: 100_000 s: 0 t: 0);
+
+    {
+        let mut chain = net.chain.write().await;
+        chain.lose_next_send_response = Some(LostSendDestination::DownloadQueue);
+        chain.queued_rejections_before_promotion = 2;
+    }
+
+    let txids = from_inputs::quick_send(
+        &mut recipient,
+        vec![(&external_address(PoolType::ORCHARD), 20_000, None)],
+    )
+    .await
+    .expect("probing resubmissions reach the storage-backed verdict");
+
+    // The wallet must not record the delivered transaction as Failed.
+    {
+        let wallet = recipient.wallet().read().await;
+        for txid in txids.iter() {
+            let status = wallet
+                .wallet_transactions
+                .get(txid)
+                .expect("the transmitted transaction stays in the wallet")
+                .status();
+            assert!(
+                !matches!(status, ConfirmationStatus::Failed(_)),
+                "transaction {txid} marked Failed while queued for download"
+            );
+        }
+    }
+
+    // send-Ok means minable NOW: mining immediately — the very race
+    // that broke test_scanning_in_watch_only_mode live — must include
+    // the transaction, with no verification-delay allowance.
+    net.chain.write().await.mine_mempool();
+    recipient.sync_and_await().await.unwrap();
     check_client_balances!(recipient, o: 70_000 s: 0 t: 0);
 }

--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -817,3 +817,61 @@ async fn from_t_z_o_tz_to_zo_tzo_to_orchard() {
     total_expected_fee += 10_000;
     assert_eq!(get_fees_paid_by_client(&client).await, total_expected_fee);
 }
+
+/// Deterministic reproduction of issue #2450 (no live original: the
+/// live shape is a load-dependent flake — three libtonode tests
+/// failing whenever a slow validator response crosses the wallet's
+/// send timeout). The first submission is accepted into the mock
+/// mempool but its response is lost; the wallet's retry then receives
+/// the validator's duplicate rejection, verbatim as zainod surfaces it
+/// (zingolabs/zaino#1392). That rejection is proof of successful
+/// transmission: the send must return Ok, the transaction must not be
+/// marked Failed, and it must confirm with ordinary balance
+/// arithmetic.
+#[tokio::test]
+async fn send_survives_lost_response_and_duplicate_rejection() {
+    use zingo_status::confirmation_status::ConfirmationStatus;
+
+    let mut net = MockNet::launch().await;
+    let mut recipient = net
+        .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+        .await;
+    let recipient_ua =
+        get_base_address(&recipient, PoolType::Shielded(ShieldedProtocol::Orchard)).await;
+
+    net.chain.write().await.mine_empty_blocks(1);
+    fund(&net, vec![(&recipient_ua, 100_000, None)], 1).await;
+    recipient.sync_and_await().await.unwrap();
+    check_client_balances!(recipient, o: 100_000 s: 0 t: 0);
+
+    net.chain.write().await.lose_next_send_response = true;
+
+    let txids = from_inputs::quick_send(
+        &mut recipient,
+        vec![(&external_address(PoolType::ORCHARD), 20_000, None)],
+    )
+    .await
+    .expect("a duplicate-in-mempool rejection proves transmission succeeded");
+
+    // The wallet must not record the live transaction as Failed.
+    {
+        let wallet = recipient.wallet().read().await;
+        for txid in txids.iter() {
+            let status = wallet
+                .wallet_transactions
+                .get(txid)
+                .expect("the transmitted transaction stays in the wallet")
+                .status();
+            assert!(
+                !matches!(status, ConfirmationStatus::Failed(_)),
+                "transaction {txid} marked Failed while live in the mempool"
+            );
+        }
+    }
+
+    net.chain.write().await.mine_mempool();
+    recipient.sync_and_await().await.unwrap();
+    // Identical arithmetic to `funded_send_confirms_on_the_mock_chain`:
+    // the lost response and duplicate rejection must not perturb it.
+    check_client_balances!(recipient, o: 70_000 s: 0 t: 0);
+}

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -20,6 +20,14 @@ use crate::wallet::output::OutputRef;
 
 const MAX_RETRIES: u8 = 3;
 
+/// A "queued for download" duplicate rejection proves delivery but not
+/// minability: zebra is still verifying the earlier submission
+/// (observed to lag it by seconds under load). Each resubmission is a
+/// free probe of zebra's own state; wait up to this many probes, on
+/// the retry loop's one-second cadence, for the verdict to become
+/// storage-backed (issue #2450).
+const MAX_QUEUED_PROBES: u8 = 30;
+
 impl LightClient {
     async fn send(
         &mut self,
@@ -160,6 +168,7 @@ impl LightClient {
                 })?;
 
             let mut retry_count = 0;
+            let mut queued_probes = 0;
             let txid_from_server = loop {
                 let transmission_result = self
                     .indexer
@@ -183,21 +192,44 @@ impl LightClient {
                         break Ok(txid);
                     }
                     Err(e) => {
-                        // The node's rejection of resubmitted bytes is
-                        // positive confirmation that an earlier
-                        // submission succeeded: the transaction is
-                        // live, so transmission is complete (issue
-                        // #2450). A substring match because zainod
-                        // surfaces the rejection untyped
-                        // (zingolabs/zaino#1392); upgrade to a typed
-                        // check when that lands.
-                        if let SendError::TransmissionError(TransmissionError::TransmissionFailed(
-                            message,
-                        )) = &e
-                            && (message.contains("transaction already exists in mempool")
-                                || message.contains("transaction already in block chain"))
+                        // The node's rejections of resubmitted bytes
+                        // are positive confirmation that an earlier
+                        // submission was received (issue #2450).
+                        // Substring matches because zainod surfaces
+                        // the rejections untyped (zingolabs/zaino#1392);
+                        // upgrade to typed checks when that lands.
+                        if let SendError::TransmissionError(
+                            TransmissionError::TransmissionFailed(message),
+                        ) = &e
                         {
-                            break Ok(txid.to_string());
+                            // Storage-backed duplicates: the earlier
+                            // submission is minable (in the mempool)
+                            // or already mined, so transmission is
+                            // complete.
+                            if message.contains("transaction already exists in mempool")
+                                || message.contains("transaction already in block chain")
+                            {
+                                break Ok(txid.to_string());
+                            }
+                            // "Queued for download" proves delivery,
+                            // not minability: zebra is still verifying
+                            // the earlier submission. Hold success
+                            // until the verdict is storage-backed, so
+                            // send-Ok keeps meaning the transaction is
+                            // minable now.
+                            if message.contains("already queued for download") {
+                                if queued_probes >= MAX_QUEUED_PROBES {
+                                    pepper_sync::set_transactions_failed(
+                                        &mut wallet.wallet_transactions,
+                                        vec![*txid],
+                                    );
+                                    wallet.save_required = true;
+                                    break Err(e);
+                                }
+                                queued_probes += 1;
+                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                                continue;
+                            }
                         }
                         if retry_count >= MAX_RETRIES {
                             pepper_sync::set_transactions_failed(

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -183,6 +183,22 @@ impl LightClient {
                         break Ok(txid);
                     }
                     Err(e) => {
+                        // The node's rejection of resubmitted bytes is
+                        // positive confirmation that an earlier
+                        // submission succeeded: the transaction is
+                        // live, so transmission is complete (issue
+                        // #2450). A substring match because zainod
+                        // surfaces the rejection untyped
+                        // (zingolabs/zaino#1392); upgrade to a typed
+                        // check when that lands.
+                        if let SendError::TransmissionError(TransmissionError::TransmissionFailed(
+                            message,
+                        )) = &e
+                            && (message.contains("transaction already exists in mempool")
+                                || message.contains("transaction already in block chain"))
+                        {
+                            break Ok(txid.to_string());
+                        }
                         if retry_count >= MAX_RETRIES {
                             pepper_sync::set_transactions_failed(
                                 &mut wallet.wallet_transactions,

--- a/zingolib/src/testutils/mock_indexer.rs
+++ b/zingolib/src/testutils/mock_indexer.rs
@@ -83,11 +83,24 @@ pub struct MockChain {
     sapling_tree: SaplingTree,
     orchard_tree: OrchardTree,
     mempool: Vec<Vec<u8>>,
-    /// One-shot fault: the next `send_transaction` accepts the bytes
-    /// into the mempool but answers with an error — the
-    /// accepted-but-unanswered submission of issue #2450. Cleared on
-    /// use.
-    pub lose_next_send_response: bool,
+    /// Raw transactions delivered but still in the validator's
+    /// download/verification queue: present enough to reject a
+    /// resubmission ("already queued for download"), not yet in the
+    /// mempool. [`MockChain::promote_download_queue`] is the validator
+    /// finishing verification.
+    download_queue: Vec<Vec<u8>>,
+    /// One-shot fault: the next `send_transaction` takes the bytes —
+    /// into the mempool or the download queue per the destination —
+    /// but answers with an error. The accepted-but-unanswered
+    /// submission of issue #2450, in either of the validator's two
+    /// pre-mining phases. Cleared on use.
+    pub lose_next_send_response: Option<LostSendDestination>,
+    /// The verification delay, made deterministic: how many "already
+    /// queued for download" rejections the mock answers before the
+    /// download queue promotes to the mempool. Decremented on each
+    /// duplicate probe of a queued transaction; at zero the probe is
+    /// answered with the mempool-phase rejection instead.
+    pub queued_rejections_before_promotion: u8,
     /// One entry per `GetTaddressTxids` request served: the address, the
     /// requested range, and how many transactions were streamed back.
     /// Diagnostic surface for transparent-detection failures.
@@ -101,6 +114,20 @@ pub struct MockChain {
 
 fn fabricated_block_hash(height: u32) -> Vec<u8> {
     fabricated_branch_hash(height, 0)
+}
+
+/// Where a lost-response submission lands, mirroring the validator's
+/// two pre-mining phases: zebra queues a submission for download and
+/// verification before accepting it into the mempool, and rejects a
+/// duplicate differently in each phase.
+#[derive(Clone, Copy, Debug)]
+pub enum LostSendDestination {
+    /// Verification already finished: the duplicate rejection reads
+    /// "transaction already exists in mempool".
+    Mempool,
+    /// Verification still pending: the duplicate rejection reads
+    /// "transaction dropped because it is already queued for download".
+    DownloadQueue,
 }
 
 /// Height- and branch-seeded fabricated hash. Seed 0 reproduces the
@@ -148,7 +175,9 @@ impl MockChain {
             sapling_tree,
             orchard_tree,
             mempool: Vec::new(),
-            lose_next_send_response: false,
+            download_queue: Vec::new(),
+            lose_next_send_response: None,
+            queued_rejections_before_promotion: 0,
             taddr_request_log: Vec::new(),
             branch_seed: 0,
         }
@@ -172,6 +201,13 @@ impl MockChain {
         let txid = transaction.txid().to_string();
         self.mempool.push(bytes);
         txid
+    }
+
+    /// The validator finishing verification: queued transactions enter
+    /// the mempool.
+    pub fn promote_download_queue(&mut self) {
+        let verified = std::mem::take(&mut self.download_queue);
+        self.mempool.extend(verified);
     }
 
     /// Mines every mempool transaction into the next block.
@@ -508,29 +544,57 @@ impl CompactTxStreamer for MockIndexerService {
         let mut chain = self.chain.write().await;
         let bytes = request.into_inner().data;
         // The validator rejects resubmitted bytes rather than
-        // re-accepting them; reproduce that rejection verbatim as
-        // zainod 0.6.0-rc.1 surfaces it (zingolabs/zaino#1392), so
-        // client handling is exercised against the message it really
-        // receives.
+        // re-accepting them, with a phase-specific message; reproduce
+        // both rejections verbatim as zainod 0.6.0-rc.1 surfaces them
+        // (zingolabs/zaino#1392), so client handling is exercised
+        // against the messages it really receives.
         if chain.mempool.contains(&bytes) {
             return Err(Status::internal(
                 "unhandled rpc-specific zaino_fetch::jsonrpsee::response::SendTransactionError \
                  error: RPC Error (code: -1): transaction already exists in mempool",
             ));
         }
-        let txid = chain.submit_transaction(bytes);
-        if chain.lose_next_send_response {
-            chain.lose_next_send_response = false;
-            // The fault of issue #2450: acceptance happened, the
-            // caller never learns.
-            return Err(Status::deadline_exceeded(
-                "mock fault: response lost after mempool acceptance",
+        if chain.download_queue.contains(&bytes) {
+            if chain.queued_rejections_before_promotion == 0 {
+                // Verification finished between probes: the queue
+                // promotes and this probe already sees the
+                // mempool-phase rejection.
+                chain.promote_download_queue();
+                return Err(Status::internal(
+                    "unhandled rpc-specific zaino_fetch::jsonrpsee::response::SendTransactionError \
+                     error: RPC Error (code: -1): transaction already exists in mempool",
+                ));
+            }
+            chain.queued_rejections_before_promotion -= 1;
+            return Err(Status::internal(
+                "unhandled rpc-specific zaino_fetch::jsonrpsee::response::SendTransactionError \
+                 error: RPC Error (code: -1): transaction dropped because it is already queued \
+                 for download",
             ));
         }
-        Ok(Response::new(SendResponse {
-            error_code: 0,
-            error_message: txid,
-        }))
+        // The fault of issue #2450: delivery happened, the caller
+        // never learns.
+        match chain.lose_next_send_response.take() {
+            Some(LostSendDestination::Mempool) => {
+                chain.submit_transaction(bytes);
+                Err(Status::deadline_exceeded(
+                    "mock fault: response lost after mempool acceptance",
+                ))
+            }
+            Some(LostSendDestination::DownloadQueue) => {
+                chain.download_queue.push(bytes);
+                Err(Status::deadline_exceeded(
+                    "mock fault: response lost while queued for download",
+                ))
+            }
+            None => {
+                let txid = chain.submit_transaction(bytes);
+                Ok(Response::new(SendResponse {
+                    error_code: 0,
+                    error_message: txid,
+                }))
+            }
+        }
     }
 
     type GetTaddressTxidsStream = ResponseStream<RawTransaction>;

--- a/zingolib/src/testutils/mock_indexer.rs
+++ b/zingolib/src/testutils/mock_indexer.rs
@@ -83,6 +83,11 @@ pub struct MockChain {
     sapling_tree: SaplingTree,
     orchard_tree: OrchardTree,
     mempool: Vec<Vec<u8>>,
+    /// One-shot fault: the next `send_transaction` accepts the bytes
+    /// into the mempool but answers with an error — the
+    /// accepted-but-unanswered submission of issue #2450. Cleared on
+    /// use.
+    pub lose_next_send_response: bool,
     /// One entry per `GetTaddressTxids` request served: the address, the
     /// requested range, and how many transactions were streamed back.
     /// Diagnostic surface for transparent-detection failures.
@@ -143,6 +148,7 @@ impl MockChain {
             sapling_tree,
             orchard_tree,
             mempool: Vec::new(),
+            lose_next_send_response: false,
             taddr_request_log: Vec::new(),
             branch_seed: 0,
         }
@@ -500,7 +506,27 @@ impl CompactTxStreamer for MockIndexerService {
         request: Request<RawTransaction>,
     ) -> Result<Response<SendResponse>, Status> {
         let mut chain = self.chain.write().await;
-        let txid = chain.submit_transaction(request.into_inner().data);
+        let bytes = request.into_inner().data;
+        // The validator rejects resubmitted bytes rather than
+        // re-accepting them; reproduce that rejection verbatim as
+        // zainod 0.6.0-rc.1 surfaces it (zingolabs/zaino#1392), so
+        // client handling is exercised against the message it really
+        // receives.
+        if chain.mempool.contains(&bytes) {
+            return Err(Status::internal(
+                "unhandled rpc-specific zaino_fetch::jsonrpsee::response::SendTransactionError \
+                 error: RPC Error (code: -1): transaction already exists in mempool",
+            ));
+        }
+        let txid = chain.submit_transaction(bytes);
+        if chain.lose_next_send_response {
+            chain.lose_next_send_response = false;
+            // The fault of issue #2450: acceptance happened, the
+            // caller never learns.
+            return Err(Status::deadline_exceeded(
+                "mock fault: response lost after mempool acceptance",
+            ));
+        }
         Ok(Response::new(SendResponse {
             error_code: 0,
             error_message: txid,


### PR DESCRIPTION
Closes #2450.

## The defect

When a send's first submission lands in the validator's mempool but its
response is lost, `transmit_transactions` re-submits the identical
bytes and the node correctly answers `RPC error -1: transaction already
exists in mempool`. The retry loop counted that rejection as a failure
and, after `MAX_RETRIES`, called `set_transactions_failed` on a
transaction that was live and about to confirm — a spend-tracking lie.
The live shape was three load-dependent libtonode flakes in the
2026-07-11 container run (`test_scanning_in_watch_only_mode` and two
`chain_generics` tests), diagnosed from the observatory traffic records
in #2450.

## The fix

The duplicate rejection is positive confirmation that an earlier
submission succeeded, so the retry loop now breaks `Ok` with the
calculated txid when it sees it ("transaction already exists in
mempool", or its mined sibling "already in block chain"). The
discrimination is a substring match because zainod surfaces the
rejection through an untyped `Internal` catch-all — filed as
zingolabs/zaino#1392 — and the comment in `send.rs` carries that
pointer so the match upgrades to a typed check when it lands.

## The test

The mock chain grows the two validator semantics needed to reproduce
the incident deterministically, as real behaviors rather than test
hooks: resubmitted bytes are rejected with zainod 0.6.0-rc.1's verbatim
message, and a one-shot `lose_next_send_response` fault accepts bytes
into the mempool while failing the reply — exactly the
accepted-but-unanswered submission the observatory recorded.

`mock_chain_tests::send_survives_lost_response_and_duplicate_rejection`
funds a wallet, injects the fault, sends, and asserts the send returns
`Ok`, the transaction is never marked `Failed`, and after mining the
mempool the balance carries the same ZIP-317 arithmetic as the
untampered send test. It was confirmed red against the unfixed loop —
failing with the byte-for-byte production error — and goes green with
this fix. Deterministic, ~14 s, no LocalNet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
