### PR TITLE
fix(ci): stop forwarding set-but-empty RUST_LOG into the test container

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -178,6 +178,20 @@ container_nextest_run() {
   local -a args
   mapfile -t args < <(nextest_args "$@")
 
+  # ZINGO_REGENERATE_CHAIN_CACHE and RUST_LOG are forwarded only when
+  # set AND non-empty. Never use -e "VAR=${VAR:-}" — that manufactures
+  # a set-but-empty variable in the container — and never forward an
+  # empty value either: an empty (or restrictive) RUST_LOG silences
+  # zainod's "Syncing block" markers, hanging the harness's
+  # log-contract convergence barrier (2026-07-20 stall forensics).
+  local -a forwarded_env=()
+  if [[ -n "${ZINGO_REGENERATE_CHAIN_CACHE:-}" ]]; then
+    forwarded_env+=(-e ZINGO_REGENERATE_CHAIN_CACHE)
+  fi
+  if [[ -n "${RUST_LOG:-}" ]]; then
+    forwarded_env+=(-e RUST_LOG)
+  fi
+
   "${runtime}" run --rm --init \
     --pids-limit -1 \
     -v "${PWD}:/workspace" \
@@ -186,8 +200,7 @@ container_nextest_run() {
     -v "zingolib-cargo-registry:/root/.cargo/registry${mount_suffix}" \
     -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=${NEXTEST_EXPERIMENTAL_LIBTEST_JSON}" \
     -e "TEST_BINARIES_DIR=/workspace/test_binaries/bins" \
-    -e "ZINGO_REGENERATE_CHAIN_CACHE=${ZINGO_REGENERATE_CHAIN_CACHE:-}" \
-    -e "RUST_LOG=${RUST_LOG:-}" \
+    "${forwarded_env[@]}" \
     -w /workspace \
     "${IMAGE_NAME}:${tag}" \
     bash -lc 'mkdir -p test_binaries/bins && ln -sf /usr/bin/zainod /usr/bin/zebrad test_binaries/bins/ && exec "$@"' \


### PR DESCRIPTION
Fixes: #2488 

Every containerized chain-bound run on this branch currently stalls in scenario setup. The container task forwards `RUST_LOG` and `ZINGO_REGENERATE_CHAIN_CACHE` with `-e "VAR=${VAR:-}"`, which manufactures a set-but-empty variable in the container whenever the invoking shell leaves it unset. zainod initializes logging with `EnvFilter::try_from_default_env()` falling back to `info`: unset yields normal info logs, but set-but-empty parses to a filter with zero directives and disables all logging. `zcash_local_net`'s indexer-convergence barrier is a log-format contract that polls zainod's stdout for `Syncing block, height: N`, and `sync_client_to_validator_tip` awaits that barrier before every wallet sync — so a silenced zainod hangs every setup, and cold chain-cache builds die before the export. "Caches aren't building" and "tests aren't completing" were one defect.

The full evidence chain is preserved in issue #2488: a commit-level A/B (ten consecutive cold passes without the forwarding, deterministic stalls with it, on byte-identical container images and provisioning binaries), a source trace through `zainod::init_logging` and the harness's `SYNC_MARKER` contract, and a live podman experiment against the pinned zainod binary proving the silencing. The previously suspected `IncorrectTreeSize` hardening (a8d1dc0a6) is exonerated: it is present in both A/B arms and the forwarding-free arm passes with it.

The fix collects the two variables into a `forwarded_env` array and adds a name-only `-e` flag solely when the variable is set and non-empty. Set-but-empty is deliberately treated as unset, because an empty `RUST_LOG` can only mean "silence everything," which the harness cannot survive.

One sharp edge remains out of scope: a restrictive but non-empty filter (for example `RUST_LOG=pepper_sync=debug` without `zainodlib=info`) still starves the barrier's markers. The durable fix belongs in the `zcash_local_net` Zainod launcher, which should pin its child's logging env; a spec for that change is written in the infrastructure repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)