### PR TITLE
fix: sync quiescence for the drain and the stored proposal, behind shipped APIs

### DIFF
--- a/zingolib/CONTEXT.md
+++ b/zingolib/CONTEXT.md
@@ -115,6 +115,8 @@
 
 **SyncMode** — The current state of the sync engine: `NotRunning`, `Running`, `Paused`, or `Shutdown`.
 
+**SyncQuiescence** — A held value that witnesses the sync engine is quiescent — paused or not running — and keeps it so for as long as the value lives. `LightClient::quiesce_sync` is the sole constructor: it pauses a running engine, and dropping the witness restores the prior sync mode. The Orchard→Ironwood drain demands the witness as a parameter, so planning under a running sync is unrepresentable for that path; the Two-phase Send holds one internally beside the stored Proposal, giving the shipped propose/send protocol the same guarantee without a signature change.
+
 **SyncConfig** — Configuration for the sync engine: performance level and transparent address discovery settings.
 
 **Performance Level** — Controls batch size and nullifier map scope: `Low`, `Medium`, `High`, or `Maximum`.
@@ -133,7 +135,7 @@
 
 **Transmission** — The step in which the client attempts a send: it submits a Calculated Transaction to the Indexer and verifies that the server-reported txid matches the locally calculated txid. Ironwood migration parts are instead *broadcast* (see **Migration Broadcast Endpoint**); the two words name distinct submission paths.
 
-**Two-phase Send** — The standard send path: `propose_send` (or `propose_shield`) followed by `send_stored_proposal`. Allows the caller to inspect the Proposal (e.g. fees) before committing. Proposing automatically pauses the sync engine to release the wallet write lock; `send_stored_proposal(resume_sync: true)` resumes it after transmission. `quick_send` / `quick_shield` are single-shot convenience wrappers that handle the pause/resume cycle internally.
+**Two-phase Send** — The standard send path: `propose_send` (or `propose_shield`) followed by `send_stored_proposal`. Allows the caller to inspect the Proposal (e.g. fees) before committing. Proposing quiesces the sync engine and the client holds that quiescence (a **SyncQuiescence**) while the Proposal is stored, so the state proposed against cannot shift before the send builds it. The quiescence ends with the Proposal: `send_stored_proposal(resume_sync: true)` and `clear_proposal` (the decline path) restore the engine's prior mode, `resume_sync: false` leaves it paused for the caller, and a proposing call that fails restores the engine on its way out. `quick_send` / `quick_shield` are single-shot convenience wrappers that hold the quiescence for the span of one call.
 
 ---
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -112,6 +112,12 @@ pub struct LightClient {
     sync_handle: Option<JoinHandle<Result<SyncResult, SyncError<WalletError>>>>,
     save_active: Arc<AtomicBool>,
     save_handle: Option<JoinHandle<std::io::Result<()>>>,
+    /// Held while a stored proposal is pending, so the wallet state the
+    /// proposal selected against cannot shift before the send builds it.
+    /// Process-lifetime state beside the stored proposal itself (ADR 0006):
+    /// never serialized, minted by the proposing calls, released when the
+    /// proposal is consumed, cleared, or fails to come into existence.
+    proposal_quiescence: Option<sync::SyncQuiescence>,
 }
 
 impl LightClient {
@@ -169,6 +175,7 @@ impl LightClient {
             sync_handle: None,
             save_active: Arc::new(AtomicBool::new(false)),
             save_handle: None,
+            proposal_quiescence: None,
         })
     }
 
@@ -193,6 +200,7 @@ impl LightClient {
             sync_handle: None,
             save_active: Arc::new(AtomicBool::new(false)),
             save_handle: None,
+            proposal_quiescence: None,
         }
     }
 
@@ -235,6 +243,7 @@ impl LightClient {
             sync_handle: None,
             save_active: Arc::new(AtomicBool::new(false)),
             save_handle: None,
+            proposal_quiescence: None,
         })
     }
 
@@ -435,9 +444,13 @@ impl LightClient {
         self.wallet().read().await.recovery_info()
     }
 
-    /// Clears any stored send proposal.
+    /// Clears any stored send proposal and restores the sync engine to the
+    /// mode it held before the proposal was created — the decline path of
+    /// the two-phase send. Previously the pause a proposal took outlived a
+    /// declined proposal until some later send opted into resuming.
     pub async fn clear_proposal(&mut self) {
         self.wallet().write().await.clear_proposal();
+        self.release_proposal_quiescence(true);
     }
 
     /// Returns `true` if the wallet has unsaved changes.

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -23,6 +23,7 @@ use zcash_primitives::transaction::TxId;
 
 use crate::lightclient::LightClient;
 use crate::lightclient::error::{LightClientError, MigrationError};
+use crate::lightclient::sync::SyncQuiescence;
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::wallet::LightWallet;
@@ -677,8 +678,17 @@ impl LightClient {
         &mut self,
         account: zip32::AccountId,
     ) -> Result<DrainSummary, LightClientError> {
+        // A scheduled migration rejects the drain regardless of chain state,
+        // so check before paying for a sync. The presynced body re-checks
+        // after the sync lands.
+        if self.wallet().read().await.migration.is_some() {
+            return Err(MigrationError::AlreadyInProgress.into());
+        }
+
         self.sync_and_await().await?;
-        self.drain_orchard_to_ironwood_presynced(account).await
+        let sync = self.quiesce_sync()?;
+        self.drain_orchard_to_ironwood_presynced(account, &sync)
+            .await
     }
 
     /// Broadcasts the immediate Orchard→Ironwood drain against the wallet's
@@ -689,16 +699,33 @@ impl LightClient {
     /// background sync running continuously (e.g. zingo-mobile). Calling the
     /// syncing variant from such a consumer collides with the running sync
     /// and fails with [`pepper_sync::error::SyncModeError::SyncAlreadyRunning`];
-    /// this entry point lets the caller drive sync itself, matching the
-    /// `send`/`shield` mutation paths.
+    /// this entry point lets the caller drive sync itself.
     ///
-    /// The caller is responsible for keeping the wallet synced before calling.
-    /// Everything else — the plan, the `pause_sync`/`resume_sync` bracketing
-    /// around build and transmit, the chunked broadcast, and the idempotent
-    /// cleanup on partial failure — is identical to the syncing variant.
+    /// The caller is responsible for keeping the wallet synced before
+    /// calling, and proves it has quiesced its sync by presenting the
+    /// [`SyncQuiescence`] witness — [`Self::quiesce_sync`] pauses a running
+    /// engine and resumes it when the witness drops. Planning and building
+    /// therefore observe one stable wallet state, the same
+    /// pause-before-proposing invariant the `send`/`shield` mutation paths
+    /// establish. Everything else — the plan, the chunked broadcast, and the
+    /// idempotent cleanup on partial failure — is identical to the syncing
+    /// variant.
+    ///
+    /// Calling without the witness does not compile — a stable wallet state
+    /// across plan and build is a compile-time precondition, not a runtime
+    /// courtesy:
+    ///
+    /// ```compile_fail
+    /// # async fn caller(client: &mut zingolib::lightclient::LightClient) {
+    /// let _ = client
+    ///     .drain_orchard_to_ironwood_presynced(zip32::AccountId::ZERO)
+    ///     .await;
+    /// # }
+    /// ```
     pub async fn drain_orchard_to_ironwood_presynced(
         &mut self,
         account: zip32::AccountId,
+        sync: &SyncQuiescence,
     ) -> Result<DrainSummary, LightClientError> {
         // A scheduled migration soft-reserves the notes its parts are bound to.
         // Draining them would invalidate those parts behind its back.
@@ -712,7 +739,7 @@ impl LightClient {
         }
 
         let txids = self
-            .build_and_transmit(&plan.transactions, |wallet, planned| {
+            .build_and_transmit(&plan.transactions, sync, |wallet, planned| {
                 wallet.build_drain_transaction(account, planned)
             })
             .await?;
@@ -726,32 +753,26 @@ impl LightClient {
     }
 
     /// Builds and transmits one batch of planned migration transactions under
-    /// a paused sync, enforcing the shared cleanup contract: a build failure
-    /// fails the transactions already built, and a transmit failure fails
-    /// every transaction still unsent, so no note stays spent by a
-    /// transaction that will never reach the network. Both the drain flow and
-    /// the note-splitting rounds send through here.
+    /// a caller-held [`SyncQuiescence`], enforcing the shared cleanup
+    /// contract: a build failure fails the transactions already built, and a
+    /// transmit failure fails every transaction still unsent, so no note
+    /// stays spent by a transaction that will never reach the network. Both
+    /// the drain flow and the note-splitting rounds send through here. The
+    /// witness parameter is pure evidence — the caller's witness performs the
+    /// pause and its drop the resume, on every exit path.
     async fn build_and_transmit<T>(
         &mut self,
         planned: &[T],
+        _sync: &SyncQuiescence,
         build: impl Fn(&mut LightWallet, &T) -> Result<TxId, WalletError>,
     ) -> Result<Vec<TxId>, LightClientError> {
-        let _ignore_error = self.pause_sync();
-        let built = self.build_transactions(planned, build).await;
-        let txids = match built {
-            Ok(txids) => txids,
-            Err(e) => {
-                let _ignore_error = self.resume_sync();
-                return Err(e);
-            }
-        };
+        let txids = self.build_transactions(planned, build).await?;
 
         let transmitted = self
             .transmit_transactions(
                 NonEmpty::from_vec(txids.clone()).expect("planned batches are never empty"),
             )
             .await;
-        let _ignore_error = self.resume_sync();
 
         if let Err(e) = transmitted {
             // `transmit_transactions` marks the transaction that failed, but
@@ -930,11 +951,14 @@ impl LightClient {
                 .into_iter()
                 .next()
                 .expect("unsplit plan has at least one round");
+            let sync = self.quiesce_sync()?;
             let round_txids = self
-                .build_and_transmit(&round, |wallet, planned| {
+                .build_and_transmit(&round, &sync, |wallet, planned| {
                     wallet.build_note_split_transaction(account, planned)
                 })
                 .await?;
+            // The confirmation wait syncs; release the quiescence first.
+            drop(sync);
             split_txids.extend(round_txids.iter().copied());
 
             self.await_migration_confirmations(&round_txids).await?;
@@ -1270,5 +1294,33 @@ mod tests {
         let part = &wallet.migration.as_ref().unwrap().parts[0];
         assert_eq!(part.state, PartState::Broadcast);
         assert_eq!(part.attempts, 1, "the attempt was recorded before submit");
+    }
+
+    /// A scheduled migration rejects the syncing drain *before* the drain
+    /// pays for a sync. The client here is offline, so any attempt to sync
+    /// first surfaces as [`LightClientError::Offline`] instead of the
+    /// pre-condition's [`MigrationError::AlreadyInProgress`] — which is
+    /// exactly how this test stays red while the wrapper syncs before
+    /// checking, and green once the check runs first. The presynced body
+    /// keeps its own post-sync check; this pins the wrapper's early one.
+    #[tokio::test]
+    async fn scheduled_migration_rejects_drain_before_syncing() {
+        let (mut wallet, bound_note) = wallet_with_migration_note(360);
+        let params = MigrationParams::provisional(wallet.chain_type());
+        let mut part = PartRecord::new(PartId(0), NOTE_VALUE, bound_note);
+        part.assign(0).expect("fresh parts are bound");
+        wallet.migration = Some(scheduled_state(params, vec![part]));
+
+        let mut client = LightClient::new_for_test(wallet).await;
+        let result = client.drain_orchard_to_ironwood(AccountId::ZERO).await;
+        assert!(
+            matches!(
+                result,
+                Err(crate::lightclient::error::LightClientError::MigrationError(
+                    crate::lightclient::error::MigrationError::AlreadyInProgress
+                ))
+            ),
+            "the drain must reject a scheduled migration without syncing, got {result:?}"
+        );
     }
 }

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -27,24 +27,62 @@ impl LightClient {
     }
 
     /// Creates and stores a proposal from a transaction request.
+    ///
+    /// Quiesces the sync engine before the first wallet read and holds that
+    /// quiescence beside the stored proposal, so the state the proposal
+    /// selected against cannot shift before the send builds it. A proposal
+    /// that fails to come into existence releases the quiescence on the way
+    /// out, restoring the engine to the mode it was found in.
     pub async fn propose_send(
         &mut self,
         request: TransactionRequest,
         account_id: zip32::AccountId,
     ) -> Result<ProportionalFeeProposal, ProposeSendError> {
-        let _ignore_error = self.pause_sync();
-        let mut wallet = self.wallet().write().await;
-        let proposal = wallet.create_send_proposal(request, account_id)?;
-        wallet.store_proposal(ZingoProposal::Send {
-            proposal: proposal.clone(),
-            sending_account: account_id,
-        });
-
-        Ok(proposal)
+        let minted = self.hold_proposal_quiescence();
+        let result = {
+            let mut wallet = self.wallet().write().await;
+            wallet
+                .create_send_proposal(request, account_id)
+                .inspect(|proposal| {
+                    wallet.store_proposal(ZingoProposal::Send {
+                        proposal: proposal.clone(),
+                        sending_account: account_id,
+                    });
+                })
+        };
+        if result.is_err() && minted {
+            self.release_proposal_quiescence(true);
+        }
+        result
     }
 
     /// Creates and stores a proposal for sending all shielded funds from a specified account to a given `address`.
+    ///
+    /// The quiescence a proposal holds (see [`Self::propose_send`]) is
+    /// established before the send-all sizing: the [`Self::max_send_value`]
+    /// trial proposals are wallet reads the sizing must not race a running
+    /// engine for, and the value they compute must still hold when the real
+    /// proposal is created.
     pub async fn propose_send_all(
+        &mut self,
+        address: ZcashAddress,
+        zennies_for_zingo: bool,
+        memo: Option<zcash_protocol::memo::MemoBytes>,
+        account_id: zip32::AccountId,
+    ) -> Result<ProportionalFeeProposal, ProposeSendError> {
+        let minted = self.hold_proposal_quiescence();
+        let result = self
+            .propose_send_all_quiesced(address, zennies_for_zingo, memo, account_id)
+            .await;
+        if result.is_err() && minted {
+            self.release_proposal_quiescence(true);
+        }
+        result
+    }
+
+    /// The [`Self::propose_send_all`] body, from sizing through storing,
+    /// which its caller runs under the stored proposal's quiescence.
+    async fn propose_send_all_quiesced(
         &mut self,
         address: ZcashAddress,
         zennies_for_zingo: bool,
@@ -63,7 +101,6 @@ impl LightClient {
         }
         let request = transaction_request_from_receivers(receivers)
             .map_err(ProposeSendError::TransactionRequestFailed)?;
-        let _ignore_error = self.pause_sync();
         let mut wallet = self.wallet().write().await;
         let proposal = wallet.create_send_proposal(request, account_id)?;
         wallet.store_proposal(ZingoProposal::Send {
@@ -74,19 +111,30 @@ impl LightClient {
         Ok(proposal)
     }
 
-    /// Creates and stores a proposal for shielding all transparent funds..
+    /// Creates and stores a proposal for shielding all transparent funds,
+    /// under the same stored-proposal quiescence as [`Self::propose_send`].
+    /// The shield path previously read spendable coins without quiescing
+    /// the engine at all.
     pub async fn propose_shield(
         &mut self,
         account_id: zip32::AccountId,
     ) -> Result<ProportionalFeeShieldProposal, ProposeShieldError> {
-        let mut wallet = self.wallet().write().await;
-        let proposal = wallet.create_shield_proposal(account_id)?;
-        wallet.store_proposal(ZingoProposal::Shield {
-            proposal: proposal.clone(),
-            shielding_account: account_id,
-        });
-
-        Ok(proposal)
+        let minted = self.hold_proposal_quiescence();
+        let result = {
+            let mut wallet = self.wallet().write().await;
+            wallet
+                .create_shield_proposal(account_id)
+                .inspect(|proposal| {
+                    wallet.store_proposal(ZingoProposal::Shield {
+                        proposal: proposal.clone(),
+                        shielding_account: account_id,
+                    });
+                })
+        };
+        if result.is_err() && minted {
+            self.release_proposal_quiescence(true);
+        }
+        result
     }
 
     /// Returns the maximum value that can be sent from the given `account_id`.
@@ -1599,5 +1647,73 @@ mod quiescence_contract {
 
         drop(engine_holds_wallet);
         call.await.unwrap().unwrap();
+    }
+
+    /// A request against a running-engine client that a proposal succeeds
+    /// for, shared by the stored-quiescence protocol tests below.
+    async fn client_with_stored_proposal() -> LightClient {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .orchard_note(100_000)
+            .build();
+        let mut client = client_with_running_engine(wallet).await;
+        let request = transaction_request_from_receivers(vec![Receiver::new(
+            external_address(PoolType::ORCHARD),
+            Zatoshis::const_from_u64(10_000),
+            None,
+        )])
+        .unwrap();
+        client
+            .propose_send(request, zip32::AccountId::ZERO)
+            .await
+            .unwrap();
+        client
+    }
+
+    /// A successful proposal holds its quiescence for as long as the
+    /// proposal is stored: the engine stays paused, so the state the
+    /// proposal selected against cannot shift before the send builds it.
+    #[tokio::test]
+    async fn proposing_holds_the_pause_for_the_stored_proposal() {
+        let client = client_with_stored_proposal().await;
+
+        assert_eq!(
+            client.sync_mode(),
+            SyncMode::Paused,
+            "a stored proposal must hold the engine quiescent"
+        );
+    }
+
+    /// Clearing a stored proposal — the decline path of the two-phase
+    /// send — restores the engine to the mode it held before proposing.
+    /// Previously the pause outlived the declined proposal until some
+    /// later send opted into resuming.
+    #[tokio::test]
+    async fn clearing_the_proposal_restores_the_engine() {
+        let mut client = client_with_stored_proposal().await;
+
+        client.clear_proposal().await;
+
+        assert_eq!(
+            client.sync_mode(),
+            SyncMode::Running,
+            "declining a proposal must restore the engine"
+        );
+    }
+
+    /// An Indexerless send attempt fails before consuming the stored
+    /// proposal (ADR 0006), so the proposal — and the quiescence guarding
+    /// it — survive for retry once an Indexer is configured.
+    #[tokio::test]
+    async fn offline_send_failure_keeps_the_proposal_guarded() {
+        let mut client = client_with_stored_proposal().await;
+
+        let result = client.send_stored_proposal(true).await;
+
+        assert!(result.is_err(), "an Indexerless send must fail");
+        assert_eq!(
+            client.sync_mode(),
+            SyncMode::Paused,
+            "a send that consumed nothing must release nothing"
+        );
     }
 }

--- a/zingolib/src/lightclient/propose.rs
+++ b/zingolib/src/lightclient/propose.rs
@@ -1435,3 +1435,169 @@ mod proposal_shape {
         assert!(change < 10_000, "change {change} implies oversized inputs");
     }
 }
+
+/// The propose/send family must never read wallet state a running engine
+/// could be mutating, and a pause it takes must serve a pending proposal —
+/// never outlive one. Each test here pins one way the imperative pause
+/// discipline violates that contract; all four run red until the stored
+/// quiescence discipline lands later on this branch.
+#[cfg(test)]
+mod quiescence_contract {
+    use std::sync::atomic;
+
+    use pepper_sync::wallet::SyncMode;
+    use zcash_protocol::PoolType;
+    use zcash_protocol::value::Zatoshis;
+
+    use crate::data::receivers::{Receiver, transaction_request_from_receivers};
+    use crate::lightclient::LightClient;
+    use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+    use crate::wallet::LightWallet;
+    use crate::wallet::keys::unified::ReceiverSelection;
+
+    /// An address belonging to a different wallet, so the send is external.
+    fn external_address(pool: PoolType) -> zcash_address::ZcashAddress {
+        let mut external_wallet =
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::ABANDON_ART_SEED).build();
+        let selection = match pool {
+            PoolType::ORCHARD | PoolType::IRONWOOD => ReceiverSelection::orchard_only(),
+            PoolType::SAPLING => ReceiverSelection::sapling_only(),
+            _ => unimplemented!("only shielded destinations are needed here"),
+        };
+        let (_, unified_address) = external_wallet
+            .generate_unified_address(selection, zip32::AccountId::ZERO)
+            .unwrap();
+        crate::utils::conversion::address_from_str(
+            &unified_address.encode(&external_wallet.chain_type()),
+        )
+        .unwrap()
+    }
+
+    /// A synthetic-wallet client whose sync-mode atomic reads `Running`,
+    /// simulating a consumer whose background sync engine is between
+    /// batches. No engine task exists, so every mode transition observed —
+    /// or leaked — is the code under test's own.
+    async fn client_with_running_engine(wallet: LightWallet) -> LightClient {
+        let client = LightClient::new_for_test(wallet).await;
+        client
+            .sync_mode
+            .store(SyncMode::Running as u8, atomic::Ordering::Release);
+        client
+    }
+
+    /// The pause a proposal takes exists for the proposal it stores. A
+    /// proposing call that fails stores nothing, so it must restore the
+    /// engine on its way out. The imperative discipline pauses first and
+    /// error-returns past every resume, leaving a consumer's background
+    /// sync silently suspended with nothing pending.
+    #[tokio::test]
+    async fn failed_proposal_leaves_no_leaked_pause() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .orchard_note(10_000)
+            .build();
+        let mut client = client_with_running_engine(wallet).await;
+        let request = transaction_request_from_receivers(vec![Receiver::new(
+            external_address(PoolType::ORCHARD),
+            Zatoshis::const_from_u64(50_000),
+            None,
+        )])
+        .unwrap();
+
+        let result = client.propose_send(request, zip32::AccountId::ZERO).await;
+
+        assert!(result.is_err(), "a 50_000 send from 10_000 must fail");
+        assert_eq!(
+            client.sync_mode(),
+            SyncMode::Running,
+            "a failed proposal must leave the engine as it found it"
+        );
+    }
+
+    /// A shield proposal must not come into existence while the engine is
+    /// running: the proposal reads spendable coins the engine mutates.
+    /// `propose_send` pauses for exactly this reason; the shield path
+    /// never did.
+    #[tokio::test]
+    async fn shield_proposal_is_never_created_under_a_running_engine() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .transparent_coin(100_000)
+            .build();
+        let mut client = client_with_running_engine(wallet).await;
+
+        let result = client.propose_shield(zip32::AccountId::ZERO).await;
+
+        assert!(
+            result.is_err() || client.sync_mode() != SyncMode::Running,
+            "a shield proposal was created while the engine ran"
+        );
+    }
+
+    /// `quick_shield` goes further than proposing: it builds and stores
+    /// signed transactions, so its first wallet read must already run
+    /// under quiescence. Simulate the engine mid-batch by holding the
+    /// wallet write lock: the call blocks on that lock, so if the mode
+    /// still reads `Running` while the call is in flight, the build began
+    /// without quiescing the engine first.
+    #[tokio::test]
+    async fn quick_shield_never_builds_under_a_running_engine() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .transparent_coin(100_000)
+            .build();
+        let mut client = client_with_running_engine(wallet).await;
+        let sync_mode = client.sync_mode.clone();
+        let wallet_handle = client.wallet().clone();
+        let engine_holds_wallet = wallet_handle.write().await;
+
+        let call = tokio::spawn(async move {
+            let _offline_transmission_failure = client.quick_shield(zip32::AccountId::ZERO).await;
+        });
+        // The current-thread runtime polls the spawned call until it
+        // blocks on the held wallet lock.
+        tokio::task::yield_now().await;
+
+        assert_ne!(
+            SyncMode::from_atomic_u8(sync_mode).unwrap(),
+            SyncMode::Running,
+            "quick_shield began its wallet reads while the engine ran"
+        );
+
+        drop(engine_holds_wallet);
+        call.await.unwrap();
+    }
+
+    /// The send-all sizing (the `max_send_value` trial proposals) is
+    /// `propose_send_all`'s first wallet read and must already run under
+    /// quiescence. Simulate the engine mid-batch by holding the wallet
+    /// write lock: the sizing blocks on that lock, so if the engine's mode
+    /// still reads `Running` while the call is in flight, the call began
+    /// its reads without quiescing the engine first.
+    #[tokio::test]
+    async fn send_all_sizing_runs_under_quiescence() {
+        let wallet = SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .orchard_note(100_000)
+            .build();
+        let mut client = client_with_running_engine(wallet).await;
+        let sync_mode = client.sync_mode.clone();
+        let wallet_handle = client.wallet().clone();
+        let engine_holds_wallet = wallet_handle.write().await;
+
+        let address = external_address(PoolType::ORCHARD);
+        let call = tokio::spawn(async move {
+            client
+                .propose_send_all(address, false, None, zip32::AccountId::ZERO)
+                .await
+        });
+        // The current-thread runtime polls the spawned call until it
+        // blocks on the held wallet lock.
+        tokio::task::yield_now().await;
+
+        assert_ne!(
+            SyncMode::from_atomic_u8(sync_mode).unwrap(),
+            SyncMode::Running,
+            "the send-all sizing began while the engine ran"
+        );
+
+        drop(engine_holds_wallet);
+        call.await.unwrap().unwrap();
+    }
+}

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -141,7 +141,11 @@ impl LightClient {
 
     /// Creates and transmits transactions from a stored proposal.
     ///
-    /// If sync was running prior to creating a send proposal, sync will have been paused. If `resume_sync` is `true`, sync will be resumed after sending the stored proposal.
+    /// If sync was running prior to creating a send proposal, sync will have
+    /// been paused. If `resume_sync` is `true`, the engine is restored to
+    /// the mode it held before the proposal was created — a pause the
+    /// caller established before proposing is preserved, not overridden. If
+    /// `false`, the engine stays paused for the caller to resume.
     pub async fn send_stored_proposal(
         &mut self,
         resume_sync: bool,
@@ -160,9 +164,7 @@ impl LightClient {
                 } => self.shield(proposal, shielding_account).await,
             };
 
-            if resume_sync {
-                let _ignore_error = self.resume_sync();
-            }
+            self.release_proposal_quiescence(resume_sync);
 
             txids
         } else {
@@ -193,44 +195,53 @@ impl LightClient {
         let indexerless = self.indexer.is_none();
         let mut wallet = self.wallet().write().await;
         let opt_proposal = wallet.take_proposal();
-        if let Some(proposal) = opt_proposal {
-            let chain_type = wallet.chain_type();
-            let txids = match proposal {
-                ZingoProposal::Send {
-                    proposal,
-                    sending_account,
-                } => {
-                    let proposal = if indexerless {
-                        retarget_for_offline_signing(&proposal, &chain_type)
-                            .map_err(SendError::RetargetError)?
-                    } else {
-                        proposal
-                    };
-                    wallet
+        let Some(proposal) = opt_proposal else {
+            return Err(SendError::NoStoredProposal.into());
+        };
+        let chain_type = wallet.chain_type();
+        let result = match proposal {
+            ZingoProposal::Send {
+                proposal,
+                sending_account,
+            } => {
+                let retargeted = if indexerless {
+                    retarget_for_offline_signing(&proposal, &chain_type)
+                        .map_err(SendError::RetargetError)
+                } else {
+                    Ok(proposal)
+                };
+                match retargeted {
+                    Ok(proposal) => wallet
                         .calculate_transactions(proposal, sending_account)
                         .await
-                        .map_err(SendError::CalculateSendError)?
+                        .map_err(SendError::CalculateSendError),
+                    Err(e) => Err(e),
                 }
-                ZingoProposal::Shield {
-                    proposal,
-                    shielding_account,
-                } => {
-                    let proposal = if indexerless {
-                        retarget_for_offline_signing(&proposal, &chain_type)
-                            .map_err(SendError::RetargetError)?
-                    } else {
-                        proposal
-                    };
-                    wallet
+            }
+            ZingoProposal::Shield {
+                proposal,
+                shielding_account,
+            } => {
+                let retargeted = if indexerless {
+                    retarget_for_offline_signing(&proposal, &chain_type)
+                        .map_err(SendError::RetargetError)
+                } else {
+                    Ok(proposal)
+                };
+                match retargeted {
+                    Ok(proposal) => wallet
                         .calculate_transactions(proposal, shielding_account)
                         .await
-                        .map_err(SendError::CalculateShieldError)?
+                        .map_err(SendError::CalculateShieldError),
+                    Err(e) => Err(e),
                 }
-            };
-            Ok(txids)
-        } else {
-            Err(SendError::NoStoredProposal.into())
-        }
+            }
+        };
+        drop(wallet);
+        // The proposal is consumed on every path above, so its quiescence
+        // has nothing left to guard; the engine returns to its prior mode.
+        self.release_proposal_quiescence(true);
+        result.map_err(LightClientError::from)
     }
 
     /// Transmits previously calculated transactions to the Indexer, in the
@@ -247,7 +258,10 @@ impl LightClient {
 
     /// Proposes and transmits transactions from a transaction request skipping proposal confirmation.
     ///
-    /// If sync is running, sync will be paused before creating the send proposal. If `resume_sync` is `true`, sync will be resumed after send.
+    /// If sync is running, it is quiesced before creating the send proposal.
+    /// If `resume_sync` is `true`, the engine is restored to its prior mode
+    /// after the send, on every exit path; if `false`, it stays paused for
+    /// the caller to resume.
     pub async fn quick_send(
         &mut self,
         request: TransactionRequest,
@@ -256,7 +270,7 @@ impl LightClient {
     ) -> Result<NonEmpty<TxId>, LightClientError> {
         // Proposing is an Indexerless capability; only the calculate/transmit
         // stage below demands a connection.
-        let _ignore_error = self.pause_sync();
+        let witness = self.quiesce_sync().ok();
         let proposal_result = self
             .wallet()
             .write()
@@ -267,20 +281,27 @@ impl LightClient {
             Ok(proposal) => self.send(proposal, account_id).await,
             Err(e) => Err(e.into()),
         };
-        if resume_sync {
-            let _ignore_error = self.resume_sync();
+        if let Some(witness) = witness
+            && !resume_sync
+        {
+            witness.disarm();
         }
 
         txids
     }
 
-    /// Shields all transparent funds skipping proposal confirmation.
+    /// Shields all transparent funds skipping proposal confirmation. The
+    /// sync engine is quiesced before the proposal's wallet reads and
+    /// restored to its prior mode when the call returns; the shield path
+    /// previously proposed, built, and stored transactions under a running
+    /// engine.
     pub async fn quick_shield(
         &mut self,
         account_id: zip32::AccountId,
     ) -> Result<NonEmpty<TxId>, LightClientError> {
         // Proposing is an Indexerless capability; only the calculate/transmit
         // stage below demands a connection.
+        let _witness = self.quiesce_sync().ok();
         let proposal = self
             .wallet()
             .write()

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -248,6 +248,37 @@ impl LightClient {
         }
     }
 
+    /// Quiesces the engine for the lifetime of a stored proposal, keeping
+    /// the witness in the client until the proposal is consumed (sent or
+    /// calculated), cleared, or fails to come into existence. Returns
+    /// whether this call minted the witness, so a proposing call's error
+    /// path can release exactly what it took while an already-held witness
+    /// keeps guarding the proposal it was minted for. A shutting-down
+    /// engine cannot be quiesced; the proposal then proceeds unguarded,
+    /// exactly as the imperative pause discipline did.
+    pub(crate) fn hold_proposal_quiescence(&mut self) -> bool {
+        if self.proposal_quiescence.is_none()
+            && let Ok(witness) = self.quiesce_sync()
+        {
+            self.proposal_quiescence = Some(witness);
+            return true;
+        }
+        false
+    }
+
+    /// Releases the stored proposal's quiescence witness, if one is held.
+    /// `restore: true` drops the witness, returning the engine to the mode
+    /// it held before the proposal was created; `restore: false` disarms
+    /// it, leaving the engine paused for the caller to resume — the
+    /// shipped `resume_sync: false` semantics.
+    pub(crate) fn release_proposal_quiescence(&mut self, restore: bool) {
+        if let Some(witness) = self.proposal_quiescence.take()
+            && !restore
+        {
+            witness.disarm();
+        }
+    }
+
     /// Polls the sync task and, if it failed, returns the recommended
     /// recovery action alongside the error description.
     ///
@@ -283,6 +314,18 @@ impl LightClient {
 pub struct SyncQuiescence {
     sync_mode: Arc<atomic::AtomicU8>,
     resume_on_drop: bool,
+}
+
+impl SyncQuiescence {
+    /// Cancels the restore-on-drop: the engine stays exactly as the witness
+    /// held it, so a pause taken by [`LightClient::quiesce_sync`] persists
+    /// past the witness. Crate-internal on purpose — the public contract
+    /// remains "drop restores the prior mode"; only the shipped
+    /// `resume_sync: false` protocol needs to keep an engine paused for the
+    /// caller to resume later.
+    pub(crate) fn disarm(mut self) {
+        self.resume_on_drop = false;
+    }
 }
 
 impl Drop for SyncQuiescence {

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -1,6 +1,7 @@
 //! Sync implementations for [`crate::lightclient::LightClient`] and related types.
 
 use std::borrow::BorrowMut;
+use std::sync::Arc;
 use std::sync::atomic;
 use std::time::Duration;
 
@@ -208,6 +209,45 @@ impl LightClient {
         self.await_sync().await
     }
 
+    /// Quiesces the sync engine and returns the witness that proves it.
+    ///
+    /// A running engine is paused and resumes when the witness drops. A
+    /// paused or not-running engine is already quiescent, so the witness
+    /// changes nothing — in particular, dropping it never resumes a pause
+    /// somebody else established. A shutting-down engine still scans its
+    /// final batch, so it is *not* quiescent; the call fails with
+    /// [`SyncModeError::SyncAlreadyRunning`] and the caller should await
+    /// shutdown first.
+    pub fn quiesce_sync(&self) -> Result<SyncQuiescence, SyncModeError> {
+        loop {
+            let resume_on_drop = match self.sync_mode() {
+                SyncMode::Running => {
+                    if self
+                        .sync_mode
+                        .compare_exchange(
+                            SyncMode::Running as u8,
+                            SyncMode::Paused as u8,
+                            atomic::Ordering::AcqRel,
+                            atomic::Ordering::Acquire,
+                        )
+                        .is_err()
+                    {
+                        // The engine changed state between the read and the
+                        // exchange; reclassify from the fresh mode.
+                        continue;
+                    }
+                    true
+                }
+                SyncMode::Paused | SyncMode::NotRunning => false,
+                SyncMode::Shutdown => return Err(SyncModeError::SyncAlreadyRunning),
+            };
+            return Ok(SyncQuiescence {
+                sync_mode: self.sync_mode.clone(),
+                resume_on_drop,
+            });
+        }
+    }
+
     /// Polls the sync task and, if it failed, returns the recommended
     /// recovery action alongside the error description.
     ///
@@ -226,6 +266,110 @@ impl LightClient {
             }
             _ => None,
         }
+    }
+}
+
+/// Evidence that the sync engine is quiescent — paused or not running — for
+/// as long as this value lives.
+///
+/// [`LightClient::quiesce_sync`] is the only constructor: it performs the one
+/// side effect (pausing a running engine) up front and undoes it on drop. A
+/// function that takes `&SyncQuiescence` performs no sync-mode transitions of
+/// its own — the parameter is pure evidence that the caller already quiesced
+/// sync, so wallet state cannot shift under the callee between its reads and
+/// its writes. That turns the requirement into a compile-time contract: the
+/// racy call shape — planning against a wallet a running sync is still
+/// mutating — has no well-typed spelling.
+pub struct SyncQuiescence {
+    sync_mode: Arc<atomic::AtomicU8>,
+    resume_on_drop: bool,
+}
+
+impl Drop for SyncQuiescence {
+    fn drop(&mut self) {
+        if self.resume_on_drop {
+            // Resume only if the engine is still paused: a stop_sync issued
+            // while the witness was held must win over the resume.
+            let _ignore_raced_transition = self.sync_mode.compare_exchange(
+                SyncMode::Paused as u8,
+                SyncMode::Running as u8,
+                atomic::Ordering::AcqRel,
+                atomic::Ordering::Acquire,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pepper_sync::wallet::SyncMode;
+
+    use super::atomic;
+    use crate::lightclient::LightClient;
+    use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+    /// An offline client whose sync-mode atomic the tests drive directly;
+    /// no engine runs, so every observed transition is the witness's own.
+    async fn offline_client(mode: SyncMode) -> LightClient {
+        let wallet =
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED).build();
+        let client = LightClient::new_for_test(wallet).await;
+        client
+            .sync_mode
+            .store(mode as u8, atomic::Ordering::Release);
+        client
+    }
+
+    #[tokio::test]
+    async fn running_pauses_and_drop_resumes() {
+        let client = offline_client(SyncMode::Running).await;
+        let witness = client.quiesce_sync().expect("a running engine quiesces");
+        assert_eq!(client.sync_mode(), SyncMode::Paused);
+        drop(witness);
+        assert_eq!(client.sync_mode(), SyncMode::Running);
+    }
+
+    #[tokio::test]
+    async fn not_running_is_a_no_op_witness() {
+        let client = offline_client(SyncMode::NotRunning).await;
+        let witness = client.quiesce_sync().expect("no engine is quiescent");
+        assert_eq!(client.sync_mode(), SyncMode::NotRunning);
+        drop(witness);
+        assert_eq!(client.sync_mode(), SyncMode::NotRunning);
+    }
+
+    #[tokio::test]
+    async fn paused_witness_does_not_steal_the_resume() {
+        let client = offline_client(SyncMode::Paused).await;
+        let witness = client.quiesce_sync().expect("a paused engine is quiescent");
+        drop(witness);
+        assert_eq!(
+            client.sync_mode(),
+            SyncMode::Paused,
+            "whoever paused the engine owns its resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_not_quiescent() {
+        let client = offline_client(SyncMode::Shutdown).await;
+        assert!(
+            client.quiesce_sync().is_err(),
+            "a shutting-down engine still scans its final batch"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_while_held_wins_over_the_resume() {
+        let client = offline_client(SyncMode::Running).await;
+        let witness = client.quiesce_sync().expect("a running engine quiesces");
+        client.stop_sync().expect("a paused engine can be stopped");
+        drop(witness);
+        assert_eq!(
+            client.sync_mode(),
+            SyncMode::Shutdown,
+            "the drop must not overwrite a shutdown request"
+        );
     }
 }
 


### PR DESCRIPTION
## What this does

The review of #2489 found that `drain_orchard_to_ironwood_presynced` planned against the wallet while the caller's background sync could still be mutating it — the pause happened only later, inside the build stage. This PR fixes that race and, while pinning it with tests, fixes three latent defects of the same pause discipline in the shipped propose/send family — **without changing any shipped public signature**.

## The shape of the fix

**`SyncQuiescence`** is an RAII witness: `quiesce_sync()` pauses a running engine (a paused or not-running engine is already quiescent), and dropping the witness restores the prior sync mode. A `stop_sync` issued while the witness is held wins over the restore.

The witness appears in a public signature in exactly one place: `drain_orchard_to_ironwood_presynced` takes `&SyncQuiescence`, so the plan-under-running-sync call shape does not compile (a `compile_fail` doctest pins this). That entry point is new in #2489 with no released consumer, so nothing shipped breaks.

The shipped propose/send family keeps its API — `resume_sync: bool` and all — and holds a witness *internally*, stored beside the stored proposal (process-lifetime state, ADR 0006): minted before a proposing call's first wallet read, released when the proposal is consumed (send or calculate), cleared (`clear_proposal`), or fails to come into existence.

## Red-first

The first commit lands four `quiescence_contract` tests that fail against `feat/ironwood`, one per defect:

1. `propose_send` pauses, then error-returns past every resume — a failed proposal leaves a consumer's background sync silently suspended.
2. `propose_shield` never paused: a shield proposal is created under a running engine.
3. `quick_shield` never paused: it builds and stores signed transactions under a running engine.
4. `propose_send_all` runs its send-all sizing (the `max_send_value` trial proposals) before its pause.

They stay red through the witness and drain commits and turn green at the implementation commit, behind unchanged signatures. Three further tests pin the corrected protocol: a stored proposal holds its pause; `clear_proposal` (the decline path) restores the engine; an Indexerless send failure, which consumes nothing, releases nothing.

## Behavioral notes for consumers

- No call-site changes anywhere: zingo-cli, the test suites, and mobile's shipped integration compile and behave as before on the happy path.
- One deliberate refinement: `send_stored_proposal(resume_sync: true)` now restores the engine's *prior* mode instead of unconditionally resuming, so a pause the caller established before proposing is preserved rather than overridden.
- `clear_proposal` now ends the proposal's pause. Previously a declined proposal left sync suspended until some later send opted into resuming.

## Deferred

Converting the shipped propose/send span to a caller-held witness (the API-breaking form) is deferred to a coordinated move with mobile.

Verified: 224-test zingolib suite green, drain `compile_fail` doctest green, the four contract tests verified red at each pre-implementation commit, workspace check/clippy/fmt clean. Chain-bound libtonode call sites are compile-verified (container-only on this host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
