### PR TITLE
fix: restore migration state on every broadcast-path exit

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -3,9 +3,17 @@
 
 # Zaino image tag used to provide zainod (https://hub.docker.com/r/zingodevops/zainod)
 ZAINO_IMAGE_TAG=0.6.0-rc.1-no-tls
+# Manifest digest the tag resolved to when pinned (2026-07-17). Tags are
+# mutable pointers; the digest is content. docker-ci consumes
+# tag@digest, so an upstream repush of the tag fails the build loudly
+# instead of silently changing which zainod the tests run. Note the
+# binary inside this image self-identifies as 0.4.3-ironwood.1.
+ZAINO_IMAGE_DIGEST=sha256:e48b133dbf53dbed77b872de74d65aa8a45357a3844b658ea472a340949feb7f
 
 # Zebra Git tag without the leading "v" (https://github.com/ZcashFoundation/zebra/releases)
 ZEBRA_VERSION=6.0.0
+# Same tag-vs-content discipline as the zaino digest above (2026-07-17).
+ZEBRA_IMAGE_DIGEST=sha256:78a10b7f24b83a86e6223d97e857094a353454e3268f84a87bd987e7140a33bb
 
 # cargo-nextest version compatible with the pinned Rust toolchain.
 NEXTEST_VERSION=0.9.128

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -186,6 +186,8 @@ container_nextest_run() {
     -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
     -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
     -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
+    -e "ZINGO_REGENERATE_CHAIN_CACHE=${ZINGO_REGENERATE_CHAIN_CACHE:-}" \
+    -e "RUST_LOG=${RUST_LOG:-}" \
     -w /workspace \
     "${IMAGE_NAME}:${tag}" \
     bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/zainod /usr/bin/zebrad test_binaries/bins/ && exec "$@"' \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -239,7 +239,9 @@ echo "  NEXTEST_VERSION=${NEXTEST_VERSION}"
   -f docker-ci/Dockerfile \
   --build-arg "RUST_VERSION=${RUST_VERSION}" \
   --build-arg "ZAINO_IMAGE_TAG=${ZAINO_IMAGE_TAG}" \
+  --build-arg "ZAINO_IMAGE_DIGEST=${ZAINO_IMAGE_DIGEST}" \
   --build-arg "ZEBRA_VERSION=${ZEBRA_VERSION}" \
+  --build-arg "ZEBRA_IMAGE_DIGEST=${ZEBRA_IMAGE_DIGEST}" \
   --build-arg "NEXTEST_VERSION=${NEXTEST_VERSION}" \
   -t "${IMAGE_NAME}:${tag}" \
   docker-ci

--- a/docker-ci/Dockerfile
+++ b/docker-ci/Dockerfile
@@ -1,10 +1,21 @@
-ARG RUST_VERSION=1.90
-ARG ZAINO_IMAGE_TAG=0.6.0-rc.1-no-tls
-ARG ZEBRA_VERSION=6.0.0
-ARG NEXTEST_VERSION=0.9.128
+# No ARG defaults, deliberately: .env.testing-artifacts is the single
+# source of truth for every pinned value (and rust-toolchain.toml for
+# RUST_VERSION, which the Makefile derives). Build through
+# `makers build-image`, which sources the env file and passes each
+# value; a bare `docker build` without --build-args fails loudly
+# instead of assembling an image from stale duplicated defaults.
+ARG RUST_VERSION
+ARG ZAINO_IMAGE_TAG
+ARG ZEBRA_VERSION
+ARG NEXTEST_VERSION
+# Digests pin the CONTENT the tags merely point at; tag@digest fails
+# loudly if upstream repushes a tag, so every machine building from
+# the same commit provisions byte-identical binaries.
+ARG ZAINO_IMAGE_DIGEST
+ARG ZEBRA_IMAGE_DIGEST
 
-FROM docker.io/zingodevops/zaino:${ZAINO_IMAGE_TAG} AS zainod-downloader
-FROM docker.io/zfnd/zebra:${ZEBRA_VERSION} AS zebrad-downloader
+FROM docker.io/zingodevops/zaino:${ZAINO_IMAGE_TAG}@${ZAINO_IMAGE_DIGEST} AS zainod-downloader
+FROM docker.io/zfnd/zebra:${ZEBRA_VERSION}@${ZEBRA_IMAGE_DIGEST} AS zebrad-downloader
 
 FROM debian:trixie-slim AS runner
 

--- a/docker-ci/README.txt
+++ b/docker-ci/README.txt
@@ -2,7 +2,9 @@ The container test image is versioned from `.env.testing-artifacts`,
 `rust-toolchain.toml`, and this `docker-ci` directory.
 
 For local reproducible test runs:
- - update `.env.testing-artifacts` if zebra or the Zaino image tag changes
+ - update `.env.testing-artifacts` if zebra or the Zaino image tag changes,
+   always together with the tag's manifest digest (the file is the single
+   source of truth; the Dockerfile ARGs carry no defaults)
  - run `makers build-image` to build the local image
  - run `makers run` to execute tests inside the image
 

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -270,78 +270,74 @@ impl LightClient {
         // parts yield their raw bytes directly. No expensive work happens here.
         let (prove_handles, pre_proven, strategy) = {
             let mut wallet = self.wallet().write().await;
-            let Some(mut state) = wallet.migration.take() else {
-                return Err(MigrationError::NoMigration.into());
-            };
+            wallet
+                .with_migration_state(|wallet, state| {
+                    let now_height = wallet
+                        .sync_state
+                        .last_known_chain_height()
+                        .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
+                    let current_bucket =
+                        schedule::bucket_index(now_height, state.params.bucket_modulus);
 
-            let now_height = wallet
-                .sync_state
-                .last_known_chain_height()
-                .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
-            let current_bucket = schedule::bucket_index(now_height, state.params.bucket_modulus);
-            let strategy = state.strategy;
+                    let mut prove_handles: Vec<ProveHandle> = Vec::new();
+                    let mut pre_proven: Vec<(usize, TxId, Vec<u8>, BlockHeight)> = Vec::new();
 
-            let mut prove_handles: Vec<ProveHandle> = Vec::new();
-            let mut pre_proven: Vec<(usize, TxId, Vec<u8>, BlockHeight)> = Vec::new();
-
-            let phase_a: Result<(), crate::wallet::error::WalletError> = (|| {
-                for index in 0..state.parts.len() {
-                    let due = {
-                        let part = &state.parts[index];
-                        matches!(part.state, PartState::Assigned | PartState::Signed)
-                            && part.bucket_index == Some(current_bucket)
-                            && part.target_height.is_none_or(|t| now_height >= t)
-                            && only.is_none_or(|part_id| part.id == part_id)
-                    };
-                    if !due {
-                        continue;
-                    }
-
-                    if state.parts[index].state == PartState::Assigned {
-                        let account = state.account;
-                        let params = state.params.clone();
-                        match wallet.prepare_part(account, &mut state.parts[index], &params)? {
-                            PrepareResult::Ready { prove, .. } => {
-                                prove_handles.push(tokio::task::spawn_blocking(move || {
-                                    prove().map(|(txid, raw_tx)| (index, txid, raw_tx))
-                                }));
-                            }
-                            PrepareResult::Skip(reason) => {
-                                log::info!(
-                                    "skipping part {index}: {reason:?}; it falls to reconciliation"
-                                );
-                            }
-                        }
-                    } else {
-                        // Signed already (an earlier submit failed): recover
-                        // the bytes from the blob or the wallet's tx record.
-                        let part = &state.parts[index];
-                        let txid = part.txid.expect("signed parts have txids");
-                        let expiry = part
-                            .expiry_height
-                            .expect("signed parts have expiry heights");
-                        let bytes = match &part.signed_blob {
-                            Some(blob) => blob.clone(),
-                            None => {
-                                let tx = wallet.wallet_transactions.get(&txid).ok_or(
-                                    crate::wallet::error::WalletError::TransactionNotFound(txid),
-                                )?;
-                                let mut bytes = Vec::new();
-                                tx.transaction()
-                                    .write(&mut bytes)
-                                    .map_err(crate::wallet::error::WalletError::TransactionWrite)?;
-                                bytes
-                            }
+                    for index in 0..state.parts.len() {
+                        let due = {
+                            let part = &state.parts[index];
+                            matches!(part.state, PartState::Assigned | PartState::Signed)
+                                && part.bucket_index == Some(current_bucket)
+                                && part.target_height.is_none_or(|t| now_height >= t)
+                                && only.is_none_or(|part_id| part.id == part_id)
                         };
-                        pre_proven.push((index, txid, bytes, expiry));
-                    }
-                }
-                Ok(())
-            })();
+                        if !due {
+                            continue;
+                        }
 
-            wallet.migration = Some(state);
-            phase_a?;
-            (prove_handles, pre_proven, strategy)
+                        if state.parts[index].state == PartState::Assigned {
+                            let account = state.account;
+                            let params = state.params.clone();
+                            match wallet.prepare_part(account, &mut state.parts[index], &params)? {
+                                PrepareResult::Ready { prove, .. } => {
+                                    prove_handles.push(tokio::task::spawn_blocking(move || {
+                                        prove().map(|(txid, raw_tx)| (index, txid, raw_tx))
+                                    }));
+                                }
+                                PrepareResult::Skip(reason) => {
+                                    log::info!(
+                                        "skipping part {index}: {reason:?}; it falls to reconciliation"
+                                    );
+                                }
+                            }
+                        } else {
+                            // Signed already (an earlier submit failed): recover
+                            // the bytes from the blob or the wallet's tx record.
+                            let part = &state.parts[index];
+                            let txid = part.txid.expect("signed parts have txids");
+                            let expiry = part
+                                .expiry_height
+                                .expect("signed parts have expiry heights");
+                            let bytes = match &part.signed_blob {
+                                Some(blob) => blob.clone(),
+                                None => {
+                                    let tx = wallet.wallet_transactions.get(&txid).ok_or(
+                                        crate::wallet::error::WalletError::TransactionNotFound(
+                                            txid,
+                                        ),
+                                    )?;
+                                    let mut bytes = Vec::new();
+                                    tx.transaction().write(&mut bytes).map_err(
+                                        crate::wallet::error::WalletError::TransactionWrite,
+                                    )?;
+                                    bytes
+                                }
+                            };
+                            pre_proven.push((index, txid, bytes, expiry));
+                        }
+                    }
+                    Ok::<_, LightClientError>((prove_handles, pre_proven, state.strategy))
+                })
+                .ok_or(MigrationError::NoMigration)??
         }; // wallet write lock released — Phase B runs without the lock
 
         // ── Phase B: parallel proving (no wallet lock held) ───────────────
@@ -356,64 +352,72 @@ impl LightClient {
         }
 
         // ── Phase C: record results + submit under the wallet write lock ──
+        // The migration state is inside the wallet at every await point, so
+        // neither an error nor a cancelled future can strand it outside.
         let mut wallet = self.wallet().write().await;
-        let Some(mut state) = wallet.migration.take() else {
-            return Err(MigrationError::NoMigration.into());
-        };
 
-        let result = async {
-            // Record all newly proved parts (mark Signed, store tx in wallet).
-            let mut newly_proven_with_expiry: Vec<(usize, TxId, Vec<u8>, BlockHeight)> = Vec::new();
-            for (index, txid, raw_tx) in newly_proven {
-                let bucket = state.parts[index]
-                    .bucket_index
-                    .expect("assigned parts carry a bucket");
-                let boundary = schedule::boundary_of(bucket, state.params.bucket_modulus);
-                let target_height = boundary + 1;
-                let expiry_height = boundary + state.params.expiry_delta;
-                wallet.record_part_result(
-                    &mut state.parts[index],
-                    txid,
-                    &raw_tx,
-                    target_height,
-                    expiry_height,
-                    strategy,
-                )?;
-                newly_proven_with_expiry.push((index, txid, raw_tx, expiry_height));
-            }
+        // Record all newly proved parts (mark Signed, store tx in wallet),
+        // then combine proved and pre-proven in original part order.
+        let all_to_submit = wallet
+            .with_migration_state(|wallet, state| {
+                let mut newly_proven_with_expiry: Vec<(usize, TxId, Vec<u8>, BlockHeight)> =
+                    Vec::new();
+                for (index, txid, raw_tx) in newly_proven {
+                    let bucket = state.parts[index]
+                        .bucket_index
+                        .expect("assigned parts carry a bucket");
+                    let boundary = schedule::boundary_of(bucket, state.params.bucket_modulus);
+                    let target_height = boundary + 1;
+                    let expiry_height = boundary + state.params.expiry_delta;
+                    wallet.record_part_result(
+                        &mut state.parts[index],
+                        txid,
+                        &raw_tx,
+                        target_height,
+                        expiry_height,
+                        strategy,
+                    )?;
+                    newly_proven_with_expiry.push((index, txid, raw_tx, expiry_height));
+                }
 
-            // Combine proved and pre-proven, maintaining original part order.
-            let mut all_to_submit: Vec<(usize, TxId, Vec<u8>, BlockHeight)> =
-                newly_proven_with_expiry
-                    .into_iter()
-                    .chain(pre_proven.into_iter())
-                    .collect();
-            all_to_submit.sort_by_key(|(index, ..)| *index);
+                let mut all_to_submit: Vec<(usize, TxId, Vec<u8>, BlockHeight)> =
+                    newly_proven_with_expiry
+                        .into_iter()
+                        .chain(pre_proven.into_iter())
+                        .collect();
+                all_to_submit.sort_by_key(|(index, ..)| *index);
+                Ok::<_, LightClientError>(all_to_submit)
+            })
+            .ok_or(MigrationError::NoMigration)??;
 
-            let mut sent = Vec::new();
-            for (index, txid, raw_tx, expiry_height) in all_to_submit {
-                // Record the attempt before submission so a crash between
-                // submit and record is detectable via nullifier on reconcile.
-                state.parts[index].record_attempt();
-                wallet.save_required = true;
-                match client.submit(raw_tx, expiry_height).await {
-                    Ok(_) => {
-                        state.parts[index].mark_broadcast()?;
-                        wallet.save_required = true;
-                        sent.push(txid);
-                    }
-                    Err(e) => {
-                        log::warn!("part submission failed, leaving the part signed: {e}");
-                        break;
-                    }
+        let mut sent = Vec::new();
+        for (index, txid, raw_tx, expiry_height) in all_to_submit {
+            // Record the attempt before submission so a crash between
+            // submit and record is detectable via nullifier on reconcile.
+            wallet
+                .with_migration_state(|wallet, state| {
+                    state.parts[index].record_attempt();
+                    wallet.save_required = true;
+                })
+                .ok_or(MigrationError::NoMigration)?;
+            match client.submit(raw_tx, expiry_height).await {
+                Ok(_) => {
+                    wallet
+                        .with_migration_state(|wallet, state| {
+                            state.parts[index].mark_broadcast()?;
+                            wallet.save_required = true;
+                            Ok::<_, crate::wallet::error::WalletError>(())
+                        })
+                        .ok_or(MigrationError::NoMigration)??;
+                    sent.push(txid);
+                }
+                Err(e) => {
+                    log::warn!("part submission failed, leaving the part signed: {e}");
+                    break;
                 }
             }
-            Ok(sent)
         }
-        .await;
-
-        wallet.migration = Some(state);
-        result
+        Ok(sent)
     }
 
     /// Abandons the migration. Parts already confirmed naturally stand.
@@ -441,68 +445,63 @@ impl LightClient {
     /// on every launch. It never synchronizes.
     pub async fn reconcile_migration(&mut self) -> Result<ReconcileReport, LightClientError> {
         let mut wallet = self.wallet().write().await;
-        let Some(mut state) = wallet.migration.take() else {
-            return Err(MigrationError::NoMigration.into());
-        };
-
-        let result = (|| {
-            let report = reconcile(&state, &*wallet);
-            for action in &report.actions {
-                match action {
-                    RecommendedAction::PromoteConfirmed { part, height } => {
-                        state.parts[part.0 as usize].mark_confirmed(*height)?;
-                    }
-                    RecommendedAction::MarkInvalidated { part } => {
-                        state.parts[part.0 as usize].mark_invalidated()?;
-                    }
-                    RecommendedAction::Rebuild { part } => {
-                        let part = &mut state.parts[part.0 as usize];
-                        if part.state != PartState::Expired {
-                            part.mark_expired()?;
+        wallet
+            .with_migration_state(|wallet, state| {
+                let report = reconcile(state, &*wallet);
+                for action in &report.actions {
+                    match action {
+                        RecommendedAction::PromoteConfirmed { part, height } => {
+                            state.parts[part.0 as usize].mark_confirmed(*height)?;
                         }
-                        let now_height = wallet
-                            .sync_state
-                            .last_known_chain_height()
-                            .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
-                        let next_bucket =
-                            schedule::bucket_index(now_height, state.params.bucket_modulus) + 1;
-                        part.reassign(next_bucket)?;
+                        RecommendedAction::MarkInvalidated { part } => {
+                            state.parts[part.0 as usize].mark_invalidated()?;
+                        }
+                        RecommendedAction::Rebuild { part } => {
+                            let part = &mut state.parts[part.0 as usize];
+                            if part.state != PartState::Expired {
+                                part.mark_expired()?;
+                            }
+                            let now_height = wallet
+                                .sync_state
+                                .last_known_chain_height()
+                                .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
+                            let next_bucket =
+                                schedule::bucket_index(now_height, state.params.bucket_modulus) + 1;
+                            part.reassign(next_bucket)?;
+                        }
+                        RecommendedAction::BindAndSchedule => {
+                            let account = state.account;
+                            wallet.bind_parts_to_notes(state, account)?;
+                            let now_height = wallet
+                                .sync_state
+                                .last_known_chain_height()
+                                .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
+                            plan_schedule(
+                                &mut state.parts,
+                                now_height,
+                                &state.params,
+                                &mut rand::rngs::OsRng,
+                            )?;
+                            state.phase = MigrationPhase::PartsScheduled;
+                        }
+                        RecommendedAction::MarkComplete { residual } => {
+                            state.phase = MigrationPhase::Complete {
+                                residual: *residual,
+                            };
+                        }
+                        // Left to the caller: user-facing disclosure or fresh
+                        // consent required, or nothing to apply.
+                        RecommendedAction::PromptCatchUp { .. }
+                        | RecommendedAction::ReplanRemainder
+                        | RecommendedAction::RetrySplit { .. }
+                        | RecommendedAction::AwaitSplitConfirmation
+                        | RecommendedAction::ContinueNoteSplitting => (),
                     }
-                    RecommendedAction::BindAndSchedule => {
-                        let account = state.account;
-                        wallet.bind_parts_to_notes(&mut state, account)?;
-                        let now_height = wallet
-                            .sync_state
-                            .last_known_chain_height()
-                            .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
-                        plan_schedule(
-                            &mut state.parts,
-                            now_height,
-                            &state.params,
-                            &mut rand::rngs::OsRng,
-                        )?;
-                        state.phase = MigrationPhase::PartsScheduled;
-                    }
-                    RecommendedAction::MarkComplete { residual } => {
-                        state.phase = MigrationPhase::Complete {
-                            residual: *residual,
-                        };
-                    }
-                    // Left to the caller: user-facing disclosure or fresh
-                    // consent required, or nothing to apply.
-                    RecommendedAction::PromptCatchUp { .. }
-                    | RecommendedAction::ReplanRemainder
-                    | RecommendedAction::RetrySplit { .. }
-                    | RecommendedAction::AwaitSplitConfirmation
-                    | RecommendedAction::ContinueNoteSplitting => (),
                 }
-            }
-            wallet.save_required = true;
-            Ok(report)
-        })();
-
-        wallet.migration = Some(state);
-        result
+                wallet.save_required = true;
+                Ok::<_, LightClientError>(report)
+            })
+            .ok_or(MigrationError::NoMigration)?
     }
 
     /// Sends overdue parts now, in sequence with `spacing` between
@@ -532,27 +531,24 @@ impl LightClient {
 
         {
             let mut wallet = self.wallet().write().await;
-            let Some(mut state) = wallet.migration.take() else {
-                return Err(MigrationError::NoMigration.into());
-            };
-            let shift = (|| -> Result<(), crate::wallet::error::WalletError> {
-                let now_height = wallet
-                    .sync_state
-                    .last_known_chain_height()
-                    .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
-                let current_bucket =
-                    schedule::bucket_index(now_height, state.params.bucket_modulus);
-                for part_id in &overdue {
-                    let part = &mut state.parts[part_id.0 as usize];
-                    if part.state == PartState::Assigned {
-                        part.shift(current_bucket)?;
+            wallet
+                .with_migration_state(|wallet, state| {
+                    wallet.save_required = true;
+                    let now_height = wallet
+                        .sync_state
+                        .last_known_chain_height()
+                        .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
+                    let current_bucket =
+                        schedule::bucket_index(now_height, state.params.bucket_modulus);
+                    for part_id in &overdue {
+                        let part = &mut state.parts[part_id.0 as usize];
+                        if part.state == PartState::Assigned {
+                            part.shift(current_bucket)?;
+                        }
                     }
-                }
-                Ok(())
-            })();
-            wallet.migration = Some(state);
-            wallet.save_required = true;
-            shift?;
+                    Ok::<_, crate::wallet::error::WalletError>(())
+                })
+                .ok_or(MigrationError::NoMigration)??;
         }
         self.wallet().write().await.refresh_part_witnesses()?;
 
@@ -1021,6 +1017,85 @@ mod tests {
             account: AccountId::ZERO,
             phase: MigrationPhase::PartsScheduled,
             parts,
+        }
+    }
+
+    /// An error raised after the migration state is taken out of the wallet
+    /// must not destroy the state. [`SyncState::last_known_chain_height`] is
+    /// the end of the last scan range, so it is `None` exactly when the scan
+    /// ranges are empty; the two tests here are identical except for the
+    /// route into that state, and the pair triangulates. `via_clear_all`
+    /// pins that a production path — a rescan — really produces the
+    /// dangerous combination of a live migration and no height, and its
+    /// guard assertions fail loudly if [`LightWallet::clear_all`] ever
+    /// cancels migrations or rebuilds scan ranges eagerly.
+    /// `via_empty_sync_state` pins the broadcast path's contract on the
+    /// state itself, however it arises (a never-synced wallet, future
+    /// clearing paths), and survives any evolution of `clear_all`. One test
+    /// red with the other green names the layer that changed.
+    mod no_sync_data_preserves_migration_state {
+        use pepper_sync::wallet::SyncState;
+
+        use super::*;
+        use crate::lightclient::error::LightClientError;
+        use crate::wallet::error::WalletError;
+
+        /// The shared scenario, parameterized only by how the wallet's last
+        /// known chain height becomes `None`. The resulting
+        /// [`WalletError::NoSyncData`] is correct and expected; the
+        /// consented migration schedule surviving it is what the assertions
+        /// pin, because the broadcast path's early `?`-return between take
+        /// and restore silently discarded the state, and any later save
+        /// persisted the loss.
+        async fn broadcast_error_must_preserve_the_state(
+            empty_the_sync_state: impl FnOnce(&mut LightWallet),
+        ) {
+            let (mut wallet, bound_note) = wallet_with_migration_note(360);
+            let params = MigrationParams::provisional(wallet.chain_type());
+            let mut part = PartRecord::new(PartId(0), NOTE_VALUE, bound_note);
+            part.assign(0).expect("fresh parts are bound");
+            wallet.migration = Some(scheduled_state(params, vec![part]));
+
+            empty_the_sync_state(&mut wallet);
+            assert!(wallet.sync_state.last_known_chain_height().is_none());
+            assert!(
+                wallet.migration.is_some(),
+                "emptying the sync data must keep the migration"
+            );
+
+            let mut client = LightClient::new_for_test(wallet).await;
+            let broadcast_client = MockBroadcastClient::default();
+            let result = client.broadcast_due_parts_with(&broadcast_client).await;
+            assert!(
+                matches!(
+                    result,
+                    Err(LightClientError::WalletError(WalletError::NoSyncData))
+                ),
+                "the broadcast must fail with NoSyncData, got {result:?}"
+            );
+
+            let wallet = client.wallet().read().await;
+            assert!(
+                wallet.migration.is_some(),
+                "an error before the restore must not destroy the migration state"
+            );
+        }
+
+        /// The production route: a rescan empties the scan ranges and keeps
+        /// the migration.
+        #[tokio::test]
+        async fn via_clear_all() {
+            broadcast_error_must_preserve_the_state(LightWallet::clear_all).await;
+        }
+
+        /// The fabricated route: the state contract alone, independent of
+        /// any particular path into it.
+        #[tokio::test]
+        async fn via_empty_sync_state() {
+            broadcast_error_must_preserve_the_state(|wallet| {
+                wallet.sync_state = SyncState::new();
+            })
+            .await;
         }
     }
 

--- a/zingolib/src/wallet/migration.rs
+++ b/zingolib/src/wallet/migration.rs
@@ -140,6 +140,29 @@ impl MigrationState {
     }
 }
 
+impl crate::wallet::LightWallet {
+    /// The take/use/restore bracket for the wallet's [`MigrationState`],
+    /// made total. `f` receives the wallet and the state as two independent
+    /// `&mut` borrows — the reason the state must leave the wallet at all —
+    /// and the state is restored on every exit path before `f`'s result is
+    /// returned: an early `?`-return inside `f` cannot skip the restore,
+    /// and because `f` is synchronous the state is never out of the wallet
+    /// across an `.await` point, so a cancelled future cannot strand it.
+    /// The bracket itself is unobservable — the migration slot is `Some`
+    /// after exactly when it was `Some` before, and every mutation belongs
+    /// to `f`. Returns `None`, without calling `f`, when no migration is
+    /// active; the caller chooses what a missing migration means.
+    pub(crate) fn with_migration_state<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self, &mut MigrationState) -> R,
+    ) -> Option<R> {
+        let mut state = self.migration.take()?;
+        let result = f(self, &mut state);
+        self.migration = Some(state);
+        Some(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     /// Structural decoupling lint (ZIP 318: a broadcast session must never

--- a/zingolib/src/wallet/migration/parts.rs
+++ b/zingolib/src/wallet/migration/parts.rs
@@ -395,10 +395,7 @@ impl crate::wallet::LightWallet {
     /// retention window is finite and a captured witness is good forever.
     #[allow(clippy::result_large_err)]
     pub fn refresh_part_witnesses(&mut self) -> Result<(), WalletError> {
-        let Some(mut state) = self.migration.take() else {
-            return Ok(());
-        };
-        let result = (|| {
+        self.with_migration_state(|wallet, state| {
             for part in state
                 .parts
                 .iter_mut()
@@ -408,15 +405,14 @@ impl crate::wallet::LightWallet {
                     continue;
                 };
                 let boundary = super::schedule::boundary_of(bucket, state.params.bucket_modulus);
-                if let Some(witness) = self.capture_boundary_witness(part, boundary)? {
+                if let Some(witness) = wallet.capture_boundary_witness(part, boundary)? {
                     part.anchor_witness = Some(witness);
-                    self.save_required = true;
+                    wallet.save_required = true;
                 }
             }
             Ok(())
-        })();
-        self.migration = Some(state);
-        result
+        })
+        .unwrap_or(Ok(()))
     }
 
     /// Extracts all wallet data needed to prove one [`PartState::Assigned`]

--- a/zingolib_testutils/src/chain_cache.rs
+++ b/zingolib_testutils/src/chain_cache.rs
@@ -131,7 +131,15 @@ impl CacheManifest {
         stage: CachedStage,
     ) -> Self {
         CacheManifest(serde_json::json!({
-            "schema": 2,
+            // Schema 3 (2026-07-17): the drain rewrite changed cached-chain
+            // SEMANTICS (self-send → orchard drain) without changing any
+            // manifest key, and pre-drain caches replayed as green-shaped
+            // chains against post-drain expectations for a full day of
+            // misdiagnosis. Any change to what setup writes into the chain
+            // must bump `setup_semantics` (or the schema), so stale caches
+            // self-discard instead of impersonating current behavior.
+            "schema": 3,
+            "setup_semantics": "offload+drain-v1",
             "validator": std::any::type_name::<crate::scenarios::network_combo::DefaultValidator>(),
             "indexer": std::any::type_name::<crate::scenarios::network_combo::DefaultIndexer>(),
             "stage": format!("{stage:?}"),

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -593,6 +593,29 @@ pub async fn faucet(
 
     sync_client_to_validator_tip(&local_net, &mut faucet).await;
 
+    // Replay-time twin of the fresh-build invariant inside the
+    // normalization: a cache whose chain shape predates the current setup
+    // semantics otherwise replays cleanly and fails blocks later at some
+    // unrelated balance assert (2026-07-17: pre-drain caches did exactly
+    // that for a day). The manifest's setup_semantics key should discard
+    // such caches before this fires; this assert is the backstop that
+    // names the cache instead of the downstream test.
+    if replayed && matches!(mine_to_pool, PoolType::Shielded(ShieldedPool::Ironwood)) {
+        let ironwood_confirmed = faucet
+            .account_balance(zip32::AccountId::ZERO)
+            .await
+            .expect("the freshly synced faucet reports a balance")
+            .confirmed_ironwood_balance
+            .map(zcash_protocol::value::Zatoshis::into_u64)
+            .unwrap_or(0);
+        assert_eq!(
+            ironwood_confirmed,
+            funded_faucet_ironwood_balance(),
+            "replayed chain does not satisfy current setup semantics — stale chain cache? \
+             (the manifest's schema/setup_semantics should have discarded it)"
+        );
+    }
+
     if let Some((dir, manifest)) = export {
         chain_cache::export(&local_net, &dir, &manifest).await;
     }


### PR DESCRIPTION
The due-part broadcast path takes the migration state out of the wallet so it can mutate the state and the wallet through independent `&mut` borrows, and an early `?`-return on `WalletError::NoSyncData` fired before the restore, silently destroying the consented ZIP 318 migration schedule; the next save persisted the loss. The state is production-reachable: `LightWallet::clear_all` empties the scan ranges — the sole source of `last_known_chain_height` — while keeping the migration, so a rescan followed by any broadcast driver (`auto_broadcast_if_due`, `broadcast_due_parts`, `catch_up_migration`, or `migrate_to_ironwood`) lost the schedule. This is finding B1 of the #2419 review.

The fix makes the leak structurally impossible rather than patching the one site. A new `LightWallet::with_migration_state` combinator owns the take/use/restore bracket: the body is a function argument, the state is restored on every exit path, and because the body is synchronous the state can never be out of the wallet across an `.await` point — which also closes a second instance of the same class, discovered during the conversion: broadcast Phase C held the state outside the wallet across its per-part network submits, so a cancelled future (a timeout wrapper, a `select!`) would strand it with no error at all. Phase C is restructured as a bracketed recording step followed by a submit loop whose awaits all run with the state inside the wallet. `reconcile_migration`, the catch-up shift block, and `refresh_part_witnesses` convert to the same combinator; the take-and-drop in `cancel_ironwood_migration` is intentional destruction and stays.

The regression test is a DRY pair inside `mod no_sync_data_preserves_migration_state`: one shared scenario function parameterized only by how the height becomes `None`, with `via_clear_all` pinning that the production rescan route really produces a live migration with no height (its guards fail loudly if `clear_all` ever changes semantics), and `via_empty_sync_state` pinning the contract on the state itself, independent of any route into it. One test red with the other green names the layer that changed.

Verification: `cargo nextest run -p zingolib` passes (209 tests) on the host, clippy is silent, and fmt is applied. The chain-bound libtonode suites are container-only in this tree and were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
