### PR TITLE
docs(adr): record the sealed-wallet at-rest encryption design as ADR 0012

### DIFF
--- a/.agent-plans/sealed-wallet.md
+++ b/.agent-plans/sealed-wallet.md
@@ -1,0 +1,26 @@
+# Sealed wallet: at-rest encryption
+
+Grilling session of 2026-07-21 resolved the design; the decisions are
+recorded in `docs/adr/0012-sealed-wallet-at-rest-encryption.md` and the terms
+in `zingolib/CONTEXT.md` (Persistence section). Implementation has not
+started.
+
+## Resolved decisions
+
+The library encrypts and the caller unlocks: zingolib takes a raw 32-byte
+Unlock Key, and biometrics live entirely in the consumer. Envelope encryption
+(ChaCha20-Poly1305) wraps a random inner key, so rekeying is cheap. One seal
+covers the whole file; the background-sync trade-off is the consumer's
+keystore policy, not a format tier. Sealing is opt-in and sticky, with a
+deliberate unseal; plaintext stays legitimate. The API is open, seal, rekey,
+unseal — no mid-session lock. The CLI derives its key with in-tree PBKDF2
+behind a KDF identifier in the header. Nym state stays ephemeral (pinned
+invariant), and the log is starved of secrets rather than encrypted. No new
+dependencies.
+
+## File claims
+
+This stream owns `docs/adr/0012-sealed-wallet-at-rest-encryption.md`, the
+Persistence entries of `zingolib/CONTEXT.md`, and this file. Implementation
+claims (wallet disk I/O, LightClient API, zingo-cli commands) will be added
+here before any code edit.

--- a/docs/adr/0012-sealed-wallet-at-rest-encryption.md
+++ b/docs/adr/0012-sealed-wallet-at-rest-encryption.md
@@ -1,0 +1,75 @@
+# The wallet file is sealed at rest under a caller-supplied key
+
+To protect on-disk wallet data from any reader of the device's storage, the
+Wallet File can be stored encrypted — Sealed. zingolib defines the sealed
+format and performs all encryption and decryption; the consumer supplies the
+secret. The library's entire key interface is a raw 32-byte symmetric key, the
+Unlock Key, presented when a sealed wallet is opened. How that key is
+produced, stored, and released is deliberately outside this repository:
+zingo-mobile guards it with the platform keystore behind a biometric prompt,
+and zingo-cli derives it from a passphrase. The library never sees a
+passphrase, a biometric, or a platform keystore.
+
+## Envelope encryption and the four operations
+
+Inside the format, a random data-encryption key encrypts the wallet bytes with
+ChaCha20-Poly1305, and the Unlock Key merely wraps that inner key. Rekeying —
+a new device keystore, a changed passphrase — therefore rewraps one small
+blob rather than rewriting the wallet. The API is four operations: open a
+sealed wallet by presenting the Unlock Key at load time, seal a plaintext
+wallet, rekey a sealed one, and unseal as the deliberate way back to
+plaintext. After open, only the inner key stays in memory (held via `secrecy`,
+zeroized on drop), so the periodic save task re-seals without the Unlock Key.
+
+There is no mid-session locked state. zecwallet-light-cli's lock/unlock pair
+poisoned every API method with a key-absent error path, and a consumer reaches
+the same security state by dropping the client. A client is open or it is gone.
+
+## One seal, not a sync/spend split
+
+We considered a two-tier format — viewing keys and sync state under an
+always-available key, spend authority under a stricter one — so background
+sync could survive a strict biometric policy. We chose a single seal over the
+whole file. The trade-off the split serves is real, but it belongs to the
+consumer's key-release policy, not to the file format: a mobile keystore key
+minted as "available after first device unlock" preserves background sync,
+while "require per-use authentication" trades sync-while-closed for strength.
+Encoding that policy choice into the format would have doubled the
+serialization, the API, and every save path for a knob the platform already
+provides.
+
+## Opt-in, sticky, and honest about plaintext
+
+Sealing is opt-in per wallet, and plaintext remains a legitimate at-rest state:
+every deployed `zingo-wallet.dat` is plaintext today, and headless consumers
+must keep working without inventing key management. A sealed file carries a
+magic header with a format version and a KDF identifier; anything else parses
+as legacy plaintext. Once a wallet is sealed, every save re-seals — the
+library never silently writes plaintext again — and only an explicit unseal
+goes back. We rejected making the seal irreversible: the seed restores the
+wallet anywhere, so irreversibility would brick files without protecting
+anything.
+
+## Cryptography from the existing lockfile
+
+The dependency rule (no new dependencies, no patches) holds: the scheme is
+built entirely from crates already in `Cargo.lock` — `chacha20poly1305`,
+`blake2b_simd`, `getrandom`, `secrecy`, `zeroize`, and, for the CLI's
+passphrase path, `pbkdf2` (HMAC-SHA-512, iteration count in the hundreds of
+thousands, per-wallet random salt stored in the header). We acknowledge PBKDF2
+is weaker against GPU offline attack than the memory-hard argon2, which would
+require a dependency ratification like the nym stack received. The mobile
+path never touches a KDF — a keystore key is full-entropy — so PBKDF2 guards
+only users who choose passphrases, and the header's KDF identifier lets a
+future format adopt argon2 without a break.
+
+## The rest of the disk: starve, don't encrypt
+
+"All on-disk data" resolves to three surfaces. The Wallet File is sealed as
+above. Nym mixnet state is kept off disk entirely: the client is constructed
+ephemeral (`MixnetClientBuilder::new_ephemeral()`), and that ephemerality is a
+pinned invariant — switching to persistent nym storage would create plaintext
+mixnet identity keys and must revisit this ADR. The debug log is an
+append-stream, and we refuse to encrypt a stream we can instead starve: no key
+material, seeds, or addresses may be logged, and file logging stays off by
+default for connected use.

--- a/zingolib/CONTEXT.md
+++ b/zingolib/CONTEXT.md
@@ -177,6 +177,16 @@
 
 **Dirty Flag** — An internal boolean on `LightWallet` that records whether unsaved changes exist. Set automatically by all mutating operations; cleared after a successful write. Exposed to external code via `LightWallet::mark_dirty()`.
 
+**Sealed Wallet** — A Wallet File stored encrypted at rest. The seal covers the whole file: without the Unlock Key, no wallet data — keys, notes, or history — is readable from disk. See `docs/adr/0012-sealed-wallet-at-rest-encryption.md`.
+
+**Unlock Key** — The caller-supplied 32-byte symmetric key that opens a Sealed Wallet. zingolib accepts exactly this key; producing and releasing it is the consumer's concern (zingo-mobile guards it with the platform keystore behind a biometric prompt; zingo-cli derives it from a passphrase). The library never sees a passphrase or a biometric.
+
+**Unlock** — The act of presenting the Unlock Key to open a Sealed Wallet for a session. An unlocked wallet lives decrypted in memory only; every save re-seals. There is no mid-session locked state: a client is either open or dropped.
+
+**Seal / Unseal** — The deliberate transitions between at-rest states. Sealing adopts encryption for a plaintext Wallet File; once sealed, every save re-seals, and only an explicit Unseal returns to plaintext. Plaintext remains a legitimate at-rest state for wallets that never opt in.
+
+**Rekey** — Replacing the Unlock Key of a Sealed Wallet without rewriting the wallet data. Serves consumer key rotation: a new device's keystore, a changed passphrase.
+
 ---
 
 ## Consumers


### PR DESCRIPTION
Closes nothing yet — this is the documentation half of #2494, which tracks the implementation. This PR preserves the complete sealed-wallet design so the plan survives independent of any session: ADR 0012, five glossary terms, and the `.agent-plans` stream declaration. Implementation is deliberately deferred.

## The design being recorded

The goal is to protect all on-disk wallet data from any reader of the device's storage, with unlock delegated to the consumer (biometrics on mobile, a passphrase on the CLI). A grilling session on 2026-07-21 resolved every branch of the decision tree:

**Trust boundary.** zingolib defines the sealed wallet-file format and performs all encryption; its entire key interface is a raw 32-byte **Unlock Key** presented at open time. zingo-mobile guards that key with the platform keystore behind a biometric prompt; zingo-cli derives it from a passphrase. The library never sees a passphrase, a biometric, or a keystore. (Rejected: biometric APIs in the library; trusting OS file encryption alone.)

**Envelope encryption.** A random inner data-encryption key encrypts the wallet bytes with ChaCha20-Poly1305; the Unlock Key wraps only that inner key, so rekeying rewraps one blob without rewriting the wallet. After open, only the inner key stays in memory (`secrecy`-held, zeroized on drop), letting the autosave task re-seal without the Unlock Key.

**One seal, no tier split.** The seal covers the whole file. The background-sync trade-off is the consumer's key-release policy — a keystore key minted "available after first device unlock" preserves background sync; "require per-use authentication" trades it for strength. (Rejected: a two-tier sync/spend format, which doubles serialization, API, and save paths for a knob the keystore already provides.)

**Opt-in, sticky, reversible.** Plaintext remains legitimate; a sealed file carries a magic header with format version and KDF identifier, and anything else parses as legacy. Once sealed, every save re-seals and only an explicit unseal goes back. (Rejected: mandatory sealing; irreversible sealing — the seed restores anywhere, so irreversibility only bricks files.)

**Four operations, no mid-session lock.** Open, `seal(key)`, `rekey(new_key)`, `unseal(key)`. No locked-while-alive state: the zecwallet-era lock poisoned every method with a key-absent error path, and dropping the client reaches the same security state.

**CLI KDF.** PBKDF2 from the in-tree crate (HMAC-SHA-512, hundreds of thousands of iterations, per-wallet salt in the header), honestly documented as weaker than argon2, which would need a dependency ratification; the header's KDF identifier permits a later argon2 format without a break. The mobile path never touches a KDF.

**No new dependencies.** Everything builds from crates already in `Cargo.lock`: `chacha20poly1305`, `blake2b_simd`, `getrandom`, `secrecy`, `zeroize`, `pbkdf2`.

**The rest of the disk.** The wallet file is the only artifact zingolib writes to the wallet directory. Nym mixnet state stays off disk (`new_ephemeral()`), pinned as an invariant by the ADR. The debug log is starved of secrets rather than encrypted, and file logging stays off by default for connected use.

## Contents

- `docs/adr/0012-sealed-wallet-at-rest-encryption.md` — the decision record with the rejected alternatives.
- `zingolib/CONTEXT.md` — glossary entries for Sealed Wallet, Unlock Key, Unlock, Seal / Unseal, and Rekey in the Persistence section.
- `.agent-plans/sealed-wallet.md` — the stream declaration and file claims for the eventual implementation.

## Caveats for review

The ADR is numbered 0012 while `dev` holds ADRs through 0008: numbers 0009–0011 belong to the in-flight nym stream, which this ADR references (ADR 0011 and the `new_ephemeral()` construction do not exist on `dev` yet). If the nym stream's docs land first this merges cleanly; if this merges first, the references are forward-looking until it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
