### PR TITLE
feat: offline signing with no expiry height, exposed as zingo-cli calculate and transmit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,8 +952,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -984,8 +983,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2391,7 +2389,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -3280,6 +3278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,6 +3713,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,14 +3744,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -3732,8 +3774,14 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -4472,6 +4520,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
@@ -4644,8 +4701,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "bech32",
  "bs58",
@@ -4659,8 +4715,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "base64",
  "bech32",
@@ -4710,8 +4765,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "corez",
  "hex",
@@ -4721,8 +4775,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "bech32",
  "bip32",
@@ -4751,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.7.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=bump_to_NU6.3#1a7bb7efb90d09c21b4e3178a7bac5c0078ac26b"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b228c06ae82365f306ff364e164da#537f84d3d81b228c06ae82365f306ff364e164da"
 dependencies = [
  "hex",
  "reqwest",
@@ -4761,6 +4814,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "toml",
  "tracing",
  "zingo-consensus",
  "zingo_test_vectors",
@@ -4782,8 +4836,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -4836,8 +4889,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "corez",
  "document-features",
@@ -4875,8 +4927,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "bip32",
  "bs58",
@@ -5000,6 +5051,7 @@ dependencies = [
  "indoc",
  "json",
  "log",
+ "nonempty",
  "pepper-sync",
  "rustyline",
  "shellwords",
@@ -5013,6 +5065,7 @@ dependencies = [
  "zcash_keys",
  "zcash_protocol",
  "zingo-netutils",
+ "zingo-status 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zingo_common_components",
  "zingo_grpc_proxy",
  "zingolib",
@@ -5022,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "zingo-consensus"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=bump_to_NU6.3#1a7bb7efb90d09c21b4e3178a7bac5c0078ac26b"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b228c06ae82365f306ff364e164da#537f84d3d81b228c06ae82365f306ff364e164da"
 
 [[package]]
 name = "zingo-memo"
@@ -5120,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=bump_to_NU6.3#1a7bb7efb90d09c21b4e3178a7bac5c0078ac26b"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b228c06ae82365f306ff364e164da#537f84d3d81b228c06ae82365f306ff364e164da"
 
 [[package]]
 name = "zingolib"
@@ -5216,8 +5269,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+source = "git+https://github.com/zingolabs/librustzcash?branch=zingo_expiry_override_zp_0_28_0#701d1e787d1b62f1ab4b167942d3ec11f22936e7"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,22 @@ opt-level = 3
 
 [patch.crates-io]
 time = { git = "https://github.com/time-rs/time", tag = "v0.3.47" }
+# The librustzcash workspace at the zcash_client_backend-0.23.0 release tag
+# (every crate version below matches its crates.io release exactly) plus one
+# additive seam in zcash_primitives: an expiry-height override so offline
+# signing can build with the ZIP 203 no-expiry sentinel
+# (zingolabs/zingolib#2455). The sibling crates are patched to the same
+# commit so the whole family keeps a single type identity.
+zcash_primitives = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+zcash_client_backend = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+zcash_keys = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+zcash_transparent = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+zcash_protocol = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+zcash_address = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+zcash_encoding = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+zip321 = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+equihash = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
+f4jumble = { git = "https://github.com/zingolabs/librustzcash", branch = "zingo_expiry_override_zp_0_28_0" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["tonic-prost"]

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1984,6 +1984,12 @@ where
 }
 
 /// Transaction status will be set to `Failed` if it's still unconfirmed when the chain reaches it's expiry height.
+///
+/// An expiry height of zero is the ZIP 203 no-expiry sentinel — the
+/// transaction never expires (offline signing builds with it, see
+/// zingolib issue #2455) — so zero is excluded here: naively compared,
+/// every chain height exceeds zero and the transaction would be failed
+/// on the first sync after it was calculated.
 fn expire_transactions<W>(wallet: &mut W) -> Result<(), SyncError<W::Error>>
 where
     W: SyncWallet + SyncTransactions,
@@ -2000,8 +2006,10 @@ where
     let expired_txids = wallet_transactions
         .values()
         .filter(|transaction| {
+            let expiry_height = transaction.transaction().expiry_height();
             transaction.status().is_pending()
-                && last_known_chain_height >= transaction.transaction().expiry_height()
+                && u32::from(expiry_height) != 0
+                && last_known_chain_height >= expiry_height
         })
         .map(super::wallet::WalletTransaction::txid)
         .collect::<Vec<_>>();

--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -19,7 +19,9 @@ http = { workspace = true }
 indoc = { workspace = true }
 json = { workspace = true }
 log = { workspace = true }
+nonempty = { workspace = true }
 rustyline = { workspace = true }
+zingo-status = { workspace = true }
 shellwords = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1405,6 +1405,143 @@ impl Command for ConfirmCommand {
     }
 }
 
+struct CalculateCommand {}
+impl Command for CalculateCommand {
+    fn help(&self) -> &'static str {
+        concat!(
+            "Calculates (signs) the latest proposal without transmitting it, for offline signing.\n",
+            "Consumes the stored proposal, builds and signs its transaction(s) with no Indexer\n",
+            "required, and stores them in the wallet with Calculated status. Transmit them later\n",
+            "with the 'transmit' command once an Indexer is available.\n",
+            "Fails if a proposal has not already been created with the 'send', 'send_all' or\n",
+            "'shield' commands.\n",
+            "\n",
+            "NO EXPIRY HEIGHT: transactions calculated by this command are deliberately built\n",
+            "without an expiry height (nExpiryHeight = 0, the ZIP 203 no-expiry sentinel), so a\n",
+            "stale offline chain view cannot invalidate them before transmission. They NEVER\n",
+            "expire: each remains valid to transmit at any later time, until it is transmitted\n",
+            "or its inputs are spent by another transaction. Treat a Calculated transaction as\n",
+            "live value in flight.\n",
+            "\n",
+            "Usage:\n",
+            "    calculate\n",
+            "Example:\n",
+            "    send ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
+            "    calculate\n",
+            "    transmit\n",
+        )
+    }
+
+    fn short_help(&self) -> &'static str {
+        "Signs the latest proposal without transmitting it; built with no expiry height, it never expires."
+    }
+
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+        if !args.is_empty() {
+            return format!(
+                "Error: {}\nTry 'help calculate' for correct usage and examples.",
+                error::CommandError::InvalidArguments
+            );
+        }
+
+        RT.block_on(async move {
+            match lightclient.calculate_stored_proposal().await {
+                Ok(txids) => {
+                    object! {
+                        "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+                        "expiry_height" => "none: built with the ZIP 203 no-expiry sentinel, this transaction never expires",
+                    }
+                }
+                Err(e) => {
+                    object! { "error" => e.to_string() }
+                }
+            }
+            .pretty(2)
+        })
+    }
+}
+
+struct TransmitCommand {}
+impl Command for TransmitCommand {
+    fn help(&self) -> &'static str {
+        concat!(
+            "Transmits previously calculated transactions to the Indexer.\n",
+            "With no arguments, transmits every transaction in the wallet with Calculated\n",
+            "status, ordered by target height. To control the order explicitly — required for\n",
+            "multi-step proposals such as TEX sends, whose first step must be transmitted\n",
+            "first — pass the txids in the order the 'calculate' command printed them.\n",
+            "\n",
+            "Remember that transactions from 'calculate' carry no expiry height: any that you\n",
+            "do not transmit remain valid indefinitely, until their inputs are spent.\n",
+            "\n",
+            "Usage:\n",
+            "    transmit [txid ...]\n",
+            "Example:\n",
+            "    transmit\n",
+        )
+    }
+
+    fn short_help(&self) -> &'static str {
+        "Transmits previously calculated transactions to the Indexer."
+    }
+
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+        RT.block_on(async move {
+            let txids = if args.is_empty() {
+                // All Calculated transactions, ordered by target height and
+                // then txid for determinism.
+                let wallet = lightclient.wallet().read().await;
+                let mut calculated: Vec<_> = wallet
+                    .wallet_transactions
+                    .iter()
+                    .filter(|(_, transaction)| {
+                        matches!(
+                            transaction.status(),
+                            zingo_status::confirmation_status::ConfirmationStatus::Calculated(_)
+                        )
+                    })
+                    .map(|(txid, transaction)| (transaction.status().get_height(), *txid))
+                    .collect();
+                calculated.sort_by_key(|&(height, txid)| (height, txid.as_ref().to_owned()));
+                calculated.into_iter().map(|(_, txid)| txid).collect()
+            } else {
+                match args
+                    .iter()
+                    .map(|arg| zingolib::utils::conversion::txid_from_hex_encoded_str(arg))
+                    .collect::<Result<Vec<_>, _>>()
+                {
+                    Ok(txids) => txids,
+                    Err(e) => {
+                        return format!(
+                            "Error: {e}\nTry 'help transmit' for correct usage and examples."
+                        );
+                    }
+                }
+            };
+
+            let Some(txids) = nonempty::NonEmpty::from_vec(txids) else {
+                return object! { "error" => "no calculated transactions to transmit" }.pretty(2);
+            };
+
+            match lightclient.transmit_calculated(txids).await {
+                Ok(txids) => {
+                    object! { "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>() }
+                }
+                Err(e) => {
+                    object! { "error" => e.to_string() }
+                }
+            }
+            .pretty(2)
+        })
+    }
+}
+
 // TODO: add a decline command which deletes latest proposal?
 
 struct DeleteCommand {}
@@ -1977,7 +2114,9 @@ pub fn get_wallet_commands() -> HashMap<&'static str, Box<dyn Command>> {
         ("check_address", Box::new(CheckAddressCommand {})),
         ("clear", Box::new(ClearCommand {})),
         ("coins", Box::new(CoinsCommand {})),
+        ("calculate", Box::new(CalculateCommand {})),
         ("confirm", Box::new(ConfirmCommand {})),
+        ("transmit", Box::new(TransmitCommand {})),
         ("current_price", Box::new(CurrentPriceCommand {})),
         ("delete", Box::new(DeleteCommand {})),
         ("export_ufvk", Box::new(ExportUfvkCommand {})),

--- a/zingo-cli/src/examples.rs
+++ b/zingo-cli/src/examples.rs
@@ -78,3 +78,5 @@ pub(crate) const SEED_PHRASE: &str = "abandon abandon abandon abandon abandon ab
 pub(crate) const BIRTHDAY: &str = "600000";
 #[cfg(test)]
 pub(crate) const DATA_DIR: &str = "/tmp/zingo-test-data";
+#[cfg(test)]
+pub(crate) const TXID: &str = "8f7a03e9aac8bd1b7ed64c773b445d0da2ab4bd0ab26eb0e0f78e6b6b9d63f2e";

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -193,6 +193,25 @@ mod mode_of_operation {
         }
 
         #[test]
+        fn calculate() {
+            assert_no_arg_command("calculate");
+        }
+
+        #[test]
+        fn transmit() {
+            assert_no_arg_command("transmit");
+        }
+
+        #[test]
+        fn transmit_with_txids() {
+            assert_command(
+                &[examples::BIN_NAME, "transmit", examples::TXID],
+                "transmit",
+                &[examples::TXID],
+            );
+        }
+
+        #[test]
         fn shield() {
             assert_no_arg_command("shield");
         }

--- a/zingolib/src/lightclient/offline.rs
+++ b/zingolib/src/lightclient/offline.rs
@@ -107,8 +107,11 @@ mod test {
     /// selects witnesses, proves, and signs — a real transaction from the
     /// stored proposal over synthetic wallet state, with no Indexer
     /// anywhere. The signed transaction lands in the wallet with
-    /// `Calculated` status, and only the transmission half demands a
-    /// connection.
+    /// `Calculated` status, is built with **no expiry height** (the
+    /// ZIP 203 sentinel, `nExpiryHeight = 0` — it never expires, so the
+    /// stale offline chain view cannot invalidate it before
+    /// transmission; issue #2455), and only the transmission half
+    /// demands a connection.
     #[tokio::test]
     async fn offline_calculate_signs_and_transmit_refuses() {
         use crate::testutils::lightclient::from_inputs;
@@ -132,10 +135,17 @@ mod test {
         {
             let wallet = client.wallet().read().await;
             for txid in calculated_txids.iter() {
+                let transaction = wallet.wallet_transactions.get(txid).unwrap();
                 assert!(matches!(
-                    wallet.wallet_transactions.get(txid).unwrap().status(),
+                    transaction.status(),
                     ConfirmationStatus::Calculated(_)
                 ));
+                assert_eq!(
+                    u32::from(transaction.transaction().expiry_height()),
+                    0,
+                    "offline-calculated transactions carry the ZIP 203 \
+                     no-expiry sentinel: no expiry height is used"
+                );
             }
         }
 

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -109,11 +109,13 @@ impl LightClient {
     /// them with [`Self::transmit_calculated`] once an Indexer is
     /// configured.
     ///
-    /// The transactions' expiry heights derive from the proposal's target
-    /// height — the wallet's possibly stale chain view — so a transaction
-    /// calculated long offline can be expired by transmission time. The
-    /// ratified no-expiry sentinel for offline signing is blocked on
-    /// upstream expiry control in `zcash_client_backend` (issue #2455).
+    /// These transactions are built with **no expiry height** — the ZIP 203
+    /// sentinel, `nExpiryHeight = 0` — because they are meant to outlive the
+    /// wallet's possibly stale chain view until an Indexer is available.
+    /// They never expire: a Calculated transaction remains transmittable
+    /// indefinitely, until it is transmitted or its inputs are spent by
+    /// another transaction, so treat the Calculated record as live value in
+    /// flight (issue #2455).
     pub async fn calculate_stored_proposal(&mut self) -> Result<NonEmpty<TxId>, LightClientError> {
         let mut wallet = self.wallet().write().await;
         let opt_proposal = wallet.take_proposal();
@@ -123,14 +125,14 @@ impl LightClient {
                     proposal,
                     sending_account,
                 } => wallet
-                    .calculate_transactions(proposal, sending_account)
+                    .calculate_transactions_no_expiry(proposal, sending_account)
                     .await
                     .map_err(SendError::CalculateSendError)?,
                 ZingoProposal::Shield {
                     proposal,
                     shielding_account,
                 } => wallet
-                    .calculate_transactions(proposal, shielding_account)
+                    .calculate_transactions_no_expiry(proposal, shielding_account)
                     .await
                     .map_err(SendError::CalculateShieldError)?,
             };

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -23,9 +23,33 @@ impl LightWallet {
         proposal: Proposal<zip317::FeeRule, NoteRef>,
         sending_account: zip32::AccountId,
     ) -> Result<NonEmpty<TxId>, CalculateTransactionError<NoteRef>> {
+        self.calculate_transactions_inner(proposal, sending_account, false)
+            .await
+    }
+
+    /// [`Self::calculate_transactions`], but the transactions are built with
+    /// the ZIP 203 no-expiry sentinel (`nExpiryHeight = 0`): they never
+    /// expire. This is the offline-signing build — a transaction calculated
+    /// against an Indexerless wallet's stale chain view must not be expired
+    /// by the time an Indexer is available to transmit it (issue #2455).
+    pub(crate) async fn calculate_transactions_no_expiry<NoteRef>(
+        &mut self,
+        proposal: Proposal<zip317::FeeRule, NoteRef>,
+        sending_account: zip32::AccountId,
+    ) -> Result<NonEmpty<TxId>, CalculateTransactionError<NoteRef>> {
+        self.calculate_transactions_inner(proposal, sending_account, true)
+            .await
+    }
+
+    async fn calculate_transactions_inner<NoteRef>(
+        &mut self,
+        proposal: Proposal<zip317::FeeRule, NoteRef>,
+        sending_account: zip32::AccountId,
+        no_expiry: bool,
+    ) -> Result<NonEmpty<TxId>, CalculateTransactionError<NoteRef>> {
         let calculated_txids = match proposal.steps().len() {
             1 => {
-                self.create_proposed_transactions(proposal, sending_account)
+                self.create_proposed_transactions(proposal, sending_account, no_expiry)
                     .await?
             }
             2 if proposal.steps()[1]
@@ -44,7 +68,7 @@ impl LightWallet {
                     )
                 }) =>
             {
-                self.create_proposed_transactions(proposal, sending_account)
+                self.create_proposed_transactions(proposal, sending_account, no_expiry)
                     .await?
             }
 
@@ -59,6 +83,7 @@ impl LightWallet {
         &mut self,
         proposal: Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, NoteRef>,
         sending_account: zip32::AccountId,
+        no_expiry: bool,
     ) -> Result<NonEmpty<TxId>, CalculateTransactionError<NoteRef>> {
         let chain_type = self.chain_type;
         let usk: zcash_keys::keys::UnifiedSpendingKey = self
@@ -73,6 +98,12 @@ impl LightWallet {
                 .map_err(CalculateTransactionError::SaplingParams)?;
         let sapling_prover =
             zcash_proofs::prover::LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
+        // The guard is thread-scoped and `create_proposed_transactions` below
+        // is synchronous, so the override cannot leak across an `.await`; it
+        // drops when this function returns. Do not move an `.await` inside
+        // the guard's lifetime.
+        let _no_expiry_guard = no_expiry
+            .then(zcash_primitives::transaction::builder::ExpiryHeightOverrideGuard::no_expiry);
         zcash_client_backend::data_api::wallet::create_proposed_transactions(
             self,
             &chain_type,


### PR DESCRIPTION
Extends Offline mode with the calculate/transmit split that was requested for zingo-cli testing: `calculate` signs the stored proposal with no Indexer, and `transmit` sends the resulting Calculated transactions once an Indexer is available.

## No expiry height

Transactions built by `calculate` deliberately carry **no expiry height** — the ZIP 203 sentinel, `nExpiryHeight = 0`. A transaction signed against an Indexerless wallet's stale chain view must not be expired by the time an Indexer is available to transmit it (#2455). The consequence is framed plainly in the command help, the `calculate` output, and the API docs: these transactions **never expire**; each remains valid to transmit at any later time, until it is transmitted or its inputs are spent by another transaction, so a Calculated record is live value in flight.

Two supporting changes make the sentinel safe:

- **`[patch.crates-io]` to `zingolabs/librustzcash@zingo_expiry_override_zp_0_28_0`.** Expiry is fixed inside `zcash_primitives`' `Builder` and `zcash_client_backend` exposes no parameter for it. The fork branch is the `zcash_client_backend-0.23.0` release tag — every patched crate version matches its crates.io release exactly — plus one additive seam: a guard-scoped expiry-height override read by non-coinbase `Builder::new`, inert unless a guard is live. zingolib installs the guard only inside `create_proposed_transactions`, around the synchronous construction call, under the wallet write lock that serializes builds. The sibling crates are patched to the same commit so the family keeps a single type identity.
- **pepper-sync excludes the sentinel from its expiry check.** Naively compared, every chain height exceeds zero, and a never-expiring transaction would have been marked `Failed` on the first sync after calculation — exactly the offline-to-online transition offline signing exists for.

## CLI surface

- `calculate` — consumes the stored proposal (from `send`, `send_all`, or `shield`), signs offline, stores the transactions with `Calculated` status, and reports the txids alongside an explicit `expiry_height: none` field.
- `transmit [txid ...]` — transmits Calculated transactions: all of them ordered by target height by default, or specific txids in caller order (multi-step proposals, such as TEX sends, must transmit step one first).

The offline signing test now pins `nExpiryHeight = 0`, and parse tests cover both commands. 257 tests pass across zingolib, zingo-cli, and pepper-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
