### PR TITLE
Integrate the #2419 review fixes: six edges, normalization drain, pin cleanups, AllFunds

### DIFF
--- a/.agent-plans/allfunds-pure-selection.md
+++ b/.agent-plans/allfunds-pure-selection.md
@@ -1,0 +1,23 @@
+# Claim: AllFunds selection — TDD fix (grilling session, 2026-07-17)
+
+The #2419 review verified that `select_spendable_notes` panics on
+`TargetValue::AllFunds` (zingolib/src/wallet/zcb_traits.rs), the sole
+verified finding without an owner. The user ratified a TDD pair on
+branch `fix/allfunds-pure-selection` (based on feat/ironwood,
+independent of PR #2479): first a red test pinning the contract, then
+the fix implemented as a side-effect-free pure function
+(functional-core/imperative-shell — the wallet reads gather
+candidates at the edge; a pure `all_funds_selection` decides).
+
+Contract: `MaxSpendable` selects every spend-worthy note (dust
+discipline `> MARGINAL_FEE`, matching budgeted selection and the
+drain); `Everything` refuses with a typed error until its
+unspendable-funds audit exists, because a wrong Ok would silently
+strand funds and the panic it replaces killed the process.
+
+## File claims
+
+- `zingolib/src/wallet/zcb_traits.rs` (AllFunds arm, pure functions,
+  test module; NOTE: PR #2478 also touches this file in the OutputRef
+  label region — disjoint hunks expected)
+- `zingolib/src/wallet/error.rs` (one new WalletError variant)

--- a/.agent-plans/pr2419-findings-verification.md
+++ b/.agent-plans/pr2419-findings-verification.md
@@ -1,0 +1,41 @@
+# Claim: independent verification of the #2419 review findings (2026-07-16)
+
+Session working in the `feat_ironwood` worktree on branch `feat_ironwood`.
+The user handed over six correctness findings from a reviewer of PR #2419
+and asked for an independent review plus an attempted failing test that
+demonstrates each finding. The deliverable is test code and a verdict per
+finding, not fixes. Any product-source change waits for the user's
+ratification.
+
+## Scope
+
+The work began as tests only; the user then ratified fixing each confirmed
+finding, with test and fix combined per commit on the `six_edges_tested`
+branch (PR against feat/ironwood, Oscar reviewing). Verdicts: findings 1,
+3, 4, 6a, 6b, and 6c confirmed and fixed; finding 2 resolved in the code's
+favor (the comment was stale) and pinned by test; finding 5 refuted and
+pinned by test. Fixtures added while DRYing the tests:
+`testutils::synthetic_wallet::inject_confirmed_orchard_notes`, the
+migrate.rs test-module scaffold helpers, and `planned_state` in the store
+tests.
+
+## File claims (test-only additions)
+
+- `zingolib/src/wallet/zcb_traits.rs` (findings 1 and 2: AllFunds panic,
+  ironwood OutputRef pool label)
+- `zingolib/src/lightclient/migrate.rs` (finding 3: paused sync leak on the
+  note-split round)
+- `pepper-sync/src/sync/state.rs` (finding 4: chain-tip range fallback with
+  empty ironwood shard ranges)
+- `zingolib/src/wallet/migration/schedule.rs` and
+  `zingolib/src/wallet/migration/reconcile.rs` (finding 5: open-window part
+  at relaunch; finding 6c: unknown txid treated as failed)
+- `zingolib/src/wallet/migration/store.rs` (finding 6a: u64 to usize
+  truncation)
+- `pepper-sync/src/scan/compact_blocks.rs` (finding 6b: lenient ironwood
+  tree-size check)
+- Possibly a new test file under `zingolib/tests/` or
+  `pepper-sync/tests/` if an inline `mod tests` does not fit.
+
+No behavior changes to product source. Long test suites stay with the user,
+this session runs only targeted fast tests through `cargo nextest run`.

--- a/.agent-plans/zebrad-6-0-0-bump.md
+++ b/.agent-plans/zebrad-6-0-0-bump.md
@@ -79,6 +79,19 @@ test-logs/observatory/concrete__*.log. Root-cause analysis and a
 patched/rc dependency audit are delegated to background agents this
 session.
 
+## Resolution (2026-07-17): PR #2479
+
+Root cause of the three mining-balance reds: wallet commit 731b2b761
+(pool-preference selection, merged with #2468 after the caches were
+mined) defeated the normalization self-send; zebrad exonerated by a
+fresh-chain rc.0 A/B. Fixed by draining orchard via
+drain_orchard_to_ironwood in normalize_shielded_faucet_balance
+(d7196e8a4); user-confirmed green with regenerated caches. Shipped as
+PR #2479 (chore/drop-time-patch → feat/ironwood) together with the
+audit's two pin cleanups: the time [patch.crates-io] drop (a46f5e632)
+and the zaino-proto git→crates.io 0.2.0 migration (4c36bcd2e; a
+benign duplicate copy remains via zingo_grpc_proxy's own git pin).
+
 ## Merge state (2026-07-17)
 
 PR #2475 (with #2477's two commits inside) is MERGED into

--- a/.agent-plans/zebrad-6-0-0-bump.md
+++ b/.agent-plans/zebrad-6-0-0-bump.md
@@ -53,6 +53,42 @@ work is publication-ready: branch `feat/zebrad-6-boundary-fix`, three
 staged commits, PR against feat/ironwood (messages and body drafted
 in-session).
 
+## CI caveat (2026-07-17): the local green was partially cache-masked
+
+Chain-cache manifests key on validator TYPE, not version, so
+rc.0-mined caches replayed in the local runs after the bump. PR
+#2476's CI mines fresh 6.0.0 chains and deterministically (two runs,
+identical values) fails three concrete.rs balance tests —
+mine_to_ironwood, send_mined_ironwood_to_ironwood,
+send_orchard_back_and_forth — each short exactly one post-stream
+block reward (618_780_000 zats). tip_spend_rejection passed in CI, so
+the acceptance re-pin holds on fresh chains. Open: root-cause the
+off-by-one (suspect launch-mine/generate semantics under 6.0.0);
+local repro via ZINGO_REGENERATE_CHAIN_CACHE=1; follow-up: hash the
+zebrad binary into the cache manifest. #2476 must not merge until
+resolved.
+
+## Repro confirmed (2026-07-17)
+
+The user's ZINGO_REGENERATE_CHAIN_CACHE=1 container run reproduced
+all three mining-balance failures locally with values byte-identical
+to CI (observed = expected − 618_780_000 in each), proving the
+cache-masking mechanism and establishing the off-by-one as a property
+of freshly mined zebrad 6.0.0 chains. Observatory logs captured under
+test-logs/observatory/concrete__*.log. Root-cause analysis and a
+patched/rc dependency audit are delegated to background agents this
+session.
+
+## Merge state (2026-07-17)
+
+PR #2475 (with #2477's two commits inside) is MERGED into
+feat/ironwood. PR #2476 remains OPEN — none of its three commits are
+in feat/ironwood, so the branch still pins zebrad 6.0.0-rc.0 and has
+no attribution module or suite re-pin. GitHub reports #2476
+MERGEABLE (no file overlap with #2475) but UNSTABLE (the two red
+mining-balance shards). The off-by-one work continues on
+feat/zebrad-6-boundary-fix.
+
 ## File claims
 
 - `.env.testing-artifacts` (ZEBRA_VERSION pin)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -920,7 +920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1745,7 +1745,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1984,7 +1984,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2927,7 +2927,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3396,7 +3396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3490,7 +3490,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4239,7 +4239,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4631,6 +4631,18 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zaino-proto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e9bb92547921333d63d8dc96ca7489694d5a87dc6e805152468bdd435646b"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -5096,7 +5108,7 @@ name = "zingo_grpc_proxy"
 version = "0.1.0"
 source = "git+https://github.com/zingolabs/grpc_proxy.git?rev=bad24e29529a0bb381f71f02f977752c20c26613#bad24e29529a0bb381f71f02f977752c20c26613"
 dependencies = [
- "zaino-proto",
+ "zaino-proto 0.2.0 (git+https://github.com/zingolabs/zaino.git?rev=2e2816cb3755e7ff4d18bed1a96b95dc07c1549c)",
 ]
 
 [[package]]
@@ -5145,7 +5157,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "zaino-proto",
+ "zaino-proto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_address",
  "zcash_client_backend",
  "zcash_encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5020,6 +5020,7 @@ dependencies = [
  "rustyline",
  "shellwords",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3545,7 +3545,8 @@ dependencies = [
 [[package]]
 name = "time"
 version = "0.3.47"
-source = "git+https://github.com/time-rs/time?tag=v0.3.47#d5144cd2874862d46466c900910cd8577d066019"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3559,12 +3560,14 @@ dependencies = [
 [[package]]
 name = "time-core"
 version = "0.1.8"
-source = "git+https://github.com/time-rs/time?tag=v0.3.47#d5144cd2874862d46466c900910cd8577d066019"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
 version = "0.2.27"
-source = "git+https://github.com/time-rs/time?tag=v0.3.47#d5144cd2874862d46466c900910cd8577d066019"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,8 +162,6 @@ rust-embed = "8"
 opt-level = 3
 
 [patch.crates-io]
-time = { git = "https://github.com/time-rs/time", tag = "v0.3.47" }
-
 # Ironwood (NU6.3) proto fields (CompactTx.ironwoodActions, TreeState.ironwoodTree,
 # ShieldedProtocol.ironwood, ChainMetadata.ironwoodCommitmentTreeSize). The rev is
 # upstream main after PR #5 merged the Ironwood protos; the crate version is still

--- a/libtonode-tests/tests/concrete.rs
+++ b/libtonode-tests/tests/concrete.rs
@@ -479,14 +479,14 @@ async fn mine_to_orchard() {
     .await;
     check_client_balances!(
         faucet,
-        i: 0 o: (scenarios::funded_faucet_ironwood_balance()) s: (scenarios::BLOCK_ONE_SAPLING_COINBASE) t: 0
+        i: 0 o: 1_237_500_000 s: (scenarios::BLOCK_ONE_SAPLING_COINBASE) t: 0
     );
     increase_height_and_wait_for_client(&local_net, &mut faucet, 1)
         .await
         .unwrap();
     check_client_balances!(
         faucet,
-        i: 0 o: (scenarios::funded_faucet_ironwood_balance() + scenarios::POST_STREAM_BLOCK_REWARD) s: (scenarios::BLOCK_ONE_SAPLING_COINBASE) t: 0
+        i: 0 o: (1_237_500_000 + scenarios::POST_STREAM_BLOCK_REWARD) s: (scenarios::BLOCK_ONE_SAPLING_COINBASE) t: 0
     );
 }
 

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -302,40 +302,50 @@ fn check_tree_size(
     compact_block: &CompactBlock,
     wallet_block: &WalletBlock,
 ) -> Result<(), ScanError> {
-    if let Some(chain_metadata) = &compact_block.chain_metadata {
-        if chain_metadata.sapling_commitment_tree_size
-            != wallet_block.tree_bounds().sapling_final_tree_size
-        {
-            return Err(ScanError::IncorrectTreeSize {
-                shielded_protocol: PoolType::Shielded(ShieldedPool::Sapling),
-                block_metadata_size: chain_metadata.sapling_commitment_tree_size,
-                calculated_size: wallet_block.tree_bounds().sapling_final_tree_size,
-            });
+    let Some(chain_metadata) = &compact_block.chain_metadata else {
+        return Ok(());
+    };
+    let matched = |pool, block_metadata_size, calculated_size| {
+        if block_metadata_size == calculated_size {
+            Ok(())
+        } else {
+            Err(ScanError::IncorrectTreeSize {
+                shielded_protocol: PoolType::Shielded(pool),
+                block_metadata_size,
+                calculated_size,
+            })
         }
-        if chain_metadata.orchard_commitment_tree_size
-            != wallet_block.tree_bounds().orchard_final_tree_size
-        {
-            return Err(ScanError::IncorrectTreeSize {
-                shielded_protocol: PoolType::Shielded(ShieldedPool::Orchard),
-                block_metadata_size: chain_metadata.orchard_commitment_tree_size,
-                calculated_size: wallet_block.tree_bounds().orchard_final_tree_size,
-            });
-        }
-        if chain_metadata.ironwood_commitment_tree_size
-            != wallet_block.tree_bounds().ironwood_final_tree_size
-        {
-            // A mismatch is expected while parts of the ecosystem do not
-            // serve ironwood data (wallet blocks synced before ironwood
-            // tracking carry zero sizes, and servers without support send
-            // zero metadata against real actions). Warn instead of failing
-            // sync until ironwood serving is universal.
-            tracing::warn!(
-                "ironwood tree size mismatch at block {}.\nwallet block: {}\ncompact block metadata: {}",
-                wallet_block.block_height(),
-                wallet_block.tree_bounds().ironwood_final_tree_size,
-                chain_metadata.ironwood_commitment_tree_size
-            );
-        }
+    };
+
+    matched(
+        ShieldedPool::Sapling,
+        chain_metadata.sapling_commitment_tree_size,
+        wallet_block.tree_bounds().sapling_final_tree_size,
+    )?;
+    matched(
+        ShieldedPool::Orchard,
+        chain_metadata.orchard_commitment_tree_size,
+        wallet_block.tree_bounds().orchard_final_tree_size,
+    )?;
+    // Ironwood tolerates a zero on either side while parts of the ecosystem
+    // do not serve ironwood data (wallet blocks synced before ironwood
+    // tracking carry zero sizes, and servers without support send zero
+    // metadata against real actions): warn instead of failing sync until
+    // ironwood serving is universal. Two nonzero sizes disagreeing is
+    // neither of those cases: both sides are actively tracking the pool, so
+    // the mismatch is corruption and is rejected exactly as for the other
+    // pools.
+    let metadata_size = chain_metadata.ironwood_commitment_tree_size;
+    let calculated_size = wallet_block.tree_bounds().ironwood_final_tree_size;
+    if metadata_size != 0 && calculated_size != 0 {
+        matched(ShieldedPool::Ironwood, metadata_size, calculated_size)?;
+    } else if metadata_size != calculated_size {
+        tracing::warn!(
+            "ironwood tree size mismatch at block {}.\nwallet block: {}\ncompact block metadata: {}",
+            wallet_block.block_height(),
+            calculated_size,
+            metadata_size
+        );
     }
 
     Ok(())
@@ -548,5 +558,63 @@ fn set_checkpoint_retentions<L>(
             // NOTE: if there are no outputs in the block, this last retention will be a checkpoint and nothing will need to be mutated.
             _ => (),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zingo_netutils::lightwallet_protocol::ChainMetadata;
+
+    use super::*;
+
+    fn wallet_block_with_ironwood_size(size: u32) -> WalletBlock {
+        WalletBlock {
+            block_height: BlockHeight::from_u32(100),
+            block_hash: BlockHash([1; 32]),
+            prev_hash: BlockHash([0; 32]),
+            time: 0,
+            txids: vec![],
+            tree_bounds: TreeBounds {
+                sapling_initial_tree_size: 10,
+                sapling_final_tree_size: 10,
+                orchard_initial_tree_size: 10,
+                orchard_final_tree_size: 10,
+                ironwood_initial_tree_size: size,
+                ironwood_final_tree_size: size,
+            },
+        }
+    }
+
+    fn compact_block_with_ironwood_size(size: u32) -> CompactBlock {
+        CompactBlock {
+            height: 100,
+            hash: vec![1; 32],
+            prev_hash: vec![0; 32],
+            time: 0,
+            header: vec![],
+            vtx: vec![],
+            chain_metadata: Some(ChainMetadata {
+                sapling_commitment_tree_size: 10,
+                orchard_commitment_tree_size: 10,
+                ironwood_commitment_tree_size: size,
+            }),
+        }
+    }
+
+    /// A server actively serving ironwood metadata (nonzero) that disagrees
+    /// with the wallet's own nonzero calculation is corruption, not the
+    /// known "server does not serve ironwood yet" case (metadata zero).
+    /// Validation must reject it exactly as it does for sapling and orchard.
+    #[test]
+    fn nonzero_ironwood_tree_size_mismatch_is_rejected() {
+        let compact_block = compact_block_with_ironwood_size(999);
+        let wallet_block = wallet_block_with_ironwood_size(7);
+        assert!(matches!(
+            check_tree_size(&compact_block, &wallet_block),
+            Err(ScanError::IncorrectTreeSize {
+                shielded_protocol: PoolType::Shielded(ShieldedPool::Ironwood),
+                ..
+            })
+        ));
     }
 }

--- a/pepper-sync/src/sync/state.rs
+++ b/pepper-sync/src/sync/state.rs
@@ -568,9 +568,23 @@ fn determine_block_range(
             let start = if let Some(range) = shard_ranges.last() {
                 range.end - 1
             } else {
+                // With no shard ranges at all (a server that does not serve
+                // this pool, or a pool freshly activated), fall back to the
+                // pool's own history: the wallet birthday clamped to the
+                // pool's activation height. An unclamped birthday would let
+                // the chain-tip punch flood the entire wallet range.
+                let pool_upgrade = match shielded_protocol {
+                    ShieldedPool::Sapling => consensus::NetworkUpgrade::Sapling,
+                    ShieldedPool::Orchard => consensus::NetworkUpgrade::Nu5,
+                    ShieldedPool::Ironwood => consensus::NetworkUpgrade::Nu6_3,
+                };
+                let activation = consensus_parameters
+                    .activation_height(pool_upgrade)
+                    .expect("the pool was selected because its upgrade is active");
                 sync_state
                     .wallet_birthday()
                     .expect("scan range should not be empty")
+                    .max(activation)
             };
             let end = sync_state
                 .last_known_chain_height()
@@ -1209,6 +1223,60 @@ mod tests {
         );
         assert_eq!(range.start, BlockHeight::from_u32(100));
         assert_eq!(range.end, BlockHeight::from_u32(150));
+    }
+
+    /// Mainnet-shaped network: NU6.3 activates recently, near the chain tip.
+    const TIP_ACTIVATION_NETWORK: LocalNetwork = LocalNetwork {
+        overwinter: Some(BlockHeight::from_u32(1)),
+        sapling: Some(BlockHeight::from_u32(1)),
+        blossom: Some(BlockHeight::from_u32(1)),
+        heartwood: Some(BlockHeight::from_u32(1)),
+        canopy: Some(BlockHeight::from_u32(1)),
+        nu5: Some(BlockHeight::from_u32(1)),
+        nu6: Some(BlockHeight::from_u32(1)),
+        nu6_1: Some(BlockHeight::from_u32(1)),
+        nu6_2: Some(BlockHeight::from_u32(1)),
+        nu6_3: Some(BlockHeight::from_u32(19_000)),
+    };
+
+    #[test]
+    fn chain_tip_priority_confined_to_tip_when_ironwood_shards_are_empty() {
+        // A wallet with a long history: birthday (1_000) far below the chain tip (20_000).
+        let mut sync_state = sync_state_with_ranges(1_000, 20_000);
+
+        // Sapling and orchard have complete shards reaching near the tip, so their
+        // incomplete tip shards start close to the chain tip (17_999 and 18_499).
+        sync_state.sapling_shard_ranges =
+            vec![BlockHeight::from_u32(1_000)..BlockHeight::from_u32(18_000)];
+        sync_state.orchard_shard_ranges =
+            vec![BlockHeight::from_u32(1_000)..BlockHeight::from_u32(18_500)];
+        // Ironwood shard ranges are empty: a tolerated server condition, and the
+        // universal state on every network immediately after NU6.3 activation.
+        assert!(sync_state.ironwood_shard_ranges.is_empty());
+
+        set_chain_tip_scan_range(
+            &TIP_ACTIVATION_NETWORK,
+            &mut sync_state,
+            BlockHeight::from_u32(20_000),
+        );
+
+        let chain_tip_start = sync_state
+            .scan_ranges()
+            .iter()
+            .filter(|range| range.priority() == ScanPriority::ChainTip)
+            .map(|range| range.block_range().start)
+            .min()
+            .expect("chain tip punch should mark at least one range");
+
+        // The chain-tip region must stay confined near the tip. The lowest
+        // legitimate anchor is the sapling incomplete tip shard start (17_999);
+        // an ironwood fallback may reach no lower than the NU6.3 activation
+        // height (19_000). It must never flood down to the wallet birthday.
+        assert!(
+            chain_tip_start >= BlockHeight::from_u32(17_999),
+            "ChainTip priority flooded down to {chain_tip_start} (wallet birthday is 1_000); \
+             expected the chain-tip region confined to the tip shards (start >= 17_999)"
+        );
     }
 
     #[test]

--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -27,6 +27,7 @@ shellwords = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
 zip32 = { workspace = true }
+thiserror.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -2105,6 +2105,224 @@ fn render_migration_phase(phase: &MigrationPhase) -> String {
     }
 }
 
+/// Typed failure of the migration command family — the audit Issue-Q
+/// pattern PR #2464 established: the discriminant lives in the type,
+/// argument parsing happens before any wallet access, and prose is
+/// produced at exactly one rendering site per command. Each Display
+/// message is byte-identical to the in-band string it replaced, so no
+/// frontend observes the change.
+#[derive(Debug, thiserror::Error)]
+enum MigrationCommandError {
+    #[error("migrate command expects no arguments. Type \"help migrate\" for usage.")]
+    UnexpectedArguments,
+    #[error("migration command expects a sub-command. Type \"help migration\" for usage.")]
+    MissingSubCommand,
+    #[error("invalid sub-command. Type \"help migration\" for usage.")]
+    InvalidSubCommand,
+    #[error("migration start expects the plan hash printed by \"migration plan\".")]
+    MissingPlanHash,
+    #[error("the plan hash must be 64 hex characters.")]
+    MalformedPlanHash,
+    #[error("--per-bucket expects a positive integer.")]
+    MalformedPerBucket,
+    #[error("spacing must be a number of seconds.")]
+    MalformedSpacing,
+    #[error("sync failed: {0}")]
+    Sync(zingolib::lightclient::error::LightClientError),
+    #[error("{0}")]
+    Client(#[from] zingolib::lightclient::error::LightClientError),
+}
+
+/// The migration family's typed request: arguments parse completely
+/// into this enum before any wallet access.
+#[derive(Debug, PartialEq, Eq)]
+enum MigrationSubCommand {
+    Plan,
+    Start {
+        plan_hash: [u8; 32],
+        per_bucket: Option<u32>,
+    },
+    Auto,
+    Status,
+    Reconcile,
+    Catchup {
+        spacing: std::time::Duration,
+    },
+    Cancel,
+}
+
+/// Pure parser for the migration command family's arguments.
+fn parse_migration_args(args: &[&str]) -> Result<MigrationSubCommand, MigrationCommandError> {
+    let Some(sub_command) = args.first() else {
+        return Err(MigrationCommandError::MissingSubCommand);
+    };
+    match *sub_command {
+        "plan" => Ok(MigrationSubCommand::Plan),
+        "start" => {
+            let hash_hex = args.get(1).ok_or(MigrationCommandError::MissingPlanHash)?;
+            let plan_hash: [u8; 32] = hex::decode(hash_hex)
+                .ok()
+                .and_then(|bytes| bytes.try_into().ok())
+                .ok_or(MigrationCommandError::MalformedPlanHash)?;
+            let mut per_bucket = None;
+            let mut remaining = args[2..].iter();
+            while let Some(arg) = remaining.next() {
+                if *arg == "--per-bucket" {
+                    per_bucket = Some(
+                        remaining
+                            .next()
+                            .and_then(|value| value.parse::<u32>().ok())
+                            .ok_or(MigrationCommandError::MalformedPerBucket)?,
+                    );
+                }
+            }
+            Ok(MigrationSubCommand::Start {
+                plan_hash,
+                per_bucket,
+            })
+        }
+        "auto" => Ok(MigrationSubCommand::Auto),
+        "status" => Ok(MigrationSubCommand::Status),
+        "reconcile" => Ok(MigrationSubCommand::Reconcile),
+        "catchup" => {
+            let spacing = match args.get(1) {
+                Some(seconds) => std::time::Duration::from_secs(
+                    seconds
+                        .parse::<u64>()
+                        .map_err(|_| MigrationCommandError::MalformedSpacing)?,
+                ),
+                None => std::time::Duration::from_secs(30),
+            };
+            Ok(MigrationSubCommand::Catchup { spacing })
+        }
+        "cancel" => Ok(MigrationSubCommand::Cancel),
+        _ => Err(MigrationCommandError::InvalidSubCommand),
+    }
+}
+
+/// Renders displayable ids as a JSON array of strings.
+fn txids_json<T: ToString>(txids: &[T]) -> json::JsonValue {
+    txids
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .into()
+}
+
+/// The migrate command's typed core; its `exec` renders errors at the
+/// single boundary site.
+fn run_migrate(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, MigrationCommandError> {
+    if !args.is_empty() {
+        return Err(MigrationCommandError::UnexpectedArguments);
+    }
+    let summary = RT.block_on(lightclient.migrate_to_ironwood(zip32::AccountId::ZERO))?;
+    Ok(object! {
+        "split_txids" => txids_json(&summary.split_txids),
+        "part_txids" => txids_json(&summary.part_txids),
+        "stranded" => summary.stranded,
+    }
+    .pretty(2))
+}
+
+/// The migration command's typed core: parse first, then act.
+fn run_migration(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, MigrationCommandError> {
+    Ok(match parse_migration_args(args)? {
+        MigrationSubCommand::Plan => {
+            let plan = RT.block_on(lightclient.plan_ironwood_migration(zip32::AccountId::ZERO))?;
+            object! {
+                "split_rounds" => plan.split_rounds.len(),
+                "split_transactions" => plan.split_rounds.iter().map(Vec::len).sum::<usize>(),
+                "split_fee" => plan.split_fee(),
+                "parts" => plan.parts.clone(),
+                "stranded" => plan.stranded,
+                "plan_hash" => hex::encode(migration::plan_hash(&plan)),
+            }
+            .pretty(2)
+        }
+        MigrationSubCommand::Start {
+            plan_hash,
+            per_bucket,
+        } => {
+            RT.block_on(lightclient.start_ironwood_migration(
+                zip32::AccountId::ZERO,
+                migration::SigningStrategy::LazyAtBoundary,
+                plan_hash,
+                per_bucket,
+            ))?;
+            "Migration started.".to_string()
+        }
+        MigrationSubCommand::Auto => {
+            RT.block_on(lightclient.sync_and_await())
+                .map_err(MigrationCommandError::Sync)?;
+            let txids = RT.block_on(lightclient.auto_broadcast_if_due())?;
+            if txids.is_empty() {
+                "No parts due yet.".to_string()
+            } else {
+                object! { "broadcast" => txids_json(&txids) }.pretty(2)
+            }
+        }
+        MigrationSubCommand::Status => {
+            let status = RT.block_on(lightclient.migration_status())?;
+            object! {
+                "orchard_confirmed_spendable" => status.orchard_confirmed_spendable,
+                "phase" => status.phase.as_ref().map(render_migration_phase),
+                "parts_total" => status.parts_total,
+                "parts_confirmed" => status.parts_confirmed,
+                "value_total" => status.value_total,
+                "value_migrated" => status.value_migrated,
+                "next_wakes" => status
+                    .next_wakes
+                    .iter()
+                    .map(|wake| object! {
+                        "bucket_index" => wake.bucket_index,
+                        "boundary" => u32::from(wake.boundary),
+                        "part_ids" => wake.part_ids.iter().map(|id| id.0).collect::<Vec<_>>(),
+                        "estimated_unix_time" => wake.estimated_unix_time,
+                    })
+                    .collect::<Vec<_>>(),
+            }
+            .pretty(2)
+        }
+        MigrationSubCommand::Reconcile => {
+            let report = RT.block_on(lightclient.reconcile_migration())?;
+            object! {
+                "assessments" => report
+                    .assessments
+                    .iter()
+                    .map(|assessment| object! {
+                        "part" => assessment.id.0,
+                        "class" => format!("{:?}", assessment.class),
+                    })
+                    .collect::<Vec<_>>(),
+                "actions" => report
+                    .actions
+                    .iter()
+                    .map(|action| format!("{action:?}"))
+                    .collect::<Vec<_>>(),
+            }
+            .pretty(2)
+        }
+        MigrationSubCommand::Catchup { spacing } => {
+            let txids = RT.block_on(lightclient.catch_up_migration(spacing))?;
+            if txids.is_empty() {
+                "No overdue parts.".to_string()
+            } else {
+                object! { "part_txids" => txids_json(&txids) }.pretty(2)
+            }
+        }
+        MigrationSubCommand::Cancel => {
+            RT.block_on(lightclient.cancel_ironwood_migration())?;
+            "Migration canceled.".to_string()
+        }
+    })
+}
+
 struct MigrateCommand {}
 impl Command for MigrateCommand {
     fn help(&self) -> &'static str {
@@ -2130,22 +2348,10 @@ impl Command for MigrateCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
-        if !args.is_empty() {
-            return "Error: migrate command expects no arguments. Type \"help migrate\" for usage."
-                .to_string();
+        match run_migrate(args, lightclient) {
+            Ok(rendered) => rendered,
+            Err(e) => format!("Error: {e}"),
         }
-
-        RT.block_on(async move {
-            match lightclient.migrate_to_ironwood(zip32::AccountId::ZERO).await {
-                Ok(summary) => object! {
-                    "split_txids" => summary.split_txids.iter().map(ToString::to_string).collect::<Vec<_>>(),
-                    "part_txids" => summary.part_txids.iter().map(ToString::to_string).collect::<Vec<_>>(),
-                    "stranded" => summary.stranded,
-                }
-                .pretty(2),
-                Err(e) => format!("Error: {e}"),
-            }
-        })
     }
 }
 
@@ -2192,156 +2398,9 @@ impl Command for MigrationCommand {
     }
 
     fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
-        let Some(sub_command) = args.first() else {
-            return "Error: migration command expects a sub-command. Type \"help migration\" for usage."
-                .to_string();
-        };
-
-        match *sub_command {
-            "plan" => RT.block_on(async move {
-                match lightclient
-                    .plan_ironwood_migration(zip32::AccountId::ZERO)
-                    .await
-                {
-                    Ok(plan) => object! {
-                        "split_rounds" => plan.split_rounds.len(),
-                        "split_transactions" => plan.split_rounds.iter().map(Vec::len).sum::<usize>(),
-                        "split_fee" => plan.split_fee(),
-                        "parts" => plan.parts.clone(),
-                        "stranded" => plan.stranded,
-                        "plan_hash" => hex::encode(migration::plan_hash(&plan)),
-                    }
-                    .pretty(2),
-                    Err(e) => format!("Error: {e}"),
-                }
-            }),
-            "start" => {
-                let Some(hash_hex) = args.get(1) else {
-                    return "Error: migration start expects the plan hash printed by \"migration plan\"."
-                        .to_string();
-                };
-                let hash: [u8; 32] = match hex::decode(hash_hex)
-                    .ok()
-                    .and_then(|bytes| bytes.try_into().ok())
-                {
-                    Some(hash) => hash,
-                    None => return "Error: the plan hash must be 64 hex characters.".to_string(),
-                };
-                // Parse optional --per-bucket N flag from remaining args.
-                let per_bucket = {
-                    let mut value = None;
-                    let mut iter = args[2..].iter();
-                    while let Some(arg) = iter.next() {
-                        if *arg == "--per-bucket" {
-                            match iter.next().and_then(|v| v.parse::<u32>().ok()) {
-                                Some(n) => { value = Some(n); }
-                                None => return "Error: --per-bucket expects a positive integer.".to_string(),
-                            }
-                        }
-                    }
-                    value
-                };
-                RT.block_on(async move {
-                    match lightclient
-                        .start_ironwood_migration(
-                            zip32::AccountId::ZERO,
-                            migration::SigningStrategy::LazyAtBoundary,
-                            hash,
-                            per_bucket,
-                        )
-                        .await
-                    {
-                        Ok(()) => "Migration started.".to_string(),
-                        Err(e) => format!("Error: {e}"),
-                    }
-                })
-            }
-            "auto" => RT.block_on(async move {
-                if let Err(e) = lightclient.sync_and_await().await {
-                    return format!("Error: sync failed: {e}");
-                }
-                match lightclient.auto_broadcast_if_due().await {
-                    Ok(txids) if txids.is_empty() => "No parts due yet.".to_string(),
-                    Ok(txids) => object! {
-                        "broadcast" => txids.iter().map(ToString::to_string).collect::<Vec<_>>(),
-                    }
-                    .pretty(2),
-                    Err(e) => format!("Error: {e}"),
-                }
-            }),
-            "status" => RT.block_on(async move {
-                match lightclient.migration_status().await {
-                    Ok(status) => object! {
-                        "orchard_confirmed_spendable" => status.orchard_confirmed_spendable,
-                        "phase" => status.phase.as_ref().map(render_migration_phase),
-                        "parts_total" => status.parts_total,
-                        "parts_confirmed" => status.parts_confirmed,
-                        "value_total" => status.value_total,
-                        "value_migrated" => status.value_migrated,
-                        "next_wakes" => status
-                            .next_wakes
-                            .iter()
-                            .map(|wake| object! {
-                                "bucket_index" => wake.bucket_index,
-                                "boundary" => u32::from(wake.boundary),
-                                "part_ids" => wake.part_ids.iter().map(|id| id.0).collect::<Vec<_>>(),
-                                "estimated_unix_time" => wake.estimated_unix_time,
-                            })
-                            .collect::<Vec<_>>(),
-                    }
-                    .pretty(2),
-                    Err(e) => format!("Error: {e}"),
-                }
-            }),
-            "reconcile" => RT.block_on(async move {
-                match lightclient.reconcile_migration().await {
-                    Ok(report) => object! {
-                        "assessments" => report
-                            .assessments
-                            .iter()
-                            .map(|assessment| object! {
-                                "part" => assessment.id.0,
-                                "class" => format!("{:?}", assessment.class),
-                            })
-                            .collect::<Vec<_>>(),
-                        "actions" => report
-                            .actions
-                            .iter()
-                            .map(|action| format!("{action:?}"))
-                            .collect::<Vec<_>>(),
-                    }
-                    .pretty(2),
-                    Err(e) => format!("Error: {e}"),
-                }
-            }),
-            "catchup" => {
-                let spacing = match args.get(1) {
-                    Some(seconds) => match seconds.parse::<u64>() {
-                        Ok(seconds) => std::time::Duration::from_secs(seconds),
-                        Err(_) => {
-                            return "Error: spacing must be a number of seconds.".to_string();
-                        }
-                    },
-                    None => std::time::Duration::from_secs(30),
-                };
-                RT.block_on(async move {
-                    match lightclient.catch_up_migration(spacing).await {
-                        Ok(txids) if txids.is_empty() => "No overdue parts.".to_string(),
-                        Ok(txids) => object! {
-                            "part_txids" => txids.iter().map(ToString::to_string).collect::<Vec<_>>(),
-                        }
-                        .pretty(2),
-                        Err(e) => format!("Error: {e}"),
-                    }
-                })
-            }
-            "cancel" => RT.block_on(async move {
-                match lightclient.cancel_ironwood_migration().await {
-                    Ok(()) => "Migration canceled.".to_string(),
-                    Err(e) => format!("Error: {e}"),
-                }
-            }),
-            _ => "Error: invalid sub-command. Type \"help migration\" for usage.".to_string(),
+        match run_migration(args, lightclient) {
+            Ok(rendered) => rendered,
+            Err(e) => format!("Error: {e}"),
         }
     }
 }
@@ -2433,5 +2492,57 @@ pub fn do_user_command(cmd: &str, args: &[&str], lightclient: &mut LightClient) 
     match get_commands().get(cmd.to_ascii_lowercase().as_str()) {
         Some(cmd) => cmd.exec(args, lightclient),
         None => format!("Unknown command : {cmd}. Type 'help' for a list of commands"),
+    }
+}
+
+#[cfg(test)]
+mod migration_command_parsing {
+    //! Pins the pure argument parser and the byte-identity of the typed
+    //! errors' rendering with the in-band strings they replaced.
+
+    use super::*;
+
+    #[test]
+    fn start_parses_hash_and_per_bucket() {
+        let hash_hex = "11".repeat(32);
+        let parsed = parse_migration_args(&["start", &hash_hex, "--per-bucket", "3"])
+            .expect("well-formed arguments parse");
+        assert_eq!(
+            parsed,
+            MigrationSubCommand::Start {
+                plan_hash: [0x11; 32],
+                per_bucket: Some(3),
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_plan_hash_is_typed() {
+        assert!(matches!(
+            parse_migration_args(&["start", "abc"]),
+            Err(MigrationCommandError::MalformedPlanHash)
+        ));
+    }
+
+    #[test]
+    fn catchup_defaults_spacing_to_thirty_seconds() {
+        assert_eq!(
+            parse_migration_args(&["catchup"]).expect("bare catchup parses"),
+            MigrationSubCommand::Catchup {
+                spacing: std::time::Duration::from_secs(30),
+            }
+        );
+    }
+
+    #[test]
+    fn errors_render_byte_identically_to_the_replaced_strings() {
+        assert_eq!(
+            format!("Error: {}", MigrationCommandError::MissingSubCommand),
+            "Error: migration command expects a sub-command. Type \"help migration\" for usage."
+        );
+        assert_eq!(
+            format!("Error: {}", MigrationCommandError::MalformedPerBucket),
+            "Error: --per-bucket expects a positive integer."
+        );
     }
 }

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -36,6 +36,21 @@ use zingolib::wallet::migration::{self, MigrationPhase};
 
 pub static RT: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
 
+/// Typed failure of a CLI command. `do_user_command` remains the single
+/// site that renders these to prose for string frontends; typed
+/// frontends consume them directly via `do_user_command_result`.
+#[derive(Debug, thiserror::Error)]
+pub enum CommandError {
+    #[error(transparent)]
+    Migration(#[from] MigrationCommandError),
+    /// Transitional quarantine for commands whose failure prose is not
+    /// yet typed: the message is stored WITHOUT the "Error: " prefix
+    /// (the renderer adds it). Every construction site is a candidate
+    /// for a dedicated variant; none may ever be string-matched.
+    #[error("{0}")]
+    NotYetTyped(String),
+}
+
 /// This command interface is used both by cli and also consumers.
 pub trait Command {
     /// display command help (in cli)
@@ -44,10 +59,13 @@ pub trait Command {
     /// A one-line summary shown in the two-column command listing.
     fn short_help(&self) -> &'static str;
 
-    /// in zingocli, this string is printed to console
+    /// in zingocli, the success string is printed to console
     /// consumers occasionally make assumptions about this
     /// e. expect it to be a json object
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String;
+    ///
+    /// Failure crosses the boundary structurally as a [`CommandError`];
+    /// [`do_user_command`] renders it to prose for string frontends.
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError>;
 }
 
 /// A command that can execute without an active [`LightClient`].
@@ -73,8 +91,8 @@ impl Command for GetVersionCommand {
         "Get version of build code"
     }
 
-    fn exec(&self, _args: &[&str], _lightclient: &mut LightClient) -> String {
-        zingolib::git_description().to_string()
+    fn exec(&self, _args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(zingolib::git_description().to_string())
     }
 }
 
@@ -98,8 +116,8 @@ impl Command for ChangeServerCommand {
         "Change indexer server"
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             match args.len() {
                 0 => match lightclient.set_indexer_uri(http::Uri::default()).await {
                     Ok(()) => "server set".to_string(),
@@ -120,7 +138,7 @@ impl Command for ChangeServerCommand {
                 },
                 _ => self.help().to_string(),
             }
-        })
+        }))
     }
 }
 
@@ -139,8 +157,8 @@ impl Command for BirthdayCommand {
         "Returns block height wallet was created"
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        lightclient.birthday().to_string()
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(lightclient.birthday().to_string())
     }
 }
 
@@ -158,8 +176,8 @@ impl Command for WalletKindCommand {
         "Displays the kind of wallet currently loaded"
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             if lightclient.mnemonic_phrase().is_some() {
                 object! {"kind" => "Loaded from mnemonic (seed or phrase)",
                         "transparent" => true,
@@ -199,7 +217,7 @@ impl Command for WalletKindCommand {
                     .pretty(4),
                 }
             }
-        })
+        }))
     }
 }
 
@@ -222,9 +240,9 @@ impl Command for ParseAddressCommand {
         "Parse an address"
     }
 
-    fn exec(&self, args: &[&str], _lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() > 1 || args.is_empty() {
-            return self.help().to_string();
+            return Ok(self.help().to_string());
         }
         fn make_decoded_chain_pair(
             address: &str,
@@ -240,44 +258,45 @@ impl Command for ParseAddressCommand {
             .iter()
             .find_map(|chain| Address::decode(chain, address).zip(Some(*chain)))
         }
-        if let Some((recipient_address, chain_name)) = make_decoded_chain_pair(args[0]) {
-            #[allow(unreachable_patterns)]
-            let chain_name_string = match chain_name {
-                zingolib::config::ChainType::Mainnet => "main",
-                zingolib::config::ChainType::Testnet => "test",
-                zingolib::config::ChainType::Regtest(_) => "regtest",
-                _ => unreachable!("Invalid chain type"),
-            };
-            match recipient_address {
-                Address::Sapling(_) => object! {
-                    "status" => "success",
-                    "chain_name" => chain_name_string,
-                    "address_kind" => "sapling",
-                }
-                .to_string(),
-                Address::Transparent(_) => object! {
-                    "status" => "success",
-                    "chain_name" => chain_name_string,
-                    "address_kind" => "transparent",
-                }
-                .to_string(),
-                Address::Tex(_) => object! {
-                    "status" => "success",
-                    "chain_name" => chain_name_string,
-                    "address_kind" => "tex",
-                }
-                .to_string(),
-                Address::Unified(ua) => {
-                    let mut receivers_available = vec![];
-                    if ua.sapling().is_some() {
-                        receivers_available.push("sapling");
+        Ok(
+            if let Some((recipient_address, chain_name)) = make_decoded_chain_pair(args[0]) {
+                #[allow(unreachable_patterns)]
+                let chain_name_string = match chain_name {
+                    zingolib::config::ChainType::Mainnet => "main",
+                    zingolib::config::ChainType::Testnet => "test",
+                    zingolib::config::ChainType::Regtest(_) => "regtest",
+                    _ => unreachable!("Invalid chain type"),
+                };
+                match recipient_address {
+                    Address::Sapling(_) => object! {
+                        "status" => "success",
+                        "chain_name" => chain_name_string,
+                        "address_kind" => "sapling",
                     }
-                    if ua.transparent().is_some() {
-                        receivers_available.push("transparent");
+                    .to_string(),
+                    Address::Transparent(_) => object! {
+                        "status" => "success",
+                        "chain_name" => chain_name_string,
+                        "address_kind" => "transparent",
                     }
-                    if ua.orchard().is_some() {
-                        receivers_available.push("orchard");
-                        object! {
+                    .to_string(),
+                    Address::Tex(_) => object! {
+                        "status" => "success",
+                        "chain_name" => chain_name_string,
+                        "address_kind" => "tex",
+                    }
+                    .to_string(),
+                    Address::Unified(ua) => {
+                        let mut receivers_available = vec![];
+                        if ua.sapling().is_some() {
+                            receivers_available.push("sapling");
+                        }
+                        if ua.transparent().is_some() {
+                            receivers_available.push("transparent");
+                        }
+                        if ua.orchard().is_some() {
+                            receivers_available.push("orchard");
+                            object! {
                             "status" => "success",
                             "chain_name" => chain_name_string,
                             "address_kind" => "unified",
@@ -285,25 +304,26 @@ impl Command for ParseAddressCommand {
                             "only_orchard_ua" => zcash_keys::address::UnifiedAddress::from_receivers(ua.orchard().copied(), None, None).expect("To construct UA").encode(&chain_name),
                         }
                         .to_string()
-                    } else {
-                        object! {
-                            "status" => "success",
-                            "chain_name" => chain_name_string,
-                            "address_kind" => "unified",
-                            "receivers_available" => receivers_available,
+                        } else {
+                            object! {
+                                "status" => "success",
+                                "chain_name" => chain_name_string,
+                                "address_kind" => "unified",
+                                "receivers_available" => receivers_available,
+                            }
+                            .to_string()
                         }
-                        .to_string()
                     }
                 }
-            }
-        } else {
-            object! {
-                "status" => "Invalid address",
-                "chain_name" => json::JsonValue::Null,
-                "address_kind" => json::JsonValue::Null,
-            }
-            .to_string()
-        }
+            } else {
+                object! {
+                    "status" => "Invalid address",
+                    "chain_name" => json::JsonValue::Null,
+                    "address_kind" => json::JsonValue::Null,
+                }
+                .to_string()
+            },
+        )
     }
 }
 
@@ -326,8 +346,8 @@ impl Command for ParseViewKeyCommand {
         "Parse a view_key."
     }
 
-    fn exec(&self, args: &[&str], _lightclient: &mut LightClient) -> String {
-        match args.len() {
+    fn exec(&self, args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(match args.len() {
             1 => json::stringify_pretty(
                 match Ufvk::decode(args[0]) {
                     Ok((network, ufvk)) => {
@@ -369,7 +389,7 @@ impl Command for ParseViewKeyCommand {
                 4,
             ),
             _ => self.help().to_string(),
-        }
+        })
     }
 }
 
@@ -401,49 +421,52 @@ impl Command for SyncCommand {
         "Sync the wallet to the latest state of the blockchain."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() != 1 {
-            return "Error: sync command expects 1 argument. Type \"help sync\" for usage."
-                .to_string();
+            return Err(CommandError::NotYetTyped(
+                "sync command expects 1 argument. Type \"help sync\" for usage.".to_string(),
+            ));
         }
 
         match args[0] {
             "run" => {
                 if lightclient.sync_mode() == SyncMode::Paused {
                     lightclient.resume_sync().expect("sync should be paused");
-                    "Resuming sync task...".to_string()
+                    Ok("Resuming sync task...".to_string())
                 } else {
                     RT.block_on(async move {
                         match lightclient.sync().await {
-                            Ok(()) => "Launching sync task...".to_string(),
-                            Err(e) => format!("Error: {e}"),
+                            Ok(()) => Ok("Launching sync task...".to_string()),
+                            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
                         }
                     })
                 }
             }
             "pause" => match lightclient.pause_sync() {
-                Ok(()) => "Pausing sync task...".to_string(),
-                Err(e) => format!("Error: {e}"),
+                Ok(()) => Ok("Pausing sync task...".to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             },
             "stop" => match lightclient.stop_sync() {
-                Ok(()) => "Stopping sync task...".to_string(),
-                Err(e) => format!("Error: {e}"),
+                Ok(()) => Ok("Stopping sync task...".to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             },
             "status" => RT.block_on(async move {
                 match pepper_sync::sync_status(&*lightclient.wallet().read().await).await {
-                    Ok(status) => json::JsonValue::from(status).pretty(2),
-                    Err(e) => format!("Error: {e}"),
+                    Ok(status) => Ok(json::JsonValue::from(status).pretty(2)),
+                    Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
                 }
             }),
             "poll" => match lightclient.poll_sync() {
-                PollReport::NoHandle => "Sync task has not been launched.".to_string(),
-                PollReport::NotReady => "Sync task is not complete.".to_string(),
+                PollReport::NoHandle => Ok("Sync task has not been launched.".to_string()),
+                PollReport::NotReady => Ok("Sync task is not complete.".to_string()),
                 PollReport::Ready(result) => match result {
-                    Ok(sync_result) => sync_result.to_string(),
-                    Err(e) => format!("Error: {e}"),
+                    Ok(sync_result) => Ok(sync_result.to_string()),
+                    Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
                 },
             },
-            _ => "Error: invalid sub-command. Type \"help sync\" for usage.".to_string(),
+            _ => Err(CommandError::NotYetTyped(
+                "invalid sub-command. Type \"help sync\" for usage.".to_string(),
+            )),
         }
     }
 }
@@ -464,16 +487,17 @@ impl Command for RescanCommand {
         "Rescan the wallet, clearing all wallet data obtained from the blockchain and launching sync from the wallet birthday."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if !args.is_empty() {
-            return "Error: rescan command expects no arguments. Type \"rescan help\" for usage."
-                .to_string();
+            return Err(CommandError::NotYetTyped(
+                "rescan command expects no arguments. Type \"rescan help\" for usage.".to_string(),
+            ));
         }
 
         RT.block_on(async move {
             match lightclient.rescan().await {
-                Ok(()) => "Launching rescan...".to_string(),
-                Err(e) => format!("Error: {e}"),
+                Ok(()) => Ok("Launching rescan...".to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -495,13 +519,13 @@ impl Command for ClearCommand {
         "Clear the wallet state, rolling back the wallet to an empty state."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             lightclient.wallet().write().await.clear_all();
 
             let result = object! { "result" => "success" };
             result.pretty(2)
-        })
+        }))
     }
 }
 
@@ -525,8 +549,8 @@ impl Command for HelpCommand {
         "Lists all available commands"
     }
 
-    fn exec(&self, args: &[&str], _: &mut LightClient) -> String {
-        format_help(args)
+    fn exec(&self, args: &[&str], _: &mut LightClient) -> Result<String, CommandError> {
+        Ok(format_help(args))
     }
 }
 
@@ -594,15 +618,15 @@ impl Command for InfoCommand {
         "Get the indexer server's info"
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         // The presentation boundary: typed data becomes rendered JSON and
         // typed failure becomes display text here, and nowhere earlier.
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient.info().await {
                 Ok(info) => json::JsonValue::from(info).pretty(2),
                 Err(e) => e.to_string(),
             }
-        })
+        }))
     }
 }
 
@@ -626,8 +650,8 @@ impl Command for CurrentPriceCommand {
         "Updates and returns current price of ZEC."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             match lightclient
                 .wallet()
                 .write()
@@ -638,7 +662,7 @@ impl Command for CurrentPriceCommand {
                 Ok(price) => format!("current price: {price}"),
                 Err(e) => format!("error: {e}"),
             }
-        })
+        }))
     }
 }
 
@@ -654,11 +678,11 @@ impl Command for BalanceCommand {
         "Return the wallet ZEC balance for each pool (account 0)."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         RT.block_on(async move {
             match lightclient.account_balance(zip32::AccountId::ZERO).await {
-                Ok(bal) => bal.to_string(),
-                Err(e) => format!("Error: {e}"),
+                Ok(bal) => Ok(bal.to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -680,18 +704,18 @@ impl Command for SpendableBalanceCommand {
         "Display the wallet's spendable balance."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         RT.block_on(async move {
             let wallet = lightclient.wallet().read().await;
             let spendable_balance =
                 match wallet.shielded_spendable_balance(zip32::AccountId::ZERO, false) {
                     Ok(bal) => bal,
-                    Err(e) => return format!("Error: {e}"),
+                    Err(e) => return Err(CommandError::NotYetTyped(e.to_string())),
                 };
-            object! {
+            Ok(object! {
                 "spendable_balance" => spendable_balance.into_u64(),
             }
-            .pretty(2)
+            .pretty(2))
         })
     }
 }
@@ -721,16 +745,16 @@ impl Command for MaxSendValueCommand {
         "Display the maximum value the wallet can currently send to a given address."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         let (address, zennies_for_zingo) = match utils::parse_max_send_value_args(args) {
             Ok(address_and_zennies) => address_and_zennies,
             Err(e) => {
-                return format!(
-                    "Error: {e}\nTry 'help max_send_value' for correct usage and examples."
-                );
+                return Err(CommandError::NotYetTyped(format!(
+                    "{e}\nTry 'help max_send_value' for correct usage and examples."
+                )));
             }
         };
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient
                 .max_send_value(address, zennies_for_zingo, zip32::AccountId::ZERO)
                 .await
@@ -745,7 +769,7 @@ impl Command for MaxSendValueCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -777,15 +801,15 @@ impl Command for NewUnifiedAddressCommand {
         "Create a new unified address."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() != 1 {
-            return format!("No address type specified\n{}", self.help());
+            return Ok(format!("No address type specified\n{}", self.help()));
         }
         if !args[0].contains('o') && !args[0].contains('z') {
-            return format!("No address type specified\n{}", self.help());
+            return Ok(format!("No address type specified\n{}", self.help()));
         }
 
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             let chain_type = lightclient.chain_type();
             let mut wallet = lightclient.wallet().write().await;
             let receivers = ReceiverSelection {
@@ -806,7 +830,7 @@ impl Command for NewUnifiedAddressCommand {
                 Err(e) => object! { "error" => e.to_string() },
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -825,8 +849,8 @@ impl Command for NewTransparentAddressCommand {
         "Create a new transparent address."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             let chain_type = lightclient.chain_type();
             let mut wallet = lightclient.wallet().write().await;
             match wallet.generate_transparent_address(zip32::AccountId::ZERO, true) {
@@ -841,7 +865,7 @@ impl Command for NewTransparentAddressCommand {
                 Err(e) => object! { "error" => e.to_string() },
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -875,8 +899,8 @@ impl Command for NewTransparentAddressAllowGapCommand {
         "Create a new transparent address (even if the last one did not receive any funds)."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             // Generate without enforcing the no-gap constraint
             let chain_type= lightclient.chain_type();
             let mut wallet = lightclient.wallet().write().await;
@@ -893,7 +917,7 @@ impl Command for NewTransparentAddressAllowGapCommand {
                 Err(e) => object! { "error" => e.to_string() },
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -913,8 +937,8 @@ impl Command for UnifiedAddressesCommand {
         "List unified addresses in the wallet."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move { lightclient.unified_addresses_json().await.pretty(2) })
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move { lightclient.unified_addresses_json().await.pretty(2) }))
     }
 }
 
@@ -934,8 +958,8 @@ impl Command for TransparentAddressesCommand {
         "List transparent addresses in the wallet."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move { lightclient.transparent_addresses_json().await.pretty(2) })
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move { lightclient.transparent_addresses_json().await.pretty(2) }))
     }
 }
 
@@ -957,12 +981,12 @@ impl Command for CheckAddressCommand {
         "Checks if the given encoded address is derived by the wallet's keys."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() != 1 {
-            return json::object! { "error" => "no address specified. try 'help check_address' for correct usage and examples."
-                .to_string() }.pretty(2)            ;
+            return Ok(json::object! { "error" => "no address specified. try 'help check_address' for correct usage and examples."
+                .to_string() }.pretty(2))            ;
         }
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient
                 .wallet()
                 .read()
@@ -1029,7 +1053,7 @@ impl Command for CheckAddressCommand {
                 Err(e) => json::object! { "error" => e.to_string() },
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1049,8 +1073,8 @@ impl Command for ExportUfvkCommand {
         "Export unified full viewing key for the wallet."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             let ufvk: UnifiedFullViewingKey = match lightclient
                 .wallet()
                 .read()
@@ -1068,7 +1092,7 @@ impl Command for ExportUfvkCommand {
                 "birthday" => lightclient.birthday()
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1100,21 +1124,25 @@ impl Command for SendCommand {
         "Propose a transfer of ZEC to the given address(es) and display a proposal for confirmation."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         let receivers = match utils::parse_send_args(args) {
             Ok(receivers) => receivers,
             Err(e) => {
-                return format!("Error: {e}\nTry 'help send' for correct usage and examples.");
+                return Err(CommandError::NotYetTyped(format!(
+                    "{e}\nTry 'help send' for correct usage and examples."
+                )));
             }
         };
         let request = match zingolib::data::receivers::transaction_request_from_receivers(receivers)
         {
             Ok(request) => request,
             Err(e) => {
-                return format!("Error: {e}\nTry 'help send' for correct usage and examples.");
+                return Err(CommandError::NotYetTyped(format!(
+                    "{e}\nTry 'help send' for correct usage and examples."
+                )));
             }
         };
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient
                 .propose_send(request, zip32::AccountId::ZERO)
                 .await
@@ -1131,7 +1159,7 @@ impl Command for SendCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1165,14 +1193,16 @@ impl Command for SendAllCommand {
         "Propose to transfer all ZEC from shielded pools to a given address and display a proposal for confirmation."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         let (address, zennies_for_zingo, memo) = match utils::parse_send_all_args(args) {
             Ok(parse_results) => parse_results,
             Err(e) => {
-                return format!("Error: {e}\nTry 'help sendall' for correct usage and examples.");
+                return Err(CommandError::NotYetTyped(format!(
+                    "{e}\nTry 'help sendall' for correct usage and examples."
+                )));
             }
         };
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient
                 .propose_send_all(address, zennies_for_zingo, memo, zip32::AccountId::ZERO)
                 .await
@@ -1196,7 +1226,7 @@ impl Command for SendAllCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1227,21 +1257,25 @@ impl Command for QuickSendCommand {
         "Send ZEC to the given address(es). Combines `send` and `confirm` into a single command."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         let receivers = match utils::parse_send_args(args) {
             Ok(receivers) => receivers,
             Err(e) => {
-                return format!("Error: {e}\nTry 'help quicksend' for correct usage and examples.");
+                return Err(CommandError::NotYetTyped(format!(
+                    "{e}\nTry 'help quicksend' for correct usage and examples."
+                )));
             }
         };
         let request = match zingolib::data::receivers::transaction_request_from_receivers(receivers)
         {
             Ok(request) => request,
             Err(e) => {
-                return format!("Error: {e}\nTry 'help quicksend' for correct usage and examples.");
+                return Err(CommandError::NotYetTyped(format!(
+                    "{e}\nTry 'help quicksend' for correct usage and examples."
+                )));
             }
         };
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient.quick_send(request, zip32::AccountId::ZERO, true).await {
                 Ok(txids) => {
                     object! { "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>() }
@@ -1251,7 +1285,7 @@ impl Command for QuickSendCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1276,15 +1310,15 @@ impl Command for ShieldCommand {
         "Propose a shield of transparent funds to the ironwood pool and display a proposal for confirmation.."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if !args.is_empty() {
-            return format!(
-                "Error: {}\nTry 'help shield' for correct usage and examples.",
+            return Err(CommandError::NotYetTyped(format!(
+                "{}\nTry 'help shield' for correct usage and examples.",
                 error::CommandError::InvalidArguments
-            );
+            )));
         }
 
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient.propose_shield(zip32::AccountId::ZERO).await {
                 Ok(proposal) => {
                     if proposal.steps().len() != 1 {
@@ -1310,7 +1344,7 @@ impl Command for ShieldCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1332,15 +1366,15 @@ impl Command for QuickShieldCommand {
         "Shield transparent funds to the ironwood pool. Combines `shield` and `confirm` into a single command."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if !args.is_empty() {
-            return format!(
-                "Error: {}\nTry 'help shield' for correct usage and examples.",
+            return Err(CommandError::NotYetTyped(format!(
+                "{}\nTry 'help shield' for correct usage and examples.",
                 error::CommandError::InvalidArguments
-            );
+            )));
         }
 
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient
                 .quick_shield(zip32::AccountId::ZERO)
                 .await {
@@ -1352,7 +1386,7 @@ impl Command for QuickShieldCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1382,15 +1416,15 @@ impl Command for ConfirmCommand {
         "Confirms the latest proposal, constructing and transmitting the transaction(s) and resuming the sync task."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if !args.is_empty() {
-            return format!(
-                "Error: {}\nTry 'help confirm' for correct usage and examples.",
+            return Err(CommandError::NotYetTyped(format!(
+                "{}\nTry 'help confirm' for correct usage and examples.",
                 error::CommandError::InvalidArguments
-            );
+            )));
         }
 
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient
                 .send_stored_proposal(true)
                 .await {
@@ -1402,7 +1436,7 @@ impl Command for ConfirmCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1444,15 +1478,15 @@ impl Command for CalculateCommand {
         "Signs the latest proposal without transmitting it; in Offline mode it stays valid until the next network upgrade."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if !args.is_empty() {
-            return format!(
-                "Error: {}\nTry 'help calculate' for correct usage and examples.",
+            return Err(CommandError::NotYetTyped(format!(
+                "{}\nTry 'help calculate' for correct usage and examples.",
                 error::CommandError::InvalidArguments
-            );
+            )));
         }
 
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             match lightclient.calculate_stored_proposal().await {
                 Ok(txids) => {
                     object! {
@@ -1464,7 +1498,7 @@ impl Command for CalculateCommand {
                 }
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1493,7 +1527,7 @@ impl Command for TransmitCommand {
         "Transmits previously calculated transactions to the Indexer."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         RT.block_on(async move {
             let txids = if args.is_empty() {
                 // All Calculated transactions, ordered by target height and
@@ -1520,18 +1554,20 @@ impl Command for TransmitCommand {
                 {
                     Ok(txids) => txids,
                     Err(e) => {
-                        return format!(
-                            "Error: {e}\nTry 'help transmit' for correct usage and examples."
-                        );
+                        return Err(CommandError::NotYetTyped(format!(
+                            "{e}\nTry 'help transmit' for correct usage and examples."
+                        )));
                     }
                 }
             };
 
             let Some(txids) = nonempty::NonEmpty::from_vec(txids) else {
-                return object! { "error" => "no calculated transactions to transmit" }.pretty(2);
+                return Ok(
+                    object! { "error" => "no calculated transactions to transmit" }.pretty(2),
+                );
             };
 
-            match lightclient.transmit_calculated(txids).await {
+            Ok(match lightclient.transmit_calculated(txids).await {
                 Ok(txids) => {
                     object! { "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>() }
                 }
@@ -1539,7 +1575,7 @@ impl Command for TransmitCommand {
                     object! { "error" => e.to_string() }
                 }
             }
-            .pretty(2)
+            .pretty(2))
         })
     }
 }
@@ -1563,8 +1599,8 @@ impl Command for DeleteCommand {
         "Delete wallet file from disk"
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             match lightclient.delete_wallet_file().await {
                 Ok(()) => {
                     let r = object! { "result" => "success",
@@ -1579,7 +1615,7 @@ impl Command for DeleteCommand {
                     r.pretty(2)
                 }
             }
-        })
+        }))
     }
 }
 
@@ -1601,13 +1637,13 @@ impl Command for RecoveryInfoCommand {
         "Display the wallet's seed phrase, birthday and number of accounts in use."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             match lightclient.wallet().read().await.recovery_info() {
                 Some(backup_info) => backup_info.to_string(),
                 None => "error: no mnemonic found. wallet loaded from key.".to_string(),
             }
-        })
+        }))
     }
 }
 
@@ -1627,11 +1663,11 @@ impl Command for ValueTransfersCommand {
         "List all value transfers for this wallet."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         RT.block_on(async move {
             match lightclient.value_transfers(false).await {
-                Ok(value_transfers) => value_transfers.to_string(),
-                Err(e) => format!("Error: {e}"),
+                Ok(value_transfers) => Ok(value_transfers.to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -1656,16 +1692,17 @@ impl Command for MessagesFilterCommand {
         "List memos for this wallet."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() > 1 {
-            return "Error: invalid arguments\nTry 'help messages' for correct usage and examples"
-                .to_string();
+            return Err(CommandError::NotYetTyped(
+                "invalid arguments\nTry 'help messages' for correct usage and examples".to_string(),
+            ));
         }
 
         RT.block_on(async move {
             match lightclient.messages_containing(args.first().copied()).await {
-                Ok(value_transfers) => json::JsonValue::from(value_transfers).pretty(2),
-                Err(e) => format!("Error: {e}"),
+                Ok(value_transfers) => Ok(json::JsonValue::from(value_transfers).pretty(2)),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -1686,15 +1723,17 @@ impl Command for TransactionsCommand {
         "Provides a list of transaction summaries related to this wallet in order of blockheight."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if !args.is_empty() {
-            return "Error: invalid arguments\nTry 'help transactions' for correct usage and examples"
-                .to_string();
+            return Err(CommandError::NotYetTyped(
+                "invalid arguments\nTry 'help transactions' for correct usage and examples"
+                    .to_string(),
+            ));
         }
         RT.block_on(async move {
             match lightclient.transaction_summaries(false).await {
-                Ok(transactions) => transactions.to_string(),
-                Err(e) => format!("Error: {e}"),
+                Ok(transactions) => Ok(transactions.to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -1714,15 +1753,15 @@ impl Command for MemoBytesToAddressCommand {
         "Show by address memo_bytes transfers for this seed."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() > 1 {
-            return format!("didn't understand arguments\n{}", self.help());
+            return Ok(format!("didn't understand arguments\n{}", self.help()));
         }
 
         RT.block_on(async move {
             match lightclient.do_total_memobytes_to_address().await {
-                Ok(total_memo_bytes) => json::JsonValue::from(total_memo_bytes).pretty(2),
-                Err(e) => format!("Error: {e}"),
+                Ok(total_memo_bytes) => Ok(json::JsonValue::from(total_memo_bytes).pretty(2)),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -1742,15 +1781,15 @@ impl Command for ValueToAddressCommand {
         "Show by address value transfers for this seed."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() > 1 {
-            return format!("didn't understand arguments\n{}", self.help());
+            return Ok(format!("didn't understand arguments\n{}", self.help()));
         }
 
         RT.block_on(async move {
             match lightclient.do_total_value_to_address().await {
-                Ok(total_values) => json::JsonValue::from(total_values).pretty(2),
-                Err(e) => format!("Error: {e}"),
+                Ok(total_values) => Ok(json::JsonValue::from(total_values).pretty(2)),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -1770,15 +1809,15 @@ impl Command for SendsToAddressCommand {
         "Show by address number of sends for this seed."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() > 1 {
-            return format!("didn't understand arguments\n{}", self.help());
+            return Ok(format!("didn't understand arguments\n{}", self.help()));
         }
 
         RT.block_on(async move {
             match lightclient.do_total_spends_to_address().await {
-                Ok(total_spends) => json::JsonValue::from(total_spends).pretty(2),
-                Err(e) => format!("Error: {e}"),
+                Ok(total_spends) => Ok(json::JsonValue::from(total_spends).pretty(2)),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -1810,19 +1849,19 @@ impl Command for SettingsCommand {
         "Show or set wallet settings."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         RT.block_on(async move {
             let mut wallet = lightclient.wallet().write().await;
 
             if args.is_empty() {
-                return format!(
+                return Ok(format!(
                     r"
 performance: {}
 min confirmations: {}
             ",
                     wallet.wallet_settings.sync_config.performance_level,
                     wallet.wallet_settings.min_confirmations,
-                );
+                ));
             }
 
             match args[0] {
@@ -1832,33 +1871,41 @@ min confirmations: {}
                     "high" => wallet.wallet_settings.sync_config.performance_level = PerformanceLevel::High,
                     "maximum" => wallet.wallet_settings.sync_config.performance_level = PerformanceLevel::Maximum,
                     _ => {
-                return "Error: invalid arguments\nTry 'help settings' for correct usage and examples"
-                    .to_string();}
+                return Err(CommandError::NotYetTyped(
+                    "invalid arguments\nTry 'help settings' for correct usage and examples"
+                        .to_string(),
+                ));}
                     },
                 "min_confirmations" => {
                     let min_confirmations = match args[1].parse::<u32>() {
                         Ok(m) => match NonZeroU32::try_from(m) {
                             Ok(m) => m,
                             Err(_) => {
-                                return "Error: invalid arguments\nTry 'help settings' for correct usage and examples"
-                                    .to_string();
+                                return Err(CommandError::NotYetTyped(
+                                    "invalid arguments\nTry 'help settings' for correct usage and examples"
+                                        .to_string(),
+                                ));
                             }
                         },
                         Err(_) => {
-                            return "Error: invalid arguments\nTry 'help settings' for correct usage and examples"
-                                .to_string();
+                            return Err(CommandError::NotYetTyped(
+                                "invalid arguments\nTry 'help settings' for correct usage and examples"
+                                    .to_string(),
+                            ));
                         }
                     };
                     wallet.wallet_settings.min_confirmations = min_confirmations;
                 }
                 _ => {
-            return "Error: invalid arguments\nTry 'help settings' for correct usage and examples"
-                .to_string();}
+            return Err(CommandError::NotYetTyped(
+                "invalid arguments\nTry 'help settings' for correct usage and examples"
+                    .to_string(),
+            ));}
             }
 
             wallet.mark_dirty();
 
-            "Successfully updated settings.".to_string()
+            Ok("Successfully updated settings.".to_string())
         })
     }
 }
@@ -1879,10 +1926,10 @@ impl Command for HeightCommand {
         "Returns the blockchain height at the time the wallet last requested the latest block height from the server."
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
-        RT.block_on(async move {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(RT.block_on(async move {
             object! { "height" => json::JsonValue::from(lightclient.wallet().read().await.sync_state.last_known_chain_height().map_or(0, u32::from))}.pretty(2)
-        })
+        }))
     }
 }
 
@@ -1901,10 +1948,10 @@ impl Command for NotesCommand {
         "Show all notes (shielded outputs) in this wallet"
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         // Parse the args.
         if args.len() > 1 {
-            return self.short_help().to_string();
+            return Ok(self.short_help().to_string());
         }
 
         // Make sure we can parse the amount
@@ -1912,16 +1959,16 @@ impl Command for NotesCommand {
             match args[0] {
                 "all" => true,
                 a => {
-                    return format!(
+                    return Ok(format!(
                         "Invalid argument \"{a}\". Specify 'all' to include spent notes"
-                    );
+                    ));
                 }
             }
         } else {
             false
         };
 
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             let wallet = lightclient.wallet().read().await;
 
             json::object! {
@@ -1930,7 +1977,7 @@ impl Command for NotesCommand {
                 "sapling_notes" => json::JsonValue::from(wallet.note_summaries::<SaplingNote>(all_notes)),
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1949,10 +1996,10 @@ impl Command for CoinsCommand {
         "Show all coins (transparent outputs) in this wallet"
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         // Parse the args.
         if args.len() > 1 {
-            return self.short_help().to_string();
+            return Ok(self.short_help().to_string());
         }
 
         // Make sure we can parse the amount
@@ -1960,21 +2007,21 @@ impl Command for CoinsCommand {
             match args[0] {
                 "all" => true,
                 a => {
-                    return format!(
+                    return Ok(format!(
                         "Invalid argument \"{a}\". Specify 'all' to include spent coins"
-                    );
+                    ));
                 }
             }
         } else {
             false
         };
 
-        RT.block_on(async move {
+        Ok(RT.block_on(async move {
             json::object! {
                 "transparent_coins" => json::JsonValue::from(lightclient.wallet().read().await.coin_summaries(all_coins)),
             }
             .pretty(2)
-        })
+        }))
     }
 }
 
@@ -1996,15 +2043,16 @@ impl Command for RemoveTransactionCommand {
         "Removes a failed transaction from the wallet with the given txid."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() != 1 {
-            return "Error: remove command expects 1 argument. Type \"help remove\" for usage."
-                .to_string();
+            return Err(CommandError::NotYetTyped(
+                "remove command expects 1 argument. Type \"help remove\" for usage.".to_string(),
+            ));
         }
 
         let txid = match txid_from_hex_encoded_str(args[0]) {
             Ok(txid) => txid,
-            Err(e) => return format!("Error: {e}"),
+            Err(e) => return Err(CommandError::NotYetTyped(e.to_string())),
         };
 
         RT.block_on(async move {
@@ -2014,8 +2062,8 @@ impl Command for RemoveTransactionCommand {
                 .await
                 .remove_failed_transaction(txid)
             {
-                Ok(()) => "Successfully removed failed transaction.".to_string(),
-                Err(e) => format!("Error: {e}"),
+                Ok(()) => Ok("Successfully removed failed transaction.".to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             }
         })
     }
@@ -2040,32 +2088,33 @@ impl Command for SaveCommand {
         "Launches a save task. Not intended to be called manually."
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         if args.len() != 1 {
-            return "Error: save command expects 1 argument. Type \"help save\" for usage."
-                .to_string();
+            return Err(CommandError::NotYetTyped(
+                "save command expects 1 argument. Type \"help save\" for usage.".to_string(),
+            ));
         }
 
         match args[0] {
             "run" => {
                 RT.block_on(async move { lightclient.save_task().await });
-                "Launching save task...".to_string()
+                Ok("Launching save task...".to_string())
             }
             "check" => match RT.block_on(async move { lightclient.check_save_error().await }) {
-                Ok(()) => String::new(),
-                Err(e) => {
-                    format!("Error: save failed. {e}\nRestarting save task...")
-                }
+                Ok(()) => Ok(String::new()),
+                Err(e) => Err(CommandError::NotYetTyped(format!(
+                    "save failed. {e}\nRestarting save task..."
+                ))),
             },
             "shutdown" => {
                 match RT.block_on(async move { lightclient.shutdown_save_task().await }) {
-                    Ok(()) => "Save task shutdown successfully.".to_string(),
-                    Err(e) => {
-                        format!("Error: save failed. {e}")
-                    }
+                    Ok(()) => Ok("Save task shutdown successfully.".to_string()),
+                    Err(e) => Err(CommandError::NotYetTyped(format!("save failed. {e}"))),
                 }
             }
-            _ => "Error: invalid sub-command. Type \"help save\" for usage.".to_string(),
+            _ => Err(CommandError::NotYetTyped(
+                "invalid sub-command. Type \"help save\" for usage.".to_string(),
+            )),
         }
     }
 }
@@ -2085,10 +2134,10 @@ impl Command for QuitCommand {
         "Quit the lightwallet, saving state to disk"
     }
 
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> String {
+    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         let save_shutdown = do_user_command("save", &["shutdown"], lightclient);
 
-        format!("{save_shutdown}\nZingo CLI quit successfully.")
+        Ok(format!("{save_shutdown}\nZingo CLI quit successfully."))
     }
 }
 
@@ -2112,7 +2161,7 @@ fn render_migration_phase(phase: &MigrationPhase) -> String {
 /// message is byte-identical to the in-band string it replaced, so no
 /// frontend observes the change.
 #[derive(Debug, thiserror::Error)]
-enum MigrationCommandError {
+pub enum MigrationCommandError {
     #[error("migrate command expects no arguments. Type \"help migrate\" for usage.")]
     UnexpectedArguments,
     #[error("migration command expects a sub-command. Type \"help migration\" for usage.")]
@@ -2209,8 +2258,8 @@ fn txids_json<T: ToString>(txids: &[T]) -> json::JsonValue {
         .into()
 }
 
-/// The migrate command's typed core; its `exec` renders errors at the
-/// single boundary site.
+/// The migrate command's typed core; its errors cross `exec` as
+/// [`CommandError::Migration`] and render at `do_user_command`.
 fn run_migrate(
     args: &[&str],
     lightclient: &mut LightClient,
@@ -2347,11 +2396,8 @@ impl Command for MigrateCommand {
         "Migrate all Orchard funds to the Ironwood pool in one interactive run"
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
-        match run_migrate(args, lightclient) {
-            Ok(rendered) => rendered,
-            Err(e) => format!("Error: {e}"),
-        }
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(run_migrate(args, lightclient)?)
     }
 }
 
@@ -2397,11 +2443,8 @@ impl Command for MigrationCommand {
         "Drive the scheduled Orchard to Ironwood migration"
     }
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> String {
-        match run_migration(args, lightclient) {
-            Ok(rendered) => rendered,
-            Err(e) => format!("Error: {e}"),
-        }
+    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(run_migration(args, lightclient)?)
     }
 }
 
@@ -2484,14 +2527,33 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
     all
 }
 
+/// Dispatches a user command by name to the appropriate [`Command`] implementation,
+/// exposing the typed success/failure crossing.
+///
+/// An unknown command returns its "Unknown command" prose via `Ok`, mirroring
+/// the string entry point's historical behavior of not treating it as an error.
+pub fn do_user_command_result(
+    cmd: &str,
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    match get_commands().get(cmd.to_ascii_lowercase().as_str()) {
+        Some(cmd) => cmd.exec(args, lightclient),
+        None => Ok(format!(
+            "Unknown command : {cmd}. Type 'help' for a list of commands"
+        )),
+    }
+}
+
 /// Dispatches a user command by name to the appropriate [`Command`] implementation.
 ///
 /// Returns the command's output string, or an "Unknown command" message
-/// if no command with the given name exists.
+/// if no command with the given name exists. This is the single site that
+/// renders [`CommandError`] to prose for string frontends.
 pub fn do_user_command(cmd: &str, args: &[&str], lightclient: &mut LightClient) -> String {
-    match get_commands().get(cmd.to_ascii_lowercase().as_str()) {
-        Some(cmd) => cmd.exec(args, lightclient),
-        None => format!("Unknown command : {cmd}. Type 'help' for a list of commands"),
+    match do_user_command_result(cmd, args, lightclient) {
+        Ok(output) => output,
+        Err(e) => format!("Error: {e}"),
     }
 }
 

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -75,7 +75,7 @@ zingo-status = { workspace = true }
 zingo_common_components = { workspace = true }
 zingo_test_vectors = { workspace = true, optional = true }
 zip32.workspace = true
-zaino-proto = { git = "https://github.com/zingolabs/zaino.git", rev = "2e2816cb3755e7ff4d18bed1a96b95dc07c1549c", version = "0.2.0", default-features = false, features = ["grpc_proxy_server"], optional = true }
+zaino-proto = { version = "0.2.0", default-features = false, features = ["grpc_proxy_server"], optional = true }
 tokio-stream = { workspace = true, optional = true }
 
 [build-dependencies]
@@ -88,7 +88,7 @@ proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio-stream.workspace = true
 tracing-subscriber = { workspace = true }
-zaino-proto = { git = "https://github.com/zingolabs/zaino.git", rev = "2e2816cb3755e7ff4d18bed1a96b95dc07c1549c", default-features = false, features = ["grpc_proxy_server"] }
+zaino-proto = { version = "0.2.0", default-features = false, features = ["grpc_proxy_server"] }
 zingo_test_vectors = { workspace = true }
 
 [badges]

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -25,6 +25,8 @@ use crate::lightclient::LightClient;
 use crate::lightclient::error::{LightClientError, MigrationError};
 use zcash_protocol::consensus::BlockHeight;
 
+use crate::wallet::LightWallet;
+use crate::wallet::error::WalletError;
 use crate::wallet::migration::{
     BroadcastClient, ChainView, ConsentBinding, DrainPlan, MigrationParams, MigrationPhase,
     MigrationPlan, MigrationState, PartId, PartState, PrepareResult, RecommendedAction,
@@ -686,8 +688,33 @@ impl LightClient {
             return Err(crate::wallet::error::WalletError::NothingToMigrate.into());
         }
 
+        let txids = self
+            .build_and_transmit(&plan.transactions, |wallet, planned| {
+                wallet.build_drain_transaction(account, planned)
+            })
+            .await?;
+
+        Ok(DrainSummary {
+            txids,
+            migrated: plan.migrated,
+            fee: plan.fee,
+            stranded: plan.stranded,
+        })
+    }
+
+    /// Builds and transmits one batch of planned migration transactions under
+    /// a paused sync, enforcing the shared cleanup contract: a build failure
+    /// fails the transactions already built, and a transmit failure fails
+    /// every transaction still unsent, so no note stays spent by a
+    /// transaction that will never reach the network. Both the drain flow and
+    /// the note-splitting rounds send through here.
+    async fn build_and_transmit<T>(
+        &mut self,
+        planned: &[T],
+        build: impl Fn(&mut LightWallet, &T) -> Result<TxId, WalletError>,
+    ) -> Result<Vec<TxId>, LightClientError> {
         let _ignore_error = self.pause_sync();
-        let built = self.build_drain_transactions(account, &plan).await;
+        let built = self.build_transactions(planned, build).await;
         let txids = match built {
             Ok(txids) => txids,
             Err(e) => {
@@ -698,7 +725,7 @@ impl LightClient {
 
         let transmitted = self
             .transmit_transactions(
-                NonEmpty::from_vec(txids.clone()).expect("a non-empty plan builds transactions"),
+                NonEmpty::from_vec(txids.clone()).expect("planned batches are never empty"),
             )
             .await;
         let _ignore_error = self.resume_sync();
@@ -707,32 +734,27 @@ impl LightClient {
             // `transmit_transactions` marks the transaction that failed, but
             // the ones queued behind it stay `Calculated`: their notes would
             // remain spent by transactions that will never reach the network.
-            // Fail them so the next call re-plans them.
-            self.fail_unsent_drain_transactions(&txids).await;
+            // Fail them so the next pass re-plans them.
+            self.fail_unsent_transactions(&txids).await;
             return Err(e);
         }
 
-        Ok(DrainSummary {
-            txids,
-            migrated: plan.migrated,
-            fee: plan.fee,
-            stranded: plan.stranded,
-        })
+        Ok(txids)
     }
 
-    /// Builds every transaction of a drain plan under one wallet lock. On
-    /// failure, fails the transactions already built so their notes do not stay
-    /// spent by transactions that will never be sent.
-    async fn build_drain_transactions(
+    /// Builds every planned transaction under one wallet lock. On failure,
+    /// fails the transactions already built so their notes do not stay spent
+    /// by transactions that will never be sent.
+    async fn build_transactions<T>(
         &mut self,
-        account: zip32::AccountId,
-        plan: &DrainPlan,
+        planned: &[T],
+        build: impl Fn(&mut LightWallet, &T) -> Result<TxId, WalletError>,
     ) -> Result<Vec<TxId>, LightClientError> {
         let mut wallet = self.wallet().write().await;
-        let mut txids = Vec::with_capacity(plan.transactions.len());
+        let mut txids = Vec::with_capacity(planned.len());
 
-        for planned in &plan.transactions {
-            match wallet.build_drain_transaction(account, planned) {
+        for item in planned {
+            match build(&mut wallet, item) {
                 Ok(txid) => txids.push(txid),
                 Err(e) => {
                     if !txids.is_empty() {
@@ -750,9 +772,9 @@ impl LightClient {
         Ok(txids)
     }
 
-    /// Marks every drain transaction still sitting in `Calculated` as failed,
+    /// Marks every transaction still sitting in `Calculated` as failed,
     /// releasing the notes it reserved.
-    async fn fail_unsent_drain_transactions(&mut self, txids: &[TxId]) {
+    async fn fail_unsent_transactions(&mut self, txids: &[TxId]) {
         let mut wallet = self.wallet().write().await;
         let unsent: Vec<TxId> = txids
             .iter()
@@ -885,22 +907,11 @@ impl LightClient {
                 .into_iter()
                 .next()
                 .expect("unsplit plan has at least one round");
-            let _ignore_error = self.pause_sync();
-            let mut round_txids = Vec::new();
-            for planned in &round {
-                round_txids.push(
-                    self.wallet()
-                        .write()
-                        .await
-                        .build_note_split_transaction(account, planned)?,
-                );
-            }
-            self.transmit_transactions(
-                NonEmpty::from_vec(round_txids.clone())
-                    .expect("note-splitting round has at least one transaction"),
-            )
-            .await?;
-            let _ignore_error = self.resume_sync();
+            let round_txids = self
+                .build_and_transmit(&round, |wallet, planned| {
+                    wallet.build_note_split_transaction(account, planned)
+                })
+                .await?;
             split_txids.extend(round_txids.iter().copied());
 
             self.await_migration_confirmations(&round_txids).await?;

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -962,10 +962,56 @@ mod tests {
     use crate::lightclient::LightClient;
     use crate::mocks::broadcast::MockBroadcastClient;
     use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+    use crate::wallet::LightWallet;
     use crate::wallet::migration::{
         BoundNote, ConsentBinding, MigrationParams, MigrationPhase, MigrationState, PartId,
         PartRecord, PartState, SigningStrategy, schedule,
     };
+
+    /// The value of the one fabricated note every scenario here binds a
+    /// migration part to.
+    const NOTE_VALUE: u64 = 100_000;
+
+    /// A synthetic wallet fully scanned through `tip`, holding one
+    /// [`NOTE_VALUE`] legacy-Orchard note, plus that note's binding for a
+    /// migration part.
+    fn wallet_with_migration_note(tip: u32) -> (LightWallet, BoundNote) {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .orchard_note(NOTE_VALUE)
+            .tip(tip)
+            .build();
+        let bound_note = wallet
+            .wallet_transactions
+            .values()
+            .flat_map(OrchardNote::transaction_outputs)
+            .find(|note| note.value() == NOTE_VALUE)
+            .map(|note| BoundNote {
+                output_id: note.output_id(),
+                nullifier: note
+                    .nullifier()
+                    .expect("scanned notes carry nullifiers")
+                    .to_bytes(),
+                commitment: [0; 32],
+            })
+            .expect("the wallet holds the fabricated note");
+        (wallet, bound_note)
+    }
+
+    /// A consented, parts-scheduled migration state over `parts`.
+    fn scheduled_state(params: MigrationParams, parts: Vec<PartRecord>) -> MigrationState {
+        MigrationState {
+            consent: ConsentBinding {
+                params_hash: params.params_hash(),
+                plan_hash: [0; 32],
+                consented_at: 0,
+            },
+            params,
+            strategy: SigningStrategy::LazyAtBoundary,
+            account: AccountId::ZERO,
+            phase: MigrationPhase::PartsScheduled,
+            parts,
+        }
+    }
 
     /// Offline twin of the libtonode
     /// `unavailable_boundary_tree_state_skips_without_sync` scenario: a due
@@ -988,27 +1034,7 @@ mod tests {
         // pepper-sync's 100-block checkpoint retention.
         const TIP: u32 = 360;
 
-        let mut wallet =
-            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
-                .orchard_note(100_000)
-                .tip(TIP)
-                .build();
-
-        let (output_id, nullifier) = wallet
-            .wallet_transactions
-            .values()
-            .flat_map(OrchardNote::transaction_outputs)
-            .find(|note| note.value() == 100_000)
-            .map(|note| {
-                (
-                    note.output_id(),
-                    note.nullifier()
-                        .expect("scanned notes carry nullifiers")
-                        .to_bytes(),
-                )
-            })
-            .expect("the wallet holds the 100_000 note");
-
+        let (mut wallet, bound_note) = wallet_with_migration_note(TIP);
         let params = MigrationParams::provisional(wallet.chain_type());
         let known_height = wallet
             .sync_state
@@ -1020,28 +1046,9 @@ mod tests {
             "the tip must sit past a bucket boundary"
         );
 
-        let mut part = PartRecord::new(
-            PartId(0),
-            100_000,
-            BoundNote {
-                output_id,
-                nullifier,
-                commitment: [0; 32],
-            },
-        );
+        let mut part = PartRecord::new(PartId(0), NOTE_VALUE, bound_note);
         part.assign(current_bucket).expect("fresh parts are bound");
-        wallet.migration = Some(MigrationState {
-            consent: ConsentBinding {
-                params_hash: params.params_hash(),
-                plan_hash: [0; 32],
-                consented_at: 0,
-            },
-            params,
-            strategy: SigningStrategy::LazyAtBoundary,
-            account: AccountId::ZERO,
-            phase: MigrationPhase::PartsScheduled,
-            parts: vec![part],
-        });
+        wallet.migration = Some(scheduled_state(params, vec![part]));
         let mut client = LightClient::new_for_test(wallet).await;
 
         let broadcast_client = MockBroadcastClient::default();
@@ -1065,5 +1072,90 @@ mod tests {
             Some(known_height),
             "the skip must not move the wallet's known height"
         );
+    }
+
+    /// Open windows at relaunch: a part whose bucket window is *currently
+    /// open* (opened before now, not yet closed) is reachable immediately
+    /// after a process relaunch, without waiting to become Overdue.
+    /// `next_wakes` lists only future buckets and `reconcile` classifies the
+    /// open window as OnTrack with no action; the open window belongs to the
+    /// third leg, `broadcast_due_parts` (driven at startup or after sync by
+    /// `auto_broadcast_if_due`), whose due predicate selects
+    /// `bucket_index == current_bucket`.
+    #[tokio::test]
+    async fn open_window_part_is_broadcast_at_relaunch() {
+        use zcash_primitives::transaction::TxId;
+
+        use crate::wallet::migration::{PartClass, next_wakes, reconcile};
+
+        // Tip 300 sits mid-window in bucket 1 of the provisional M = 256:
+        // the window [256, 512) opened before "now" and has not closed.
+        const TIP: u32 = 300;
+
+        let (mut wallet, bound_note) = wallet_with_migration_note(TIP);
+        let params = MigrationParams::provisional(wallet.chain_type());
+        let now_height = wallet
+            .sync_state
+            .last_known_chain_height()
+            .expect("the synthetic wallet is fully synced");
+        let current_bucket = schedule::bucket_index(now_height, params.bucket_modulus);
+        let window_start = schedule::boundary_of(current_bucket, params.bucket_modulus);
+        let window_end = schedule::boundary_of(current_bucket + 1, params.bucket_modulus);
+        assert!(
+            window_start < now_height && now_height < window_end,
+            "the part's window must be open at relaunch"
+        );
+
+        // The part was signed in a previous session; the relaunch sees only
+        // this persisted record.
+        let own_txid = TxId::from_bytes([7; 32]);
+        let signed_blob = vec![0xAB; 64];
+        let mut part = PartRecord::new(PartId(0), NOTE_VALUE, bound_note);
+        part.assign(current_bucket).expect("fresh parts are bound");
+        part.mark_signed(own_txid, window_end, Some(signed_blob.clone()))
+            .expect("assigned parts sign");
+        wallet.migration = Some(scheduled_state(params.clone(), vec![part]));
+
+        // The two true premises of #2419 review finding 5: the wake listing
+        // omits the open window and reconciliation classifies it OnTrack
+        // with no action.
+        {
+            let state = wallet.migration.as_ref().expect("just set");
+            assert!(
+                next_wakes(&state.parts, now_height, 0, u64::MAX, &params).is_empty(),
+                "next_wakes lists future buckets only"
+            );
+            let report = reconcile(state, &wallet);
+            assert_eq!(report.assessments[0].class, PartClass::OnTrack);
+            assert!(report.actions.is_empty());
+        }
+
+        // The finding's conclusion is nevertheless false: the due-part
+        // broadcast path covers the open window at relaunch.
+        let mut client = LightClient::new_for_test(wallet).await;
+        let broadcast_client = MockBroadcastClient::default();
+        let sent = client
+            .broadcast_due_parts_with(&broadcast_client)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            sent,
+            vec![own_txid],
+            "the open-window part broadcasts now instead of slipping to Overdue"
+        );
+        {
+            let submissions = broadcast_client.submissions.lock().unwrap();
+            assert_eq!(submissions.len(), 1, "the endpoint received the part");
+            assert_eq!(
+                submissions[0].0, signed_blob,
+                "the persisted blob was submitted"
+            );
+        }
+
+        let wallet = client.wallet().read().await;
+        let part = &wallet.migration.as_ref().unwrap().parts[0];
+        assert_eq!(part.state, PartState::Broadcast);
+        assert_eq!(part.attempts, 1, "the attempt was recorded before submit");
     }
 }

--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -959,3 +959,116 @@ async fn send_survives_lost_response_and_queued_duplicate_rejection() {
     recipient.sync_and_await().await.unwrap();
     check_client_balances!(recipient, i: 70_000 o: 0 s: 0 t: 0);
 }
+
+/// A failed transmit inside a note-splitting round must not leave any
+/// transaction stranded in `Calculated`. The drain sibling
+/// (`drain_orchard_to_ironwood`) fails every unsent transaction so the
+/// notes it reserved become spendable again; the split round in
+/// `migrate_to_ironwood` must enforce the same invariant, or the
+/// transactions queued behind the failing one keep their notes marked
+/// spent by transactions that never reached the network, and a replan
+/// silently excludes that value until expiry self-heals it (~40 blocks
+/// plus a sync).
+///
+/// Setup: 34 fabricated legacy-Orchard (V2) notes make the provisional
+/// planner (max_actions_per_split_tx = 32) emit a first reduction round of
+/// TWO merge transactions. The mock indexer's lost-response fault plus an
+/// effectively-infinite download-queue rejection budget makes the FIRST
+/// submission fail deterministically after the wallet's probe budget; the
+/// second transaction must not stay stranded.
+#[tokio::test]
+async fn failed_split_round_transmit_strands_calculated_transactions() {
+    use zcash_primitives::transaction::TxId;
+    use zip32::AccountId;
+
+    use pepper_sync::wallet::{OrchardNote, OutputInterface as _};
+    use zingo_status::confirmation_status::ConfirmationStatus;
+
+    use crate::testutils::mock_indexer::LostSendDestination;
+    use crate::testutils::synthetic_wallet::inject_confirmed_orchard_notes;
+
+    const NOTES: u32 = 34;
+    const NOTE_VALUE: u64 = 60_000;
+    const TIP: u32 = 41;
+
+    // A real mock-net client, synced over an empty chain so the wallet
+    // carries genuine wallet blocks and scan state, then handed 34
+    // spendable legacy-Orchard notes whose nullifiers are really derived,
+    // so pepper-sync's spend detection marks them when the round spends
+    // them.
+    let mut net = MockNet::launch().await;
+    net.chain.write().await.mine_empty_blocks(TIP);
+    let mut client = net
+        .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+        .await;
+    client
+        .sync_and_await()
+        .await
+        .expect("initial sync succeeds");
+    {
+        let wallet_lock = client.wallet().clone();
+        let mut wallet = wallet_lock.write().await;
+        inject_confirmed_orchard_notes(&mut wallet, NOTES, NOTE_VALUE, TIP);
+    }
+
+    // Arm the deterministic transmit failure: the first send's response is
+    // lost while the bytes sit in the validator's download queue, and the
+    // queue never promotes, so every duplicate probe is rejected until the
+    // wallet's probe budget is exhausted and it marks that transaction
+    // Failed and errors out of transmit_transactions.
+    {
+        let mut chain = net.chain.write().await;
+        chain.lose_next_send_response = Some(LostSendDestination::DownloadQueue);
+        chain.queued_rejections_before_promotion = u8::MAX;
+    }
+
+    let err = client
+        .migrate_to_ironwood(AccountId::ZERO)
+        .await
+        .expect_err("the first split transaction's transmit fails");
+    eprintln!("migrate_to_ironwood returned: {err:?}");
+
+    // Diagnostics and precondition: the round must have reached the
+    // transmit stage (exactly one transaction Failed there).
+    let wallet = client.wallet().read().await;
+    let mut failed = Vec::new();
+    let mut calculated = Vec::new();
+    for tx in wallet.wallet_transactions.values() {
+        match tx.status() {
+            ConfirmationStatus::Calculated(_) => {
+                let spent_inputs: Vec<(TxId, u64)> = wallet
+                    .wallet_transactions
+                    .values()
+                    .flat_map(OrchardNote::transaction_outputs)
+                    .filter(|note| note.spending_transaction() == Some(tx.txid()))
+                    .map(|note| (note.output_id().txid(), note.value()))
+                    .collect();
+                eprintln!(
+                    "stranded Calculated transaction {} spends {} notes still \
+                     marked spent: {spent_inputs:?}",
+                    tx.txid(),
+                    spent_inputs.len(),
+                );
+                calculated.push(tx.txid());
+            }
+            ConfirmationStatus::Failed(_) => failed.push(tx.txid()),
+            _ => (),
+        }
+    }
+    assert!(
+        !failed.is_empty(),
+        "precondition: the transmit stage must have failed the first split \
+         transaction (otherwise this test failed before transmit)"
+    );
+
+    // The invariant the drain path enforces (fail_unsent_transactions) and
+    // the split path must too: after a failed round, nothing may remain
+    // Calculated — its notes would stay spent by transactions that will
+    // never broadcast, and a replan silently excludes them.
+    assert!(
+        calculated.is_empty(),
+        "a failed note-split round stranded {} transaction(s) in Calculated \
+         with their input notes marked spent: {calculated:?}",
+        calculated.len()
+    );
+}

--- a/zingolib/src/testutils/synthetic_wallet.rs
+++ b/zingolib/src/testutils/synthetic_wallet.rs
@@ -355,3 +355,80 @@ impl SyntheticWalletBuilder {
         wallet
     }
 }
+
+/// Injects `count` confirmed, unspent legacy-Orchard (V2) notes of `value`
+/// zatoshis into an already-synced wallet, replacing the orchard anchor
+/// checkpoint at `tip` so it covers the appended leaves.
+///
+/// The builder above fabricates whole wallets and assigns fabricated
+/// nullifiers, which proposing never checks. This sibling serves tests that
+/// drive pepper-sync's spend bookkeeping on a mock net: each nullifier is
+/// derived from the wallet's own orchard key, so a transaction that later
+/// spends one of these notes is matched by nullifier and the note is marked
+/// spent.
+pub fn inject_confirmed_orchard_notes(wallet: &mut LightWallet, count: u32, value: u64, tip: u32) {
+    let orchard_fvk: orchard::keys::FullViewingKey = wallet
+        .unified_key_store
+        .get(&zip32::AccountId::ZERO)
+        .expect("account zero exists")
+        .try_into()
+        .expect("mnemonic wallets carry an orchard key");
+    let recipient = orchard_fvk.address_at(0u32, zip32::Scope::External);
+
+    for index in 0..count {
+        // The same txid range the builder uses for orchard notes, clear of
+        // its ironwood (1..) and sapling (0x80..) ranges.
+        let txid = TxId::from_bytes([0x40 + u8::try_from(index).expect("small note corpus"); 32]);
+        let crypto_note = OrchardCryptoNoteBuilder::default()
+            .recipient(recipient)
+            .value(NoteValue::from_raw(value))
+            .note_version(orchard::NoteVersion::V2)
+            .build();
+        wallet
+            .shard_trees
+            .orchard
+            .append(
+                MerkleHashOrchard::from_cmx(&crypto_note.commitment().into()),
+                Retention::Marked,
+            )
+            .expect("appending to the in-memory orchard tree succeeds");
+        let nullifier = crypto_note.nullifier(&orchard_fvk);
+        let note = OrchardNote::new_for_test(
+            OutputId::new(txid, 0),
+            zip32::AccountId::ZERO,
+            zip32::Scope::External,
+            crypto_note,
+            Memo::Empty,
+            Some(Position::from(u64::from(index))),
+        )
+        .with_nullifier_for_test(nullifier);
+        wallet.wallet_transactions.insert(
+            txid,
+            WalletTransaction::new_for_test_with_orchard_notes(
+                txid,
+                ConfirmationStatus::Confirmed(BlockHeight::from_u32(2 + index)),
+                vec![note],
+                vec![],
+            ),
+        );
+    }
+
+    // The synced checkpoint at the tip predates the appended leaves; replace
+    // it so the anchor covers them.
+    let tip = BlockHeight::from_u32(tip);
+    wallet
+        .shard_trees
+        .orchard
+        .store_mut()
+        .remove_checkpoint(&tip)
+        .expect("infallible on the memory store");
+    wallet
+        .shard_trees
+        .orchard
+        .store_mut()
+        .add_checkpoint(
+            tip,
+            Checkpoint::at_position(Position::from(u64::from(count) - 1)),
+        )
+        .expect("infallible on the memory store");
+}

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -110,6 +110,9 @@ pub enum WalletError {
         "Cannot create a new wallet: a wallet file already exists at this path. Use WalletConfig::Read to load the existing wallet."
     )]
     WalletAlreadyCreated,
+    /// All-funds note selection (`TargetValue::AllFunds`) is not implemented.
+    #[error("All-funds note selection is not supported.")]
+    AllFundsSelectionUnsupported,
 }
 
 /// Price error

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -96,6 +96,13 @@ pub enum WalletError {
     /// worth more than it would cost to spend.
     #[error("No spendable Orchard notes to migrate.")]
     NothingToMigrate,
+    /// `TargetValue::AllFunds(MaxSpendMode::Everything)` was requested. Its
+    /// contract — fail if ANY unspendable funds exist — requires a
+    /// whole-wallet audit this selector does not yet perform, and a wrong
+    /// success would silently strand funds, so the request is refused with
+    /// this typed error instead.
+    #[error("AllFunds(Everything) is not supported: the unspendable-funds audit is unimplemented.")]
+    AllFundsEverythingUnsupported,
     /// Conversion failed
     // TODO: move to lightclient?
     #[error("Conversion failed. {0}")]

--- a/zingolib/src/wallet/migration/reconcile.rs
+++ b/zingolib/src/wallet/migration/reconcile.rs
@@ -329,9 +329,13 @@ impl ChainView for crate::wallet::LightWallet {
     }
 
     fn transaction_failed(&self, txid: &TxId) -> bool {
+        // An absent record is *unknown*, not failed: after a restore from
+        // backup an in-flight split transaction has no wallet record yet may
+        // still confirm. Reporting it failed would retry the split and race
+        // the original.
         self.wallet_transactions
             .get(txid)
-            .is_none_or(|transaction| transaction.status().is_failed())
+            .is_some_and(|transaction| transaction.status().is_failed())
     }
 
     fn orchard_confirmed_spendable(&self, account: zip32::AccountId) -> u64 {
@@ -626,6 +630,43 @@ mod tests {
         assert_eq!(
             report.actions,
             vec![RecommendedAction::ContinueNoteSplitting]
+        );
+    }
+
+    /// After a restore from backup the wallet's transaction map no longer
+    /// contains an in-flight split transaction, but the persisted migration
+    /// state still names it in `pending_txids`. An unknown txid is not
+    /// *recorded as failed* (the `ChainView::transaction_failed` contract),
+    /// so reconciliation must keep waiting rather than retry the split and
+    /// race its own in-flight transaction. This exercises the real
+    /// `LightWallet` implementation, not `MockChainView`.
+    #[test]
+    fn unknown_txid_after_restore_is_not_classified_failed() {
+        use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+        let wallet =
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED).build();
+
+        let in_flight_txid = TxId::from_bytes([42; 32]);
+        assert!(!wallet.wallet_transactions.contains_key(&in_flight_txid));
+
+        // Contract-level assertion: an unknown transaction is not failed.
+        assert!(
+            !wallet.transaction_failed(&in_flight_txid),
+            "an unknown txid must not be reported as failed",
+        );
+
+        // Behavior-level assertion: reconciliation awaits confirmation
+        // instead of recommending a retry that races the in-flight split.
+        let mut state = scheduled_state(Vec::new());
+        state.phase = MigrationPhase::NoteSplitting {
+            round: 0,
+            pending_txids: vec![in_flight_txid],
+        };
+        let report = reconcile(&state, &wallet);
+        assert_eq!(
+            report.actions,
+            vec![RecommendedAction::AwaitSplitConfirmation],
         );
     }
 }

--- a/zingolib/src/wallet/migration/store.rs
+++ b/zingolib/src/wallet/migration/store.rs
@@ -88,7 +88,13 @@ pub fn read<R: Read>(mut reader: R) -> io::Result<MigrationState> {
     let bucket_modulus = reader.read_u32::<LittleEndian>()?;
     let k_max = reader.read_u32::<LittleEndian>()?;
     let target_sessions = reader.read_u32::<LittleEndian>()?;
-    let max_actions_per_split_tx = reader.read_u64::<LittleEndian>()? as usize;
+    let max_actions_per_split_tx =
+        usize::try_from(reader.read_u64::<LittleEndian>()?).map_err(|_| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "max_actions_per_split_tx does not fit in this platform's usize",
+            )
+        })?;
     let expiry_delta = reader.read_u32::<LittleEndian>()?;
     let part_fee = reader.read_u64::<LittleEndian>()?;
     let params = MigrationParams {
@@ -471,9 +477,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unknown_inner_version_is_rejected() {
-        let state = MigrationState {
+    /// A freshly planned mainnet state, the smallest well-formed fixture.
+    fn planned_state() -> MigrationState {
+        MigrationState {
             params: MigrationParams::provisional(crate::config::ChainType::Mainnet),
             consent: ConsentBinding {
                 params_hash: [0; 32],
@@ -484,10 +490,50 @@ mod tests {
             account: zip32::AccountId::ZERO,
             phase: MigrationPhase::Planned,
             parts: Vec::new(),
-        };
+        }
+    }
+
+    #[test]
+    fn unknown_inner_version_is_rejected() {
         let mut bytes = Vec::new();
-        write(&mut bytes, &state).expect("writes");
+        write(&mut bytes, &planned_state()).expect("writes");
         bytes[0] = INNER_VERSION + 1;
         assert!(read(bytes.as_slice()).is_err());
+    }
+
+    /// The `as usize` cast reading `max_actions_per_split_tx` silently
+    /// truncates on 32-bit targets. This test patches a serialized stream so
+    /// the persisted value exceeds `u32::MAX`: the read must either reject
+    /// the stream (the desired `usize::try_from` + `InvalidData` behavior)
+    /// or preserve the value. It passes vacuously on 64-bit hosts; run under
+    /// a 32-bit target (e.g. i686-unknown-linux-gnu) to observe the failure.
+    #[test]
+    fn max_actions_read_never_silently_truncates() {
+        const SENTINEL: u64 = 0x1122_3344;
+        const PATCHED: u64 = 0x1_1122_3344; // does not fit in u32
+
+        let mut state = planned_state();
+        state.params.max_actions_per_split_tx = SENTINEL as usize;
+
+        let mut bytes = Vec::new();
+        write(&mut bytes, &state).expect("writes");
+
+        // Locate the sentinel's unique little-endian encoding and set a high
+        // byte, producing the stream a 64-bit writer (or corruption) would
+        // carry.
+        let needle = SENTINEL.to_le_bytes();
+        let position = bytes
+            .windows(8)
+            .position(|window| window == needle)
+            .expect("sentinel is unique in the fixture");
+        bytes[position..position + 8].copy_from_slice(&PATCHED.to_le_bytes());
+
+        match read(bytes.as_slice()) {
+            Err(error) => assert_eq!(error.kind(), ErrorKind::InvalidData),
+            Ok(read_state) => assert_eq!(
+                read_state.params.max_actions_per_split_tx as u64, PATCHED,
+                "read silently truncated the persisted value"
+            ),
+        }
     }
 }

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -882,7 +882,10 @@ impl InputSource for LightWallet {
                     )
                 }
                 TargetValue::AllFunds(_max_spend_mode) => {
-                    panic!("TargetValue::Allfunds not currently supported!");
+                    // Upstream drives this arm through propose_send_max; an
+                    // unsupported mode must surface through the trait's error
+                    // channel, never abort the process.
+                    return Err(WalletError::AllFundsSelectionUnsupported);
                 }
             };
 
@@ -1100,5 +1103,46 @@ impl InputSource for LightWallet {
         _exclude: &[Self::NoteRef],
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_client_backend::data_api::MaxSpendMode;
+
+    use super::*;
+    use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+    /// `InputSource::select_spendable_notes` is driven by upstream
+    /// `zcash_client_backend` (`propose_send_max`) with
+    /// `TargetValue::AllFunds`. An unsupported request must surface
+    /// through the trait's error channel (`Result<_, WalletError>`),
+    /// never abort the process.
+    #[test]
+    fn select_spendable_notes_all_funds_returns_err_not_panic() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .sapling_note(100_000)
+            .orchard_note(100_000)
+            .ironwood_note(100_000)
+            .build();
+
+        let result = wallet.select_spendable_notes(
+            zip32::AccountId::ZERO,
+            TargetValue::AllFunds(MaxSpendMode::MaxSpendable),
+            &[
+                ShieldedPool::Sapling,
+                ShieldedPool::Orchard,
+                ShieldedPool::Ironwood,
+            ],
+            BlockHeight::from_u32(21).into(),
+            ConfirmationsPolicy::MIN,
+            &[],
+        );
+
+        assert!(
+            result.is_err(),
+            "TargetValue::AllFunds is unsupported: that must be reported \
+             through the trait's error channel, not a panic; got {result:?}"
+        );
     }
 }

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -971,10 +971,11 @@ impl InputSource for LightWallet {
                 ReceivedNote::from_parts(
                     OutputRef::new(
                         OutputId::new(note.output_id().txid(), note.output_id().output_index()),
-                        // Label V3 notes as ORCHARD in the OutputRef: upstream detects Ironwood inputs
-                        // by note.version() == V3, not by the pool label. Labeling IRONWOOD here
-                        // confuses the proposal engine's pool-involvement accounting.
-                        // FIXME: is this comment still relevant? should we change to ORCHARD?
+                        // The label must match the ReceivedNotes vector this
+                        // note is returned in. Upstream never reads it, but it
+                        // round-trips through the `exclude` split at the top of
+                        // select_spendable_notes when the input selector prunes
+                        // dust, and that split routes each ref by pool_type().
                         PoolType::IRONWOOD,
                     ),
                     note.output_id().txid(),
@@ -1109,6 +1110,7 @@ impl InputSource for LightWallet {
 #[cfg(test)]
 mod tests {
     use zcash_client_backend::data_api::MaxSpendMode;
+    use zcash_protocol::value::Zatoshis;
 
     use super::*;
     use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
@@ -1143,6 +1145,92 @@ mod tests {
             result.is_err(),
             "TargetValue::AllFunds is unsupported: that must be reported \
              through the trait's error channel, not a panic; got {result:?}"
+        );
+    }
+
+    /// Pins the resolution of the FIXME at the `PoolType::IRONWOOD` label in
+    /// `InputSource::select_spendable_notes`: the code is right and the comment
+    /// above it is stale.
+    ///
+    /// The `OutputRef` pool label is never read by the upstream proposal
+    /// engine — pool-involvement accounting, bundle attribution, and fee
+    /// calculation all dispatch on the embedded `Note` enum (stamped by
+    /// `ReceivedNotes::into_vec` from the vector the note occupies), not on
+    /// the `NoteRef`. The label's one consumer is this wallet's own `exclude`
+    /// split at the top of `select_spendable_notes`: upstream's
+    /// `GreedyInputSelector` hands previously selected refs back verbatim as
+    /// `exclude` when the change strategy reports `ChangeError::DustInputs`,
+    /// and the split routes each ref to a pool bucket by `pool_type()`. An
+    /// ironwood note labeled `ORCHARD` (as the stale comment mandates) would
+    /// land in the orchard bucket, never be excluded from ironwood selection,
+    /// and be re-selected forever — the selector would then abort with
+    /// `InsufficientFunds` instead of pruning the dust.
+    #[test]
+    fn ironwood_noteref_pool_label_round_trips_through_exclude() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .ironwood_note(100_000)
+            .ironwood_note(100_000)
+            .build();
+
+        let confirmations_policy =
+            ConfirmationsPolicy::new_symmetrical(1.try_into().expect("nonzero"), false);
+        let target_height = TargetHeight::from(BlockHeight::from_u32(21));
+        let sources = [
+            ShieldedPool::Ironwood,
+            ShieldedPool::Orchard,
+            ShieldedPool::Sapling,
+        ];
+
+        // Phase 1: selection over ironwood-only funds labels every selected
+        // ref IRONWOOD, matching the vector (and hence the Note-enum pool)
+        // the note is returned in.
+        let selected = wallet
+            .select_spendable_notes(
+                zip32::AccountId::ZERO,
+                TargetValue::AtLeast(Zatoshis::const_from_u64(150_000)),
+                &sources,
+                target_height,
+                confirmations_policy,
+                &[],
+            )
+            .expect("selection over synthetic funds succeeds");
+        assert_eq!(
+            selected.ironwood().len(),
+            2,
+            "both fabricated ironwood notes are selected"
+        );
+        let refs: Vec<_> = selected
+            .ironwood()
+            .iter()
+            .map(|note| *note.internal_note_id())
+            .collect();
+        for output_ref in &refs {
+            assert_eq!(
+                output_ref.pool_type(),
+                PoolType::IRONWOOD,
+                "an ironwood note's ref must carry the IRONWOOD label so the \
+                 exclude split routes it back to the ironwood bucket"
+            );
+        }
+
+        // Phase 2: the refs round-trip through `exclude` exactly as the
+        // greedy input selector's dust-pruning path replays them. Correctly
+        // labeled refs suppress re-selection; ORCHARD-labeled refs would fall
+        // into the wrong bucket and the same notes would come back.
+        let reselected = wallet
+            .select_spendable_notes(
+                zip32::AccountId::ZERO,
+                TargetValue::AtLeast(Zatoshis::const_from_u64(150_000)),
+                &sources,
+                target_height,
+                confirmations_policy,
+                &refs,
+            )
+            .expect("selection with exclusions succeeds");
+        assert!(
+            reselected.ironwood().is_empty(),
+            "excluded ironwood refs must not be re-selected; re-selection \
+             means the exclude split routed them to the wrong pool bucket"
         );
     }
 }

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -1102,3 +1102,92 @@ impl InputSource for LightWallet {
         unimplemented!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! The TDD pair for the `TargetValue::AllFunds` contract. These tests
+    //! began red: the `AllFunds` match arm was a `panic!`, so a request
+    //! any upstream sweep proposal can legitimately make took down the
+    //! whole process. They pin the replacement contract: `MaxSpendable`
+    //! selects every spend-worthy note, and `Everything` refuses with the
+    //! wallet's typed error until its unspendable-funds audit exists.
+
+    use zcash_client_backend::data_api::MaxSpendMode;
+
+    use super::*;
+    use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+    use crate::wallet::LightWallet;
+    use crate::wallet::error::WalletError;
+
+    /// One spendable note per shielded pool, plus an orchard note at the
+    /// dust line (`MARGINAL_FEE`) that budgeted selection would also
+    /// refuse to spend.
+    fn funded_wallet() -> LightWallet {
+        SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .tip(20)
+            .sapling_note(50_000)
+            .orchard_note(100_000)
+            .ironwood_note(70_000)
+            .orchard_note(5_000)
+            .build()
+    }
+
+    fn select_all_funds(
+        wallet: &LightWallet,
+        mode: MaxSpendMode,
+    ) -> Result<ReceivedNotes<OutputRef>, WalletError> {
+        wallet.select_spendable_notes(
+            zip32::AccountId::ZERO,
+            TargetValue::AllFunds(mode),
+            &[
+                ShieldedPool::Ironwood,
+                ShieldedPool::Orchard,
+                ShieldedPool::Sapling,
+            ],
+            TargetHeight::from(21),
+            ConfirmationsPolicy::new_symmetrical(NonZeroU32::new(1).expect("nonzero"), false),
+            &[],
+        )
+    }
+
+    #[test]
+    fn all_funds_max_spendable_selects_every_spend_worthy_note() {
+        let notes = select_all_funds(&funded_wallet(), MaxSpendMode::MaxSpendable)
+            .expect("all-funds selection must succeed on a funded, synced wallet");
+        assert_eq!(notes.sapling().len(), 1);
+        assert_eq!(
+            notes.orchard().len(),
+            1,
+            "the dust orchard note must be left behind"
+        );
+        assert_eq!(notes.ironwood().len(), 1);
+        let total: u64 = notes
+            .sapling()
+            .iter()
+            .map(|note| note.note().value().inner())
+            .chain(
+                notes
+                    .orchard()
+                    .iter()
+                    .map(|note| note.note().value().inner()),
+            )
+            .chain(
+                notes
+                    .ironwood()
+                    .iter()
+                    .map(|note| note.note().value().inner()),
+            )
+            .sum();
+        assert_eq!(total, 220_000);
+    }
+
+    #[test]
+    fn all_funds_everything_is_a_typed_error_not_an_abort() {
+        let error = select_all_funds(&funded_wallet(), MaxSpendMode::Everything)
+            .expect_err("Everything mode is unimplemented and must refuse, not abort");
+        assert!(
+            matches!(error, WalletError::AllFundsEverythingUnsupported),
+            "the refusal must be the dedicated typed error, observed: {error}"
+        );
+    }
+}

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -6,7 +6,7 @@ use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
         Account, AccountBirthday, AccountPurpose, Balance, BlockMetadata, CoinbaseFilter,
-        InputSource, NullifierQuery, ORCHARD_SHARD_HEIGHT, ReceivedNotes,
+        InputSource, MaxSpendMode, NullifierQuery, ORCHARD_SHARD_HEIGHT, ReceivedNotes,
         ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, TargetValue, TransactionDataRequest,
         TransparentKeyOrigin, WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite,
         Zip32Derivation,
@@ -19,7 +19,7 @@ use zcash_client_backend::{
 use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
 use zcash_primitives::{
     block::BlockHash,
-    transaction::{Transaction, TxId},
+    transaction::{Transaction, TxId, fees::zip317::MARGINAL_FEE},
 };
 use zcash_protocol::{
     PoolType, ShieldedPool,
@@ -881,8 +881,51 @@ impl InputSource for LightWallet {
                         selected_ironwood_notes,
                     )
                 }
-                TargetValue::AllFunds(_max_spend_mode) => {
-                    panic!("TargetValue::Allfunds not currently supported!");
+                TargetValue::AllFunds(max_spend_mode) => {
+                    // Effects at the edge: gather the spendable candidates
+                    // per pool (strict, guaranteed-unspent view), then let
+                    // the pure selection decide. All pools participate
+                    // regardless of `sources` order, matching budgeted
+                    // selection's unconditional fallback, and
+                    // migration-reserved notes are included: all funds
+                    // means all (the reservation biases selection, never
+                    // blocks a spend).
+                    let sapling_candidates = self
+                        .spendable_notes::<SaplingNote>(
+                            anchor_height,
+                            &exclude_sapling,
+                            account,
+                            false,
+                        )?
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    let orchard_candidates = self
+                        .spendable_notes::<OrchardNote>(
+                            anchor_height,
+                            &exclude_orchard,
+                            account,
+                            false,
+                        )?
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    let ironwood_candidates = self
+                        .spendable_notes::<IronwoodNote>(
+                            anchor_height,
+                            &exclude_ironwood,
+                            account,
+                            false,
+                        )?
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    all_funds_selection(
+                        max_spend_mode,
+                        sapling_candidates,
+                        orchard_candidates,
+                        ironwood_candidates,
+                    )?
                 }
             };
 
@@ -1101,6 +1144,49 @@ impl InputSource for LightWallet {
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         unimplemented!()
     }
+}
+
+/// The per-pool selection triple `select_spendable_notes` assembles
+/// before mapping into [`ReceivedNotes`].
+type SelectedPoolNotes = (Vec<SaplingNote>, Vec<OrchardNote>, Vec<IronwoodNote>);
+
+/// Pure all-funds selection over already-gathered spendable candidates:
+/// no wallet access, no mutation — the same candidates and mode always
+/// produce the same selection, so the policy is testable without a
+/// wallet.
+///
+/// `MaxSpendable` keeps every candidate worth more than the marginal
+/// fee, the same dust discipline as budgeted selection: a note at or
+/// below [`MARGINAL_FEE`] costs more to spend than it contributes.
+///
+/// `Everything` is refused with a typed error: its contract — fail if
+/// ANY unspendable funds exist — requires a whole-wallet audit this
+/// selector does not yet perform, and a wrong success would silently
+/// strand funds. The typed refusal replaces a panic that aborted the
+/// process.
+fn all_funds_selection(
+    mode: MaxSpendMode,
+    sapling: Vec<SaplingNote>,
+    orchard: Vec<OrchardNote>,
+    ironwood: Vec<IronwoodNote>,
+) -> Result<SelectedPoolNotes, WalletError> {
+    match mode {
+        MaxSpendMode::MaxSpendable => Ok((
+            retain_spend_worthy(sapling),
+            retain_spend_worthy(orchard),
+            retain_spend_worthy(ironwood),
+        )),
+        MaxSpendMode::Everything => Err(WalletError::AllFundsEverythingUnsupported),
+    }
+}
+
+/// Pure dust filter: keeps the notes whose value exceeds the marginal
+/// fee.
+fn retain_spend_worthy<N: OutputInterface>(notes: Vec<N>) -> Vec<N> {
+    notes
+        .into_iter()
+        .filter(|note| note.value() > MARGINAL_FEE.into_u64())
+        .collect()
 }
 
 #[cfg(test)]

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -180,9 +180,6 @@ pub const POST_STREAM_BLOCK_REWARD: u64 = block_rewards::CANOPY - DEFERRED_STREA
 /// spendable balance predictable for test assertions.
 pub const FUND_OFFLOAD_AMOUNT: u64 = 624_960_000;
 
-/// Amount sent from orchard mining rewards to ironwood after nu6.3 activation.
-pub const IRONWOOD_MIGRATION_AMOUNT: u64 = 1_231_240_000;
-
 /// Total miner rewards for blocks 1..=`count` under
 /// [`default_test_activation_heights`]: block 1 pays the full subsidy;
 /// every later block pays the post-funding-stream reward.
@@ -373,6 +370,17 @@ where
 /// Mining two extra blocks first clears the upgrade ladder (tip 5, so
 /// tip+1 and the inclusion block share the NU6.2 branch id) and accumulates
 /// four pre-tip notes so oldest-first selection never reaches the tip note.
+///
+/// The orchard-to-ironwood normalization uses the migration drain rather
+/// than a self-send: 731b2b761 taught note selection to lead with the
+/// payment's own pool, so a send to an ironwood receiver no longer drains
+/// orchard (it left one orchard note un-migrated, observed as balance
+/// assertions failing exactly one block reward short on freshly mined
+/// chains while cached replays of pre-731b2b761 wallet-built blocks kept
+/// passing). The drain spends only orchard by construction, which also
+/// satisfies constraint 2 structurally. Its fee cancels the same way the
+/// offload's does — the faucet collects it back in the confirming block's
+/// coinbase — so [`funded_faucet_ironwood_balance`] is fee-invariant.
 async fn normalize_shielded_faucet_balance<V, I>(
     local_net: &LocalNet<V, I>,
     mine_to_pool: PoolType,
@@ -395,13 +403,14 @@ async fn normalize_shielded_faucet_balance<V, I>(
         .unwrap();
         local_net.validator().generate_blocks(1).await.unwrap();
         sync_client_to_validator_tip(local_net, faucet).await;
-        let faucet_orchard_address = get_base_address_macro!(faucet, "unified");
-        quick_send(
-            faucet,
-            vec![(&faucet_orchard_address, IRONWOOD_MIGRATION_AMOUNT, None)],
-        )
-        .await
-        .unwrap();
+        let drain_summary = faucet
+            .drain_orchard_to_ironwood(zip32::AccountId::ZERO)
+            .await
+            .unwrap();
+        assert_eq!(
+            drain_summary.stranded, 0,
+            "normalization must leave no orchard value behind"
+        );
         local_net.validator().generate_blocks(1).await.unwrap();
     }
 }

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -392,7 +392,13 @@ async fn normalize_shielded_faucet_balance<V, I>(
     <V as Process>::Config: Send,
     LocalNet<V, I>: IndexerConvergence,
 {
-    if !matches!(mine_to_pool, PoolType::Transparent) {
+    let chain_height = local_net.validator().get_chain_height().await;
+    let activation_heights = local_net.validator().get_activation_heights().await;
+    if !matches!(mine_to_pool, PoolType::Transparent)
+        && activation_heights
+            .nu6_3()
+            .is_some_and(|ironwood_height| chain_height >= ironwood_height)
+    {
         local_net.validator().generate_blocks(1).await.unwrap();
         sync_client_to_validator_tip(local_net, faucet).await;
         quick_send(
@@ -635,13 +641,7 @@ pub async fn faucet_recipient(
 
     // A replayed chain already contains the balance-normalization offload;
     // the freshly built faucet wallet recovers it by sync below.
-    let chain_height = local_net.validator().get_chain_height().await;
-    if !replayed
-        && matches!(DefaultValidator::PROCESS, ProcessId::Zebrad)
-        && configured_activation_heights
-            .nu6_3()
-            .is_some_and(|ironwood_height| chain_height >= ironwood_height)
-    {
+    if !replayed && matches!(DefaultValidator::PROCESS, ProcessId::Zebrad) {
         normalize_shielded_faucet_balance(&local_net, mine_to_pool, &mut faucet).await;
     }
 

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -635,7 +635,13 @@ pub async fn faucet_recipient(
 
     // A replayed chain already contains the balance-normalization offload;
     // the freshly built faucet wallet recovers it by sync below.
-    if !replayed && matches!(DefaultValidator::PROCESS, ProcessId::Zebrad) {
+    let chain_height = local_net.validator().get_chain_height().await;
+    if !replayed
+        && matches!(DefaultValidator::PROCESS, ProcessId::Zebrad)
+        && configured_activation_heights
+            .nu6_3()
+            .is_some_and(|ironwood_height| chain_height >= ironwood_height)
+    {
         normalize_shielded_faucet_balance(&local_net, mine_to_pool, &mut faucet).await;
     }
 


### PR DESCRIPTION
## Summary

This integration branch unifies the three open fix lines against
`feat/ironwood` — #2478, #2479, and #2480 — with their one semantic conflict
resolved. Merging it marks all three PRs merged, since their heads are
ancestors of this branch.

## What it contains

From #2478 (`six_edges_tested`): the verification tests and fixes for six
findings of the #2419 review — the empty-shard chain-tip fallback clamp, the
note-split abort cleanup, the migration-params `usize` cap rejection, the
nonzero ironwood tree-size mismatch rejection, the reconciliation
unknown-txid fix, and the IRONWOOD OutputRef label pinned as correct with
its stale comment retired.

From #2479 (`chore/drop-time-patch`): the root-cause fix for the three
mining-balance tests (the faucet normalization now drains orchard via
`drain_orchard_to_ironwood`, immune to 731b2b761's pool-preference
selection), plus the two dependency-audit cleanups: the `time`
`[patch.crates-io]` drop and the `zaino-proto` git-to-crates.io 0.2.0
migration.

From #2480 (`fix/allfunds-pure-selection`): the TDD pair replacing the
process-aborting `TargetValue::AllFunds` panic with an implemented
`MaxSpendable` selection through a pure `all_funds_selection` function, and
a typed refusal for `Everything`.

## The resolution (merge commit 2440eae33)

#2478 and #2480 fixed AllFunds divergently: a blanket typed error versus an
implemented `MaxSpendable`. The implementation supersedes the placeholder,
so the resolved arm is #2480's, the test modules are unioned (the ironwood
label round-trip test joins the two AllFunds contract tests), #2478's
returns-err-not-panic test is dropped because its `is_err` assertion on
`MaxSpendable` asserts the opposite of the implemented contract, and the
orphaned `AllFundsSelectionUnsupported` variant is removed.

## Verification

The zingolib unit suite passes on the resolved merge (206 tests), and the
combined branch compiles clean across `zingolib`, `zingolib_testutils`, and
`libtonode-tests` with clippy and fmt green. The component branches carry
their own runs: the full container suite was green on #2479 with regenerated
caches, and the #2478 branch ran green except the three normalization
failures it inherited from its base, which #2479's fix — now in this branch —
closes. One fresh-cache confirmation run
(`ZINGO_REGENERATE_CHAIN_CACHE=1 makers container-test`) on this branch is
the recommended merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Added scope: the typed command crossing (audit Issue Q)

Two further commits extend the branch. 964225689 types the migration
command family per #2464's pattern (also offered standalone as #2482), and
ab786a621 migrates `Command::exec` itself to
`Result<String, CommandError>`: all 47 command impls convert,
`do_user_command` becomes the single prose-rendering site for string
frontends, `do_user_command_result` exposes the typed crossing for
outcome-classifying consumers (the direction zingo-mobile#1170 takes on
the FFI side), and 41 legacy prose failures cross through the documented
transitional `NotYetTyped` variant with their exact bytes preserved — the
golden tests pass unchanged (93/93 under nextest, clippy and fmt clean).
