### PR TITLE
ci: cap every job's runtime — a hang must never hold a runner for six hours

### DIFF
--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -7,6 +7,7 @@ jobs:
   cargo-checkmate:
     name: Cargo Checkmate
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     strategy:
       matrix:
         phase: [build, check, clippy, doc, format]

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -34,6 +34,7 @@ jobs:
   cargo-hack-check:
     name: Cargo Hack Check
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -61,6 +62,7 @@ jobs:
   run-doc-tests:
     name: Run doc tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     if: github.event.pull_request.draft == false
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,6 +16,7 @@ jobs:
     name: Coverage
     needs: compute-image-tag
     runs-on: ubuntu-24.04
+    timeout-minutes: 180
     env:
       RUSTFLAGS: -D warnings
     container:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
     container:
       image: zingodevops/ci-build:${{ needs.compute-image-tag.outputs.image-tag }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     if: github.event.pull_request.draft == false
     env:
       RUSTFLAGS: -D warnings
@@ -59,6 +60,7 @@ jobs:
   run-tests:
     name: Run normal tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     if: github.event.pull_request.draft == false
     needs: [build-test-artifacts, compute-image-tag]
     env:


### PR DESCRIPTION
Superseded-run cancellation for pull requests landed in #2474, but cancellation fires only when a newer commit arrives in the same group: a job that hangs on a quiet branch still ran to GitHub's six-hour default, which is exactly what a stuck feature job did this week — six hours on a runner for a run nobody needed. No job in the repository declared `timeout-minutes`.

Every steps-running job now carries a cap comfortably above its observed ceiling: the partitioned test job at 90 minutes (the slowest partition takes about half that, including the doubled nextest ceiling for the long-chain heavies), artifact builds at 60, the hack check at 45, doc tests and the checkmate phases at 30, and the daily coverage sweep at 180. Jobs that merely call reusable workflows cannot carry a cap, so the limits live in the called jobs, where they apply to every caller — `ci-pr`, `ci-nightly`, and anything added later.

Because a pull request's workflow definition is the merge of base and head, this protects every PR into `dev` as soon as it merges, and flows to the feature-branch lineages with their next base sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
