### PR TITLE
fix!: read both orphaned wallet layouts; salvage any unreadable wallet file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ libtonode-tests/store_all_checkpoints_test
 .zingo-cli/
 .DS_Store
 .agent-plans/
+
+# Local corpus of real wallet files (live seed material — never commit)
+/data_wallets/

--- a/docs/adr/0015-landing-in-dev-ships-the-wallet-file-format.md
+++ b/docs/adr/0015-landing-in-dev-ships-the-wallet-file-format.md
@@ -19,9 +19,13 @@ reassigned; and a format change may land in dev only together with the
 read-side compatibility that keeps every previously shipped file
 loading, proven by regression tests in the same change. Version 42's
 two layouts are both read, disambiguated by an end-of-file-anchored
-dual parse of the file tail, which is deterministic because the
-revisions differ by exactly one byte. Version 43 is burned; the next
-format bump is 44.
+dual parse of the file tail: the canonical layout is preferred, so a
+file written by current code never depends on the fallback, and a tail
+that parses cleanly *both* ways is refused rather than guessed. The
+refusal covers a case that cannot arise for a migration-free tail,
+whose length is always odd while the two readings differ by exactly
+one byte, but for which no such parity argument holds once a migration
+section is present. Version 43 is burned; the next format bump is 44.
 
 Beneath the compatibility guarantee sits a salvage floor for files
 outside it — corrupt files, files from abandoned side branches, files
@@ -55,5 +59,9 @@ corpus — the example wallets, the orphaned-layout tests, and the
 local `data_wallets` sweep — is the enforcement mechanism. Retiring a
 version number is documented in `LightWallet::serialized_version`'s
 docs, which name the next free number. The dual parse for version 42
-is permanent; its cost is one buffered read of the small file tail on
-load.
+is permanent; it costs one buffered read of the small file tail and a
+second parse of it on every load. Tests that exercise a format layout
+must assert on the region the layout governs: a wallet-file test that
+checks only recovery info proves nothing about the tail, because
+recovery info is read from the file prefix and survives a misparsed
+tail intact.

--- a/docs/adr/0015-landing-in-dev-ships-the-wallet-file-format.md
+++ b/docs/adr/0015-landing-in-dev-ships-the-wallet-file-format.md
@@ -1,0 +1,59 @@
+# Landing in dev ships the wallet file format
+
+Commit `4158e20c2` re-pinned the wallet file version to 42 after the
+`allow_v6_transactions` byte was removed, and ruled that files written
+by the byte-carrying revision "are not readable" because "the removed
+byte never shipped." That justification was wrong about what shipping
+means for this project. We support users who build and run code from
+dev; there is no release gate standing between dev and those users, so
+nothing that lands in dev is unreleased. The ruling met reality on
+2026-07-24, when a tester's device held wallets written by assorted
+pre-release builds and the reader could not open them.
+
+The decision: **a wallet-file format revision is shipped the moment it
+lands in dev.** From that moment the wallet must remain readable and
+writable going forward. Concretely: the reader must open a file written
+by every format revision that has ever landed in dev; a version number,
+once used by any revision that reached users, is burned and never
+reassigned; and a format change may land in dev only together with the
+read-side compatibility that keeps every previously shipped file
+loading, proven by regression tests in the same change. Version 42's
+two layouts are both read, disambiguated by an end-of-file-anchored
+dual parse of the file tail, which is deterministic because the
+revisions differ by exactly one byte. Version 43 is burned; the next
+format bump is 44.
+
+Beneath the compatibility guarantee sits a salvage floor for files
+outside it — corrupt files, files from abandoned side branches, files
+from the future: `LightWallet::read_recovery_info` recovers the seed
+phrase, birthday, and account count from the stable prefix of any
+version 32+ file without parsing the tail, so no wallet file can
+strand its funds. The salvage floor is a backstop, not a substitute
+for compatibility: restoring from seed forfeits local transaction
+metadata and forces a rescan.
+
+## Considered Options
+
+Keeping the release-gate rule was rejected because the gate does not
+exist: dev is built and run by supported users, so "not yet released"
+describes no protective boundary. Declaring the orphaned layouts
+unreadable and directing affected users to restore from seed was
+rejected as a primary path for the same reason we keep the salvage
+floor subordinate — it destroys wallet history that compatibility
+preserves. Bumping to a fresh version number instead of disambiguating
+42's two layouts was unavailable after the fact: both layouts already
+claim the number 42 on users' disks, so only the reader can tell them
+apart.
+
+## Consequences
+
+Format changes carry their compatibility with them: the change that
+alters the layout also lands the version gate (or, where a number was
+double-assigned, the disambiguation) and the regression tests that pin
+every shipped revision to a loading wallet. The wallet-load test
+corpus — the example wallets, the orphaned-layout tests, and the
+local `data_wallets` sweep — is the enforcement mechanism. Retiring a
+version number is documented in `LightWallet::serialized_version`'s
+docs, which name the next free number. The dual parse for version 42
+is permanent; its cost is one buffered read of the small file tail on
+load.

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -793,8 +793,44 @@ pub(crate) fn startup(filled_template: &ConfigTemplate) -> std::io::Result<Comma
     ))
 }
 
+/// Falls back to the prefix-only salvage reader when the user asked for
+/// `recovery_info` but the wallet file cannot be fully parsed — the whole
+/// point of that command is to escape a wallet no current build can read.
+fn print_salvaged_recovery_info(
+    cli_config: &ConfigTemplate,
+    startup_error: &std::io::Error,
+) -> std::io::Result<()> {
+    let wallet_path = cli_config.data_dir.clone().join(DEFAULT_WALLET_NAME);
+    let wallet_file = std::fs::File::open(&wallet_path)?;
+    let recovery_info =
+        zingolib::wallet::LightWallet::read_recovery_info(std::io::BufReader::new(wallet_file))
+            .map_err(|salvage_error| {
+                std::io::Error::other(format!(
+                    "failed to load the wallet ({startup_error}), \
+                     and salvaging recovery info from the file prefix also failed: \
+                     {salvage_error}"
+                ))
+            })?;
+    eprintln!(
+        "The wallet file could not be fully loaded ({startup_error}); \
+         showing recovery info salvaged from its prefix."
+    );
+    println!("{recovery_info}");
+    Ok(())
+}
+
 fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io::Result<()> {
-    let ch = startup(cli_config)?;
+    let ch = match startup(cli_config) {
+        Ok(ch) => ch,
+        Err(startup_error) => {
+            if let ModeOfOperation::Command { name, .. } = &cli_config.mode
+                && name == "recovery_info"
+            {
+                return print_salvaged_recovery_info(cli_config, &startup_error);
+            }
+            return Err(startup_error);
+        }
+    };
     match &cli_config.mode {
         ModeOfOperation::Interactive => start_interactive(cli_config, ch),
         ModeOfOperation::Command { name, args } => {

--- a/zingolib/CONTEXT.md
+++ b/zingolib/CONTEXT.md
@@ -215,6 +215,12 @@
 
 **Dirty Flag** — An internal boolean on `LightWallet` that records whether unsaved changes exist. Set automatically by all mutating operations; cleared after a successful write. Exposed to external code via `LightWallet::mark_dirty()`.
 
+**Wallet Version** — The number leading a Wallet File that identifies its layout. A Wallet Version, once used by any revision that reached users, is burned: it is never reassigned to a different layout. (Version 43 is burned; version 42 names two layouts that the reader tells apart.)
+
+**Shipped Format** — A Wallet File layout that has landed in dev. Landing in dev is the shipping event — there is no later release gate protecting dev builders — and every Shipped Format remains readable, and the wallet writable, forever after. See ADR 0015.
+
+**Recovery Salvage** — The last-resort read that recovers the seed phrase, birthday, and account count from the stable prefix of a Wallet File whose full parse fails. A backstop beneath the Shipped Format guarantee, not a substitute for it: restoring from seed forfeits local transaction metadata and forces a rescan.
+
 ---
 
 ## Consumers

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -12,7 +12,7 @@ use log::info;
 use bip0039::Mnemonic;
 use zip32::AccountId;
 
-use zcash_encoding::{Optional, Vector};
+use zcash_encoding::{CompactSize, Optional, Vector};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::{self, BlockHeight};
@@ -23,7 +23,7 @@ use zingo_netutils::lightwallet_protocol::TreeState;
 use zingo_price::PriceList;
 
 use super::keys::unified::{ReceiverSelection, UnifiedAddressId};
-use super::{LightWallet, error::KeyError};
+use super::{LightWallet, RecoveryInfo, error::KeyError};
 use crate::wallet::{WalletSettings, legacy::WalletZecPriceInfo, utils};
 use crate::wallet::{legacy::WalletOptions, traits::ReadableWriteable};
 use crate::{
@@ -52,8 +52,12 @@ impl LightWallet {
     /// version). (A pre-release revision of 42 also wrote an
     /// `allow_v6_transactions` bool after `min_confirmations`; the setting
     /// was removed before any release carried it, so version 42 is defined
-    /// without the byte and files from those testing builds are not
-    /// readable.)
+    /// without the byte. Files from those testing builds are read by
+    /// disambiguating the tail — see [`Self::read_price_and_migration`].)
+    ///
+    /// Version 43 is retired: pre-release builds briefly wrote it with the
+    /// final version 42 layout, so it is accepted at read as 42 and must
+    /// never be assigned to a new layout. The next format bump is 44.
     #[must_use]
     pub const fn serialized_version() -> u64 {
         42
@@ -145,7 +149,9 @@ impl LightWallet {
         info!("Reading wallet version {version}");
         match version {
             ..32 => Self::read_v0(reader, chain_type, version),
-            32..=42 => Self::read_v32(reader, chain_type, version),
+            // 43 is a retired pre-release version with the final 42 layout;
+            // see the `serialized_version` docs.
+            32..=43 => Self::read_v32(reader, chain_type, version),
             _ => Err(io::Error::new(
                 ErrorKind::InvalidData,
                 format!(
@@ -605,16 +611,38 @@ impl LightWallet {
             }
         };
 
-        let price_list = if version >= 34 {
-            PriceList::read(&mut reader)?
+        let (price_list, migration) = if version == 42 {
+            // Version 42 exists in two layouts: pre-release builds wrote an
+            // `allow_v6_transactions` byte here, before the price list (see
+            // the `serialized_version` docs). Disambiguate by parsing the
+            // buffered tail anchored at end of file: the canonical layout
+            // first, then the pre-release layout with its leading bool
+            // skipped.
+            let mut tail = Vec::new();
+            reader.read_to_end(&mut tail)?;
+            match Self::read_price_and_migration(&tail) {
+                Ok(parsed) => parsed,
+                Err(canonical_error) => match tail.first() {
+                    Some(0 | 1) => {
+                        Self::read_price_and_migration(&tail[1..]).map_err(|_| canonical_error)?
+                    }
+                    _ => return Err(canonical_error),
+                },
+            }
         } else {
-            PriceList::new()
-        };
+            let price_list = if version >= 34 {
+                PriceList::read(&mut reader)?
+            } else {
+                PriceList::new()
+            };
 
-        let migration = if version >= 42 {
-            Optional::read(&mut reader, crate::wallet::migration::store::read)?
-        } else {
-            None
+            let migration = if version >= 42 {
+                Optional::read(&mut reader, crate::wallet::migration::store::read)?
+            } else {
+                None
+            };
+
+            (price_list, migration)
         };
 
         Ok(Self {
@@ -637,6 +665,79 @@ impl LightWallet {
             migration,
             send_proposal: None,
             save_required: false,
+        })
+    }
+
+    /// Parses the final section of a version 42 wallet file — the price list
+    /// followed by the optional migration section — anchored at end of file.
+    /// Trailing bytes are an error, so the two revisions of version 42
+    /// cannot be confused: the pre-release revision carries exactly one
+    /// extra leading byte, which makes exactly one of the two anchored
+    /// parses consume the whole tail.
+    fn read_price_and_migration(
+        mut tail: &[u8],
+    ) -> io::Result<(PriceList, Option<crate::wallet::migration::MigrationState>)> {
+        let price_list = PriceList::read(&mut tail)?;
+        let migration = Optional::read(&mut tail, crate::wallet::migration::store::read)?;
+        if !tail.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "unexpected trailing bytes after wallet data",
+            ));
+        }
+        Ok((price_list, migration))
+    }
+
+    /// Recovers the seed phrase, birthday, and account count from the stable
+    /// prefix of a version 32+ wallet file, without parsing the rest of the
+    /// file. This is the escape hatch when [`Self::read`] fails on a file
+    /// written by an orphaned or unknown format revision: the recovered
+    /// info suffices to restore the wallet from seed and rescan.
+    ///
+    /// Fails on legacy files (version below 32), whose seed is stored too
+    /// deep in the file to reach without a full parse, and on view-only
+    /// wallets, which store no seed.
+    pub fn read_recovery_info<R: Read>(mut reader: R) -> io::Result<RecoveryInfo> {
+        let version = reader.read_u64::<LittleEndian>()?;
+        if version < 32 {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("wallet version {version} predates the recoverable prefix layout"),
+            ));
+        }
+        if version >= 41 {
+            let _chain_type_index = reader.read_u8()?;
+        } else {
+            let _chain_name = utils::read_string(&mut reader)?;
+        }
+        let seed_bytes = Vector::read(&mut reader, byteorder::ReadBytesExt::read_u8)?;
+        if seed_bytes.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "wallet file stores no seed (view-only wallet); nothing to recover",
+            ));
+        }
+        if version < 35 {
+            let _account_index = reader.read_u32::<LittleEndian>()?;
+        }
+        let mnemonic = <Mnemonic>::from_entropy(seed_bytes)
+            .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?;
+        let birthday = reader.read_u32::<LittleEndian>()?;
+        let no_of_accounts = if version >= 35 {
+            u32::try_from(CompactSize::read(&mut reader)?).map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("stored account count is not a valid u32: {e}"),
+                )
+            })?
+        } else {
+            1
+        };
+
+        Ok(RecoveryInfo {
+            seed_phrase: mnemonic.phrase().to_string(),
+            birthday: u64::from(birthday),
+            no_of_accounts,
         })
     }
 }

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -53,7 +53,7 @@ impl LightWallet {
     /// `allow_v6_transactions` bool after `min_confirmations`; the setting
     /// was later removed and version 42 redefined without the byte, leaving
     /// two shipped layouts under one number. Both are read, disambiguated
-    /// via [`Self::read_price_and_migration`].)
+    /// via `Self::read_price_and_migration`.)
     ///
     /// Version 43 is burned: builds between the two revisions of 42 wrote
     /// it with the final version 42 layout, so it is accepted at read as 42

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -49,15 +49,20 @@ impl LightWallet {
     /// Changes in version 42:
     /// Optional Orchard→Ironwood migration section appended (see
     /// [`crate::wallet::migration::store`]; the section carries its own inner
-    /// version). (A pre-release revision of 42 also wrote an
+    /// version). (An earlier revision of 42 also wrote an
     /// `allow_v6_transactions` bool after `min_confirmations`; the setting
-    /// was removed before any release carried it, so version 42 is defined
-    /// without the byte. Files from those testing builds are read by
-    /// disambiguating the tail — see [`Self::read_price_and_migration`].)
+    /// was later removed and version 42 redefined without the byte, leaving
+    /// two shipped layouts under one number. Both are read, disambiguated
+    /// via [`Self::read_price_and_migration`].)
     ///
-    /// Version 43 is retired: pre-release builds briefly wrote it with the
-    /// final version 42 layout, so it is accepted at read as 42 and must
-    /// never be assigned to a new layout. The next format bump is 44.
+    /// Version 43 is burned: builds between the two revisions of 42 wrote
+    /// it with the final version 42 layout, so it is accepted at read as 42
+    /// and must never be assigned to a new layout. The next format bump is
+    /// 44.
+    ///
+    /// Landing in dev ships a format: every layout that has landed in dev
+    /// must remain readable, and the wallet writable, forever after (ADR
+    /// 0015, docs/adr/0015-landing-in-dev-ships-the-wallet-file-format.md).
     #[must_use]
     pub const fn serialized_version() -> u64 {
         42
@@ -149,8 +154,8 @@ impl LightWallet {
         info!("Reading wallet version {version}");
         match version {
             ..32 => Self::read_v0(reader, chain_type, version),
-            // 43 is a retired pre-release version with the final 42 layout;
-            // see the `serialized_version` docs.
+            // 43 is a burned version number with the final 42 layout; see
+            // the `serialized_version` docs and ADR 0015.
             32..=43 => Self::read_v32(reader, chain_type, version),
             _ => Err(io::Error::new(
                 ErrorKind::InvalidData,

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -42,6 +42,10 @@ use pepper_sync::{
     },
 };
 
+/// The two trailing sections of a version 42 wallet file: the price list and
+/// the optional Orchard→Ironwood migration section.
+type WalletTail = (PriceList, Option<crate::wallet::migration::MigrationState>);
+
 impl LightWallet {
     /// Changes in version 41:
     /// `ChainType` serialized as u8 instead of string to decouple from fmt::Display and reduce bytes stored.
@@ -620,20 +624,20 @@ impl LightWallet {
             // Version 42 exists in two layouts: pre-release builds wrote an
             // `allow_v6_transactions` byte here, before the price list (see
             // the `serialized_version` docs). Disambiguate by parsing the
-            // buffered tail anchored at end of file: the canonical layout
-            // first, then the pre-release layout with its leading bool
-            // skipped.
+            // buffered tail anchored at end of file, both ways.
             let mut tail = Vec::new();
             reader.read_to_end(&mut tail)?;
-            match Self::read_price_and_migration(&tail) {
-                Ok(parsed) => parsed,
-                Err(canonical_error) => match tail.first() {
-                    Some(0 | 1) => {
-                        Self::read_price_and_migration(&tail[1..]).map_err(|_| canonical_error)?
-                    }
-                    _ => return Err(canonical_error),
-                },
-            }
+
+            let canonical = Self::read_price_and_migration(&tail);
+            // The extra byte of the pre-release layout is a bool, so only 0
+            // or 1 can begin one; any other leading byte rules that layout
+            // out without a second parse.
+            let pre_release = match tail.first() {
+                Some(0 | 1) => Some(Self::read_price_and_migration(&tail[1..])),
+                _ => None,
+            };
+
+            Self::resolve_v42_tail(canonical, pre_release)?
         } else {
             let price_list = if version >= 34 {
                 PriceList::read(&mut reader)?
@@ -673,15 +677,45 @@ impl LightWallet {
         })
     }
 
+    /// Chooses between the two readings of a version 42 file tail.
+    ///
+    /// The canonical layout wins whenever it parses, so a file written by
+    /// current code never depends on the pre-release fallback. When both
+    /// readings parse cleanly the file is genuinely ambiguous and the load
+    /// fails rather than guessing: a wrong guess here would silently
+    /// substitute a different price list and migration state, and the
+    /// seed remains recoverable through [`Self::read_recovery_info`].
+    ///
+    /// Ambiguity cannot arise for a tail carrying no migration section: such
+    /// a tail is 5 bytes plus a sum of even-sized optional fields (4- and
+    /// 8-byte values, and `CompactSize` widths that grow by 2, 4, or 8), so
+    /// its length is always odd, and the two readings differ in length by
+    /// exactly one. The refusal below therefore guards only the
+    /// migration-bearing case, where no such parity argument holds.
+    fn resolve_v42_tail(
+        canonical: io::Result<WalletTail>,
+        pre_release: Option<io::Result<WalletTail>>,
+    ) -> io::Result<WalletTail> {
+        match (canonical, pre_release) {
+            (Ok(_), Some(Ok(_))) => Err(Error::new(
+                ErrorKind::InvalidData,
+                "ambiguous version 42 wallet file: its tail parses as both the \
+                 canonical and the pre-release layout, so which build wrote it \
+                 cannot be determined; recover the seed with recovery_info",
+            )),
+            (Ok(parsed), _) => Ok(parsed),
+            (Err(_), Some(Ok(parsed))) => Ok(parsed),
+            (Err(canonical_error), _) => Err(canonical_error),
+        }
+    }
+
     /// Parses the final section of a version 42 wallet file — the price list
     /// followed by the optional migration section — anchored at end of file.
-    /// Trailing bytes are an error, so the two revisions of version 42
-    /// cannot be confused: the pre-release revision carries exactly one
-    /// extra leading byte, which makes exactly one of the two anchored
-    /// parses consume the whole tail.
-    fn read_price_and_migration(
-        mut tail: &[u8],
-    ) -> io::Result<(PriceList, Option<crate::wallet::migration::MigrationState>)> {
+    /// Trailing bytes are an error, which is what lets the two revisions of
+    /// version 42 be told apart: the pre-release revision carries exactly one
+    /// extra leading byte, so the two readings end one byte apart and a
+    /// misaligned parse must consume the tail exactly to be accepted.
+    fn read_price_and_migration(mut tail: &[u8]) -> io::Result<WalletTail> {
         let price_list = PriceList::read(&mut tail)?;
         let migration = Optional::read(&mut tail, crate::wallet::migration::store::read)?;
         if !tail.is_empty() {

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -450,3 +450,79 @@ async fn recovery_info_salvages_a_wallet_file_that_fails_to_read() {
         .expect("prefix salvage must survive a corrupt tail");
     assert_eq!(salvaged, recovery_info);
 }
+
+/// Sweeps the local corpus of real wallet files in `data_wallets/` at the
+/// workspace root: every file must either fully parse or yield recovery
+/// info from the prefix salvage, so no corpus wallet is stranded.
+///
+/// The corpus holds live seed material, so it is gitignored and this test
+/// never prints seeds; it reports only per-file outcomes. On machines
+/// without the corpus (CI included) the sweep is an empty pass.
+#[test]
+fn data_wallets_corpus_parses_or_salvages() {
+    use crate::config::ChainType;
+    use crate::wallet::LightWallet;
+
+    let corpus_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("zingolib lives one level below the workspace root")
+        .join("data_wallets");
+    if !corpus_dir.is_dir() {
+        eprintln!("no data_wallets corpus on this machine; nothing to sweep");
+        return;
+    }
+
+    let mut corpus_paths = std::fs::read_dir(&corpus_dir)
+        .expect("corpus directory must be listable")
+        .map(|entry| {
+            entry
+                .expect("corpus directory entries must be readable")
+                .path()
+        })
+        .filter(|path| path.extension().is_some_and(|extension| extension == "dat"))
+        .collect::<Vec<_>>();
+    corpus_paths.sort();
+    assert!(
+        !corpus_paths.is_empty(),
+        "data_wallets exists but holds no .dat files; nothing swept"
+    );
+
+    for path in corpus_paths {
+        let file_name = path.file_name().unwrap().to_string_lossy().into_owned();
+        let bytes = std::fs::read(&path).expect("corpus files must be readable");
+
+        // Device wallets are mainnet or testnet; regtest wallets cannot
+        // occur in the corpus because their activation heights are not
+        // recoverable from the file alone.
+        let full_parse = LightWallet::read(bytes.as_slice(), ChainType::Mainnet)
+            .or_else(|_| LightWallet::read(bytes.as_slice(), ChainType::Testnet));
+
+        match full_parse {
+            Ok(wallet) => {
+                eprintln!(
+                    "{file_name}: parsed fully (stored version {})",
+                    wallet.read_version()
+                );
+            }
+            Err(read_error) => {
+                let salvaged = LightWallet::read_recovery_info(bytes.as_slice()).unwrap_or_else(
+                    |salvage_error| {
+                        panic!(
+                            "{file_name}: full parse failed ({read_error}) and prefix \
+                                 salvage also failed ({salvage_error})"
+                        )
+                    },
+                );
+                assert!(
+                    !salvaged.seed_phrase.is_empty(),
+                    "{file_name}: salvage produced an empty seed phrase"
+                );
+                eprintln!(
+                    "{file_name}: full parse failed ({read_error}); salvaged recovery info \
+                     (birthday {}, {} accounts)",
+                    salvaged.birthday, salvaged.no_of_accounts
+                );
+            }
+        }
+    }
+}

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -364,3 +364,89 @@ async fn wallet_round_trips_migration_state_at_current_version() {
     );
     assert_eq!(recovered.migration, Some(state));
 }
+
+/// Expectations and bytes for the orphaned-layout tests below: the wallet's
+/// chain type and recovery info, the file saved at the current version, and
+/// the serialized length of the file tail (price list plus optional
+/// migration section), which locates the pre-release insertion point.
+async fn current_version_wallet_bytes() -> (
+    crate::config::ChainType,
+    crate::wallet::RecoveryInfo,
+    Vec<u8>,
+    usize,
+) {
+    use zcash_encoding::Optional;
+
+    let client = NetworkSeedVersion::Regtest(RegtestSeedVersion::AbandonAbandon(
+        AbandonAbandonVersion::V26,
+    ))
+    .load_example_wallet()
+    .await;
+    let mut wallet = client.wallet().write().await;
+    wallet.save_required = true;
+    let bytes = wallet.save().unwrap().expect("save required");
+
+    let mut tail = Vec::new();
+    wallet.price_list.write(&mut tail).unwrap();
+    Optional::write(&mut tail, wallet.migration.as_ref(), |w, migration| {
+        crate::wallet::migration::store::write(w, migration)
+    })
+    .unwrap();
+
+    let chain_type = wallet.chain_type();
+    let recovery_info = wallet.recovery_info().unwrap();
+    (chain_type, recovery_info, bytes, tail.len())
+}
+
+/// Pre-release ironwood builds briefly wrote version 43 with the final
+/// version 42 layout. Those files must load as if they were version 42.
+#[tokio::test]
+async fn wallet_reads_retired_version_43_as_current() {
+    use crate::wallet::LightWallet;
+
+    let (chain_type, recovery_info, mut bytes, _tail_length) = current_version_wallet_bytes().await;
+    bytes[..8].copy_from_slice(&43u64.to_le_bytes());
+
+    let recovered = LightWallet::read(bytes.as_slice(), chain_type)
+        .expect("retired version 43 must read as the final 42 layout");
+    assert_eq!(recovered.recovery_info().unwrap(), recovery_info);
+}
+
+/// Pre-release ironwood builds before the `allow_v6_transactions` removal
+/// wrote version 42 with an extra bool between `min_confirmations` and the
+/// price list. Both bool values must load under the disambiguating reader.
+#[tokio::test]
+async fn wallet_reads_pre_release_v42_with_allow_v6_byte() {
+    use crate::wallet::LightWallet;
+
+    let (chain_type, recovery_info, bytes, tail_length) = current_version_wallet_bytes().await;
+    let insertion_point = bytes.len() - tail_length;
+
+    for allow_v6_byte in [0u8, 1u8] {
+        let mut pre_release = bytes.clone();
+        pre_release.insert(insertion_point, allow_v6_byte);
+
+        let recovered = LightWallet::read(pre_release.as_slice(), chain_type)
+            .expect("pre-release v42 layout must read via tail disambiguation");
+        assert_eq!(recovered.recovery_info().unwrap(), recovery_info);
+    }
+}
+
+/// When the full parse fails — here simulated by a truncated file — the
+/// prefix-only salvage reader must still recover seed, birthday, and
+/// account count, so no format break can strand a wallet.
+#[tokio::test]
+async fn recovery_info_salvages_a_wallet_file_that_fails_to_read() {
+    use crate::wallet::LightWallet;
+
+    let (chain_type, recovery_info, mut bytes, _tail_length) = current_version_wallet_bytes().await;
+    bytes.truncate(bytes.len() - 10);
+
+    assert!(
+        LightWallet::read(bytes.as_slice(), chain_type).is_err(),
+        "truncated file must fail the full parse for this test to be meaningful"
+    );
+    let salvaged = LightWallet::read_recovery_info(bytes.as_slice())
+        .expect("prefix salvage must survive a corrupt tail");
+    assert_eq!(salvaged, recovery_info);
+}

--- a/zingolib/src/wallet/disk/testing/tests.rs
+++ b/zingolib/src/wallet/disk/testing/tests.rs
@@ -365,17 +365,62 @@ async fn wallet_round_trips_migration_state_at_current_version() {
     assert_eq!(recovered.migration, Some(state));
 }
 
-/// Expectations and bytes for the orphaned-layout tests below: the wallet's
-/// chain type and recovery info, the file saved at the current version, and
-/// the serialized length of the file tail (price list plus optional
-/// migration section), which locates the pre-release insertion point.
-async fn current_version_wallet_bytes() -> (
-    crate::config::ChainType,
-    crate::wallet::RecoveryInfo,
-    Vec<u8>,
-    usize,
-) {
+/// What the orphaned-layout tests below assert against: the wallet's chain
+/// type, its recovery info, the serialized tail (price list plus optional
+/// migration section), and the whole file saved at the current version.
+///
+/// The tail is returned in full, not merely as a length, because asserting
+/// on it is what makes these tests meaningful. Recovery info comes from the
+/// file *prefix* and so survives even a badly misparsed tail; only comparing
+/// the tail proves the disambiguating reader chose the right layout.
+struct CurrentVersionWallet {
+    chain_type: crate::config::ChainType,
+    recovery_info: crate::wallet::RecoveryInfo,
+    tail: Vec<u8>,
+    bytes: Vec<u8>,
+}
+
+impl CurrentVersionWallet {
+    /// Offset at which the pre-release layout's `allow_v6_transactions`
+    /// byte sits, immediately before the price list.
+    fn tail_offset(&self) -> usize {
+        self.bytes.len() - self.tail.len()
+    }
+
+    /// Serializes the tail of `wallet` for comparison against this
+    /// expectation. `PriceList` has no `PartialEq`, so the round trip is
+    /// checked through the encoding, which is the property under test.
+    fn assert_tail_matches(&self, wallet: &crate::wallet::LightWallet, context: &str) {
+        use zcash_encoding::Optional;
+
+        let mut recovered_tail = Vec::new();
+        wallet.price_list.write(&mut recovered_tail).unwrap();
+        Optional::write(
+            &mut recovered_tail,
+            wallet.migration.as_ref(),
+            crate::wallet::migration::store::write,
+        )
+        .unwrap();
+
+        assert_eq!(
+            recovered_tail, self.tail,
+            "{context}: the price list and migration section must survive the read"
+        );
+    }
+}
+
+/// Saves an example wallet carrying a deliberately non-trivial tail: a price
+/// list with a start time and a populated migration state. A tail of all
+/// zeroes would be misparsed into an identical all-`None` value, so it could
+/// not detect a reader that picked the wrong layout.
+async fn current_version_wallet_bytes() -> CurrentVersionWallet {
+    use crate::wallet::migration::{
+        BoundNote, ConsentBinding, MigrationParams, MigrationPhase, MigrationState, PartId,
+        PartRecord, SigningStrategy,
+    };
+    use pepper_sync::wallet::OutputId;
     use zcash_encoding::Optional;
+    use zcash_primitives::transaction::TxId;
 
     let client = NetworkSeedVersion::Regtest(RegtestSeedVersion::AbandonAbandon(
         AbandonAbandonVersion::V26,
@@ -383,6 +428,34 @@ async fn current_version_wallet_bytes() -> (
     .load_example_wallet()
     .await;
     let mut wallet = client.wallet().write().await;
+
+    wallet.price_list.set_start_time(1_782_000_000);
+
+    let params = MigrationParams::provisional(wallet.chain_type());
+    let mut part = PartRecord::new(
+        PartId(0),
+        100_000_000,
+        BoundNote {
+            output_id: OutputId::new(TxId::from_bytes([3; 32]), 1),
+            nullifier: [4; 32],
+            commitment: [5; 32],
+        },
+    );
+    part.assign(12).unwrap();
+    wallet.migration = Some(MigrationState {
+        consent: ConsentBinding {
+            params_hash: params.params_hash(),
+            plan_hash: [6; 32],
+            consented_at: 1_782_000_000,
+        },
+        params,
+        strategy: SigningStrategy::LazyAtBoundary,
+        mode: crate::wallet::migration::MigrationMode::Scheduled,
+        account: zip32::AccountId::ZERO,
+        phase: MigrationPhase::PartsScheduled,
+        parts: vec![part],
+    });
+
     wallet.save_required = true;
     let bytes = wallet.save().unwrap().expect("save required");
 
@@ -393,9 +466,12 @@ async fn current_version_wallet_bytes() -> (
     })
     .unwrap();
 
-    let chain_type = wallet.chain_type();
-    let recovery_info = wallet.recovery_info().unwrap();
-    (chain_type, recovery_info, bytes, tail.len())
+    CurrentVersionWallet {
+        chain_type: wallet.chain_type(),
+        recovery_info: wallet.recovery_info().unwrap(),
+        tail,
+        bytes,
+    }
 }
 
 /// Pre-release ironwood builds briefly wrote version 43 with the final
@@ -404,12 +480,14 @@ async fn current_version_wallet_bytes() -> (
 async fn wallet_reads_retired_version_43_as_current() {
     use crate::wallet::LightWallet;
 
-    let (chain_type, recovery_info, mut bytes, _tail_length) = current_version_wallet_bytes().await;
+    let expected = current_version_wallet_bytes().await;
+    let mut bytes = expected.bytes.clone();
     bytes[..8].copy_from_slice(&43u64.to_le_bytes());
 
-    let recovered = LightWallet::read(bytes.as_slice(), chain_type)
+    let recovered = LightWallet::read(bytes.as_slice(), expected.chain_type)
         .expect("retired version 43 must read as the final 42 layout");
-    assert_eq!(recovered.recovery_info().unwrap(), recovery_info);
+    assert_eq!(recovered.recovery_info().unwrap(), expected.recovery_info);
+    expected.assert_tail_matches(&recovered, "version 43");
 }
 
 /// Pre-release ironwood builds before the `allow_v6_transactions` removal
@@ -419,17 +497,66 @@ async fn wallet_reads_retired_version_43_as_current() {
 async fn wallet_reads_pre_release_v42_with_allow_v6_byte() {
     use crate::wallet::LightWallet;
 
-    let (chain_type, recovery_info, bytes, tail_length) = current_version_wallet_bytes().await;
-    let insertion_point = bytes.len() - tail_length;
+    let expected = current_version_wallet_bytes().await;
 
     for allow_v6_byte in [0u8, 1u8] {
-        let mut pre_release = bytes.clone();
-        pre_release.insert(insertion_point, allow_v6_byte);
+        let mut pre_release = expected.bytes.clone();
+        pre_release.insert(expected.tail_offset(), allow_v6_byte);
 
-        let recovered = LightWallet::read(pre_release.as_slice(), chain_type)
+        let recovered = LightWallet::read(pre_release.as_slice(), expected.chain_type)
             .expect("pre-release v42 layout must read via tail disambiguation");
-        assert_eq!(recovered.recovery_info().unwrap(), recovery_info);
+        assert_eq!(recovered.recovery_info().unwrap(), expected.recovery_info);
+        expected.assert_tail_matches(
+            &recovered,
+            &format!("pre-release version 42 with allow_v6_transactions={allow_v6_byte}"),
+        );
     }
+}
+
+/// A file whose tail reads cleanly under *both* layouts is genuinely
+/// ambiguous, and the reader must refuse it rather than silently substitute
+/// one reading's price list and migration state for the other's.
+///
+/// The decision is exercised directly: constructing a byte string that
+/// satisfies both parses is not possible for a migration-free tail (see the
+/// parity argument on `resolve_v42_tail`) and impractical otherwise, so the
+/// test supplies the four parse outcomes the caller can hand it.
+#[test]
+fn ambiguous_version_42_tail_is_refused() {
+    use crate::wallet::LightWallet;
+    use zingo_price::PriceList;
+
+    let parsed = || Ok((PriceList::new(), None));
+    let failed = || {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "tail did not parse",
+        ))
+    };
+
+    let ambiguous = LightWallet::resolve_v42_tail(parsed(), Some(parsed()));
+    assert_eq!(
+        ambiguous.unwrap_err().kind(),
+        std::io::ErrorKind::InvalidData,
+        "a tail parsing both ways must be refused, not guessed"
+    );
+
+    assert!(
+        LightWallet::resolve_v42_tail(parsed(), Some(failed())).is_ok(),
+        "the canonical layout must win when only it parses"
+    );
+    assert!(
+        LightWallet::resolve_v42_tail(parsed(), None).is_ok(),
+        "a leading byte that is no bool rules out the pre-release layout"
+    );
+    assert!(
+        LightWallet::resolve_v42_tail(failed(), Some(parsed())).is_ok(),
+        "the pre-release layout must be accepted when only it parses"
+    );
+    assert!(
+        LightWallet::resolve_v42_tail(failed(), Some(failed())).is_err(),
+        "a tail parsing neither way must fail"
+    );
 }
 
 /// When the full parse fails — here simulated by a truncated file — the
@@ -439,16 +566,17 @@ async fn wallet_reads_pre_release_v42_with_allow_v6_byte() {
 async fn recovery_info_salvages_a_wallet_file_that_fails_to_read() {
     use crate::wallet::LightWallet;
 
-    let (chain_type, recovery_info, mut bytes, _tail_length) = current_version_wallet_bytes().await;
+    let expected = current_version_wallet_bytes().await;
+    let mut bytes = expected.bytes.clone();
     bytes.truncate(bytes.len() - 10);
 
     assert!(
-        LightWallet::read(bytes.as_slice(), chain_type).is_err(),
+        LightWallet::read(bytes.as_slice(), expected.chain_type).is_err(),
         "truncated file must fail the full parse for this test to be meaningful"
     );
     let salvaged = LightWallet::read_recovery_info(bytes.as_slice())
         .expect("prefix salvage must survive a corrupt tail");
-    assert_eq!(salvaged, recovery_info);
+    assert_eq!(salvaged, expected.recovery_info);
 }
 
 /// Sweeps the local corpus of real wallet files in `data_wallets/` at the


### PR DESCRIPTION
Supersedes #2528, which targeted `fix/ironwood-split-mobile`. This defect is present on `dev` itself, so the fix belongs here.

## The defect is live on dev

Both commits that created the orphaned layouts are ancestors of `dev`: `32261bb5f` removed the `allow_v6_transactions` byte and bumped the wallet version to 43, and `4158e20c2` re-pinned the version to 42 without the byte, ruling that the byte-carrying revision "never shipped." Version 42 therefore names two incompatible layouts, and version 43 names a third file population.

`dev` reads `32..=42` with no disambiguation, so it misparses a byte-carrying 42 file one byte into the price list and rejects a 43 file outright. Anyone who built and ran from `dev` between those commits has a wallet that current `dev` cannot open — which is exactly what a tester reported against a mobile build.

## The fix

`LightWallet::read` accepts version 43 as the final 42 layout (the layouts are byte-identical) and disambiguates the two revisions of 42 by an end-of-file-anchored parse of the buffered tail. The canonical layout is preferred, so files written by current code never depend on the fallback, and a tail that parses cleanly *both* ways is refused rather than guessed — accepting the wrong reading would silently substitute a different price list and migration state. Ambiguity cannot arise for a migration-free tail, whose length is always odd while the two readings differ by exactly one byte; the refusal guards the migration-bearing case, where no such parity argument holds.

Beneath that sits a salvage floor: `LightWallet::read_recovery_info` recovers the seed phrase, birthday, and account count from the stable version-32+ prefix of any file whose full parse fails, and `zingo-cli` falls back to it when the wallet will not load but the user asked for `recovery_info`. No format break can strand a wallet.

Version 43 is burned and must never be reassigned; the next format bump is 44.

## Policy

ADR 0015 records the ruling that motivated this: we support users who build and run from `dev`, so no release gate protects them, and a wallet format is shipped the moment it lands in `dev`. Shipped layouts stay readable, used version numbers are burned, and a format change lands only together with its read-side compatibility and regression tests. The `zingolib` glossary gains Wallet Version, Shipped Format, and Recovery Salvage.

## Tests

Covering version 43, both bool values of the byte-carrying layout, prefix salvage from a corrupt file, all four outcomes of the ambiguity decision, and a sweep of a local `data_wallets` corpus requiring every real wallet file to parse or salvage (gitignored, prints no seed material, passes empty in CI).

The layout tests assert on the file *tail*, not on recovery info: recovery info is read from the prefix and survives a misparsed tail intact, so a prefix-only assertion would pass against a reader that dropped the entire migration section. Both defenses were confirmed by mutation — disabling the trailing-byte check fails the tests through the refusal, and disabling both fails them on the tail comparison.

Disk suite passes 20/20 on this branch; `zingolib` and `zingo-cli` are clippy- and fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)