### PR TITLE
fix: AllFunds selection as a pure function (was a process-aborting panic)

### DIFF
--- a/.agent-plans/allfunds-pure-selection.md
+++ b/.agent-plans/allfunds-pure-selection.md
@@ -1,0 +1,23 @@
+# Claim: AllFunds selection — TDD fix (grilling session, 2026-07-17)
+
+The #2419 review verified that `select_spendable_notes` panics on
+`TargetValue::AllFunds` (zingolib/src/wallet/zcb_traits.rs), the sole
+verified finding without an owner. The user ratified a TDD pair on
+branch `fix/allfunds-pure-selection` (based on feat/ironwood,
+independent of PR #2479): first a red test pinning the contract, then
+the fix implemented as a side-effect-free pure function
+(functional-core/imperative-shell — the wallet reads gather
+candidates at the edge; a pure `all_funds_selection` decides).
+
+Contract: `MaxSpendable` selects every spend-worthy note (dust
+discipline `> MARGINAL_FEE`, matching budgeted selection and the
+drain); `Everything` refuses with a typed error until its
+unspendable-funds audit exists, because a wrong Ok would silently
+strand funds and the panic it replaces killed the process.
+
+## File claims
+
+- `zingolib/src/wallet/zcb_traits.rs` (AllFunds arm, pure functions,
+  test module; NOTE: PR #2478 also touches this file in the OutputRef
+  label region — disjoint hunks expected)
+- `zingolib/src/wallet/error.rs` (one new WalletError variant)

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -96,6 +96,13 @@ pub enum WalletError {
     /// worth more than it would cost to spend.
     #[error("No spendable Orchard notes to migrate.")]
     NothingToMigrate,
+    /// `TargetValue::AllFunds(MaxSpendMode::Everything)` was requested. Its
+    /// contract — fail if ANY unspendable funds exist — requires a
+    /// whole-wallet audit this selector does not yet perform, and a wrong
+    /// success would silently strand funds, so the request is refused with
+    /// this typed error instead.
+    #[error("AllFunds(Everything) is not supported: the unspendable-funds audit is unimplemented.")]
+    AllFundsEverythingUnsupported,
     /// Conversion failed
     // TODO: move to lightclient?
     #[error("Conversion failed. {0}")]

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -1102,3 +1102,92 @@ impl InputSource for LightWallet {
         unimplemented!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! The TDD pair for the `TargetValue::AllFunds` contract. These tests
+    //! began red: the `AllFunds` match arm was a `panic!`, so a request
+    //! any upstream sweep proposal can legitimately make took down the
+    //! whole process. They pin the replacement contract: `MaxSpendable`
+    //! selects every spend-worthy note, and `Everything` refuses with the
+    //! wallet's typed error until its unspendable-funds audit exists.
+
+    use zcash_client_backend::data_api::MaxSpendMode;
+
+    use super::*;
+    use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+    use crate::wallet::LightWallet;
+    use crate::wallet::error::WalletError;
+
+    /// One spendable note per shielded pool, plus an orchard note at the
+    /// dust line (`MARGINAL_FEE`) that budgeted selection would also
+    /// refuse to spend.
+    fn funded_wallet() -> LightWallet {
+        SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .tip(20)
+            .sapling_note(50_000)
+            .orchard_note(100_000)
+            .ironwood_note(70_000)
+            .orchard_note(5_000)
+            .build()
+    }
+
+    fn select_all_funds(
+        wallet: &LightWallet,
+        mode: MaxSpendMode,
+    ) -> Result<ReceivedNotes<OutputRef>, WalletError> {
+        wallet.select_spendable_notes(
+            zip32::AccountId::ZERO,
+            TargetValue::AllFunds(mode),
+            &[
+                ShieldedPool::Ironwood,
+                ShieldedPool::Orchard,
+                ShieldedPool::Sapling,
+            ],
+            TargetHeight::from(21),
+            ConfirmationsPolicy::new_symmetrical(NonZeroU32::new(1).expect("nonzero"), false),
+            &[],
+        )
+    }
+
+    #[test]
+    fn all_funds_max_spendable_selects_every_spend_worthy_note() {
+        let notes = select_all_funds(&funded_wallet(), MaxSpendMode::MaxSpendable)
+            .expect("all-funds selection must succeed on a funded, synced wallet");
+        assert_eq!(notes.sapling().len(), 1);
+        assert_eq!(
+            notes.orchard().len(),
+            1,
+            "the dust orchard note must be left behind"
+        );
+        assert_eq!(notes.ironwood().len(), 1);
+        let total: u64 = notes
+            .sapling()
+            .iter()
+            .map(|note| note.note().value().inner())
+            .chain(
+                notes
+                    .orchard()
+                    .iter()
+                    .map(|note| note.note().value().inner()),
+            )
+            .chain(
+                notes
+                    .ironwood()
+                    .iter()
+                    .map(|note| note.note().value().inner()),
+            )
+            .sum();
+        assert_eq!(total, 220_000);
+    }
+
+    #[test]
+    fn all_funds_everything_is_a_typed_error_not_an_abort() {
+        let error = select_all_funds(&funded_wallet(), MaxSpendMode::Everything)
+            .expect_err("Everything mode is unimplemented and must refuse, not abort");
+        assert!(
+            matches!(error, WalletError::AllFundsEverythingUnsupported),
+            "the refusal must be the dedicated typed error, observed: {error}"
+        );
+    }
+}

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -6,7 +6,7 @@ use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
         Account, AccountBirthday, AccountPurpose, Balance, BlockMetadata, CoinbaseFilter,
-        InputSource, NullifierQuery, ORCHARD_SHARD_HEIGHT, ReceivedNotes,
+        InputSource, MaxSpendMode, NullifierQuery, ORCHARD_SHARD_HEIGHT, ReceivedNotes,
         ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, TargetValue, TransactionDataRequest,
         TransparentKeyOrigin, WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite,
         Zip32Derivation,
@@ -19,7 +19,7 @@ use zcash_client_backend::{
 use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
 use zcash_primitives::{
     block::BlockHash,
-    transaction::{Transaction, TxId},
+    transaction::{Transaction, TxId, fees::zip317::MARGINAL_FEE},
 };
 use zcash_protocol::{
     PoolType, ShieldedPool,
@@ -881,8 +881,51 @@ impl InputSource for LightWallet {
                         selected_ironwood_notes,
                     )
                 }
-                TargetValue::AllFunds(_max_spend_mode) => {
-                    panic!("TargetValue::Allfunds not currently supported!");
+                TargetValue::AllFunds(max_spend_mode) => {
+                    // Effects at the edge: gather the spendable candidates
+                    // per pool (strict, guaranteed-unspent view), then let
+                    // the pure selection decide. All pools participate
+                    // regardless of `sources` order, matching budgeted
+                    // selection's unconditional fallback, and
+                    // migration-reserved notes are included: all funds
+                    // means all (the reservation biases selection, never
+                    // blocks a spend).
+                    let sapling_candidates = self
+                        .spendable_notes::<SaplingNote>(
+                            anchor_height,
+                            &exclude_sapling,
+                            account,
+                            false,
+                        )?
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    let orchard_candidates = self
+                        .spendable_notes::<OrchardNote>(
+                            anchor_height,
+                            &exclude_orchard,
+                            account,
+                            false,
+                        )?
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    let ironwood_candidates = self
+                        .spendable_notes::<IronwoodNote>(
+                            anchor_height,
+                            &exclude_ironwood,
+                            account,
+                            false,
+                        )?
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    all_funds_selection(
+                        max_spend_mode,
+                        sapling_candidates,
+                        orchard_candidates,
+                        ironwood_candidates,
+                    )?
                 }
             };
 
@@ -1101,6 +1144,49 @@ impl InputSource for LightWallet {
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         unimplemented!()
     }
+}
+
+/// The per-pool selection triple `select_spendable_notes` assembles
+/// before mapping into [`ReceivedNotes`].
+type SelectedPoolNotes = (Vec<SaplingNote>, Vec<OrchardNote>, Vec<IronwoodNote>);
+
+/// Pure all-funds selection over already-gathered spendable candidates:
+/// no wallet access, no mutation — the same candidates and mode always
+/// produce the same selection, so the policy is testable without a
+/// wallet.
+///
+/// `MaxSpendable` keeps every candidate worth more than the marginal
+/// fee, the same dust discipline as budgeted selection: a note at or
+/// below [`MARGINAL_FEE`] costs more to spend than it contributes.
+///
+/// `Everything` is refused with a typed error: its contract — fail if
+/// ANY unspendable funds exist — requires a whole-wallet audit this
+/// selector does not yet perform, and a wrong success would silently
+/// strand funds. The typed refusal replaces a panic that aborted the
+/// process.
+fn all_funds_selection(
+    mode: MaxSpendMode,
+    sapling: Vec<SaplingNote>,
+    orchard: Vec<OrchardNote>,
+    ironwood: Vec<IronwoodNote>,
+) -> Result<SelectedPoolNotes, WalletError> {
+    match mode {
+        MaxSpendMode::MaxSpendable => Ok((
+            retain_spend_worthy(sapling),
+            retain_spend_worthy(orchard),
+            retain_spend_worthy(ironwood),
+        )),
+        MaxSpendMode::Everything => Err(WalletError::AllFundsEverythingUnsupported),
+    }
+}
+
+/// Pure dust filter: keeps the notes whose value exceeds the marginal
+/// fee.
+fn retain_spend_worthy<N: OutputInterface>(notes: Vec<N>) -> Vec<N> {
+    notes
+        .into_iter()
+        .filter(|note| note.value() > MARGINAL_FEE.into_u64())
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

This PR closes the last verified finding from the #2419 review: the
`TargetValue::AllFunds` arm of `select_spendable_notes` was a `panic!`, so a
request any upstream `zcash_client_backend` sweep proposal can legitimately
make would abort the whole process. It lands as a TDD pair — the contract
tests are committed red first, failing on that exact panic, and the fix
turns them green.

## The contract

`MaxSpendable` selects every spend-worthy note: all pools participate
regardless of source order (matching budgeted selection's unconditional
fallback), migration-reserved notes are included because all funds means
all, and the dust discipline is the house rule — a note at or below
`MARGINAL_FEE` costs more to spend than it contributes, exactly as budgeted
selection and the migration drain already decide.

`Everything` is refused with a new typed error,
`WalletError::AllFundsEverythingUnsupported`, rather than half-implemented:
its upstream contract — fail if *any* unspendable funds exist — requires a
whole-wallet audit this selector does not yet perform, and a wrong success
would silently strand funds. The typed refusal keeps the process alive and
fails the proposal cleanly; the doc comment carries the reasoning for
whoever implements the audit.

## The shape

Functional core, effects at the edge: the match arm only gathers the strict
(guaranteed-unspent) spendable candidates per pool through the existing
read-only accessor, and the decision is `all_funds_selection`, a
module-level pure function — no wallet access, no mutation, same inputs to
same selection — so the policy is testable without a wallet. The tests
drive the real trait method end to end through `SyntheticWalletBuilder`:
one spendable note per shielded pool plus a dust-line orchard note,
asserting the three-note selection totals 220,000 zatoshis with the dust
left behind, and that `Everything` yields the dedicated error.

The only file-overlap risk is #2478's touch to the same file in the
`OutputRef` label region; the hunks are disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
