### PR TITLE
perf(build): kill the per-run recompile churn

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -316,11 +316,18 @@ container_nextest_run "$@"
 #   makers test packages       every workspace package EXCEPT the live ones
 #   makers test live            ONLY the live packages
 #
-# The live-package list is defined once (live_packages, below); `packages`
-# derives its exclusions from it and `live` derives its selections from it,
-# so the partition cannot drift. Explicit package-selection args replace a
-# set's scope entirely — cargo silently ignores `-p` when `--workspace` is
-# present, so merging them would swallow the user's selection.
+# The live-package list is defined once (live_packages, below); both reserved
+# words derive nextest FILTERSETS from it, so the partition cannot drift.
+# Filtersets rather than package selections, deliberately: every invocation
+# keeps the same `--workspace` build scope, cargo unifies features
+# identically, and every phase of `makers hierarchy-test` reuses ONE
+# compiled variant of each crate — a `-p`/`--exclude` scope re-unifies
+# features per selection and compiles a distinct zingolib variant per phase.
+# Explicit package-selection args still replace a set's scope entirely —
+# cargo silently ignores `-p` when `--workspace` is present, so merging
+# them would swallow the user's selection. Caveat: combining a reserved
+# word with your own `-E` unions the two filtersets (nextest semantics);
+# for intersection, pass one full expression to plain `makers test -E`.
 # ===================================================================
 
 [tasks.test]
@@ -335,16 +342,22 @@ script.main = '''
 # for the packages/live partition.
 live_packages=(libtonode-tests zingo-cli)
 
+# The filterset matching every live package's tests; its negation is the
+# hermetic remainder. Space-free, so each expression rides as one argv token.
+live_filter=""
+for pkg in "${live_packages[@]}"; do
+  live_filter+="${live_filter:+|}package(${pkg})"
+done
+
 set_args=()
 if [[ "$#" -gt 0 ]]; then
   case "$1" in
     packages)
       shift
-      set_args+=(--workspace)
-      for pkg in "${live_packages[@]}"; do set_args+=(--exclude "${pkg}"); done ;;
+      set_args+=(--workspace -E "!(${live_filter})") ;;
     live)
       shift
-      for pkg in "${live_packages[@]}"; do set_args+=(--package "${pkg}"); done ;;
+      set_args+=(--workspace -E "${live_filter}") ;;
   esac
 fi
 

--- a/tools/workbench/src/bin/test-summary.rs
+++ b/tools/workbench/src/bin/test-summary.rs
@@ -35,11 +35,18 @@ fn is_package_selection_arg(arg: &str) -> bool {
 
 /// The phases, in order: the hermetic package tests first, then the live
 /// suites from fastest to slowest. Each entry is (display label, the
-/// `makers test` argv that selects the phase's scope).
+/// `makers test` invocation that selects the phase's TESTS).
+///
+/// Phases select tests with nextest filtersets, never with cargo package
+/// selections. Every phase then shares the front door's `--workspace`
+/// build scope, cargo unifies features identically across phases, and a
+/// hierarchy run after the first recompiles nothing. A `-p` phase scope
+/// re-unifies features per selection and compiles (then, after any source
+/// change, recompiles) a distinct variant of zingolib per phase.
 const PHASES: &[(&str, &str)] = &[
     ("packages", "packages"),
-    ("zingo-cli", "-p zingo-cli"),
-    ("libtonode", "-p libtonode-tests"),
+    ("zingo-cli", "-E 'package(zingo-cli)'"),
+    ("libtonode", "-E 'package(libtonode-tests)'"),
 ];
 
 /// One nextest run's tallies, zero where the summary line was absent.
@@ -277,6 +284,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     print_row("TOTAL:", &total);
     println!("==============================================================");
+    // Every phase runs the same --workspace build scope filtered to its
+    // own tests (one compiled variant, no per-phase feature re-unification),
+    // so nextest counts the other phases' tests as skipped in each row.
+    println!(
+        "  note: skipped counts include the other phases' tests — phases share one \
+         --workspace build scope, filtered per phase."
+    );
 
     // Every non-passing test by name, so nobody scrolls a 20-minute log to
     // learn what actually failed.
@@ -338,6 +352,23 @@ mod package_selection_guard {
             "--manifest-path=Cargo.toml",
         ] {
             assert!(is_package_selection_arg(arg), "should reject {arg}");
+        }
+    }
+
+    /// Phases must select tests (filtersets), never packages: a package
+    /// selection re-unifies features per phase and compiles a distinct
+    /// zingolib variant per phase, defeating the shared --workspace
+    /// build scope.
+    #[test]
+    fn phase_invocations_select_tests_not_packages() {
+        for (_, invocation) in PHASES {
+            for token in invocation.split_whitespace() {
+                let token = token.trim_matches('\'');
+                assert!(
+                    !is_package_selection_arg(token),
+                    "phase invocation {invocation:?} carries package-selection arg {token:?}"
+                );
+            }
         }
     }
 

--- a/zingolib/build.rs
+++ b/zingolib/build.rs
@@ -1,23 +1,87 @@
+#![forbid(unsafe_code)]
+//! Build-time inputs: the Sapling proving parameters (fetched once,
+//! copied beside the crate for mobile packaging) and the `git describe`
+//! string compiled into [`zingolib::git_description`].
+//!
+//! The script registers its watch set explicitly. Without any
+//! `cargo:rerun-if-changed` directive cargo falls back to watching the
+//! whole package tree — and this script WRITES into that tree
+//! (`zcash-params/`), so the fallback made every build dirty the next
+//! one: an unconditional rerun (network fetch included) plus a full
+//! recompile cascade through every dependent crate, on every run.
+
 use std::io::Write;
-use std::{env, fs::File, path::Path, process::Command};
+use std::path::{Path, PathBuf};
+use std::{env, fs::File, process::Command};
 
-fn git_description() {
-    let _fetch = Command::new("git")
-        .args(["fetch", "--tags", "https://github.com/zingolabs/zingolib"])
-        .output()
-        .expect("Failed to execute git command");
+/// Register everything this script's output depends on. Emitting any
+/// directive disables cargo's whole-package fallback, which is the
+/// point: the package tree contains this script's own outputs.
+fn register_rerun_watches() {
+    println!("cargo:rerun-if-changed=build.rs");
+    // The params copies: deleting either one triggers a rerun, which
+    // restores it. While both exist the fetch is skipped entirely.
+    println!("cargo:rerun-if-changed=zcash-params/sapling-spend.params");
+    println!("cargo:rerun-if-changed=zcash-params/sapling-output.params");
+    // The git state behind `git describe`: HEAD moves live in the
+    // worktree's own git dir; tags and packed refs live in the common
+    // dir (they differ in linked worktrees). The `--dirty` suffix is
+    // deliberately NOT kept live — that would require watching the
+    // whole tree, which is exactly the every-run rebuild this watch
+    // set exists to end; it reflects the state at the last rerun.
+    if let Some(git_dir) = git_path_query("--git-dir") {
+        println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    }
+    if let Some(common_dir) = git_path_query("--git-common-dir") {
+        println!(
+            "cargo:rerun-if-changed={}",
+            common_dir.join("packed-refs").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            common_dir.join("refs").display()
+        );
+    }
+}
+
+/// A path from `git rev-parse <flag>`, or `None` outside a git
+/// checkout (a published-crate build), where the git watches simply
+/// don't apply.
+fn git_path_query(flag: &str) -> Option<PathBuf> {
     let output = Command::new("git")
-        .args(["describe", "--dirty", "--always", "--long"])
+        .args(["rev-parse", flag])
         .output()
-        .expect("Failed to execute git command");
-
-    eprintln!("Git command output: {output:?}");
-    println!("Git command output: {output:?}");
-
-    let git_description = String::from_utf8(output.stdout)
-        .unwrap()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout)
+        .ok()?
         .trim_end()
         .to_string();
+    if path.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(path))
+}
+
+fn git_description() {
+    // No network here: a build must describe the state it builds from,
+    // and the tags already fetched are part of that state. (The
+    // previous `git fetch --tags` on every rerun was both a per-build
+    // network round-trip and a source of description drift.)
+    let description = Command::new("git")
+        .args(["describe", "--dirty", "--always", "--long"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| stdout.trim_end().to_string())
+        .filter(|description| !description.is_empty())
+        // Outside a usable git checkout (published crate, bind-mounted
+        // container workspace with unresolved ownership), fall back to
+        // the crate version rather than embedding an empty string.
+        .unwrap_or_else(|| format!("v{}", env::var("CARGO_PKG_VERSION").unwrap_or_default()));
 
     // Write the git description to a file which will be included in the crate
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -29,14 +93,23 @@ fn git_description() {
         /// The most recent tag name, the number\n\
         /// of commits above it, and the hash of\n\
         /// the most recent commit\n\
-        pub fn git_description() -> &'static str {{\"{git_description}\"}}"
+        pub fn git_description() -> &'static str {{\"{description}\"}}"
     )
     .unwrap();
 }
 
 /// Checks if zcash params are available and downloads them if not.
 /// Also copies them to an internal location for use by mobile platforms.
+/// Skipped entirely while both copies exist: rewriting them
+/// unconditionally is what used to dirty the package on every build.
 fn get_zcash_params() {
+    let internal_params_path = Path::new("zcash-params");
+    let spend_dest = internal_params_path.join("sapling-spend.params");
+    let output_dest = internal_params_path.join("sapling-output.params");
+    if spend_dest.exists() && output_dest.exists() {
+        return;
+    }
+
     println!("Checking if params are available...");
 
     let params_path = match zcash_proofs::download_sapling_parameters(Some(400)) {
@@ -53,22 +126,13 @@ fn get_zcash_params() {
     };
 
     // Copy the params to the internal location.
-    let internal_params_path = Path::new("zcash-params");
     std::fs::create_dir_all(internal_params_path).unwrap();
-    std::fs::copy(
-        params_path.spend,
-        internal_params_path.join("sapling-spend.params"),
-    )
-    .unwrap();
-
-    std::fs::copy(
-        params_path.output,
-        internal_params_path.join("sapling-output.params"),
-    )
-    .unwrap();
+    std::fs::copy(params_path.spend, spend_dest).unwrap();
+    std::fs::copy(params_path.output, output_dest).unwrap();
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    register_rerun_watches();
     get_zcash_params();
     git_description();
     Ok(())


### PR DESCRIPTION
Every containerized test run was paying ~10–15 seconds of recompilation on an unchanged tree, and `makers hierarchy-test` recompiled `zingolib` again between each of its three phases. Two commits, one cause each.

**`fix(build)`: register `build.rs` inputs.** `zingolib/build.rs` emitted no `cargo:rerun-if-changed` directives, so cargo watched the whole package tree — which the script itself wrote into, unconditionally rewriting `zcash-params/` on every run. Every build dirtied the next: an unconditional build-script rerun (including a `git fetch --tags` network round-trip on every compile) followed by a recompile of `zingolib` and every dependent. The script now registers its true inputs (itself, the params copies, and the git state behind `git describe`, resolved worktree-aware via `git rev-parse`), skips the params fetch while the copies exist, drops the network fetch outright, and falls back to the crate version where `git describe` is unusable (e.g. inside the container, whose bind mount cannot reach a linked worktree's git dir). Verified with cargo's fingerprint log: back-to-back runs are no-ops on host and in the container; deleting a params copy self-heals with one rebuild. One documented trade-off: the `--dirty` suffix reflects the last actual rerun — keeping it live is precisely the every-run rebuild this removes.

**`refactor(test)`: phases select tests, not build scope.** Cargo unifies features per package selection, so `hierarchy-test`'s three phase scopes (`--workspace --exclude …`, `-p zingo-cli`, `-p libtonode-tests`) were three distinct build variants of the same code — each recompiled after any source change. The `packages`/`live` reserved words now expand to `--workspace -E <filterset>` (the live filter and its negation, derived from the single `live_packages` list), and `test-summary`'s phases pass `-E 'package(…)'` through the front door. Every phase — and plain `makers test` — shares one feature-unification universe and therefore one compiled variant of each crate. A unit test pins that no phase invocation carries a package-selection arg, and nextest fails loudly if the partition ever names a package that no longer exists. Two documented consequences: each phase's nextest summary now counts the other phases' tests as skipped (the combined table carries an explanatory note), and stacking a user `-E` on a reserved word unions filtersets per nextest semantics.

Expected behavior after merge: the first `hierarchy-test` pays a one-time build of the shared workspace variant; every run after that starts its tests with no compile phase at all. Verification so far: workbench unit suite 16/16 (including the new phase-invocation guard), bash expansion of the reserved words checked against the intended argv, filterset syntax validated against nextest's parser, clippy and fmt clean, and fingerprint-log confirmation of no-op rebuilds in the exact container image and volumes the test tasks use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)