### PR TITLE
Six edges tested: verification and fixes for the #2419 review findings

### DIFF
--- a/.agent-plans/pr2419-findings-verification.md
+++ b/.agent-plans/pr2419-findings-verification.md
@@ -1,0 +1,41 @@
+# Claim: independent verification of the #2419 review findings (2026-07-16)
+
+Session working in the `feat_ironwood` worktree on branch `feat_ironwood`.
+The user handed over six correctness findings from a reviewer of PR #2419
+and asked for an independent review plus an attempted failing test that
+demonstrates each finding. The deliverable is test code and a verdict per
+finding, not fixes. Any product-source change waits for the user's
+ratification.
+
+## Scope
+
+The work began as tests only; the user then ratified fixing each confirmed
+finding, with test and fix combined per commit on the `six_edges_tested`
+branch (PR against feat/ironwood, Oscar reviewing). Verdicts: findings 1,
+3, 4, 6a, 6b, and 6c confirmed and fixed; finding 2 resolved in the code's
+favor (the comment was stale) and pinned by test; finding 5 refuted and
+pinned by test. Fixtures added while DRYing the tests:
+`testutils::synthetic_wallet::inject_confirmed_orchard_notes`, the
+migrate.rs test-module scaffold helpers, and `planned_state` in the store
+tests.
+
+## File claims (test-only additions)
+
+- `zingolib/src/wallet/zcb_traits.rs` (findings 1 and 2: AllFunds panic,
+  ironwood OutputRef pool label)
+- `zingolib/src/lightclient/migrate.rs` (finding 3: paused sync leak on the
+  note-split round)
+- `pepper-sync/src/sync/state.rs` (finding 4: chain-tip range fallback with
+  empty ironwood shard ranges)
+- `zingolib/src/wallet/migration/schedule.rs` and
+  `zingolib/src/wallet/migration/reconcile.rs` (finding 5: open-window part
+  at relaunch; finding 6c: unknown txid treated as failed)
+- `zingolib/src/wallet/migration/store.rs` (finding 6a: u64 to usize
+  truncation)
+- `pepper-sync/src/scan/compact_blocks.rs` (finding 6b: lenient ironwood
+  tree-size check)
+- Possibly a new test file under `zingolib/tests/` or
+  `pepper-sync/tests/` if an inline `mod tests` does not fit.
+
+No behavior changes to product source. Long test suites stay with the user,
+this session runs only targeted fast tests through `cargo nextest run`.

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -302,40 +302,50 @@ fn check_tree_size(
     compact_block: &CompactBlock,
     wallet_block: &WalletBlock,
 ) -> Result<(), ScanError> {
-    if let Some(chain_metadata) = &compact_block.chain_metadata {
-        if chain_metadata.sapling_commitment_tree_size
-            != wallet_block.tree_bounds().sapling_final_tree_size
-        {
-            return Err(ScanError::IncorrectTreeSize {
-                shielded_protocol: PoolType::Shielded(ShieldedPool::Sapling),
-                block_metadata_size: chain_metadata.sapling_commitment_tree_size,
-                calculated_size: wallet_block.tree_bounds().sapling_final_tree_size,
-            });
+    let Some(chain_metadata) = &compact_block.chain_metadata else {
+        return Ok(());
+    };
+    let matched = |pool, block_metadata_size, calculated_size| {
+        if block_metadata_size == calculated_size {
+            Ok(())
+        } else {
+            Err(ScanError::IncorrectTreeSize {
+                shielded_protocol: PoolType::Shielded(pool),
+                block_metadata_size,
+                calculated_size,
+            })
         }
-        if chain_metadata.orchard_commitment_tree_size
-            != wallet_block.tree_bounds().orchard_final_tree_size
-        {
-            return Err(ScanError::IncorrectTreeSize {
-                shielded_protocol: PoolType::Shielded(ShieldedPool::Orchard),
-                block_metadata_size: chain_metadata.orchard_commitment_tree_size,
-                calculated_size: wallet_block.tree_bounds().orchard_final_tree_size,
-            });
-        }
-        if chain_metadata.ironwood_commitment_tree_size
-            != wallet_block.tree_bounds().ironwood_final_tree_size
-        {
-            // A mismatch is expected while parts of the ecosystem do not
-            // serve ironwood data (wallet blocks synced before ironwood
-            // tracking carry zero sizes, and servers without support send
-            // zero metadata against real actions). Warn instead of failing
-            // sync until ironwood serving is universal.
-            tracing::warn!(
-                "ironwood tree size mismatch at block {}.\nwallet block: {}\ncompact block metadata: {}",
-                wallet_block.block_height(),
-                wallet_block.tree_bounds().ironwood_final_tree_size,
-                chain_metadata.ironwood_commitment_tree_size
-            );
-        }
+    };
+
+    matched(
+        ShieldedPool::Sapling,
+        chain_metadata.sapling_commitment_tree_size,
+        wallet_block.tree_bounds().sapling_final_tree_size,
+    )?;
+    matched(
+        ShieldedPool::Orchard,
+        chain_metadata.orchard_commitment_tree_size,
+        wallet_block.tree_bounds().orchard_final_tree_size,
+    )?;
+    // Ironwood tolerates a zero on either side while parts of the ecosystem
+    // do not serve ironwood data (wallet blocks synced before ironwood
+    // tracking carry zero sizes, and servers without support send zero
+    // metadata against real actions): warn instead of failing sync until
+    // ironwood serving is universal. Two nonzero sizes disagreeing is
+    // neither of those cases: both sides are actively tracking the pool, so
+    // the mismatch is corruption and is rejected exactly as for the other
+    // pools.
+    let metadata_size = chain_metadata.ironwood_commitment_tree_size;
+    let calculated_size = wallet_block.tree_bounds().ironwood_final_tree_size;
+    if metadata_size != 0 && calculated_size != 0 {
+        matched(ShieldedPool::Ironwood, metadata_size, calculated_size)?;
+    } else if metadata_size != calculated_size {
+        tracing::warn!(
+            "ironwood tree size mismatch at block {}.\nwallet block: {}\ncompact block metadata: {}",
+            wallet_block.block_height(),
+            calculated_size,
+            metadata_size
+        );
     }
 
     Ok(())
@@ -548,5 +558,63 @@ fn set_checkpoint_retentions<L>(
             // NOTE: if there are no outputs in the block, this last retention will be a checkpoint and nothing will need to be mutated.
             _ => (),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zingo_netutils::lightwallet_protocol::ChainMetadata;
+
+    use super::*;
+
+    fn wallet_block_with_ironwood_size(size: u32) -> WalletBlock {
+        WalletBlock {
+            block_height: BlockHeight::from_u32(100),
+            block_hash: BlockHash([1; 32]),
+            prev_hash: BlockHash([0; 32]),
+            time: 0,
+            txids: vec![],
+            tree_bounds: TreeBounds {
+                sapling_initial_tree_size: 10,
+                sapling_final_tree_size: 10,
+                orchard_initial_tree_size: 10,
+                orchard_final_tree_size: 10,
+                ironwood_initial_tree_size: size,
+                ironwood_final_tree_size: size,
+            },
+        }
+    }
+
+    fn compact_block_with_ironwood_size(size: u32) -> CompactBlock {
+        CompactBlock {
+            height: 100,
+            hash: vec![1; 32],
+            prev_hash: vec![0; 32],
+            time: 0,
+            header: vec![],
+            vtx: vec![],
+            chain_metadata: Some(ChainMetadata {
+                sapling_commitment_tree_size: 10,
+                orchard_commitment_tree_size: 10,
+                ironwood_commitment_tree_size: size,
+            }),
+        }
+    }
+
+    /// A server actively serving ironwood metadata (nonzero) that disagrees
+    /// with the wallet's own nonzero calculation is corruption, not the
+    /// known "server does not serve ironwood yet" case (metadata zero).
+    /// Validation must reject it exactly as it does for sapling and orchard.
+    #[test]
+    fn nonzero_ironwood_tree_size_mismatch_is_rejected() {
+        let compact_block = compact_block_with_ironwood_size(999);
+        let wallet_block = wallet_block_with_ironwood_size(7);
+        assert!(matches!(
+            check_tree_size(&compact_block, &wallet_block),
+            Err(ScanError::IncorrectTreeSize {
+                shielded_protocol: PoolType::Shielded(ShieldedPool::Ironwood),
+                ..
+            })
+        ));
     }
 }

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -568,9 +568,23 @@ fn determine_block_range(
             let start = if let Some(range) = shard_ranges.last() {
                 range.end - 1
             } else {
+                // With no shard ranges at all (a server that does not serve
+                // this pool, or a pool freshly activated), fall back to the
+                // pool's own history: the wallet birthday clamped to the
+                // pool's activation height. An unclamped birthday would let
+                // the chain-tip punch flood the entire wallet range.
+                let pool_upgrade = match shielded_protocol {
+                    ShieldedPool::Sapling => consensus::NetworkUpgrade::Sapling,
+                    ShieldedPool::Orchard => consensus::NetworkUpgrade::Nu5,
+                    ShieldedPool::Ironwood => consensus::NetworkUpgrade::Nu6_3,
+                };
+                let activation = consensus_parameters
+                    .activation_height(pool_upgrade)
+                    .expect("the pool was selected because its upgrade is active");
                 sync_state
                     .wallet_birthday()
                     .expect("scan range should not be empty")
+                    .max(activation)
             };
             let end = sync_state
                 .last_known_chain_height()
@@ -1209,6 +1223,60 @@ mod tests {
         );
         assert_eq!(range.start, BlockHeight::from_u32(100));
         assert_eq!(range.end, BlockHeight::from_u32(150));
+    }
+
+    /// Mainnet-shaped network: NU6.3 activates recently, near the chain tip.
+    const TIP_ACTIVATION_NETWORK: LocalNetwork = LocalNetwork {
+        overwinter: Some(BlockHeight::from_u32(1)),
+        sapling: Some(BlockHeight::from_u32(1)),
+        blossom: Some(BlockHeight::from_u32(1)),
+        heartwood: Some(BlockHeight::from_u32(1)),
+        canopy: Some(BlockHeight::from_u32(1)),
+        nu5: Some(BlockHeight::from_u32(1)),
+        nu6: Some(BlockHeight::from_u32(1)),
+        nu6_1: Some(BlockHeight::from_u32(1)),
+        nu6_2: Some(BlockHeight::from_u32(1)),
+        nu6_3: Some(BlockHeight::from_u32(19_000)),
+    };
+
+    #[test]
+    fn chain_tip_priority_confined_to_tip_when_ironwood_shards_are_empty() {
+        // A wallet with a long history: birthday (1_000) far below the chain tip (20_000).
+        let mut sync_state = sync_state_with_ranges(1_000, 20_000);
+
+        // Sapling and orchard have complete shards reaching near the tip, so their
+        // incomplete tip shards start close to the chain tip (17_999 and 18_499).
+        sync_state.sapling_shard_ranges =
+            vec![BlockHeight::from_u32(1_000)..BlockHeight::from_u32(18_000)];
+        sync_state.orchard_shard_ranges =
+            vec![BlockHeight::from_u32(1_000)..BlockHeight::from_u32(18_500)];
+        // Ironwood shard ranges are empty: a tolerated server condition, and the
+        // universal state on every network immediately after NU6.3 activation.
+        assert!(sync_state.ironwood_shard_ranges.is_empty());
+
+        set_chain_tip_scan_range(
+            &TIP_ACTIVATION_NETWORK,
+            &mut sync_state,
+            BlockHeight::from_u32(20_000),
+        );
+
+        let chain_tip_start = sync_state
+            .scan_ranges()
+            .iter()
+            .filter(|range| range.priority() == ScanPriority::ChainTip)
+            .map(|range| range.block_range().start)
+            .min()
+            .expect("chain tip punch should mark at least one range");
+
+        // The chain-tip region must stay confined near the tip. The lowest
+        // legitimate anchor is the sapling incomplete tip shard start (17_999);
+        // an ironwood fallback may reach no lower than the NU6.3 activation
+        // height (19_000). It must never flood down to the wallet birthday.
+        assert!(
+            chain_tip_start >= BlockHeight::from_u32(17_999),
+            "ChainTip priority flooded down to {chain_tip_start} (wallet birthday is 1_000); \
+             expected the chain-tip region confined to the tip shards (start >= 17_999)"
+        );
     }
 
     #[test]

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -25,6 +25,8 @@ use crate::lightclient::LightClient;
 use crate::lightclient::error::{LightClientError, MigrationError};
 use zcash_protocol::consensus::BlockHeight;
 
+use crate::wallet::LightWallet;
+use crate::wallet::error::WalletError;
 use crate::wallet::migration::{
     BroadcastClient, ChainView, ConsentBinding, DrainPlan, MigrationParams, MigrationPhase,
     MigrationPlan, MigrationState, PartId, PartState, PrepareResult, RecommendedAction,
@@ -686,8 +688,33 @@ impl LightClient {
             return Err(crate::wallet::error::WalletError::NothingToMigrate.into());
         }
 
+        let txids = self
+            .build_and_transmit(&plan.transactions, |wallet, planned| {
+                wallet.build_drain_transaction(account, planned)
+            })
+            .await?;
+
+        Ok(DrainSummary {
+            txids,
+            migrated: plan.migrated,
+            fee: plan.fee,
+            stranded: plan.stranded,
+        })
+    }
+
+    /// Builds and transmits one batch of planned migration transactions under
+    /// a paused sync, enforcing the shared cleanup contract: a build failure
+    /// fails the transactions already built, and a transmit failure fails
+    /// every transaction still unsent, so no note stays spent by a
+    /// transaction that will never reach the network. Both the drain flow and
+    /// the note-splitting rounds send through here.
+    async fn build_and_transmit<T>(
+        &mut self,
+        planned: &[T],
+        build: impl Fn(&mut LightWallet, &T) -> Result<TxId, WalletError>,
+    ) -> Result<Vec<TxId>, LightClientError> {
         let _ignore_error = self.pause_sync();
-        let built = self.build_drain_transactions(account, &plan).await;
+        let built = self.build_transactions(planned, build).await;
         let txids = match built {
             Ok(txids) => txids,
             Err(e) => {
@@ -698,7 +725,7 @@ impl LightClient {
 
         let transmitted = self
             .transmit_transactions(
-                NonEmpty::from_vec(txids.clone()).expect("a non-empty plan builds transactions"),
+                NonEmpty::from_vec(txids.clone()).expect("planned batches are never empty"),
             )
             .await;
         let _ignore_error = self.resume_sync();
@@ -707,32 +734,27 @@ impl LightClient {
             // `transmit_transactions` marks the transaction that failed, but
             // the ones queued behind it stay `Calculated`: their notes would
             // remain spent by transactions that will never reach the network.
-            // Fail them so the next call re-plans them.
-            self.fail_unsent_drain_transactions(&txids).await;
+            // Fail them so the next pass re-plans them.
+            self.fail_unsent_transactions(&txids).await;
             return Err(e);
         }
 
-        Ok(DrainSummary {
-            txids,
-            migrated: plan.migrated,
-            fee: plan.fee,
-            stranded: plan.stranded,
-        })
+        Ok(txids)
     }
 
-    /// Builds every transaction of a drain plan under one wallet lock. On
-    /// failure, fails the transactions already built so their notes do not stay
-    /// spent by transactions that will never be sent.
-    async fn build_drain_transactions(
+    /// Builds every planned transaction under one wallet lock. On failure,
+    /// fails the transactions already built so their notes do not stay spent
+    /// by transactions that will never be sent.
+    async fn build_transactions<T>(
         &mut self,
-        account: zip32::AccountId,
-        plan: &DrainPlan,
+        planned: &[T],
+        build: impl Fn(&mut LightWallet, &T) -> Result<TxId, WalletError>,
     ) -> Result<Vec<TxId>, LightClientError> {
         let mut wallet = self.wallet().write().await;
-        let mut txids = Vec::with_capacity(plan.transactions.len());
+        let mut txids = Vec::with_capacity(planned.len());
 
-        for planned in &plan.transactions {
-            match wallet.build_drain_transaction(account, planned) {
+        for item in planned {
+            match build(&mut wallet, item) {
                 Ok(txid) => txids.push(txid),
                 Err(e) => {
                     if !txids.is_empty() {
@@ -750,9 +772,9 @@ impl LightClient {
         Ok(txids)
     }
 
-    /// Marks every drain transaction still sitting in `Calculated` as failed,
+    /// Marks every transaction still sitting in `Calculated` as failed,
     /// releasing the notes it reserved.
-    async fn fail_unsent_drain_transactions(&mut self, txids: &[TxId]) {
+    async fn fail_unsent_transactions(&mut self, txids: &[TxId]) {
         let mut wallet = self.wallet().write().await;
         let unsent: Vec<TxId> = txids
             .iter()
@@ -885,22 +907,11 @@ impl LightClient {
                 .into_iter()
                 .next()
                 .expect("unsplit plan has at least one round");
-            let _ignore_error = self.pause_sync();
-            let mut round_txids = Vec::new();
-            for planned in &round {
-                round_txids.push(
-                    self.wallet()
-                        .write()
-                        .await
-                        .build_note_split_transaction(account, planned)?,
-                );
-            }
-            self.transmit_transactions(
-                NonEmpty::from_vec(round_txids.clone())
-                    .expect("note-splitting round has at least one transaction"),
-            )
-            .await?;
-            let _ignore_error = self.resume_sync();
+            let round_txids = self
+                .build_and_transmit(&round, |wallet, planned| {
+                    wallet.build_note_split_transaction(account, planned)
+                })
+                .await?;
             split_txids.extend(round_txids.iter().copied());
 
             self.await_migration_confirmations(&round_txids).await?;

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -962,10 +962,56 @@ mod tests {
     use crate::lightclient::LightClient;
     use crate::mocks::broadcast::MockBroadcastClient;
     use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+    use crate::wallet::LightWallet;
     use crate::wallet::migration::{
         BoundNote, ConsentBinding, MigrationParams, MigrationPhase, MigrationState, PartId,
         PartRecord, PartState, SigningStrategy, schedule,
     };
+
+    /// The value of the one fabricated note every scenario here binds a
+    /// migration part to.
+    const NOTE_VALUE: u64 = 100_000;
+
+    /// A synthetic wallet fully scanned through `tip`, holding one
+    /// [`NOTE_VALUE`] legacy-Orchard note, plus that note's binding for a
+    /// migration part.
+    fn wallet_with_migration_note(tip: u32) -> (LightWallet, BoundNote) {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .orchard_note(NOTE_VALUE)
+            .tip(tip)
+            .build();
+        let bound_note = wallet
+            .wallet_transactions
+            .values()
+            .flat_map(OrchardNote::transaction_outputs)
+            .find(|note| note.value() == NOTE_VALUE)
+            .map(|note| BoundNote {
+                output_id: note.output_id(),
+                nullifier: note
+                    .nullifier()
+                    .expect("scanned notes carry nullifiers")
+                    .to_bytes(),
+                commitment: [0; 32],
+            })
+            .expect("the wallet holds the fabricated note");
+        (wallet, bound_note)
+    }
+
+    /// A consented, parts-scheduled migration state over `parts`.
+    fn scheduled_state(params: MigrationParams, parts: Vec<PartRecord>) -> MigrationState {
+        MigrationState {
+            consent: ConsentBinding {
+                params_hash: params.params_hash(),
+                plan_hash: [0; 32],
+                consented_at: 0,
+            },
+            params,
+            strategy: SigningStrategy::LazyAtBoundary,
+            account: AccountId::ZERO,
+            phase: MigrationPhase::PartsScheduled,
+            parts,
+        }
+    }
 
     /// Offline twin of the libtonode
     /// `unavailable_boundary_tree_state_skips_without_sync` scenario: a due
@@ -988,27 +1034,7 @@ mod tests {
         // pepper-sync's 100-block checkpoint retention.
         const TIP: u32 = 360;
 
-        let mut wallet =
-            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
-                .orchard_note(100_000)
-                .tip(TIP)
-                .build();
-
-        let (output_id, nullifier) = wallet
-            .wallet_transactions
-            .values()
-            .flat_map(OrchardNote::transaction_outputs)
-            .find(|note| note.value() == 100_000)
-            .map(|note| {
-                (
-                    note.output_id(),
-                    note.nullifier()
-                        .expect("scanned notes carry nullifiers")
-                        .to_bytes(),
-                )
-            })
-            .expect("the wallet holds the 100_000 note");
-
+        let (mut wallet, bound_note) = wallet_with_migration_note(TIP);
         let params = MigrationParams::provisional(wallet.chain_type());
         let known_height = wallet
             .sync_state
@@ -1020,28 +1046,9 @@ mod tests {
             "the tip must sit past a bucket boundary"
         );
 
-        let mut part = PartRecord::new(
-            PartId(0),
-            100_000,
-            BoundNote {
-                output_id,
-                nullifier,
-                commitment: [0; 32],
-            },
-        );
+        let mut part = PartRecord::new(PartId(0), NOTE_VALUE, bound_note);
         part.assign(current_bucket).expect("fresh parts are bound");
-        wallet.migration = Some(MigrationState {
-            consent: ConsentBinding {
-                params_hash: params.params_hash(),
-                plan_hash: [0; 32],
-                consented_at: 0,
-            },
-            params,
-            strategy: SigningStrategy::LazyAtBoundary,
-            account: AccountId::ZERO,
-            phase: MigrationPhase::PartsScheduled,
-            parts: vec![part],
-        });
+        wallet.migration = Some(scheduled_state(params, vec![part]));
         let mut client = LightClient::new_for_test(wallet).await;
 
         let broadcast_client = MockBroadcastClient::default();
@@ -1065,5 +1072,90 @@ mod tests {
             Some(known_height),
             "the skip must not move the wallet's known height"
         );
+    }
+
+    /// Open windows at relaunch: a part whose bucket window is *currently
+    /// open* (opened before now, not yet closed) is reachable immediately
+    /// after a process relaunch, without waiting to become Overdue.
+    /// `next_wakes` lists only future buckets and `reconcile` classifies the
+    /// open window as OnTrack with no action; the open window belongs to the
+    /// third leg, `broadcast_due_parts` (driven at startup or after sync by
+    /// `auto_broadcast_if_due`), whose due predicate selects
+    /// `bucket_index == current_bucket`.
+    #[tokio::test]
+    async fn open_window_part_is_broadcast_at_relaunch() {
+        use zcash_primitives::transaction::TxId;
+
+        use crate::wallet::migration::{PartClass, next_wakes, reconcile};
+
+        // Tip 300 sits mid-window in bucket 1 of the provisional M = 256:
+        // the window [256, 512) opened before "now" and has not closed.
+        const TIP: u32 = 300;
+
+        let (mut wallet, bound_note) = wallet_with_migration_note(TIP);
+        let params = MigrationParams::provisional(wallet.chain_type());
+        let now_height = wallet
+            .sync_state
+            .last_known_chain_height()
+            .expect("the synthetic wallet is fully synced");
+        let current_bucket = schedule::bucket_index(now_height, params.bucket_modulus);
+        let window_start = schedule::boundary_of(current_bucket, params.bucket_modulus);
+        let window_end = schedule::boundary_of(current_bucket + 1, params.bucket_modulus);
+        assert!(
+            window_start < now_height && now_height < window_end,
+            "the part's window must be open at relaunch"
+        );
+
+        // The part was signed in a previous session; the relaunch sees only
+        // this persisted record.
+        let own_txid = TxId::from_bytes([7; 32]);
+        let signed_blob = vec![0xAB; 64];
+        let mut part = PartRecord::new(PartId(0), NOTE_VALUE, bound_note);
+        part.assign(current_bucket).expect("fresh parts are bound");
+        part.mark_signed(own_txid, window_end, Some(signed_blob.clone()))
+            .expect("assigned parts sign");
+        wallet.migration = Some(scheduled_state(params.clone(), vec![part]));
+
+        // The two true premises of #2419 review finding 5: the wake listing
+        // omits the open window and reconciliation classifies it OnTrack
+        // with no action.
+        {
+            let state = wallet.migration.as_ref().expect("just set");
+            assert!(
+                next_wakes(&state.parts, now_height, 0, u64::MAX, &params).is_empty(),
+                "next_wakes lists future buckets only"
+            );
+            let report = reconcile(state, &wallet);
+            assert_eq!(report.assessments[0].class, PartClass::OnTrack);
+            assert!(report.actions.is_empty());
+        }
+
+        // The finding's conclusion is nevertheless false: the due-part
+        // broadcast path covers the open window at relaunch.
+        let mut client = LightClient::new_for_test(wallet).await;
+        let broadcast_client = MockBroadcastClient::default();
+        let sent = client
+            .broadcast_due_parts_with(&broadcast_client)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            sent,
+            vec![own_txid],
+            "the open-window part broadcasts now instead of slipping to Overdue"
+        );
+        {
+            let submissions = broadcast_client.submissions.lock().unwrap();
+            assert_eq!(submissions.len(), 1, "the endpoint received the part");
+            assert_eq!(
+                submissions[0].0, signed_blob,
+                "the persisted blob was submitted"
+            );
+        }
+
+        let wallet = client.wallet().read().await;
+        let part = &wallet.migration.as_ref().unwrap().parts[0];
+        assert_eq!(part.state, PartState::Broadcast);
+        assert_eq!(part.attempts, 1, "the attempt was recorded before submit");
     }
 }

--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -959,3 +959,116 @@ async fn send_survives_lost_response_and_queued_duplicate_rejection() {
     recipient.sync_and_await().await.unwrap();
     check_client_balances!(recipient, i: 70_000 o: 0 s: 0 t: 0);
 }
+
+/// A failed transmit inside a note-splitting round must not leave any
+/// transaction stranded in `Calculated`. The drain sibling
+/// (`drain_orchard_to_ironwood`) fails every unsent transaction so the
+/// notes it reserved become spendable again; the split round in
+/// `migrate_to_ironwood` must enforce the same invariant, or the
+/// transactions queued behind the failing one keep their notes marked
+/// spent by transactions that never reached the network, and a replan
+/// silently excludes that value until expiry self-heals it (~40 blocks
+/// plus a sync).
+///
+/// Setup: 34 fabricated legacy-Orchard (V2) notes make the provisional
+/// planner (max_actions_per_split_tx = 32) emit a first reduction round of
+/// TWO merge transactions. The mock indexer's lost-response fault plus an
+/// effectively-infinite download-queue rejection budget makes the FIRST
+/// submission fail deterministically after the wallet's probe budget; the
+/// second transaction must not stay stranded.
+#[tokio::test]
+async fn failed_split_round_transmit_strands_calculated_transactions() {
+    use zcash_primitives::transaction::TxId;
+    use zip32::AccountId;
+
+    use pepper_sync::wallet::{OrchardNote, OutputInterface as _};
+    use zingo_status::confirmation_status::ConfirmationStatus;
+
+    use crate::testutils::mock_indexer::LostSendDestination;
+    use crate::testutils::synthetic_wallet::inject_confirmed_orchard_notes;
+
+    const NOTES: u32 = 34;
+    const NOTE_VALUE: u64 = 60_000;
+    const TIP: u32 = 41;
+
+    // A real mock-net client, synced over an empty chain so the wallet
+    // carries genuine wallet blocks and scan state, then handed 34
+    // spendable legacy-Orchard notes whose nullifiers are really derived,
+    // so pepper-sync's spend detection marks them when the round spends
+    // them.
+    let mut net = MockNet::launch().await;
+    net.chain.write().await.mine_empty_blocks(TIP);
+    let mut client = net
+        .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+        .await;
+    client
+        .sync_and_await()
+        .await
+        .expect("initial sync succeeds");
+    {
+        let wallet_lock = client.wallet().clone();
+        let mut wallet = wallet_lock.write().await;
+        inject_confirmed_orchard_notes(&mut wallet, NOTES, NOTE_VALUE, TIP);
+    }
+
+    // Arm the deterministic transmit failure: the first send's response is
+    // lost while the bytes sit in the validator's download queue, and the
+    // queue never promotes, so every duplicate probe is rejected until the
+    // wallet's probe budget is exhausted and it marks that transaction
+    // Failed and errors out of transmit_transactions.
+    {
+        let mut chain = net.chain.write().await;
+        chain.lose_next_send_response = Some(LostSendDestination::DownloadQueue);
+        chain.queued_rejections_before_promotion = u8::MAX;
+    }
+
+    let err = client
+        .migrate_to_ironwood(AccountId::ZERO)
+        .await
+        .expect_err("the first split transaction's transmit fails");
+    eprintln!("migrate_to_ironwood returned: {err:?}");
+
+    // Diagnostics and precondition: the round must have reached the
+    // transmit stage (exactly one transaction Failed there).
+    let wallet = client.wallet().read().await;
+    let mut failed = Vec::new();
+    let mut calculated = Vec::new();
+    for tx in wallet.wallet_transactions.values() {
+        match tx.status() {
+            ConfirmationStatus::Calculated(_) => {
+                let spent_inputs: Vec<(TxId, u64)> = wallet
+                    .wallet_transactions
+                    .values()
+                    .flat_map(OrchardNote::transaction_outputs)
+                    .filter(|note| note.spending_transaction() == Some(tx.txid()))
+                    .map(|note| (note.output_id().txid(), note.value()))
+                    .collect();
+                eprintln!(
+                    "stranded Calculated transaction {} spends {} notes still \
+                     marked spent: {spent_inputs:?}",
+                    tx.txid(),
+                    spent_inputs.len(),
+                );
+                calculated.push(tx.txid());
+            }
+            ConfirmationStatus::Failed(_) => failed.push(tx.txid()),
+            _ => (),
+        }
+    }
+    assert!(
+        !failed.is_empty(),
+        "precondition: the transmit stage must have failed the first split \
+         transaction (otherwise this test failed before transmit)"
+    );
+
+    // The invariant the drain path enforces (fail_unsent_transactions) and
+    // the split path must too: after a failed round, nothing may remain
+    // Calculated — its notes would stay spent by transactions that will
+    // never broadcast, and a replan silently excludes them.
+    assert!(
+        calculated.is_empty(),
+        "a failed note-split round stranded {} transaction(s) in Calculated \
+         with their input notes marked spent: {calculated:?}",
+        calculated.len()
+    );
+}

--- a/zingolib/src/testutils/synthetic_wallet.rs
+++ b/zingolib/src/testutils/synthetic_wallet.rs
@@ -355,3 +355,80 @@ impl SyntheticWalletBuilder {
         wallet
     }
 }
+
+/// Injects `count` confirmed, unspent legacy-Orchard (V2) notes of `value`
+/// zatoshis into an already-synced wallet, replacing the orchard anchor
+/// checkpoint at `tip` so it covers the appended leaves.
+///
+/// The builder above fabricates whole wallets and assigns fabricated
+/// nullifiers, which proposing never checks. This sibling serves tests that
+/// drive pepper-sync's spend bookkeeping on a mock net: each nullifier is
+/// derived from the wallet's own orchard key, so a transaction that later
+/// spends one of these notes is matched by nullifier and the note is marked
+/// spent.
+pub fn inject_confirmed_orchard_notes(wallet: &mut LightWallet, count: u32, value: u64, tip: u32) {
+    let orchard_fvk: orchard::keys::FullViewingKey = wallet
+        .unified_key_store
+        .get(&zip32::AccountId::ZERO)
+        .expect("account zero exists")
+        .try_into()
+        .expect("mnemonic wallets carry an orchard key");
+    let recipient = orchard_fvk.address_at(0u32, zip32::Scope::External);
+
+    for index in 0..count {
+        // The same txid range the builder uses for orchard notes, clear of
+        // its ironwood (1..) and sapling (0x80..) ranges.
+        let txid = TxId::from_bytes([0x40 + u8::try_from(index).expect("small note corpus"); 32]);
+        let crypto_note = OrchardCryptoNoteBuilder::default()
+            .recipient(recipient)
+            .value(NoteValue::from_raw(value))
+            .note_version(orchard::NoteVersion::V2)
+            .build();
+        wallet
+            .shard_trees
+            .orchard
+            .append(
+                MerkleHashOrchard::from_cmx(&crypto_note.commitment().into()),
+                Retention::Marked,
+            )
+            .expect("appending to the in-memory orchard tree succeeds");
+        let nullifier = crypto_note.nullifier(&orchard_fvk);
+        let note = OrchardNote::new_for_test(
+            OutputId::new(txid, 0),
+            zip32::AccountId::ZERO,
+            zip32::Scope::External,
+            crypto_note,
+            Memo::Empty,
+            Some(Position::from(u64::from(index))),
+        )
+        .with_nullifier_for_test(nullifier);
+        wallet.wallet_transactions.insert(
+            txid,
+            WalletTransaction::new_for_test_with_orchard_notes(
+                txid,
+                ConfirmationStatus::Confirmed(BlockHeight::from_u32(2 + index)),
+                vec![note],
+                vec![],
+            ),
+        );
+    }
+
+    // The synced checkpoint at the tip predates the appended leaves; replace
+    // it so the anchor covers them.
+    let tip = BlockHeight::from_u32(tip);
+    wallet
+        .shard_trees
+        .orchard
+        .store_mut()
+        .remove_checkpoint(&tip)
+        .expect("infallible on the memory store");
+    wallet
+        .shard_trees
+        .orchard
+        .store_mut()
+        .add_checkpoint(
+            tip,
+            Checkpoint::at_position(Position::from(u64::from(count) - 1)),
+        )
+        .expect("infallible on the memory store");
+}

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -110,6 +110,9 @@ pub enum WalletError {
         "Cannot create a new wallet: a wallet file already exists at this path. Use WalletConfig::Read to load the existing wallet."
     )]
     WalletAlreadyCreated,
+    /// All-funds note selection (`TargetValue::AllFunds`) is not implemented.
+    #[error("All-funds note selection is not supported.")]
+    AllFundsSelectionUnsupported,
 }
 
 /// Price error

--- a/zingolib/src/wallet/migration/reconcile.rs
+++ b/zingolib/src/wallet/migration/reconcile.rs
@@ -329,9 +329,13 @@ impl ChainView for crate::wallet::LightWallet {
     }
 
     fn transaction_failed(&self, txid: &TxId) -> bool {
+        // An absent record is *unknown*, not failed: after a restore from
+        // backup an in-flight split transaction has no wallet record yet may
+        // still confirm. Reporting it failed would retry the split and race
+        // the original.
         self.wallet_transactions
             .get(txid)
-            .is_none_or(|transaction| transaction.status().is_failed())
+            .is_some_and(|transaction| transaction.status().is_failed())
     }
 
     fn orchard_confirmed_spendable(&self, account: zip32::AccountId) -> u64 {
@@ -626,6 +630,43 @@ mod tests {
         assert_eq!(
             report.actions,
             vec![RecommendedAction::ContinueNoteSplitting]
+        );
+    }
+
+    /// After a restore from backup the wallet's transaction map no longer
+    /// contains an in-flight split transaction, but the persisted migration
+    /// state still names it in `pending_txids`. An unknown txid is not
+    /// *recorded as failed* (the `ChainView::transaction_failed` contract),
+    /// so reconciliation must keep waiting rather than retry the split and
+    /// race its own in-flight transaction. This exercises the real
+    /// `LightWallet` implementation, not `MockChainView`.
+    #[test]
+    fn unknown_txid_after_restore_is_not_classified_failed() {
+        use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+        let wallet =
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED).build();
+
+        let in_flight_txid = TxId::from_bytes([42; 32]);
+        assert!(!wallet.wallet_transactions.contains_key(&in_flight_txid));
+
+        // Contract-level assertion: an unknown transaction is not failed.
+        assert!(
+            !wallet.transaction_failed(&in_flight_txid),
+            "an unknown txid must not be reported as failed",
+        );
+
+        // Behavior-level assertion: reconciliation awaits confirmation
+        // instead of recommending a retry that races the in-flight split.
+        let mut state = scheduled_state(Vec::new());
+        state.phase = MigrationPhase::NoteSplitting {
+            round: 0,
+            pending_txids: vec![in_flight_txid],
+        };
+        let report = reconcile(&state, &wallet);
+        assert_eq!(
+            report.actions,
+            vec![RecommendedAction::AwaitSplitConfirmation],
         );
     }
 }

--- a/zingolib/src/wallet/migration/store.rs
+++ b/zingolib/src/wallet/migration/store.rs
@@ -88,7 +88,13 @@ pub fn read<R: Read>(mut reader: R) -> io::Result<MigrationState> {
     let bucket_modulus = reader.read_u32::<LittleEndian>()?;
     let k_max = reader.read_u32::<LittleEndian>()?;
     let target_sessions = reader.read_u32::<LittleEndian>()?;
-    let max_actions_per_split_tx = reader.read_u64::<LittleEndian>()? as usize;
+    let max_actions_per_split_tx =
+        usize::try_from(reader.read_u64::<LittleEndian>()?).map_err(|_| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "max_actions_per_split_tx does not fit in this platform's usize",
+            )
+        })?;
     let expiry_delta = reader.read_u32::<LittleEndian>()?;
     let part_fee = reader.read_u64::<LittleEndian>()?;
     let params = MigrationParams {
@@ -471,9 +477,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unknown_inner_version_is_rejected() {
-        let state = MigrationState {
+    /// A freshly planned mainnet state, the smallest well-formed fixture.
+    fn planned_state() -> MigrationState {
+        MigrationState {
             params: MigrationParams::provisional(crate::config::ChainType::Mainnet),
             consent: ConsentBinding {
                 params_hash: [0; 32],
@@ -484,10 +490,50 @@ mod tests {
             account: zip32::AccountId::ZERO,
             phase: MigrationPhase::Planned,
             parts: Vec::new(),
-        };
+        }
+    }
+
+    #[test]
+    fn unknown_inner_version_is_rejected() {
         let mut bytes = Vec::new();
-        write(&mut bytes, &state).expect("writes");
+        write(&mut bytes, &planned_state()).expect("writes");
         bytes[0] = INNER_VERSION + 1;
         assert!(read(bytes.as_slice()).is_err());
+    }
+
+    /// The `as usize` cast reading `max_actions_per_split_tx` silently
+    /// truncates on 32-bit targets. This test patches a serialized stream so
+    /// the persisted value exceeds `u32::MAX`: the read must either reject
+    /// the stream (the desired `usize::try_from` + `InvalidData` behavior)
+    /// or preserve the value. It passes vacuously on 64-bit hosts; run under
+    /// a 32-bit target (e.g. i686-unknown-linux-gnu) to observe the failure.
+    #[test]
+    fn max_actions_read_never_silently_truncates() {
+        const SENTINEL: u64 = 0x1122_3344;
+        const PATCHED: u64 = 0x1_1122_3344; // does not fit in u32
+
+        let mut state = planned_state();
+        state.params.max_actions_per_split_tx = SENTINEL as usize;
+
+        let mut bytes = Vec::new();
+        write(&mut bytes, &state).expect("writes");
+
+        // Locate the sentinel's unique little-endian encoding and set a high
+        // byte, producing the stream a 64-bit writer (or corruption) would
+        // carry.
+        let needle = SENTINEL.to_le_bytes();
+        let position = bytes
+            .windows(8)
+            .position(|window| window == needle)
+            .expect("sentinel is unique in the fixture");
+        bytes[position..position + 8].copy_from_slice(&PATCHED.to_le_bytes());
+
+        match read(bytes.as_slice()) {
+            Err(error) => assert_eq!(error.kind(), ErrorKind::InvalidData),
+            Ok(read_state) => assert_eq!(
+                read_state.params.max_actions_per_split_tx as u64, PATCHED,
+                "read silently truncated the persisted value"
+            ),
+        }
     }
 }

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -882,7 +882,10 @@ impl InputSource for LightWallet {
                     )
                 }
                 TargetValue::AllFunds(_max_spend_mode) => {
-                    panic!("TargetValue::Allfunds not currently supported!");
+                    // Upstream drives this arm through propose_send_max; an
+                    // unsupported mode must surface through the trait's error
+                    // channel, never abort the process.
+                    return Err(WalletError::AllFundsSelectionUnsupported);
                 }
             };
 
@@ -1100,5 +1103,46 @@ impl InputSource for LightWallet {
         _exclude: &[Self::NoteRef],
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_client_backend::data_api::MaxSpendMode;
+
+    use super::*;
+    use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+    /// `InputSource::select_spendable_notes` is driven by upstream
+    /// `zcash_client_backend` (`propose_send_max`) with
+    /// `TargetValue::AllFunds`. An unsupported request must surface
+    /// through the trait's error channel (`Result<_, WalletError>`),
+    /// never abort the process.
+    #[test]
+    fn select_spendable_notes_all_funds_returns_err_not_panic() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .sapling_note(100_000)
+            .orchard_note(100_000)
+            .ironwood_note(100_000)
+            .build();
+
+        let result = wallet.select_spendable_notes(
+            zip32::AccountId::ZERO,
+            TargetValue::AllFunds(MaxSpendMode::MaxSpendable),
+            &[
+                ShieldedPool::Sapling,
+                ShieldedPool::Orchard,
+                ShieldedPool::Ironwood,
+            ],
+            BlockHeight::from_u32(21).into(),
+            ConfirmationsPolicy::MIN,
+            &[],
+        );
+
+        assert!(
+            result.is_err(),
+            "TargetValue::AllFunds is unsupported: that must be reported \
+             through the trait's error channel, not a panic; got {result:?}"
+        );
     }
 }

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -971,10 +971,11 @@ impl InputSource for LightWallet {
                 ReceivedNote::from_parts(
                     OutputRef::new(
                         OutputId::new(note.output_id().txid(), note.output_id().output_index()),
-                        // Label V3 notes as ORCHARD in the OutputRef: upstream detects Ironwood inputs
-                        // by note.version() == V3, not by the pool label. Labeling IRONWOOD here
-                        // confuses the proposal engine's pool-involvement accounting.
-                        // FIXME: is this comment still relevant? should we change to ORCHARD?
+                        // The label must match the ReceivedNotes vector this
+                        // note is returned in. Upstream never reads it, but it
+                        // round-trips through the `exclude` split at the top of
+                        // select_spendable_notes when the input selector prunes
+                        // dust, and that split routes each ref by pool_type().
                         PoolType::IRONWOOD,
                     ),
                     note.output_id().txid(),
@@ -1109,6 +1110,7 @@ impl InputSource for LightWallet {
 #[cfg(test)]
 mod tests {
     use zcash_client_backend::data_api::MaxSpendMode;
+    use zcash_protocol::value::Zatoshis;
 
     use super::*;
     use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
@@ -1143,6 +1145,92 @@ mod tests {
             result.is_err(),
             "TargetValue::AllFunds is unsupported: that must be reported \
              through the trait's error channel, not a panic; got {result:?}"
+        );
+    }
+
+    /// Pins the resolution of the FIXME at the `PoolType::IRONWOOD` label in
+    /// `InputSource::select_spendable_notes`: the code is right and the comment
+    /// above it is stale.
+    ///
+    /// The `OutputRef` pool label is never read by the upstream proposal
+    /// engine — pool-involvement accounting, bundle attribution, and fee
+    /// calculation all dispatch on the embedded `Note` enum (stamped by
+    /// `ReceivedNotes::into_vec` from the vector the note occupies), not on
+    /// the `NoteRef`. The label's one consumer is this wallet's own `exclude`
+    /// split at the top of `select_spendable_notes`: upstream's
+    /// `GreedyInputSelector` hands previously selected refs back verbatim as
+    /// `exclude` when the change strategy reports `ChangeError::DustInputs`,
+    /// and the split routes each ref to a pool bucket by `pool_type()`. An
+    /// ironwood note labeled `ORCHARD` (as the stale comment mandates) would
+    /// land in the orchard bucket, never be excluded from ironwood selection,
+    /// and be re-selected forever — the selector would then abort with
+    /// `InsufficientFunds` instead of pruning the dust.
+    #[test]
+    fn ironwood_noteref_pool_label_round_trips_through_exclude() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .ironwood_note(100_000)
+            .ironwood_note(100_000)
+            .build();
+
+        let confirmations_policy =
+            ConfirmationsPolicy::new_symmetrical(1.try_into().expect("nonzero"), false);
+        let target_height = TargetHeight::from(BlockHeight::from_u32(21));
+        let sources = [
+            ShieldedPool::Ironwood,
+            ShieldedPool::Orchard,
+            ShieldedPool::Sapling,
+        ];
+
+        // Phase 1: selection over ironwood-only funds labels every selected
+        // ref IRONWOOD, matching the vector (and hence the Note-enum pool)
+        // the note is returned in.
+        let selected = wallet
+            .select_spendable_notes(
+                zip32::AccountId::ZERO,
+                TargetValue::AtLeast(Zatoshis::const_from_u64(150_000)),
+                &sources,
+                target_height,
+                confirmations_policy,
+                &[],
+            )
+            .expect("selection over synthetic funds succeeds");
+        assert_eq!(
+            selected.ironwood().len(),
+            2,
+            "both fabricated ironwood notes are selected"
+        );
+        let refs: Vec<_> = selected
+            .ironwood()
+            .iter()
+            .map(|note| *note.internal_note_id())
+            .collect();
+        for output_ref in &refs {
+            assert_eq!(
+                output_ref.pool_type(),
+                PoolType::IRONWOOD,
+                "an ironwood note's ref must carry the IRONWOOD label so the \
+                 exclude split routes it back to the ironwood bucket"
+            );
+        }
+
+        // Phase 2: the refs round-trip through `exclude` exactly as the
+        // greedy input selector's dust-pruning path replays them. Correctly
+        // labeled refs suppress re-selection; ORCHARD-labeled refs would fall
+        // into the wrong bucket and the same notes would come back.
+        let reselected = wallet
+            .select_spendable_notes(
+                zip32::AccountId::ZERO,
+                TargetValue::AtLeast(Zatoshis::const_from_u64(150_000)),
+                &sources,
+                target_height,
+                confirmations_policy,
+                &refs,
+            )
+            .expect("selection with exclusions succeeds");
+        assert!(
+            reselected.ironwood().is_empty(),
+            "excluded ironwood refs must not be re-selected; re-selection \
+             means the exclude split routed them to the wrong pool bucket"
         );
     }
 }


### PR DESCRIPTION
An external review of #2419 raised six potential correctness violations. This branch subjects each one to an independent verification: for every finding, a separate investigation re-derived the claimed mechanism from the source, the git history, and the pinned zcash_client_backend 0.24.0-rc.1, and then authored a test that demonstrates the defect. Every confirmed finding's test was observed failing against the unfixed tree with exactly the predicted failure before the fix was written, so each test is a true detector rather than an assertion of the fix's own behavior.

The branch carries one commit per finding, each combining the demonstrating test with its fix. Two findings needed no fix and carry pinning tests instead: the ironwood OutputRef label is correct as written (the contradicting comment was a relic of the patched 0.23 era and is replaced by the true invariant), and the open-window relaunch concern is refuted because `broadcast_due_parts` selects the currently open bucket from persisted state. The finding 3 fix routes the drain flow and the note-splitting rounds through one shared `build_and_transmit` engine, so both enforce the same cleanup contract. Test scaffolds that repeated across modules moved into reusable fixtures, notably `testutils::synthetic_wallet::inject_confirmed_orchard_notes` for already-synced mock-net wallets with really derived nullifiers. The full pepper-sync and zingolib unit suites pass (67 and 205 tests), and clippy and rustfmt are clean. The 6a demonstration is 32-bit only and passes vacuously on x86_64; running it under a 32-bit target such as i686-unknown-linux-gnu shows the failure the fix removes. The finding 3 test costs about fifty seconds, dominated by the wallet's fixed transmit-probe stalls.

| Potential violation | Test | Verdict | Commit | Fix |
| --- | --- | --- | --- | --- |
| 1. `TargetValue::AllFunds` aborts the process in `select_spendable_notes` | `select_spendable_notes_all_funds_returns_err_not_panic` | Confirmed | 569215aa8 | The arm returns the new `WalletError::AllFundsSelectionUnsupported` through the trait's error channel. |
| 2. Self-contradicting pool label on selected ironwood inputs | `ironwood_noteref_pool_label_round_trips_through_exclude` | Contradiction confirmed; the code is right, the comment was stale | 88f2b1e19 | The comment now states the real invariant: the label must match the `ReceivedNotes` vector because it round-trips through the `exclude` split. |
| 3. A failed note-split round strands `Calculated` transactions with notes marked spent | `failed_split_round_transmit_strands_calculated_transactions` | Confirmed (the paused-sync leg is unreachable today: `pause_sync` never engages under `migrate_to_ironwood`'s exclusive borrow) | 3fc286cae | Drain and split rounds share `build_and_transmit`, which fails already-built transactions on a build error and all unsent ones on a transmit error. |
| 4. Chain-tip prioritization floods the wallet range while ironwood shard ranges are empty | `chain_tip_priority_confined_to_tip_when_ironwood_shards_are_empty` | Confirmed | ba59f3b6f | The empty-shard fallback start is clamped to the pool's activation height (Sapling, Nu5, or Nu6.3). |
| 5. Open-window parts unreachable after a relaunch | `open_window_part_is_broadcast_at_relaunch` | Refuted: `broadcast_due_parts` selects `bucket_index == current_bucket` from persisted state, driven by `auto_broadcast_if_due` | 3f8cc5e9b | None needed; the test pins all three legs of the mechanism. |
| 6a. `u64` to `usize` truncation reading `max_actions_per_split_tx` | `max_actions_read_never_silently_truncates` | Confirmed, 32-bit targets only; no 64-bit misbehavior exists | c8a46a210 | `usize::try_from` with an `InvalidData` error, matching the reader's other malformed-field paths. |
| 6b. Ironwood tree-size check cannot distinguish a non-serving server from corruption | `nonzero_ironwood_tree_size_mismatch_is_rejected` | Confirmed | a8d1dc0a6 | A nonzero-versus-nonzero mismatch returns `ScanError::IncorrectTreeSize`; the warning remains for the genuine zero-sided cases. |
| 6c. Restore-from-backup's unknown txid treated as failed, re-planning an in-flight split | `unknown_txid_after_restore_is_not_classified_failed` | Confirmed | 6b0b0203c | `transaction_failed` uses `is_some_and`, so an unknown txid awaits confirmation instead of triggering `RetrySplit`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
