### PR TITLE
ci: cancel a PR's superseded runs when new commits land

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -15,6 +15,15 @@ on:
   push:
     branches: [stable, dev]
 
+# One CI tree per pull request: a new commit on a PR'd branch cancels the
+# superseded commit's still-running jobs (including the container test
+# matrix called through test.yaml), returning those runners to the pool.
+# Pushes to stable/dev group by ref but never cancel a running tree —
+# GitHub instead collapses any queued runs behind it to the newest.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   reject-trailing-whitespace:
     uses: zingolabs/infrastructure/.github/workflows/trailing-whitespace.yaml@20485fed7a080e381130ed8120419dc81acae641


### PR DESCRIPTION
Nothing in the workflows declared a concurrency policy, so every push to a pull request's branch left the previous commit's entire CI tree running to completion beside the new one — including the partitioned container test matrix, the most runner-hungry jobs in the repository. Stacked pushes to an active PR therefore multiplied runner consumption instead of superseding it.

This adds a `concurrency` group to `ci-pr.yaml`, the sole entry point for pull-request CI. The reusable workflows it calls (`test.yaml`, `cargo-checkmate.yaml`, `compute-image-tag.yaml`) execute inside the caller's run, so cancelling the caller reaps the whole tree. Groups key on the pull request number, and `cancel-in-progress` applies only to `pull_request` events: pushes to `stable` and `dev` group by ref without cancelling a running tree, letting GitHub collapse queued runs behind it to the newest instead.

Based on `dev` so the policy reaches every PR immediately, following the routing precedent of #2471's workflow repair; `feat/ironwood` picks it up on its next `dev` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)