### PR TITLE
fix(testutils): key chain caches on setup semantics; forward the regenerate env

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -186,6 +186,8 @@ container_nextest_run() {
     -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
     -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
     -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
+    -e "ZINGO_REGENERATE_CHAIN_CACHE=${ZINGO_REGENERATE_CHAIN_CACHE:-}" \
+    -e "RUST_LOG=${RUST_LOG:-}" \
     -w /workspace \
     "${IMAGE_NAME}:${tag}" \
     bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/zainod /usr/bin/zebrad test_binaries/bins/ && exec "$@"' \

--- a/zingolib_testutils/src/chain_cache.rs
+++ b/zingolib_testutils/src/chain_cache.rs
@@ -131,7 +131,15 @@ impl CacheManifest {
         stage: CachedStage,
     ) -> Self {
         CacheManifest(serde_json::json!({
-            "schema": 2,
+            // Schema 3 (2026-07-17): the drain rewrite changed cached-chain
+            // SEMANTICS (self-send → orchard drain) without changing any
+            // manifest key, and pre-drain caches replayed as green-shaped
+            // chains against post-drain expectations for a full day of
+            // misdiagnosis. Any change to what setup writes into the chain
+            // must bump `setup_semantics` (or the schema), so stale caches
+            // self-discard instead of impersonating current behavior.
+            "schema": 3,
+            "setup_semantics": "offload+drain-v1",
             "validator": std::any::type_name::<crate::scenarios::network_combo::DefaultValidator>(),
             "indexer": std::any::type_name::<crate::scenarios::network_combo::DefaultIndexer>(),
             "stage": format!("{stage:?}"),

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -593,6 +593,29 @@ pub async fn faucet(
 
     sync_client_to_validator_tip(&local_net, &mut faucet).await;
 
+    // Replay-time twin of the fresh-build invariant inside the
+    // normalization: a cache whose chain shape predates the current setup
+    // semantics otherwise replays cleanly and fails blocks later at some
+    // unrelated balance assert (2026-07-17: pre-drain caches did exactly
+    // that for a day). The manifest's setup_semantics key should discard
+    // such caches before this fires; this assert is the backstop that
+    // names the cache instead of the downstream test.
+    if replayed && matches!(mine_to_pool, PoolType::Shielded(ShieldedPool::Ironwood)) {
+        let ironwood_confirmed = faucet
+            .account_balance(zip32::AccountId::ZERO)
+            .await
+            .expect("the freshly synced faucet reports a balance")
+            .confirmed_ironwood_balance
+            .map(zcash_protocol::value::Zatoshis::into_u64)
+            .unwrap_or(0);
+        assert_eq!(
+            ironwood_confirmed,
+            funded_faucet_ironwood_balance(),
+            "replayed chain does not satisfy current setup semantics — stale chain cache? \
+             (the manifest's schema/setup_semantics should have discarded it)"
+        );
+    }
+
     if let Some((dir, manifest)) = export {
         chain_cache::export(&local_net, &dir, &manifest).await;
     }


### PR DESCRIPTION
## Summary

Three fixes that close the mechanism behind 2026-07-17's day of phantom
test failures: stale chain caches, built by superseded setup code,
replaying silently as if they were current — red on machines with old
caches, green on machines with fresh ones, identical commits and identical
binaries throughout.

## The three fixes

**Env forwarding.** `container_nextest_run` launched podman with a
two-variable allowlist, so `ZINGO_REGENERATE_CHAIN_CACHE=1` (and
`RUST_LOG`) set on the host never reached the test process — the
regenerate flag has been a silent no-op through every `makers` invocation,
with every apparent success actually a coincidental first-run or
manifest-mismatch rebuild. Both variables now forward. The per-test
"discarding and rebuilding" line is the receipt that regeneration truly
engaged.

**Setup-semantics keying.** The cache manifest recorded validator type,
stage, miner pool, and activation heights — nothing about what setup
*writes into the chain*. The drain rewrite changed cached-chain semantics
without touching any manifest key, so pre-drain caches kept replaying
self-send-shaped chains against post-drain expectations. The manifest
schema bumps to 3 and gains a `setup_semantics` key: every existing cache
fleet self-discards on next run (one rebuild, no coordination), and future
setup changes must bump the key, making staleness structurally impossible
rather than tribally managed.

**Replay invariant.** The fresh-build path asserts the normalization
invariant at its source; replays had no twin, so a stale chain failed
blocks later at an unrelated balance assert. `faucet()` now verifies the
replayed chain satisfies current semantics, with a message that names the
cache as the suspect.

## Verification

Compile, clippy, and fmt clean on `zingolib_testutils` and
`libtonode-tests`. The diagnosis this encodes was confirmed by a
two-machine A/B at identical commit and digest-identical binaries (green
with a current cache fleet, red with a stale one) and by block-level
decode of the stale caches reproducing every observed failing balance to
the zatoshi. First run after merge rebuilds each test's cache once —
expect the documented longer first-run times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
