### PR TITLE
fix: reject a zero bucket modulus at wallet-file read (PR #2501 review follow-ups)

### DIFF
--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -1118,7 +1118,8 @@ impl OutputInterface for TransparentCoin {
 
 /// The network upgrade at which a shielded pool begins to exist.
 ///
-/// This is the workspace's single pool-to-upgrade mapping (ADR 0014 in the
+/// This is the workspace's single pool-to-upgrade mapping (ADR 0014,
+/// `docs/adr/0014-pool-activation-derived-in-pepper-sync.md` in the
 /// workspace root): upstream `zcash_protocol` deliberately ships
 /// `ShieldedPool` and `NetworkUpgrade` as unrelated enums, so the mapping
 /// is defined exactly once, here. Every height clamp involving a pool's

--- a/zingolib/src/wallet/migration/params.rs
+++ b/zingolib/src/wallet/migration/params.rs
@@ -30,6 +30,8 @@ pub struct MigrationParams {
     /// against `MARGINAL_FEE` itself.
     pub sweep_min: u64,
     /// `M`: bucket boundaries are the block heights ≡ 0 (mod `M`).
+    /// Invariant: nonzero. `provisional` never produces zero and the
+    /// store rejects one at read, so bucket arithmetic may divide by it.
     pub bucket_modulus: u32,
     /// `K_MAX`: the per-cohort multiplicity bound.
     pub k_max: u32,

--- a/zingolib/src/wallet/migration/parts.rs
+++ b/zingolib/src/wallet/migration/parts.rs
@@ -874,14 +874,23 @@ mod tests {
     /// target inside the new window — see
     /// `schedule::tests::place_draws_a_fresh_target_inside_the_new_window`.
     /// The raw `reassign` transition deliberately does not manage the
-    /// target; placement does.
+    /// target; placement does. Here, the full complement: every state
+    /// except `Expired` refuses the transition.
     #[test]
     fn reassign_is_reachable_only_from_expired() {
-        let mut part = PartRecord::new(PartId(0), 100_000, bound_note());
-        assert!(
-            part.reassign(5).is_err(),
-            "bound parts assign, not reassign"
-        );
+        for state in ALL_STATES {
+            let is_expired = matches!(state, PartState::Expired);
+            let mut part = part_in(state);
+            if is_expired {
+                part.reassign(5).expect("expired parts reassign");
+            } else {
+                assert!(
+                    part.reassign(5).is_err(),
+                    "reassign must be illegal from {:?}",
+                    part.state,
+                );
+            }
+        }
     }
 
     fn part_in(state: PartState) -> PartRecord {

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -78,8 +78,10 @@ pub fn first_anchorable_boundary(activation: PoolActivation, bucket_modulus: u32
 }
 
 /// The first bucket whose boundary sits at or above the Pool Activation.
+/// The modulus is nonzero by the [`MigrationParams::bucket_modulus`]
+/// invariant (enforced at store read), as in every bucket computation.
 fn activation_bucket(activation: PoolActivation, bucket_modulus: u32) -> u64 {
-    u64::from(u32::from(activation.height())).div_ceil(u64::from(bucket_modulus.max(1)))
+    u64::from(u32::from(activation.height())).div_ceil(u64::from(bucket_modulus))
 }
 
 /// Places a part in `bucket` with a fresh random target inside the

--- a/zingolib/src/wallet/migration/store.rs
+++ b/zingolib/src/wallet/migration/store.rs
@@ -91,6 +91,14 @@ pub fn read<R: Read>(mut reader: R) -> io::Result<MigrationState> {
     let dust_floor = reader.read_u64::<LittleEndian>()?;
     let sweep_min = reader.read_u64::<LittleEndian>()?;
     let bucket_modulus = reader.read_u32::<LittleEndian>()?;
+    // Every bucket computation divides or multiplies by the modulus, so a
+    // zero from a corrupt file must fail typed here, not panic downstream.
+    if bucket_modulus == 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "bucket_modulus must be nonzero",
+        ));
+    }
     let k_max = reader.read_u32::<LittleEndian>()?;
     let target_sessions = reader.read_u32::<LittleEndian>()?;
     let max_actions_per_split_tx =
@@ -568,6 +576,21 @@ mod tests {
     /// the stream (the desired `usize::try_from` + `InvalidData` behavior)
     /// or preserve the value. It passes vacuously on 64-bit hosts; run under
     /// a 32-bit target (e.g. i686-unknown-linux-gnu) to observe the failure.
+    /// Every bucket computation divides or multiplies by the modulus, so a
+    /// zero arriving from a corrupt wallet file must fail the read typed
+    /// rather than panic downstream bucket arithmetic.
+    #[test]
+    fn zero_bucket_modulus_is_rejected_at_read() {
+        let mut state = planned_state();
+        state.params.bucket_modulus = 0;
+
+        let mut bytes = Vec::new();
+        write(&mut bytes, &state).expect("writes");
+
+        let error = read(bytes.as_slice()).expect_err("a zero modulus must not read");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+
     #[test]
     fn max_actions_read_never_silently_truncates() {
         const SENTINEL: u64 = 0x1122_3344;


### PR DESCRIPTION
PR #2501 merged while its post-merge review's three accepted follow-ups were landing; this PR carries the one stranded commit.

The substantive fix: `bucket_modulus` is deserialized from the wallet file with no validation, and every bucket computation divides or multiplies by it, so a corrupt file could panic `bucket_index` or silently collapse every boundary to height zero. The store now rejects a zero modulus at read with a typed `InvalidData` error, pinned by a test beside the existing never-silently-truncate precedent; the one scattered `.max(1)` guard drops in favor of the invariant, stated once on the field.

The two smaller items: `reassign_is_reachable_only_from_expired` now tests the rule its name states, iterating every part state and asserting only `Expired` may reassign; and the `PoolActivation` doc cites ADR 0014 by its actual path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
