### PR TITLE
chore(ci): pin the zainod and zebrad provisioning images by manifest digest

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -3,9 +3,17 @@
 
 # Zaino image tag used to provide zainod (https://hub.docker.com/r/zingodevops/zainod)
 ZAINO_IMAGE_TAG=0.6.0-rc.1-no-tls
+# Manifest digest the tag resolved to when pinned (2026-07-17). Tags are
+# mutable pointers; the digest is content. docker-ci consumes
+# tag@digest, so an upstream repush of the tag fails the build loudly
+# instead of silently changing which zainod the tests run. Note the
+# binary inside this image self-identifies as 0.4.3-ironwood.1.
+ZAINO_IMAGE_DIGEST=sha256:e48b133dbf53dbed77b872de74d65aa8a45357a3844b658ea472a340949feb7f
 
 # Zebra Git tag without the leading "v" (https://github.com/ZcashFoundation/zebra/releases)
 ZEBRA_VERSION=6.0.0
+# Same tag-vs-content discipline as the zaino digest above (2026-07-17).
+ZEBRA_IMAGE_DIGEST=sha256:78a10b7f24b83a86e6223d97e857094a353454e3268f84a87bd987e7140a33bb
 
 # cargo-nextest version compatible with the pinned Rust toolchain.
 NEXTEST_VERSION=0.9.128

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -239,7 +239,9 @@ echo "  NEXTEST_VERSION=${NEXTEST_VERSION}"
   -f docker-ci/Dockerfile \
   --build-arg "RUST_VERSION=${RUST_VERSION}" \
   --build-arg "ZAINO_IMAGE_TAG=${ZAINO_IMAGE_TAG}" \
+  --build-arg "ZAINO_IMAGE_DIGEST=${ZAINO_IMAGE_DIGEST}" \
   --build-arg "ZEBRA_VERSION=${ZEBRA_VERSION}" \
+  --build-arg "ZEBRA_IMAGE_DIGEST=${ZEBRA_IMAGE_DIGEST}" \
   --build-arg "NEXTEST_VERSION=${NEXTEST_VERSION}" \
   -t "${IMAGE_NAME}:${tag}" \
   docker-ci

--- a/docker-ci/Dockerfile
+++ b/docker-ci/Dockerfile
@@ -1,10 +1,21 @@
-ARG RUST_VERSION=1.90
-ARG ZAINO_IMAGE_TAG=0.6.0-rc.1-no-tls
-ARG ZEBRA_VERSION=6.0.0
-ARG NEXTEST_VERSION=0.9.128
+# No ARG defaults, deliberately: .env.testing-artifacts is the single
+# source of truth for every pinned value (and rust-toolchain.toml for
+# RUST_VERSION, which the Makefile derives). Build through
+# `makers build-image`, which sources the env file and passes each
+# value; a bare `docker build` without --build-args fails loudly
+# instead of assembling an image from stale duplicated defaults.
+ARG RUST_VERSION
+ARG ZAINO_IMAGE_TAG
+ARG ZEBRA_VERSION
+ARG NEXTEST_VERSION
+# Digests pin the CONTENT the tags merely point at; tag@digest fails
+# loudly if upstream repushes a tag, so every machine building from
+# the same commit provisions byte-identical binaries.
+ARG ZAINO_IMAGE_DIGEST
+ARG ZEBRA_IMAGE_DIGEST
 
-FROM docker.io/zingodevops/zaino:${ZAINO_IMAGE_TAG} AS zainod-downloader
-FROM docker.io/zfnd/zebra:${ZEBRA_VERSION} AS zebrad-downloader
+FROM docker.io/zingodevops/zaino:${ZAINO_IMAGE_TAG}@${ZAINO_IMAGE_DIGEST} AS zainod-downloader
+FROM docker.io/zfnd/zebra:${ZEBRA_VERSION}@${ZEBRA_IMAGE_DIGEST} AS zebrad-downloader
 
 FROM debian:trixie-slim AS runner
 

--- a/docker-ci/README.txt
+++ b/docker-ci/README.txt
@@ -2,7 +2,9 @@ The container test image is versioned from `.env.testing-artifacts`,
 `rust-toolchain.toml`, and this `docker-ci` directory.
 
 For local reproducible test runs:
- - update `.env.testing-artifacts` if zebra or the Zaino image tag changes
+ - update `.env.testing-artifacts` if zebra or the Zaino image tag changes,
+   always together with the tag's manifest digest (the file is the single
+   source of truth; the Dockerfile ARGs carry no defaults)
  - run `makers build-image` to build the local image
  - run `makers run` to execute tests inside the image
 


### PR DESCRIPTION
## Summary

A zingolib commit previously fixed only the provisioning image TAGS, and
tags are mutable pointers: an upstream repush changes which binaries fresh
machines pull, while machines with an already-built ci-build image keep the
old ones (`ensure-image-exists` keys on the tag-derived name) — silently
diverging machines that run identical commits. This PR makes "a given
zingolib commit fixes a given zainod (and zebrad)" true by construction.

`.env.testing-artifacts` now records the manifest digest each tag resolved
to at pin time, `docker-ci` pulls `image:tag@digest` (podman resolves the
combined form; verified by pulling the zaino reference), and the build task
threads the digests through. A repushed tag now fails the build loudly, and
because the env file's content hashes into the local image name, a digest
change forces every machine to re-assemble. The zaino pin's comment records
that the image's binary self-identifies as 0.4.3-ironwood.1, so future
archaeology starts from the truth rather than the tag name.

The digests are the registry's current values for the pinned tags
(2026-07-17); advancing either binary remains a one-line tag change, now
accompanied by its digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
