### PR TITLE
Address #2448 review: shard-truncation record and scanner-shutdown mempool grace

### DIFF
--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -467,7 +467,24 @@ async fn store_all_checkpoints_in_verification_window() {
 }
 
 /// Diagnostic for the container-only `add_subtree_roots` failure (wallet
-/// consistently 32 sapling shards short of the server's count).
+/// consistently 32 sapling shards short of the server's count, 1096 vs
+/// 1128).
+///
+/// Reproduction record (issue #2440): the failures occurred only in
+/// container runs — twice, the wallet at exactly 1096 both times, under
+/// `makers container-test` (podman on the originating machine) — while
+/// host runs of the same commit passed. "Container-only" records where
+/// it happened, not a mechanism: in the same failing container process
+/// a parallel fresh connection to the same URI saw all 1128 roots, so
+/// the healthy backend was reachable from inside the container, and a
+/// backend's state is client-independent. What pinned the wallet's
+/// channel to the stuck backend in exactly the container runs is
+/// unresolved — logging the resolved backend identity (the issue's open
+/// question) would make a recurrence attributable. Note the
+/// stream-resume defense of 9d40495b9 converts mid-flight cuts into
+/// completions but cannot conjure shards a stuck backend does not have,
+/// so present-day non-reproduction indicates a healthy backend pool
+/// (a day-later container run pulled 1128 cleanly), not a client fix.
 ///
 /// Prints, for three fresh connections, how many sapling subtree roots the
 /// stream yields and the chain height at which it ends — then the count

--- a/libtonode-tests/tests/tip_spend_rejection.rs
+++ b/libtonode-tests/tests/tip_spend_rejection.rs
@@ -8,7 +8,7 @@
 //! until the next chain tip block", during the funding send (orchard spends
 //! with an orchard output). The sapling-source rows — whose funding sends
 //! make the SAME orchard spends but with a sapling output — pass. The
-//! zebrad_shielded_funds offload historically hit the same rejection when
+//! normalize_shielded_faucet_balance offload historically hit the same rejection when
 //! it spent the tip block's coinbase note (fixed by sync-then-mine
 //! separation in f39cee419).
 //!

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -356,11 +356,14 @@ where
     let unprocessed_mempool_transactions_count = Arc::new(AtomicU8::new(0));
     let unprocessed_mempool_transactions_count_clone =
         unprocessed_mempool_transactions_count.clone();
+    let mempool_stream_connected_at = Arc::new(std::sync::OnceLock::new());
+    let mempool_stream_connected_at_clone = mempool_stream_connected_at.clone();
     let mempool_handle = tokio::spawn(async move {
         mempool_monitor(
             client,
             mempool_transaction_sender,
             unprocessed_mempool_transactions_count_clone,
+            mempool_stream_connected_at_clone,
             shutdown_mempool_clone,
         )
         .await
@@ -530,29 +533,31 @@ where
                 scanner.update(&mut *wallet.write().await, shutdown_mempool.clone(), nullifier_map_limit_exceeded).await?;
 
                 if matches!(scanner.state, ScannerState::Shutdown) {
-                    // Give the mempool monitor a bounded window to deliver
-                    // in-flight transactions, polling instead of paying a
-                    // fixed second per pass: the monitor has been streaming
-                    // since session start and the indexer serves accepted
-                    // transactions within ~100ms, so anything outstanding
-                    // normally lands within a few polls. Fall through the
-                    // moment work appears (it is processed by this select
-                    // loop); keep the old one-second ceiling as the worst
-                    // case before re-entering the loop as before.
+                    // Drain check on a 25ms cadence instead of the old
+                    // unconditional one-second sleep. The policy lives in
+                    // [`drain_verdict`]: shutdown requires a drained
+                    // scanner AND a mempool stream that has been connected
+                    // long enough to have served pre-existing content, so
+                    // a first-loop shutdown on a fully synced chain waits
+                    // for the subscription instead of closing the session
+                    // before the monitor ever connects. The old one-second
+                    // ceiling remains the worst case.
                     let shutdown_poll_started = std::time::Instant::now();
                     let mempool_drained = loop {
-                        if is_shutdown(&scanner, unprocessed_mempool_transactions_count.clone())
-                        {
-                            break true;
+                        let verdict = drain_verdict(
+                            scanner.worker_poolsize(),
+                            unprocessed_mempool_transactions_count
+                                .load(atomic::Ordering::Acquire),
+                            mempool_stream_connected_at.get().map(|at| at.elapsed()),
+                            shutdown_poll_started.elapsed(),
+                        );
+                        match verdict {
+                            DrainVerdict::Shutdown => break true,
+                            DrainVerdict::Reenter => break false,
+                            DrainVerdict::KeepPolling => {
+                                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                            }
                         }
-                        if unprocessed_mempool_transactions_count.load(atomic::Ordering::Acquire)
-                            > 0
-                            || shutdown_poll_started.elapsed()
-                                >= std::time::Duration::from_secs(1)
-                        {
-                            break false;
-                        }
-                        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
                     };
                     if mempool_drained {
                         tracing::info!("Sync successfully shutdown.");
@@ -1023,15 +1028,55 @@ pub(crate) fn set_transactions_failed_unchecked(
 }
 
 /// Returns true if the scanner and mempool are shutdown.
-fn is_shutdown<P>(
-    scanner: &Scanner<P>,
-    mempool_unprocessed_transactions_count: Arc<AtomicU8>,
-) -> bool
-where
-    P: consensus::Parameters + Sync + Send + 'static,
-{
-    scanner.worker_poolsize() == 0
-        && mempool_unprocessed_transactions_count.load(atomic::Ordering::Acquire) == 0
+/// Verdict for one pass of the scanner-shutdown drain poll. Pure over a
+/// snapshot — the caller loads the atomics and clocks; this only
+/// decides, so the whole policy is table-testable without a runtime.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DrainVerdict {
+    /// Drained and the mempool stream has settled: end the session.
+    Shutdown,
+    /// Work appeared, or the ceiling expired with workers running:
+    /// re-enter the processing loop.
+    Reenter,
+    /// Undecided: sleep one cadence and poll again.
+    KeepPolling,
+}
+
+/// The drain policy for scanner shutdown.
+///
+/// `connected_for` is the age of the mempool stream subscription
+/// (`None` until it is established). Connection — not first delivery —
+/// is deliberately the grace trigger: an empty mempool never delivers,
+/// and a delivery-based grace would hold every such session for the
+/// full ceiling, restoring the fixed second c90f8d309 removed. The
+/// settle window covers the gap between subscribing and receiving
+/// pre-existing mempool content (served within ~100ms of connect).
+fn drain_verdict(
+    scan_workers: usize,
+    unprocessed_mempool_transactions: u8,
+    connected_for: Option<Duration>,
+    poll_elapsed: Duration,
+) -> DrainVerdict {
+    /// The pre-c90f8d309 unconditional sleep, demoted to worst case: a
+    /// stream that never connects must not hold the session open.
+    const CEILING: Duration = Duration::from_secs(1);
+    /// One settle window after subscription.
+    const SETTLE: Duration = Duration::from_millis(200);
+
+    if unprocessed_mempool_transactions > 0 {
+        return DrainVerdict::Reenter;
+    }
+    if poll_elapsed >= CEILING {
+        return if scan_workers == 0 {
+            DrainVerdict::Shutdown
+        } else {
+            DrainVerdict::Reenter
+        };
+    }
+    match connected_for {
+        Some(age) if age >= SETTLE && scan_workers == 0 => DrainVerdict::Shutdown,
+        _ => DrainVerdict::KeepPolling,
+    }
 }
 
 /// Scan post-processing
@@ -1879,6 +1924,7 @@ async fn mempool_monitor<C>(
     mut client: C,
     mempool_transaction_sender: mpsc::Sender<RawTransaction>,
     unprocessed_transactions_count: Arc<AtomicU8>,
+    stream_connected_at: Arc<std::sync::OnceLock<std::time::Instant>>,
     shutdown_mempool: Arc<AtomicBool>,
 ) -> Result<(), MempoolError>
 where
@@ -1895,6 +1941,11 @@ where
 
         match response {
             Ok(mut mempool_stream) => {
+                // First successful subscription: the drain policy's
+                // grace window keys on this instant. Deliberately not
+                // reset on reconnect — any successful connect proves
+                // the indexer serves the stream.
+                let _already_set = stream_connected_at.set(std::time::Instant::now());
                 interval.reset();
                 loop {
                     tokio::select! {
@@ -1971,6 +2022,62 @@ fn max_nullifier_map_size(performance_level: PerformanceLevel) -> Option<usize> 
 
 #[cfg(test)]
 mod test {
+    /// The drain policy for scanner shutdown, exercised as a table:
+    /// pure inputs, no runtime, no clocks.
+    mod drain_verdict {
+        use std::time::Duration;
+
+        use crate::sync::DrainVerdict::{self, KeepPolling, Reenter, Shutdown};
+        use crate::sync::drain_verdict;
+
+        fn ms(millis: u64) -> Duration {
+            Duration::from_millis(millis)
+        }
+
+        #[test]
+        fn table() {
+            // (workers, unprocessed, connected_for, poll_elapsed) → verdict
+            let cases: &[(usize, u8, Option<u64>, u64, DrainVerdict, &str)] = &[
+                // The reported bug: first-loop shutdown on a fully
+                // synced chain, stream not yet connected — hold the
+                // session open instead of closing it instantly.
+                (0, 0, None, 0, KeepPolling, "no stream yet"),
+                // Connected but inside the settle window: still hold.
+                (0, 0, Some(50), 100, KeepPolling, "settling"),
+                // The typical session: stream connected long ago,
+                // scanner drained — immediate shutdown, no added cost.
+                (0, 0, Some(1_400), 0, Shutdown, "settled and drained"),
+                // Exactly the settle boundary counts as settled.
+                (0, 0, Some(200), 0, Shutdown, "settle boundary"),
+                // Unprocessed work always re-enters the processing
+                // loop, whatever the stream state — no deadline caps
+                // the processing itself.
+                (0, 3, Some(1_400), 0, Reenter, "unprocessed work"),
+                (5, 1, None, 999, Reenter, "work trumps missing stream"),
+                // Workers still draining: keep polling inside the
+                // ceiling, re-enter the loop once it expires.
+                (2, 0, Some(1_400), 500, KeepPolling, "workers draining"),
+                (2, 0, Some(1_400), 1_000, Reenter, "ceiling with workers"),
+                // Ceiling with a stream that never connected: the
+                // pre-c90f8d309 semantics — a dead stream must not
+                // hold the session open.
+                (0, 0, None, 1_000, Shutdown, "ceiling without stream"),
+            ];
+            for (workers, unprocessed, connected_ms, elapsed_ms, expected, name) in cases {
+                assert_eq!(
+                    drain_verdict(
+                        *workers,
+                        *unprocessed,
+                        connected_ms.map(ms),
+                        ms(*elapsed_ms)
+                    ),
+                    *expected,
+                    "{name}"
+                );
+            }
+        }
+    }
+
     /// The lifecycle of a note's spend mark across spend detection and `reset_spends`.
     ///
     /// The wallet remembers an on-chain spend observation in exactly one durable place: the

--- a/zingolib_testutils/Cargo.toml
+++ b/zingolib_testutils/Cargo.toml
@@ -34,4 +34,4 @@ tempfile.workspace = true
 http.workspace = true
 zip32.workspace = true
 tokio = { workspace = true, features = ["net", "time", "rt", "io-util", "sync", "macros"] }
-zingo-netutils = { version = "5.0.1", path = "../zingo-netutils" }
+zingo-netutils.workspace = true

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -194,7 +194,7 @@ pub const DEFERRED_STREAM_SKIM: u64 = block_rewards::CANOPY / 100;
 /// Miner reward for blocks at or above the funding-stream start height (2).
 pub const POST_STREAM_BLOCK_REWARD: u64 = block_rewards::CANOPY - DEFERRED_STREAM_SKIM;
 
-/// Amount `zebrad_shielded_funds` offloads from the faucet to keep its
+/// Amount `normalize_shielded_faucet_balance` offloads from the faucet to keep its
 /// spendable balance predictable for test assertions.
 pub const FUND_OFFLOAD_AMOUNT: u64 = 624_960_000;
 
@@ -307,7 +307,7 @@ pub async fn sync_client_to_validator_tip<V, I>(
 ///   note from (or anchored at) the tip block itself ("rejected from the
 ///   mempool until the next chain tip block"). When zebra says exactly
 ///   that, one separation block is mined and the send retried once,
-///   mirroring the fix in `zebrad_shielded_funds`.
+///   mirroring the fix in `normalize_shielded_faucet_balance`.
 ///
 /// Confirmation is asserted (up to a few blocks of tolerance), so a
 /// transaction that misses its block for any new reason fails HERE with the
@@ -383,7 +383,7 @@ where
 /// Mining two extra blocks first clears the upgrade ladder (tip 5, so
 /// tip+1 and the inclusion block share the NU6.2 branch id) and accumulates
 /// four pre-tip notes so oldest-first selection never reaches the tip note.
-async fn zebrad_shielded_funds<V, I>(
+async fn normalize_shielded_faucet_balance<V, I>(
     local_net: &LocalNet<V, I>,
     mine_to_pool: PoolType,
     faucet: &mut LightClient,
@@ -570,10 +570,10 @@ pub async fn faucet(
 
     let mut faucet = client_builder.build_faucet(true).await;
 
-    // A replayed chain already contains the shielded-funds transactions;
-    // the freshly built faucet wallet recovers them by sync below.
+    // A replayed chain already contains the balance-normalization offload;
+    // the freshly built faucet wallet recovers it by sync below.
     if !replayed && matches!(DefaultValidator::PROCESS, ProcessId::Zebrad) {
-        zebrad_shielded_funds(&local_net, mine_to_pool, &mut faucet).await;
+        normalize_shielded_faucet_balance(&local_net, mine_to_pool, &mut faucet).await;
     }
 
     sync_client_to_validator_tip(&local_net, &mut faucet).await;
@@ -624,10 +624,10 @@ pub async fn faucet_recipient(
         )
         .await;
 
-    // A replayed chain already contains the shielded-funds transactions;
-    // the freshly built faucet wallet recovers them by sync below.
+    // A replayed chain already contains the balance-normalization offload;
+    // the freshly built faucet wallet recovers it by sync below.
     if !replayed && matches!(DefaultValidator::PROCESS, ProcessId::Zebrad) {
-        zebrad_shielded_funds(&local_net, mine_to_pool, &mut faucet).await;
+        normalize_shielded_faucet_balance(&local_net, mine_to_pool, &mut faucet).await;
     }
 
     sync_client_to_validator_tip(&local_net, &mut faucet).await;


### PR DESCRIPTION
Answers both open review threads on #2448, in two commits against
`pre_ironwood`.

## 1. Shard-truncation record (docs, discussion r3557421519)

The `diagnose_subtree_root_stream` doc comment now records exactly what
issue #2440's isolation matrix supports:

- The failures occurred only in container runs — twice, the wallet at
  exactly 1096 sapling shards both times, under podman on the
  originating machine — while host runs of the same commit passed.
- "Container-only" records where it happened, not a mechanism: within
  the same failing container process a parallel fresh connection to the
  same URI saw all 1128 roots, so the healthy backend was reachable
  from inside the container, and a backend's state is
  client-independent.
- What pinned the wallet's channel to the stuck backend is unresolved;
  logging the resolved backend identity (issue #2440's open question)
  would make a recurrence attributable.
- The stream-resume defense of 9d40495b9 fixes the cut-stream class but
  cannot conjure shards a stuck backend does not have — so present-day
  non-reproduction indicates a healthy backend pool, not a client fix.

## 2. Scanner-shutdown mempool grace (fix, CHANGE REQUEST r3557604757)

c90f8d309's shutdown poll could conclude "drained" on a fully synced
chain before the mempool monitor had ever connected, closing the
session without the grace the removed one-second sleep used to provide.

The drain policy now lives in `drain_verdict`, a pure function over a
snapshot (worker count, unprocessed mempool transactions, stream
subscription age, poll elapsed): shutdown requires a drained scanner
AND a subscription at least one settle window (200ms) old, so a
first-loop shutdown waits for the stream instead of racing it.
Connection — not first delivery — is the grace trigger, because an
empty mempool never delivers and a delivery-based grace would restore
the fixed second on every such session. The one-second ceiling remains
the worst case (a dead stream must not hold the session open), and
unprocessed work re-enters the processing loop with no deadline — the
review's second concern: the ceiling never bounds processing, only the
idle wait.

The mempool monitor stamps a `OnceLock<Instant>` on its first
successful subscription — the policy's single observable — and the
policy is pinned by an exhaustive table test (first row: the reported
bug, stream-not-yet-connected → keep polling) that needs no runtime,
streams, or clocks. pepper-sync suite 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
