### PR TITLE
fix: sum scan-progress outputs through one pure per-pool total

### DIFF
--- a/pepper-sync/src/mocks.rs
+++ b/pepper-sync/src/mocks.rs
@@ -200,7 +200,12 @@ impl SyncBlocks for MockWallet {
         &self,
         block_height: BlockHeight,
     ) -> Result<crate::wallet::WalletBlock, Self::Error> {
-        todo!()
+        self.wallet_blocks
+            .get(&block_height)
+            .cloned()
+            .ok_or_else(|| {
+                MockWalletError::AnErrorVariant(format!("no wallet block at {block_height}"))
+            })
     }
 
     fn get_wallet_blocks_mut(

--- a/pepper-sync/src/scan/transactions.rs
+++ b/pepper-sync/src/scan/transactions.rs
@@ -621,6 +621,11 @@ where
                     address,
                 ))
             }),
+            // A unified address has no distinct ironwood receiver:
+            // receivers (and their incoming viewing keys) are scoped
+            // to the Orchard PROTOCOL, not to a pool, so the orchard
+            // receiver serves both the orchard and ironwood pools.
+            // See ZIP 326, <https://zips.z.cash/zip-0326>.
             ShieldedPool::Orchard | ShieldedPool::Ironwood => unified_address
                 .orchard()
                 .map(|address| keys::encode_orchard_receiver(consensus_parameters, address)),

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -774,14 +774,25 @@ pub async fn sync_status<W>(wallet: &W) -> Result<SyncStatus, SyncStatusError<W:
 where
     W: SyncWallet + SyncBlocks,
 {
+    /// Sums one per-pool trio of output counts into the pool-agnostic
+    /// total. Pure and total: this is the single definition of which
+    /// pools participate in scan-progress accounting, so every
+    /// consumer — the percentages and the exact u64 ratio — agrees by
+    /// construction, and adding a pool touches exactly this function.
+    fn output_pool_total(sapling: u32, orchard: u32, ironwood: u32) -> u64 {
+        u64::from(sapling) + u64::from(orchard) + u64::from(ironwood)
+    }
+
     let (
         total_sapling_outputs_scanned,
         total_orchard_outputs_scanned,
         total_ironwood_outputs_scanned,
     ) = state::calculate_scanned_outputs(wallet).map_err(SyncStatusError::WalletError)?;
-    let total_outputs_scanned = total_sapling_outputs_scanned
-        + total_orchard_outputs_scanned
-        + total_ironwood_outputs_scanned;
+    let total_outputs_scanned = output_pool_total(
+        total_sapling_outputs_scanned,
+        total_orchard_outputs_scanned,
+        total_ironwood_outputs_scanned,
+    );
 
     let sync_state = wallet
         .get_sync_state()
@@ -839,7 +850,11 @@ where
             .initial_sync_state
             .wallet_tree_bounds
             .ironwood_initial_tree_size;
-    let total_outputs = total_sapling_outputs + total_orchard_outputs + total_ironwood_outputs;
+    let total_outputs = output_pool_total(
+        total_sapling_outputs,
+        total_orchard_outputs,
+        total_ironwood_outputs,
+    );
 
     let session_blocks_scanned =
         total_blocks_scanned - sync_state.initial_sync_state.previously_scanned_blocks;
@@ -868,18 +883,22 @@ where
         - sync_state
             .initial_sync_state
             .previously_scanned_ironwood_outputs;
-    let session_outputs_scanned = session_sapling_outputs_scanned
-        + session_orchard_outputs_scanned
-        + session_ironwood_outputs_scanned;
-    let previously_scanned_outputs = sync_state
-        .initial_sync_state
-        .previously_scanned_sapling_outputs
-        + sync_state
+    let session_outputs_scanned = output_pool_total(
+        session_sapling_outputs_scanned,
+        session_orchard_outputs_scanned,
+        session_ironwood_outputs_scanned,
+    );
+    let previously_scanned_outputs = output_pool_total(
+        sync_state
             .initial_sync_state
-            .previously_scanned_orchard_outputs
-        + sync_state
+            .previously_scanned_sapling_outputs,
+        sync_state
             .initial_sync_state
-            .previously_scanned_ironwood_outputs;
+            .previously_scanned_orchard_outputs,
+        sync_state
+            .initial_sync_state
+            .previously_scanned_ironwood_outputs,
+    );
     let mut percentage_session_outputs_scanned = ((session_outputs_scanned as f32
         / (total_outputs - previously_scanned_outputs) as f32)
         * 100.0)
@@ -927,9 +946,8 @@ where
         total_ironwood_outputs_scanned,
         percentage_session_outputs_scanned,
         percentage_total_outputs_scanned,
-        total_outputs_scanned: u64::from(total_sapling_outputs_scanned)
-            + u64::from(total_orchard_outputs_scanned),
-        total_outputs: u64::from(total_sapling_outputs) + u64::from(total_orchard_outputs),
+        total_outputs_scanned,
+        total_outputs,
     })
 }
 

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -2366,6 +2366,130 @@ mod test {
         }
     }
 
+    /// The pool-accounting contract of [`crate::sync::sync_status`]:
+    /// every output total on the status — the per-pool u32 fields, the
+    /// u64 exact-ratio pair, and the f32 percentage — describes the
+    /// same per-pool trio, summed once through `output_pool_total`.
+    /// Regression for the skew where the u64 fields re-summed only
+    /// sapling and orchard while the percentages included ironwood.
+    /// Each pool contributes a distinct count, so dropping any pool
+    /// from any consumer changes an asserted value.
+    mod sync_status_pool_accounting {
+        use std::collections::BTreeMap;
+
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::consensus::BlockHeight;
+
+        use crate::mocks::MockWalletBuilder;
+        use crate::sync::{ScanPriority, ScanRange, sync_status};
+        use crate::wallet::{SyncState, TreeBounds, WalletBlock};
+
+        /// A wallet block carrying only what tree-bounds accounting
+        /// reads: its height and tree sizes.
+        fn block(height: u32, tree_bounds: TreeBounds) -> WalletBlock {
+            WalletBlock {
+                block_height: BlockHeight::from_u32(height),
+                block_hash: BlockHash([0; 32]),
+                prev_hash: BlockHash([0; 32]),
+                time: 0,
+                txids: Vec::new(),
+                tree_bounds,
+            }
+        }
+
+        /// Tree bounds whose initial and final sizes coincide, for
+        /// blocks that only mark a boundary of a scanned range.
+        fn flat_bounds(sapling: u32, orchard: u32, ironwood: u32) -> TreeBounds {
+            TreeBounds {
+                sapling_initial_tree_size: sapling,
+                sapling_final_tree_size: sapling,
+                orchard_initial_tree_size: orchard,
+                orchard_final_tree_size: orchard,
+                ironwood_initial_tree_size: ironwood,
+                ironwood_final_tree_size: ironwood,
+            }
+        }
+
+        #[tokio::test]
+        async fn exact_ratio_fields_agree_with_per_pool_totals() {
+            // One fully scanned range whose boundary blocks yield a
+            // distinct scanned count per pool: sapling 3, orchard 5,
+            // ironwood 7.
+            let mut sync_state = SyncState::new_for_test(vec![ScanRange::from_parts(
+                BlockHeight::from_u32(1_000)..BlockHeight::from_u32(1_010),
+                ScanPriority::Scanned,
+            )]);
+            sync_state.initial_sync_state.sync_start_height = BlockHeight::from_u32(1_000);
+            // Session denominators: 10 sapling + 20 orchard + 40
+            // ironwood outputs between the wallet bounds, 70 in all.
+            sync_state.initial_sync_state.wallet_tree_bounds = TreeBounds {
+                sapling_initial_tree_size: 100,
+                sapling_final_tree_size: 110,
+                orchard_initial_tree_size: 200,
+                orchard_final_tree_size: 220,
+                ironwood_initial_tree_size: 300,
+                ironwood_final_tree_size: 340,
+            };
+            sync_state
+                .initial_sync_state
+                .previously_scanned_sapling_outputs = 1;
+            sync_state
+                .initial_sync_state
+                .previously_scanned_orchard_outputs = 2;
+            sync_state
+                .initial_sync_state
+                .previously_scanned_ironwood_outputs = 3;
+
+            let wallet_blocks = BTreeMap::from([
+                (
+                    BlockHeight::from_u32(1_000),
+                    block(1_000, flat_bounds(100, 200, 300)),
+                ),
+                (
+                    BlockHeight::from_u32(1_009),
+                    block(1_009, flat_bounds(103, 205, 307)),
+                ),
+            ]);
+
+            let wallet = MockWalletBuilder::new()
+                .sync_state(sync_state)
+                .wallet_blocks(wallet_blocks)
+                .create_mock_wallet();
+
+            let status = sync_status(&wallet).await.unwrap();
+
+            assert_eq!(status.total_sapling_outputs_scanned, 3);
+            assert_eq!(status.total_orchard_outputs_scanned, 5);
+            assert_eq!(status.total_ironwood_outputs_scanned, 7);
+
+            // The regression proper: the u64 exact-ratio fields must
+            // equal the sum of the per-pool fields reported beside
+            // them. Under the skew, total_outputs_scanned was 8 (no
+            // ironwood) and total_outputs was 30.
+            assert_eq!(
+                status.total_outputs_scanned,
+                u64::from(status.total_sapling_outputs_scanned)
+                    + u64::from(status.total_orchard_outputs_scanned)
+                    + u64::from(status.total_ironwood_outputs_scanned),
+            );
+            assert_eq!(status.total_outputs_scanned, 15);
+            assert_eq!(status.total_outputs, 70);
+
+            // The percentage must describe the same ratio as the exact
+            // fields — the skew's observable symptom was these two
+            // disagreeing on ironwood chains.
+            let expected_percentage =
+                (status.total_outputs_scanned as f32 / status.total_outputs as f32) * 100.0;
+            assert!(
+                (status.percentage_total_outputs_scanned - expected_percentage).abs()
+                    < f32::EPSILON,
+                "percentage {} disagrees with the exact ratio {}",
+                status.percentage_total_outputs_scanned,
+                expected_percentage,
+            );
+        }
+    }
+
     /// The drain policy for scanner shutdown, exercised as a table:
     /// pure inputs, no runtime, no clocks.
     mod drain_verdict {

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -785,7 +785,7 @@ impl WalletTransaction {
     }
 }
 
-#[cfg(feature = "test-features")]
+#[cfg(any(test, feature = "test-features"))]
 impl SyncState {
     /// Creates sync state with the given scan ranges, for tests exercising
     /// spendability/witness gating without a chain.

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1329,7 +1329,7 @@ impl Command for QuickShieldCommand {
     }
 
     fn short_help(&self) -> &'static str {
-        "Shield transparent funds to the ironwoodpool. Combines `shield` and `confirm` into a single command."
+        "Shield transparent funds to the ironwood pool. Combines `shield` and `confirm` into a single command."
     }
 
     fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {


### PR DESCRIPTION
## Summary

Three small fixes from a review of #2475, offered as a PR into its branch so
they ride along when it merges.

## The accounting skew

`sync_status()` now computes every u32 output total ironwood-inclusively, but
the u64 exact-ratio fields (`total_outputs_scanned` / `total_outputs`) still
re-summed only sapling and orchard, so the CLI's integer progress ratio would
disagree with the percentage fields beside it on any ironwood-era chain. The
fix introduces `output_pool_total`, a pure function that is now the single
definition of which pools participate in scan-progress accounting. Every sum
site and both struct fields flow through it, so the u64 ratio, the f32
percentages, and any future consumer agree by construction — and adding a
pool touches exactly one function.

## Also included

The why-comment lost in the `Orchard | Ironwood` match-arm merge is restored
with its authority: ZIP 326 scopes receivers and incoming viewing keys to the
Orchard protocol rather than to a pool, which is why a unified address has no
distinct ironwood receiver (<https://zips.z.cash/zip-0326>). And the
"ironwoodpool" typo in QuickShield's short help gains its missing space.

## Verification

`cargo check`, `cargo clippy`, and `cargo fmt --check` are clean for
`pepper-sync` and `zingo-cli` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
