### PR TITLE
ci: halt everything unless decent_exposure proves maximum item privacy

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -25,6 +25,66 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Maximum item privacy, enforced over the whole tree: the other jobs start
+  # optimistically in parallel with this one and share warm build caches, but
+  # a privacy failure reaps the entire run — the last step cancels every
+  # in-flight job and returns its runner to the pool. Three layers run in
+  # order — rustc's unreachable_pub, rustc's missing_docs, then cargo
+  # public-api against the goldens in tools/workbench/goldens/public-api/.
+  # The driver lives in the workbench crate; run it locally with
+  #   cargo run --manifest-path tools/workbench/Cargo.toml --bin decent-exposure
+  # and regenerate the goldens by appending `-- --bless`.
+  decent_exposure:
+    name: decent_exposure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    # actions: write lets the reap step cancel this very run.
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      # cargo public-api builds rustdoc JSON, which only nightly rustdoc emits.
+      - name: Install nightly for rustdoc JSON
+        run: rustup toolchain install nightly --profile minimal
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            zingo-netutils
+            tools/workbench
+
+      - name: Install protoc
+        run: |
+          if ! command -v protoc; then
+            sudo apt-get update
+            sudo apt-get install -y protobuf-compiler
+          fi
+
+      # Pinned to the version the goldens were generated with.
+      - name: Install cargo-public-api
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-public-api@0.50.2
+
+      - name: Enforce maximum item privacy
+        run: cargo run --manifest-path tools/workbench/Cargo.toml --bin decent-exposure
+
+      # Privacy failed: reap the whole run, deallocating every runner the
+      # optimistic parallel start claimed.
+      - name: Reap the run on privacy failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+
   reject-trailing-whitespace:
     uses: zingolabs/infrastructure/.github/workflows/trailing-whitespace.yaml@20485fed7a080e381130ed8120419dc81acae641
 

--- a/libtonode-tests/src/lib.rs
+++ b/libtonode-tests/src/lib.rs
@@ -1,1 +1,14 @@
+//! Integration tests that exercise the wallet against a live regtest network.
+//!
+//! Every test in this crate launches a real Validator (`zebrad`) and a real
+//! Indexer (`zainod`) through `zcash_local_net`, then drives a `LightClient`
+//! against them, so the wallet meets the same protocol surface it meets on
+//! mainnet. The test binaries under `tests/` hold the cases themselves.
+//!
+//! The library half exists to serve those binaries. It publishes
+//! [`chain_generics`], which binds `zingolib`'s chain-generic test bodies to
+//! this regtest network by implementing `ConductChain` for it.
+
+#![forbid(unsafe_code)]
+
 pub mod chain_generics;

--- a/tools/workbench/goldens/public-api/libtonode-tests.txt
+++ b/tools/workbench/goldens/public-api/libtonode-tests.txt
@@ -1,0 +1,13 @@
+pub mod libtonode_tests
+pub mod libtonode_tests::chain_generics
+pub struct libtonode_tests::chain_generics::LibtonodeEnvironment
+pub libtonode_tests::chain_generics::LibtonodeEnvironment::client_builder: zingolib_testutils::scenarios::ClientBuilder
+pub libtonode_tests::chain_generics::LibtonodeEnvironment::local_net: zingolib_testutils::setup_metrics::MeteredNet
+impl zingolib::testutils::chain_generics::conduct_chain::ConductChain for libtonode_tests::chain_generics::LibtonodeEnvironment
+pub fn libtonode_tests::chain_generics::LibtonodeEnvironment::confirmation_patience_blocks(&self) -> usize
+pub async fn libtonode_tests::chain_generics::LibtonodeEnvironment::create_faucet(&mut self) -> zingolib::lightclient::LightClient
+pub async fn libtonode_tests::chain_generics::LibtonodeEnvironment::increase_chain_height(&mut self)
+pub fn libtonode_tests::chain_generics::LibtonodeEnvironment::lightserver_uri(&self) -> core::option::Option<http::uri::Uri>
+pub async fn libtonode_tests::chain_generics::LibtonodeEnvironment::setup() -> Self
+pub async fn libtonode_tests::chain_generics::LibtonodeEnvironment::sync_client_to_tip(&self, client: &mut zingolib::lightclient::LightClient)
+pub async fn libtonode_tests::chain_generics::LibtonodeEnvironment::zingo_config(&mut self) -> zingolib::config::ClientConfig

--- a/tools/workbench/goldens/public-api/pepper-sync.txt
+++ b/tools/workbench/goldens/public-api/pepper-sync.txt
@@ -1,0 +1,642 @@
+pub mod pepper_sync
+pub mod pepper_sync::config
+pub enum pepper_sync::config::PerformanceLevel
+pub pepper_sync::config::PerformanceLevel::High
+pub pepper_sync::config::PerformanceLevel::Low
+pub pepper_sync::config::PerformanceLevel::Maximum
+pub pepper_sync::config::PerformanceLevel::Medium
+impl pepper_sync::config::PerformanceLevel
+pub fn pepper_sync::config::PerformanceLevel::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::config::PerformanceLevel::write<W: std::io::Write>(&mut self, writer: W) -> std::io::error::Result<()>
+impl core::fmt::Display for pepper_sync::config::PerformanceLevel
+pub fn pepper_sync::config::PerformanceLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct pepper_sync::config::SyncConfig
+pub pepper_sync::config::SyncConfig::performance_level: pepper_sync::config::PerformanceLevel
+pub pepper_sync::config::SyncConfig::transparent_address_discovery: pepper_sync::config::TransparentAddressDiscovery
+impl pepper_sync::config::SyncConfig
+pub fn pepper_sync::config::SyncConfig::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::config::SyncConfig::write<W: std::io::Write>(&mut self, writer: W) -> std::io::error::Result<()>
+pub struct pepper_sync::config::TransparentAddressDiscovery
+pub pepper_sync::config::TransparentAddressDiscovery::gap_limit: u8
+pub pepper_sync::config::TransparentAddressDiscovery::scopes: pepper_sync::config::TransparentAddressDiscoveryScopes
+impl pepper_sync::config::TransparentAddressDiscovery
+pub fn pepper_sync::config::TransparentAddressDiscovery::disabled() -> Self
+pub fn pepper_sync::config::TransparentAddressDiscovery::minimal() -> Self
+pub fn pepper_sync::config::TransparentAddressDiscovery::recovery() -> Self
+impl core::default::Default for pepper_sync::config::TransparentAddressDiscovery
+pub fn pepper_sync::config::TransparentAddressDiscovery::default() -> Self
+pub struct pepper_sync::config::TransparentAddressDiscoveryScopes
+pub pepper_sync::config::TransparentAddressDiscoveryScopes::external: bool
+pub pepper_sync::config::TransparentAddressDiscoveryScopes::internal: bool
+pub pepper_sync::config::TransparentAddressDiscoveryScopes::refund: bool
+impl pepper_sync::config::TransparentAddressDiscoveryScopes
+pub fn pepper_sync::config::TransparentAddressDiscoveryScopes::recovery() -> Self
+impl core::default::Default for pepper_sync::config::TransparentAddressDiscoveryScopes
+pub fn pepper_sync::config::TransparentAddressDiscoveryScopes::default() -> Self
+pub mod pepper_sync::error
+pub enum pepper_sync::error::CompactFormatError
+pub pepper_sync::error::CompactFormatError::InvalidLength(core::array::TryFromSliceError)
+pub pepper_sync::error::CompactFormatError::InvalidValue
+impl core::fmt::Display for pepper_sync::error::CompactFormatError
+pub fn pepper_sync::error::CompactFormatError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum pepper_sync::error::ContinuityError
+pub pepper_sync::error::ContinuityError::HashDiscontinuity
+pub pepper_sync::error::ContinuityError::HashDiscontinuity::height: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::error::ContinuityError::HashDiscontinuity::prev_hash: zcash_primitives::block::BlockHash
+pub pepper_sync::error::ContinuityError::HashDiscontinuity::previous_block_hash: zcash_primitives::block::BlockHash
+pub pepper_sync::error::ContinuityError::HeightDiscontinuity
+pub pepper_sync::error::ContinuityError::HeightDiscontinuity::height: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::error::ContinuityError::HeightDiscontinuity::previous_block_height: zcash_protocol::consensus::BlockHeight
+pub enum pepper_sync::error::MempoolError
+pub pepper_sync::error::MempoolError::ServerError(pepper_sync::error::ServerError)
+pub pepper_sync::error::MempoolError::ShutdownWithoutStream
+pub enum pepper_sync::error::ScanError
+pub pepper_sync::error::ScanError::AddressParseError(zcash_address::kind::unified::ParseError)
+pub pepper_sync::error::ScanError::ContinuityError(pepper_sync::error::ContinuityError)
+pub pepper_sync::error::ScanError::DecryptedNoteDataNotFound(pepper_sync::wallet::OutputId)
+pub pepper_sync::error::ScanError::EncodingError(pepper_sync::error::EncodingInvalid)
+pub pepper_sync::error::ScanError::IncorrectTreeSize
+pub pepper_sync::error::ScanError::IncorrectTreeSize::block_metadata_size: u32
+pub pepper_sync::error::ScanError::IncorrectTreeSize::calculated_size: u32
+pub pepper_sync::error::ScanError::IncorrectTreeSize::shielded_protocol: zcash_protocol::PoolType
+pub pepper_sync::error::ScanError::IncorrectTxid
+pub pepper_sync::error::ScanError::IncorrectTxid::txid_requested: zcash_protocol::txid::TxId
+pub pepper_sync::error::ScanError::IncorrectTxid::txid_returned: zcash_protocol::txid::TxId
+pub pepper_sync::error::ScanError::InvalidMemoBytes(zcash_protocol::memo::Error)
+pub pepper_sync::error::ScanError::InvalidOrchardAction
+pub pepper_sync::error::ScanError::InvalidOrchardNullifier
+pub pepper_sync::error::ScanError::InvalidOrchardNullifierLength(usize)
+pub pepper_sync::error::ScanError::InvalidSaplingNullifier(core::array::TryFromSliceError)
+pub pepper_sync::error::ScanError::InvalidSaplingOutput
+pub pepper_sync::error::ScanError::ServerError(pepper_sync::error::ServerError)
+pub enum pepper_sync::error::ServerError
+pub pepper_sync::error::ServerError::ChainVerificationError
+pub pepper_sync::error::ServerError::FetcherDropped
+pub pepper_sync::error::ServerError::GenesisBlockOnly
+pub pepper_sync::error::ServerError::InvalidFrontier(std::io::error::Error)
+pub pepper_sync::error::ServerError::InvalidSubtreeRoot
+pub pepper_sync::error::ServerError::InvalidTransaction(std::io::error::Error)
+pub pepper_sync::error::ServerError::RequestFailed(tonic::status::Status)
+impl pepper_sync::error::ServerError
+pub fn pepper_sync::error::ServerError::recommend_same_server(&self) -> bool
+impl pepper_sync::error::ServerError
+pub fn pepper_sync::error::ServerError::recovery_recommendation(&self) -> pepper_sync::error::SyncRecoveryObservables
+pub enum pepper_sync::error::SyncError<E> where E: core::fmt::Debug + core::fmt::Display
+pub pepper_sync::error::SyncError::BirthdayBelowSapling(u32, u32)
+pub pepper_sync::error::SyncError::ChainError(u32, u32, u32)
+pub pepper_sync::error::SyncError::MempoolError(pepper_sync::error::MempoolError)
+pub pepper_sync::error::SyncError::ScanError(pepper_sync::error::ScanError)
+pub pepper_sync::error::SyncError::ServerError(pepper_sync::error::ServerError)
+pub pepper_sync::error::SyncError::ShardTreeError(shardtree::error::ShardTreeError<core::convert::Infallible>)
+pub pepper_sync::error::SyncError::SyncModeError(pepper_sync::error::SyncModeError)
+pub pepper_sync::error::SyncError::TransparentAddressDerivationError(bip32::error::Error)
+pub pepper_sync::error::SyncError::TruncationError(zcash_protocol::consensus::BlockHeight, zcash_protocol::PoolType)
+pub pepper_sync::error::SyncError::WalletError(E)
+impl<E: core::fmt::Debug + core::fmt::Display> pepper_sync::error::SyncError<E>
+pub fn pepper_sync::error::SyncError<E>::recommend_same_server(&self) -> bool
+impl<E: core::fmt::Debug + core::fmt::Display> pepper_sync::error::SyncError<E>
+pub fn pepper_sync::error::SyncError<E>::recovery_recommendation(&self) -> pepper_sync::error::SyncRecoveryObservables
+pub enum pepper_sync::error::SyncModeError
+pub pepper_sync::error::SyncModeError::InvalidSyncMode(u8)
+pub pepper_sync::error::SyncModeError::SyncAlreadyRunning
+pub pepper_sync::error::SyncModeError::SyncNotPaused
+pub pepper_sync::error::SyncModeError::SyncNotRunning
+pub enum pepper_sync::error::SyncRecoveryObservables
+pub pepper_sync::error::SyncRecoveryObservables::Abort
+pub pepper_sync::error::SyncRecoveryObservables::MaybeRecoverableServer
+pub pepper_sync::error::SyncRecoveryObservables::ServerUnavailable
+pub enum pepper_sync::error::SyncStatusError<E> where E: core::fmt::Debug + core::fmt::Display
+pub pepper_sync::error::SyncStatusError::NoSyncData
+pub pepper_sync::error::SyncStatusError::WalletError(E)
+pub struct pepper_sync::error::EncodingInvalid
+pub mod pepper_sync::keys
+pub mod pepper_sync::keys::transparent
+pub enum pepper_sync::keys::transparent::TransparentScope
+pub pepper_sync::keys::transparent::TransparentScope::External
+pub pepper_sync::keys::transparent::TransparentScope::Internal
+pub pepper_sync::keys::transparent::TransparentScope::Refund
+impl core::convert::From<pepper_sync::keys::transparent::TransparentScope> for zcash_transparent::keys::TransparentKeyScope
+pub fn zcash_transparent::keys::TransparentKeyScope::from(value: pepper_sync::keys::transparent::TransparentScope) -> Self
+impl core::convert::TryFrom<u8> for pepper_sync::keys::transparent::TransparentScope
+pub type pepper_sync::keys::transparent::TransparentScope::Error = std::io::error::Error
+pub fn pepper_sync::keys::transparent::TransparentScope::try_from(value: u8) -> std::io::error::Result<Self>
+impl core::fmt::Display for pepper_sync::keys::transparent::TransparentScope
+pub fn pepper_sync::keys::transparent::TransparentScope::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct pepper_sync::keys::transparent::TransparentAddressId
+impl pepper_sync::keys::transparent::TransparentAddressId
+pub fn pepper_sync::keys::transparent::TransparentAddressId::address_index(&self) -> zcash_transparent::keys::NonHardenedChildIndex
+pub fn pepper_sync::keys::transparent::TransparentAddressId::new(account_id: zip32::AccountId, scope: pepper_sync::keys::transparent::TransparentScope, address_index: zcash_transparent::keys::NonHardenedChildIndex) -> Self
+pub fn pepper_sync::keys::transparent::TransparentAddressId::scope(&self) -> pepper_sync::keys::transparent::TransparentScope
+impl pepper_sync::wallet::KeyIdInterface for pepper_sync::keys::transparent::TransparentAddressId
+pub fn pepper_sync::keys::transparent::TransparentAddressId::account_id(&self) -> zip32::AccountId
+pub fn pepper_sync::keys::transparent::encode_address(consensus_parameters: &impl zcash_protocol::consensus::Parameters, address: zcash_transparent::address::TransparentAddress) -> alloc::string::String
+pub struct pepper_sync::keys::KeyId
+pub pepper_sync::keys::KeyId::account_id: zip32::AccountId
+pub pepper_sync::keys::KeyId::scope: zip32::Scope
+impl memuse::DynamicUsage for pepper_sync::keys::KeyId
+pub fn pepper_sync::keys::KeyId::dynamic_usage(&self) -> usize
+pub fn pepper_sync::keys::KeyId::dynamic_usage_bounds(&self) -> (usize, core::option::Option<usize>)
+impl pepper_sync::wallet::KeyIdInterface for pepper_sync::keys::KeyId
+pub fn pepper_sync::keys::KeyId::account_id(&self) -> zip32::AccountId
+pub trait pepper_sync::keys::ScanningKeyOps<D: zcash_note_encryption::Domain, Nf>
+pub fn pepper_sync::keys::ScanningKeyOps::account_id(&self) -> &zip32::AccountId
+pub fn pepper_sync::keys::ScanningKeyOps::key_scope(&self) -> core::option::Option<zip32::Scope>
+pub fn pepper_sync::keys::ScanningKeyOps::nf(&self, note: &<D as zcash_note_encryption::Domain>::Note, note_position: incrementalmerkletree::Position) -> core::option::Option<Nf>
+pub fn pepper_sync::keys::ScanningKeyOps::prepare(&self) -> <D as zcash_note_encryption::Domain>::IncomingViewingKey
+impl<D: zcash_note_encryption::Domain, Nf, K: pepper_sync::keys::ScanningKeyOps<D, Nf>> pepper_sync::keys::ScanningKeyOps<D, Nf> for &K
+pub fn &K::account_id(&self) -> &zip32::AccountId
+pub fn &K::key_scope(&self) -> core::option::Option<zip32::Scope>
+pub fn &K::nf(&self, note: &<D as zcash_note_encryption::Domain>::Note, note_position: incrementalmerkletree::Position) -> core::option::Option<Nf>
+pub fn &K::prepare(&self) -> <D as zcash_note_encryption::Domain>::IncomingViewingKey
+pub fn pepper_sync::keys::decode_address(consensus_parameters: &impl zcash_protocol::consensus::Parameters, encoded_address: &str) -> std::io::error::Result<zcash_keys::address::Address>
+pub fn pepper_sync::keys::decode_unified_address(consensus_parameters: &impl zcash_protocol::consensus::Parameters, encoded_address: &str) -> std::io::error::Result<zcash_keys::address::UnifiedAddress>
+pub type pepper_sync::keys::AddressIndex = u32
+pub mod pepper_sync::shardtree_ext
+pub enum pepper_sync::shardtree_ext::CheckpointAppendOutcome
+pub pepper_sync::shardtree_ext::CheckpointAppendOutcome::Appended
+pub pepper_sync::shardtree_ext::CheckpointAppendOutcome::NotAboveNewest
+pub enum pepper_sync::shardtree_ext::RollbackOutcome
+pub pepper_sync::shardtree_ext::RollbackOutcome::NoSuchCheckpoint
+pub pepper_sync::shardtree_ext::RollbackOutcome::RolledBack
+pub trait pepper_sync::shardtree_ext::ShardTreeExt
+pub fn pepper_sync::shardtree_ext::ShardTreeExt::append_checkpoint(&mut self, checkpoint_id: zcash_protocol::consensus::BlockHeight) -> core::result::Result<pepper_sync::shardtree_ext::CheckpointAppendOutcome, shardtree::error::ShardTreeError<core::convert::Infallible>>
+pub fn pepper_sync::shardtree_ext::ShardTreeExt::rollback_to_checkpoint(&mut self, checkpoint_id: zcash_protocol::consensus::BlockHeight) -> core::result::Result<pepper_sync::shardtree_ext::RollbackOutcome, shardtree::error::ShardTreeError<core::convert::Infallible>>
+impl<H, const DEPTH: u8, const SHARD_HEIGHT: u8> pepper_sync::shardtree_ext::ShardTreeExt for shardtree::ShardTree<shardtree::store::memory::MemoryShardStore<H, zcash_protocol::consensus::BlockHeight>, DEPTH, SHARD_HEIGHT> where H: incrementalmerkletree::Hashable + core::clone::Clone + core::cmp::PartialEq
+pub fn shardtree::ShardTree<shardtree::store::memory::MemoryShardStore<H, zcash_protocol::consensus::BlockHeight>, DEPTH, SHARD_HEIGHT>::append_checkpoint(&mut self, checkpoint_id: zcash_protocol::consensus::BlockHeight) -> core::result::Result<pepper_sync::shardtree_ext::CheckpointAppendOutcome, shardtree::error::ShardTreeError<core::convert::Infallible>>
+pub fn shardtree::ShardTree<shardtree::store::memory::MemoryShardStore<H, zcash_protocol::consensus::BlockHeight>, DEPTH, SHARD_HEIGHT>::rollback_to_checkpoint(&mut self, checkpoint_id: zcash_protocol::consensus::BlockHeight) -> core::result::Result<pepper_sync::shardtree_ext::RollbackOutcome, shardtree::error::ShardTreeError<core::convert::Infallible>>
+pub mod pepper_sync::sync
+pub mod pepper_sync::sync::truncate
+pub enum pepper_sync::sync::truncate::PoolTruncation
+pub pepper_sync::sync::truncate::PoolTruncation::RequiresRescan
+pub pepper_sync::sync::truncate::PoolTruncation::RequiresRescan::newest_checkpoint: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::sync::truncate::PoolTruncation::ToCheckpoint
+pub pepper_sync::sync::truncate::PoolTruncation::ToCheckpoint::checkpoint: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::sync::truncate::PoolTruncation::Untouched
+pub enum pepper_sync::sync::truncate::TruncationPlan
+pub pepper_sync::sync::truncate::TruncationPlan::ClearAll
+pub pepper_sync::sync::truncate::TruncationPlan::NoOp
+pub pepper_sync::sync::truncate::TruncationPlan::Truncate
+pub pepper_sync::sync::truncate::TruncationPlan::Truncate::height: zcash_protocol::consensus::BlockHeight
+pub struct pepper_sync::sync::truncate::TreeTruncationFacts
+pub pepper_sync::sync::truncate::TreeTruncationFacts::checkpoint_at_target: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub pepper_sync::sync::truncate::TreeTruncationFacts::newest_checkpoint: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub struct pepper_sync::sync::truncate::WalletTruncationState
+pub pepper_sync::sync::truncate::WalletTruncationState::birthday: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::sync::truncate::WalletTruncationState::highest_scanned_height: zcash_protocol::consensus::BlockHeight
+pub fn pepper_sync::sync::truncate::plan_truncation(wallet_state: pepper_sync::sync::truncate::WalletTruncationState, truncate_height: zcash_protocol::consensus::BlockHeight) -> pepper_sync::sync::truncate::TruncationPlan
+pub enum pepper_sync::sync::ScanPriority
+pub pepper_sync::sync::ScanPriority::ChainTip
+pub pepper_sync::sync::ScanPriority::FoundNote
+pub pepper_sync::sync::ScanPriority::Historic
+pub pepper_sync::sync::ScanPriority::OpenAdjacent
+pub pepper_sync::sync::ScanPriority::RefetchingNullifiers
+pub pepper_sync::sync::ScanPriority::Scanned
+pub pepper_sync::sync::ScanPriority::ScannedWithoutMapping
+pub pepper_sync::sync::ScanPriority::Scanning
+pub pepper_sync::sync::ScanPriority::Verify
+impl pepper_sync::sync::ScanPriority
+pub fn pepper_sync::sync::ScanPriority::awaits_nullifier_retrieval(self) -> bool
+pub fn pepper_sync::sync::ScanPriority::is_scanned(self) -> bool
+pub struct pepper_sync::sync::ScanRange
+impl pepper_sync::sync::ScanRange
+pub fn pepper_sync::sync::ScanRange::block_range(&self) -> &core::ops::range::Range<zcash_protocol::consensus::BlockHeight>
+pub fn pepper_sync::sync::ScanRange::from_parts(block_range: core::ops::range::Range<zcash_protocol::consensus::BlockHeight>, priority: pepper_sync::sync::ScanPriority) -> Self
+pub fn pepper_sync::sync::ScanRange::is_empty(&self) -> bool
+pub fn pepper_sync::sync::ScanRange::len(&self) -> usize
+pub fn pepper_sync::sync::ScanRange::priority(&self) -> pepper_sync::sync::ScanPriority
+pub fn pepper_sync::sync::ScanRange::split_at(&self, p: zcash_protocol::consensus::BlockHeight) -> core::option::Option<(Self, Self)>
+pub fn pepper_sync::sync::ScanRange::truncate_end(&self, block_height: zcash_protocol::consensus::BlockHeight) -> core::option::Option<Self>
+pub fn pepper_sync::sync::ScanRange::truncate_start(&self, block_height: zcash_protocol::consensus::BlockHeight) -> core::option::Option<Self>
+impl core::fmt::Display for pepper_sync::sync::ScanRange
+pub fn pepper_sync::sync::ScanRange::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct pepper_sync::sync::SyncResult
+pub pepper_sync::sync::SyncResult::blocks_scanned: u32
+pub pepper_sync::sync::SyncResult::ironwood_outputs_scanned: u32
+pub pepper_sync::sync::SyncResult::orchard_outputs_scanned: u32
+pub pepper_sync::sync::SyncResult::percentage_total_outputs_scanned: f32
+pub pepper_sync::sync::SyncResult::sapling_outputs_scanned: u32
+pub pepper_sync::sync::SyncResult::sync_end_height: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::sync::SyncResult::sync_start_height: zcash_protocol::consensus::BlockHeight
+impl core::convert::From<pepper_sync::sync::SyncResult> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value: pepper_sync::sync::SyncResult) -> Self
+impl core::fmt::Display for pepper_sync::sync::SyncResult
+pub fn pepper_sync::sync::SyncResult::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct pepper_sync::sync::SyncStatus
+pub pepper_sync::sync::SyncStatus::percentage_session_blocks_scanned: f32
+pub pepper_sync::sync::SyncStatus::percentage_session_outputs_scanned: f32
+pub pepper_sync::sync::SyncStatus::percentage_total_blocks_scanned: f32
+pub pepper_sync::sync::SyncStatus::percentage_total_outputs_scanned: f32
+pub pepper_sync::sync::SyncStatus::scan_ranges: alloc::vec::Vec<pepper_sync::sync::ScanRange>
+pub pepper_sync::sync::SyncStatus::session_blocks_scanned: u32
+pub pepper_sync::sync::SyncStatus::session_ironwood_outputs_scanned: u32
+pub pepper_sync::sync::SyncStatus::session_orchard_outputs_scanned: u32
+pub pepper_sync::sync::SyncStatus::session_sapling_outputs_scanned: u32
+pub pepper_sync::sync::SyncStatus::sync_start_height: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::sync::SyncStatus::total_blocks_scanned: u32
+pub pepper_sync::sync::SyncStatus::total_ironwood_outputs_scanned: u32
+pub pepper_sync::sync::SyncStatus::total_orchard_outputs_scanned: u32
+pub pepper_sync::sync::SyncStatus::total_outputs: u64
+pub pepper_sync::sync::SyncStatus::total_outputs_scanned: u64
+pub pepper_sync::sync::SyncStatus::total_sapling_outputs_scanned: u32
+impl pepper_sync::sync::SyncStatus
+pub fn pepper_sync::sync::SyncStatus::is_complete(&self) -> bool
+impl core::convert::From<pepper_sync::sync::SyncStatus> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value: pepper_sync::sync::SyncStatus) -> Self
+impl core::fmt::Display for pepper_sync::sync::SyncStatus
+pub fn pepper_sync::sync::SyncStatus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub const pepper_sync::sync::MAX_REORG_ALLOWANCE: u32
+pub fn pepper_sync::sync::add_scan_targets(sync_state: &mut pepper_sync::wallet::SyncState, scan_targets: &[pepper_sync::wallet::ScanTarget])
+pub fn pepper_sync::sync::reset_spends(wallet_transactions: &mut std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, invalid_txids: alloc::vec::Vec<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::sync::scan_pending_transaction<W>(consensus_parameters: &impl zcash_protocol::consensus::Parameters, ufvks: &std::collections::hash::map::HashMap<zip32::AccountId, zcash_keys::keys::UnifiedFullViewingKey>, wallet: &mut W, transaction: zcash_primitives::transaction::Transaction, status: zingo_status::confirmation_status::ConfirmationStatus, datetime: u32) -> core::result::Result<(), pepper_sync::error::SyncError<<W as pepper_sync::wallet::traits::SyncWallet>::Error>> where W: pepper_sync::wallet::traits::SyncWallet + pepper_sync::wallet::traits::SyncBlocks + pepper_sync::wallet::traits::SyncTransactions + pepper_sync::wallet::traits::SyncNullifiers + pepper_sync::wallet::traits::SyncOutPoints + pepper_sync::wallet::traits::SyncShardTrees
+pub fn pepper_sync::sync::set_transactions_failed(wallet_transactions: &mut std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, failed_txids: alloc::vec::Vec<zcash_protocol::txid::TxId>)
+pub async fn pepper_sync::sync::sync<C, P, W>(client: C, consensus_parameters: &P, wallet: alloc::sync::Arc<tokio::sync::rwlock::RwLock<W>>, sync_mode: alloc::sync::Arc<core::sync::atomic::AtomicU8>, config: pepper_sync::config::SyncConfig) -> core::result::Result<pepper_sync::sync::SyncResult, pepper_sync::error::SyncError<<W as pepper_sync::wallet::traits::SyncWallet>::Error>> where C: core::clone::Clone + zingo_netutils::Indexer + zingo_netutils::globally_public::TransparentIndexer + core::marker::Sync + core::marker::Send + 'static, P: zcash_protocol::consensus::Parameters + core::marker::Sync + core::marker::Send + 'static, W: pepper_sync::wallet::traits::SyncWallet + pepper_sync::wallet::traits::SyncBlocks + pepper_sync::wallet::traits::SyncTransactions + pepper_sync::wallet::traits::SyncNullifiers + pepper_sync::wallet::traits::SyncOutPoints + pepper_sync::wallet::traits::SyncShardTrees + core::marker::Send
+pub async fn pepper_sync::sync::sync_status<W>(wallet: &W) -> core::result::Result<pepper_sync::sync::SyncStatus, pepper_sync::error::SyncStatusError<<W as pepper_sync::wallet::traits::SyncWallet>::Error>> where W: pepper_sync::wallet::traits::SyncWallet + pepper_sync::wallet::traits::SyncBlocks
+pub mod pepper_sync::wallet
+pub mod pepper_sync::wallet::serialization
+pub mod pepper_sync::wallet::traits
+pub trait pepper_sync::wallet::traits::SyncBlocks: pepper_sync::wallet::traits::SyncWallet
+pub fn pepper_sync::wallet::traits::SyncBlocks::append_wallet_blocks(&mut self, wallet_blocks: alloc::collections::btree::map::BTreeMap<zcash_protocol::consensus::BlockHeight, pepper_sync::wallet::WalletBlock>) -> core::result::Result<(), Self::Error>
+pub fn pepper_sync::wallet::traits::SyncBlocks::get_wallet_block(&self, block_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<pepper_sync::wallet::WalletBlock, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncBlocks::get_wallet_blocks_mut(&mut self) -> core::result::Result<&mut alloc::collections::btree::map::BTreeMap<zcash_protocol::consensus::BlockHeight, pepper_sync::wallet::WalletBlock>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncBlocks::truncate_wallet_blocks(&mut self, truncate_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), Self::Error>
+pub trait pepper_sync::wallet::traits::SyncNullifiers: pepper_sync::wallet::traits::SyncWallet
+pub fn pepper_sync::wallet::traits::SyncNullifiers::append_nullifiers(&mut self, nullifiers: &mut pepper_sync::wallet::NullifierMap) -> core::result::Result<(), Self::Error>
+pub fn pepper_sync::wallet::traits::SyncNullifiers::get_nullifiers(&self) -> core::result::Result<&pepper_sync::wallet::NullifierMap, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncNullifiers::get_nullifiers_mut(&mut self) -> core::result::Result<&mut pepper_sync::wallet::NullifierMap, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncNullifiers::truncate_nullifiers(&mut self, truncate_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), Self::Error>
+pub trait pepper_sync::wallet::traits::SyncOutPoints: pepper_sync::wallet::traits::SyncWallet
+pub fn pepper_sync::wallet::traits::SyncOutPoints::append_outpoints(&mut self, outpoints: &mut alloc::collections::btree::map::BTreeMap<pepper_sync::wallet::OutputId, pepper_sync::wallet::ScanTarget>) -> core::result::Result<(), Self::Error>
+pub fn pepper_sync::wallet::traits::SyncOutPoints::get_outpoints(&self) -> core::result::Result<&alloc::collections::btree::map::BTreeMap<pepper_sync::wallet::OutputId, pepper_sync::wallet::ScanTarget>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncOutPoints::get_outpoints_mut(&mut self) -> core::result::Result<&mut alloc::collections::btree::map::BTreeMap<pepper_sync::wallet::OutputId, pepper_sync::wallet::ScanTarget>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncOutPoints::truncate_outpoints(&mut self, truncate_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), Self::Error>
+pub trait pepper_sync::wallet::traits::SyncShardTrees: pepper_sync::wallet::traits::SyncWallet
+pub fn pepper_sync::wallet::traits::SyncShardTrees::clear_shard_trees(&mut self) -> core::result::Result<(), pepper_sync::error::SyncError<Self::Error>>
+pub fn pepper_sync::wallet::traits::SyncShardTrees::get_shard_trees(&self) -> core::result::Result<&pepper_sync::wallet::ShardTrees, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncShardTrees::get_shard_trees_mut(&mut self) -> core::result::Result<&mut pepper_sync::wallet::ShardTrees, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncShardTrees::truncate_shard_trees(&mut self, truncate_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), pepper_sync::error::SyncError<Self::Error>>
+pub fn pepper_sync::wallet::traits::SyncShardTrees::update_shard_trees(&mut self, fetch_request_sender: tokio::sync::mpsc::unbounded::UnboundedSender<pepper_sync::client::FetchRequest>, scan_range: &pepper_sync::sync::ScanRange, highest_scanned_height: zcash_protocol::consensus::BlockHeight, sapling_located_trees: alloc::vec::Vec<pepper_sync::witness::LocatedTreeData<sapling_crypto::tree::Node>>, orchard_located_trees: alloc::vec::Vec<pepper_sync::witness::LocatedTreeData<orchard::tree::MerkleHashOrchard>>, ironwood_located_trees: alloc::vec::Vec<pepper_sync::witness::LocatedTreeData<orchard::tree::MerkleHashOrchard>>) -> impl core::future::future::Future<Output = core::result::Result<(), pepper_sync::error::SyncError<Self::Error>>> + core::marker::Send where Self: core::marker::Send
+pub trait pepper_sync::wallet::traits::SyncTransactions: pepper_sync::wallet::traits::SyncWallet
+pub fn pepper_sync::wallet::traits::SyncTransactions::extend_wallet_transactions(&mut self, wallet_transactions: std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>) -> core::result::Result<(), Self::Error>
+pub fn pepper_sync::wallet::traits::SyncTransactions::get_wallet_transactions(&self) -> core::result::Result<&std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncTransactions::get_wallet_transactions_mut(&mut self) -> core::result::Result<&mut std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncTransactions::insert_wallet_transaction(&mut self, wallet_transaction: pepper_sync::wallet::WalletTransaction) -> core::result::Result<(), Self::Error>
+pub fn pepper_sync::wallet::traits::SyncTransactions::truncate_wallet_transactions(&mut self, truncate_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), Self::Error>
+pub trait pepper_sync::wallet::traits::SyncWallet
+pub type pepper_sync::wallet::traits::SyncWallet::Error: core::fmt::Debug + core::fmt::Display + core::error::Error
+pub fn pepper_sync::wallet::traits::SyncWallet::add_orchard_address(&mut self, account_id: zip32::AccountId, address: orchard::address::Address, diversifier_index: zip32::DiversifierIndex) -> core::result::Result<(), Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::add_sapling_address(&mut self, account_id: zip32::AccountId, address: sapling_crypto::address::PaymentAddress, diversifier_index: zip32::DiversifierIndex) -> core::result::Result<(), Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::get_birthday(&self) -> core::result::Result<zcash_protocol::consensus::BlockHeight, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::get_sync_state(&self) -> core::result::Result<&pepper_sync::wallet::SyncState, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::get_sync_state_mut(&mut self) -> core::result::Result<&mut pepper_sync::wallet::SyncState, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::get_transparent_addresses(&self) -> core::result::Result<&alloc::collections::btree::map::BTreeMap<pepper_sync::keys::transparent::TransparentAddressId, alloc::string::String>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::get_transparent_addresses_mut(&mut self) -> core::result::Result<&mut alloc::collections::btree::map::BTreeMap<pepper_sync::keys::transparent::TransparentAddressId, alloc::string::String>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::get_unified_full_viewing_keys(&self) -> core::result::Result<std::collections::hash::map::HashMap<zip32::AccountId, zcash_keys::keys::UnifiedFullViewingKey>, Self::Error>
+pub fn pepper_sync::wallet::traits::SyncWallet::set_save_flag(&mut self) -> core::result::Result<(), Self::Error>
+pub enum pepper_sync::wallet::SyncMode
+pub pepper_sync::wallet::SyncMode::NotRunning
+pub pepper_sync::wallet::SyncMode::Paused
+pub pepper_sync::wallet::SyncMode::Running
+pub pepper_sync::wallet::SyncMode::Shutdown
+impl pepper_sync::wallet::SyncMode
+pub fn pepper_sync::wallet::SyncMode::from_atomic_u8(atomic_sync_mode: alloc::sync::Arc<core::sync::atomic::AtomicU8>) -> core::result::Result<pepper_sync::wallet::SyncMode, pepper_sync::error::SyncModeError>
+pub fn pepper_sync::wallet::SyncMode::from_u8(mode: u8) -> core::result::Result<Self, pepper_sync::error::SyncModeError>
+pub struct pepper_sync::wallet::InitialSyncState
+impl pepper_sync::wallet::InitialSyncState
+pub fn pepper_sync::wallet::InitialSyncState::new() -> Self
+impl core::default::Default for pepper_sync::wallet::InitialSyncState
+pub fn pepper_sync::wallet::InitialSyncState::default() -> Self
+pub struct pepper_sync::wallet::Ironwood
+pub struct pepper_sync::wallet::NullifierMap
+pub pepper_sync::wallet::NullifierMap::ironwood: alloc::collections::btree::map::BTreeMap<orchard::note::nullifier::Nullifier, pepper_sync::wallet::ScanTarget>
+pub pepper_sync::wallet::NullifierMap::orchard: alloc::collections::btree::map::BTreeMap<orchard::note::nullifier::Nullifier, pepper_sync::wallet::ScanTarget>
+pub pepper_sync::wallet::NullifierMap::sapling: alloc::collections::btree::map::BTreeMap<sapling_crypto::note::nullifier::Nullifier, pepper_sync::wallet::ScanTarget>
+impl pepper_sync::wallet::NullifierMap
+pub fn pepper_sync::wallet::NullifierMap::clear(&mut self)
+pub fn pepper_sync::wallet::NullifierMap::new() -> Self
+impl pepper_sync::wallet::NullifierMap
+pub fn pepper_sync::wallet::NullifierMap::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::NullifierMap::write<W: std::io::Write>(&self, writer: W) -> std::io::error::Result<()>
+impl core::default::Default for pepper_sync::wallet::NullifierMap
+pub fn pepper_sync::wallet::NullifierMap::default() -> Self
+pub struct pepper_sync::wallet::Orchard
+pub struct pepper_sync::wallet::OutgoingNote<N, P>
+impl pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Ironwood>
+pub fn pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Ironwood>::read<R: std::io::Read>(reader: R, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Ironwood>::write<W: std::io::Write>(&self, writer: W, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<()>
+impl pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Orchard>
+pub fn pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Orchard>::read<R: std::io::Read>(reader: R, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Orchard>::write<W: std::io::Write>(&self, writer: W, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<()>
+impl pepper_sync::wallet::OutgoingNote<sapling_crypto::note::Note, pepper_sync::wallet::Sapling>
+pub fn pepper_sync::wallet::OutgoingNote<sapling_crypto::note::Note, pepper_sync::wallet::Sapling>::read<R: std::io::Read>(reader: R, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::OutgoingNote<sapling_crypto::note::Note, pepper_sync::wallet::Sapling>::write<W: std::io::Write>(&self, writer: W, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<()>
+pub struct pepper_sync::wallet::OutputId
+impl pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutputId::new(txid: zcash_protocol::txid::TxId, output_index: u32) -> Self
+pub fn pepper_sync::wallet::OutputId::output_index(&self) -> u32
+pub fn pepper_sync::wallet::OutputId::txid(&self) -> zcash_protocol::txid::TxId
+impl core::convert::From<&zcash_transparent::bundle::OutPoint> for pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutputId::from(value: &zcash_transparent::bundle::OutPoint) -> Self
+impl core::convert::From<pepper_sync::wallet::OutputId> for zcash_transparent::bundle::OutPoint
+pub fn zcash_transparent::bundle::OutPoint::from(value: pepper_sync::wallet::OutputId) -> Self
+impl core::fmt::Display for pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutputId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct pepper_sync::wallet::PoolActivation(_)
+impl pepper_sync::wallet::PoolActivation
+pub fn pepper_sync::wallet::PoolActivation::height(&self) -> zcash_protocol::consensus::BlockHeight
+pub fn pepper_sync::wallet::PoolActivation::max_with(&self, height: zcash_protocol::consensus::BlockHeight) -> zcash_protocol::consensus::BlockHeight
+pub fn pepper_sync::wallet::PoolActivation::of(consensus_parameters: &impl zcash_protocol::consensus::Parameters, pool: zcash_protocol::ShieldedPool) -> core::option::Option<Self>
+pub struct pepper_sync::wallet::Sapling
+pub struct pepper_sync::wallet::ScanTarget
+pub pepper_sync::wallet::ScanTarget::block_height: zcash_protocol::consensus::BlockHeight
+pub pepper_sync::wallet::ScanTarget::narrow_scan_area: bool
+pub pepper_sync::wallet::ScanTarget::txid: zcash_protocol::txid::TxId
+impl pepper_sync::wallet::ScanTarget
+pub fn pepper_sync::wallet::ScanTarget::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::ScanTarget::write<W: std::io::Write>(&self, writer: &mut W) -> std::io::error::Result<()>
+pub struct pepper_sync::wallet::ShardTrees
+pub pepper_sync::wallet::ShardTrees::ironwood: shardtree::ShardTree<pepper_sync::wallet::OrchardShardStore, { _ }, { witness::SHARD_HEIGHT }>
+pub pepper_sync::wallet::ShardTrees::orchard: shardtree::ShardTree<pepper_sync::wallet::OrchardShardStore, { _ }, { witness::SHARD_HEIGHT }>
+pub pepper_sync::wallet::ShardTrees::sapling: shardtree::ShardTree<pepper_sync::wallet::SaplingShardStore, { sapling_crypto::NOTE_COMMITMENT_TREE_DEPTH }, { witness::SHARD_HEIGHT }>
+impl pepper_sync::wallet::ShardTrees
+pub fn pepper_sync::wallet::ShardTrees::new() -> Self
+impl pepper_sync::wallet::ShardTrees
+pub fn pepper_sync::wallet::ShardTrees::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::ShardTrees::write<W: std::io::Write>(&mut self, writer: W) -> std::io::error::Result<()>
+impl core::default::Default for pepper_sync::wallet::ShardTrees
+pub fn pepper_sync::wallet::ShardTrees::default() -> Self
+pub struct pepper_sync::wallet::SyncState
+impl pepper_sync::wallet::SyncState
+pub fn pepper_sync::wallet::SyncState::fully_scanned_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn pepper_sync::wallet::SyncState::highest_scanned_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn pepper_sync::wallet::SyncState::ironwood_shard_ranges(&self) -> &[core::ops::range::Range<zcash_protocol::consensus::BlockHeight>]
+pub fn pepper_sync::wallet::SyncState::last_known_chain_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn pepper_sync::wallet::SyncState::new() -> Self
+pub fn pepper_sync::wallet::SyncState::orchard_shard_ranges(&self) -> &[core::ops::range::Range<zcash_protocol::consensus::BlockHeight>]
+pub fn pepper_sync::wallet::SyncState::sapling_shard_ranges(&self) -> &[core::ops::range::Range<zcash_protocol::consensus::BlockHeight>]
+pub fn pepper_sync::wallet::SyncState::scan_ranges(&self) -> &[pepper_sync::sync::ScanRange]
+pub fn pepper_sync::wallet::SyncState::wallet_birthday(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+impl pepper_sync::wallet::SyncState
+pub fn pepper_sync::wallet::SyncState::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::SyncState::write<W: std::io::Write>(&mut self, writer: W) -> std::io::error::Result<()>
+impl core::default::Default for pepper_sync::wallet::SyncState
+pub fn pepper_sync::wallet::SyncState::default() -> Self
+pub struct pepper_sync::wallet::TransparentCoin
+impl pepper_sync::wallet::TransparentCoin
+pub fn pepper_sync::wallet::TransparentCoin::address(&self) -> &str
+pub fn pepper_sync::wallet::TransparentCoin::script(&self) -> &zcash_transparent::address::Script
+impl pepper_sync::wallet::TransparentCoin
+pub fn pepper_sync::wallet::TransparentCoin::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::TransparentCoin::write<W: std::io::Write>(&self, writer: W) -> std::io::error::Result<()>
+impl pepper_sync::wallet::OutputInterface for pepper_sync::wallet::TransparentCoin
+pub type pepper_sync::wallet::TransparentCoin::Input = zcash_transparent::bundle::OutPoint
+pub type pepper_sync::wallet::TransparentCoin::KeyId = pepper_sync::keys::transparent::TransparentAddressId
+pub const pepper_sync::wallet::TransparentCoin::POOL_TYPE: zcash_protocol::PoolType
+pub fn pepper_sync::wallet::TransparentCoin::key_id(&self) -> Self::KeyId
+pub fn pepper_sync::wallet::TransparentCoin::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::TransparentCoin::set_spending_transaction(&mut self, spending_transaction: core::option::Option<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::wallet::TransparentCoin::spend_link(&self) -> core::option::Option<Self::Input>
+pub fn pepper_sync::wallet::TransparentCoin::spending_transaction(&self) -> core::option::Option<zcash_protocol::txid::TxId>
+pub fn pepper_sync::wallet::TransparentCoin::transaction_inputs(transaction: &pepper_sync::wallet::WalletTransaction) -> alloc::vec::Vec<&Self::Input>
+pub fn pepper_sync::wallet::TransparentCoin::transaction_outputs(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::TransparentCoin::value(&self) -> u64
+pub struct pepper_sync::wallet::TreeBounds
+pub pepper_sync::wallet::TreeBounds::ironwood_final_tree_size: u32
+pub pepper_sync::wallet::TreeBounds::ironwood_initial_tree_size: u32
+pub pepper_sync::wallet::TreeBounds::orchard_final_tree_size: u32
+pub pepper_sync::wallet::TreeBounds::orchard_initial_tree_size: u32
+pub pepper_sync::wallet::TreeBounds::sapling_final_tree_size: u32
+pub pepper_sync::wallet::TreeBounds::sapling_initial_tree_size: u32
+impl pepper_sync::wallet::TreeBounds
+pub fn pepper_sync::wallet::TreeBounds::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::TreeBounds::write<W: std::io::Write>(&self, writer: &mut W) -> std::io::error::Result<()>
+pub struct pepper_sync::wallet::WalletBlock
+impl pepper_sync::wallet::WalletBlock
+pub fn pepper_sync::wallet::WalletBlock::block_hash(&self) -> zcash_primitives::block::BlockHash
+pub fn pepper_sync::wallet::WalletBlock::block_height(&self) -> zcash_protocol::consensus::BlockHeight
+pub fn pepper_sync::wallet::WalletBlock::prev_hash(&self) -> zcash_primitives::block::BlockHash
+pub fn pepper_sync::wallet::WalletBlock::time(&self) -> u32
+pub fn pepper_sync::wallet::WalletBlock::tree_bounds(&self) -> pepper_sync::wallet::TreeBounds
+pub fn pepper_sync::wallet::WalletBlock::txids(&self) -> &[zcash_protocol::txid::TxId]
+impl pepper_sync::wallet::WalletBlock
+pub fn pepper_sync::wallet::WalletBlock::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::WalletBlock::write<W: std::io::Write>(&self, writer: W) -> std::io::error::Result<()>
+pub struct pepper_sync::wallet::WalletNote<N, Nf: core::marker::Copy, P>
+impl pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Ironwood>
+pub fn pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Ironwood>::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Ironwood>::write<W: std::io::Write>(&self, writer: W) -> std::io::error::Result<()>
+impl pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Orchard>
+pub fn pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Orchard>::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Orchard>::write<W: std::io::Write>(&self, writer: W) -> std::io::error::Result<()>
+impl pepper_sync::wallet::WalletNote<sapling_crypto::note::Note, sapling_crypto::note::nullifier::Nullifier, pepper_sync::wallet::Sapling>
+pub fn pepper_sync::wallet::WalletNote<sapling_crypto::note::Note, sapling_crypto::note::nullifier::Nullifier, pepper_sync::wallet::Sapling>::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::WalletNote<sapling_crypto::note::Note, sapling_crypto::note::nullifier::Nullifier, pepper_sync::wallet::Sapling>::write<W: std::io::Write>(&self, writer: W) -> std::io::error::Result<()>
+pub struct pepper_sync::wallet::WalletTransaction
+impl pepper_sync::wallet::WalletTransaction
+pub fn pepper_sync::wallet::WalletTransaction::datetime(&self) -> u32
+pub fn pepper_sync::wallet::WalletTransaction::ironwood_notes(&self) -> &[pepper_sync::wallet::IronwoodNote]
+pub fn pepper_sync::wallet::WalletTransaction::ironwood_notes_mut(&mut self) -> alloc::vec::Vec<&mut pepper_sync::wallet::IronwoodNote>
+pub fn pepper_sync::wallet::WalletTransaction::ironwood_nullifiers(&self) -> alloc::vec::Vec<&orchard::note::nullifier::Nullifier>
+pub fn pepper_sync::wallet::WalletTransaction::orchard_notes(&self) -> &[pepper_sync::wallet::OrchardNote]
+pub fn pepper_sync::wallet::WalletTransaction::orchard_notes_mut(&mut self) -> alloc::vec::Vec<&mut pepper_sync::wallet::OrchardNote>
+pub fn pepper_sync::wallet::WalletTransaction::orchard_nullifiers(&self) -> alloc::vec::Vec<&orchard::note::nullifier::Nullifier>
+pub fn pepper_sync::wallet::WalletTransaction::outgoing_ironwood_notes(&self) -> &[pepper_sync::wallet::OutgoingIronwoodNote]
+pub fn pepper_sync::wallet::WalletTransaction::outgoing_orchard_notes(&self) -> &[pepper_sync::wallet::OutgoingOrchardNote]
+pub fn pepper_sync::wallet::WalletTransaction::outgoing_sapling_notes(&self) -> &[pepper_sync::wallet::OutgoingSaplingNote]
+pub fn pepper_sync::wallet::WalletTransaction::outpoints(&self) -> alloc::vec::Vec<&zcash_transparent::bundle::OutPoint>
+pub fn pepper_sync::wallet::WalletTransaction::sapling_notes(&self) -> &[pepper_sync::wallet::SaplingNote]
+pub fn pepper_sync::wallet::WalletTransaction::sapling_notes_mut(&mut self) -> alloc::vec::Vec<&mut pepper_sync::wallet::SaplingNote>
+pub fn pepper_sync::wallet::WalletTransaction::sapling_nullifiers(&self) -> alloc::vec::Vec<&sapling_crypto::note::nullifier::Nullifier>
+pub fn pepper_sync::wallet::WalletTransaction::status(&self) -> zingo_status::confirmation_status::ConfirmationStatus
+pub fn pepper_sync::wallet::WalletTransaction::transaction(&self) -> &zcash_primitives::transaction::Transaction
+pub fn pepper_sync::wallet::WalletTransaction::transparent_coins(&self) -> &[pepper_sync::wallet::TransparentCoin]
+pub fn pepper_sync::wallet::WalletTransaction::transparent_coins_mut(&mut self) -> alloc::vec::Vec<&mut pepper_sync::wallet::TransparentCoin>
+pub fn pepper_sync::wallet::WalletTransaction::txid(&self) -> zcash_protocol::txid::TxId
+pub fn pepper_sync::wallet::WalletTransaction::update_status(&mut self, status: zingo_status::confirmation_status::ConfirmationStatus, datetime: u32, fail_confirmed: bool)
+impl pepper_sync::wallet::WalletTransaction
+pub fn pepper_sync::wallet::WalletTransaction::read<R: std::io::Read>(reader: R, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<Self>
+pub fn pepper_sync::wallet::WalletTransaction::write<W: std::io::Write>(&self, writer: W, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<()>
+impl pepper_sync::wallet::WalletTransaction
+pub fn pepper_sync::wallet::WalletTransaction::total_external_outgoing_note_value<Outgoing, Incoming>(&self) -> u64 where Outgoing: pepper_sync::wallet::OutgoingNoteInterface, Incoming: pepper_sync::wallet::OutputInterface
+pub fn pepper_sync::wallet::WalletTransaction::total_outgoing_note_value<Op: pepper_sync::wallet::OutgoingNoteInterface>(&self) -> u64
+pub fn pepper_sync::wallet::WalletTransaction::total_output_value<Op: pepper_sync::wallet::OutputInterface>(&self) -> u64
+pub fn pepper_sync::wallet::WalletTransaction::total_value_received(&self) -> u64
+pub fn pepper_sync::wallet::WalletTransaction::total_value_sent(&self) -> u64
+impl core::fmt::Debug for pepper_sync::wallet::WalletTransaction
+pub fn pepper_sync::wallet::WalletTransaction::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub trait pepper_sync::wallet::KeyIdInterface
+pub fn pepper_sync::wallet::KeyIdInterface::account_id(&self) -> zip32::AccountId
+impl pepper_sync::wallet::KeyIdInterface for pepper_sync::keys::KeyId
+pub fn pepper_sync::keys::KeyId::account_id(&self) -> zip32::AccountId
+impl pepper_sync::wallet::KeyIdInterface for pepper_sync::keys::transparent::TransparentAddressId
+pub fn pepper_sync::keys::transparent::TransparentAddressId::account_id(&self) -> zip32::AccountId
+pub trait pepper_sync::wallet::NoteInterface: pepper_sync::wallet::OutputInterface
+pub type pepper_sync::wallet::NoteInterface::Nullifier: core::marker::Copy + core::clone::Clone + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord
+pub type pepper_sync::wallet::NoteInterface::ZcashNote
+pub const pepper_sync::wallet::NoteInterface::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::NoteInterface::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::NoteInterface::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::NoteInterface::nullifier(&self) -> core::option::Option<Self::Nullifier>
+pub fn pepper_sync::wallet::NoteInterface::position(&self) -> core::option::Option<incrementalmerkletree::Position>
+pub fn pepper_sync::wallet::NoteInterface::refetch_nullifier_ranges(&self) -> &[core::ops::range::Range<zcash_protocol::consensus::BlockHeight>]
+impl pepper_sync::wallet::NoteInterface for pepper_sync::wallet::IronwoodNote
+pub type pepper_sync::wallet::IronwoodNote::Nullifier = <pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Ironwood> as pepper_sync::wallet::OutputInterface>::Input
+pub type pepper_sync::wallet::IronwoodNote::ZcashNote = orchard::note::Note
+pub const pepper_sync::wallet::IronwoodNote::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::IronwoodNote::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::IronwoodNote::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::IronwoodNote::nullifier(&self) -> core::option::Option<Self::Nullifier>
+pub fn pepper_sync::wallet::IronwoodNote::position(&self) -> core::option::Option<incrementalmerkletree::Position>
+pub fn pepper_sync::wallet::IronwoodNote::refetch_nullifier_ranges(&self) -> &[core::ops::range::Range<zcash_protocol::consensus::BlockHeight>]
+impl pepper_sync::wallet::NoteInterface for pepper_sync::wallet::OrchardNote
+pub type pepper_sync::wallet::OrchardNote::Nullifier = <pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Orchard> as pepper_sync::wallet::OutputInterface>::Input
+pub type pepper_sync::wallet::OrchardNote::ZcashNote = orchard::note::Note
+pub const pepper_sync::wallet::OrchardNote::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::OrchardNote::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::OrchardNote::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::OrchardNote::nullifier(&self) -> core::option::Option<Self::Nullifier>
+pub fn pepper_sync::wallet::OrchardNote::position(&self) -> core::option::Option<incrementalmerkletree::Position>
+pub fn pepper_sync::wallet::OrchardNote::refetch_nullifier_ranges(&self) -> &[core::ops::range::Range<zcash_protocol::consensus::BlockHeight>]
+impl pepper_sync::wallet::NoteInterface for pepper_sync::wallet::SaplingNote
+pub type pepper_sync::wallet::SaplingNote::Nullifier = <pepper_sync::wallet::WalletNote<sapling_crypto::note::Note, sapling_crypto::note::nullifier::Nullifier, pepper_sync::wallet::Sapling> as pepper_sync::wallet::OutputInterface>::Input
+pub type pepper_sync::wallet::SaplingNote::ZcashNote = sapling_crypto::note::Note
+pub const pepper_sync::wallet::SaplingNote::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::SaplingNote::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::SaplingNote::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::SaplingNote::nullifier(&self) -> core::option::Option<Self::Nullifier>
+pub fn pepper_sync::wallet::SaplingNote::position(&self) -> core::option::Option<incrementalmerkletree::Position>
+pub fn pepper_sync::wallet::SaplingNote::refetch_nullifier_ranges(&self) -> &[core::ops::range::Range<zcash_protocol::consensus::BlockHeight>]
+pub trait pepper_sync::wallet::OutgoingNoteInterface: core::marker::Sized
+pub type pepper_sync::wallet::OutgoingNoteInterface::Address: core::clone::Clone + core::marker::Copy + core::fmt::Debug + core::cmp::PartialEq + core::cmp::Eq
+pub type pepper_sync::wallet::OutgoingNoteInterface::Error: core::fmt::Debug + core::error::Error
+pub type pepper_sync::wallet::OutgoingNoteInterface::ZcashNote
+pub const pepper_sync::wallet::OutgoingNoteInterface::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::OutgoingNoteInterface::encoded_recipient<P>(&self, parameters: &P) -> core::result::Result<alloc::string::String, Self::Error> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingNoteInterface::encoded_recipient_full_unified_address<P>(&self, consensus_parameters: &P) -> core::option::Option<alloc::string::String> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingNoteInterface::key_id(&self) -> pepper_sync::keys::KeyId
+pub fn pepper_sync::wallet::OutgoingNoteInterface::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::OutgoingNoteInterface::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::OutgoingNoteInterface::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutgoingNoteInterface::recipient(&self) -> Self::Address
+pub fn pepper_sync::wallet::OutgoingNoteInterface::recipient_full_unified_address(&self) -> core::option::Option<&zcash_keys::address::UnifiedAddress>
+pub fn pepper_sync::wallet::OutgoingNoteInterface::transaction_outgoing_notes(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::OutgoingNoteInterface::value(&self) -> u64
+impl pepper_sync::wallet::OutgoingNoteInterface for pepper_sync::wallet::OutgoingIronwoodNote
+pub type pepper_sync::wallet::OutgoingIronwoodNote::Address = orchard::address::Address
+pub type pepper_sync::wallet::OutgoingIronwoodNote::Error = zcash_address::kind::unified::ParseError
+pub type pepper_sync::wallet::OutgoingIronwoodNote::ZcashNote = orchard::note::Note
+pub const pepper_sync::wallet::OutgoingIronwoodNote::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::encoded_recipient<P>(&self, parameters: &P) -> core::result::Result<alloc::string::String, Self::Error> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::encoded_recipient_full_unified_address<P>(&self, consensus_parameters: &P) -> core::option::Option<alloc::string::String> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::key_id(&self) -> pepper_sync::keys::KeyId
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::recipient(&self) -> Self::Address
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::recipient_full_unified_address(&self) -> core::option::Option<&zcash_keys::address::UnifiedAddress>
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::transaction_outgoing_notes(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::OutgoingIronwoodNote::value(&self) -> u64
+impl pepper_sync::wallet::OutgoingNoteInterface for pepper_sync::wallet::OutgoingOrchardNote
+pub type pepper_sync::wallet::OutgoingOrchardNote::Address = orchard::address::Address
+pub type pepper_sync::wallet::OutgoingOrchardNote::Error = zcash_address::kind::unified::ParseError
+pub type pepper_sync::wallet::OutgoingOrchardNote::ZcashNote = orchard::note::Note
+pub const pepper_sync::wallet::OutgoingOrchardNote::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::OutgoingOrchardNote::encoded_recipient<P>(&self, parameters: &P) -> core::result::Result<alloc::string::String, Self::Error> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingOrchardNote::encoded_recipient_full_unified_address<P>(&self, consensus_parameters: &P) -> core::option::Option<alloc::string::String> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingOrchardNote::key_id(&self) -> pepper_sync::keys::KeyId
+pub fn pepper_sync::wallet::OutgoingOrchardNote::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::OutgoingOrchardNote::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::OutgoingOrchardNote::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutgoingOrchardNote::recipient(&self) -> Self::Address
+pub fn pepper_sync::wallet::OutgoingOrchardNote::recipient_full_unified_address(&self) -> core::option::Option<&zcash_keys::address::UnifiedAddress>
+pub fn pepper_sync::wallet::OutgoingOrchardNote::transaction_outgoing_notes(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::OutgoingOrchardNote::value(&self) -> u64
+impl pepper_sync::wallet::OutgoingNoteInterface for pepper_sync::wallet::OutgoingSaplingNote
+pub type pepper_sync::wallet::OutgoingSaplingNote::Address = sapling_crypto::address::PaymentAddress
+pub type pepper_sync::wallet::OutgoingSaplingNote::Error = core::convert::Infallible
+pub type pepper_sync::wallet::OutgoingSaplingNote::ZcashNote = sapling_crypto::note::Note
+pub const pepper_sync::wallet::OutgoingSaplingNote::SHIELDED_PROTOCOL: zcash_protocol::ShieldedPool
+pub fn pepper_sync::wallet::OutgoingSaplingNote::encoded_recipient<P>(&self, consensus_parameters: &P) -> core::result::Result<alloc::string::String, Self::Error> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingSaplingNote::encoded_recipient_full_unified_address<P>(&self, consensus_parameters: &P) -> core::option::Option<alloc::string::String> where P: zcash_protocol::consensus::Parameters + zcash_protocol::consensus::NetworkConstants
+pub fn pepper_sync::wallet::OutgoingSaplingNote::key_id(&self) -> pepper_sync::keys::KeyId
+pub fn pepper_sync::wallet::OutgoingSaplingNote::memo(&self) -> &zcash_protocol::memo::Memo
+pub fn pepper_sync::wallet::OutgoingSaplingNote::note(&self) -> &Self::ZcashNote
+pub fn pepper_sync::wallet::OutgoingSaplingNote::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutgoingSaplingNote::recipient(&self) -> Self::Address
+pub fn pepper_sync::wallet::OutgoingSaplingNote::recipient_full_unified_address(&self) -> core::option::Option<&zcash_keys::address::UnifiedAddress>
+pub fn pepper_sync::wallet::OutgoingSaplingNote::transaction_outgoing_notes(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::OutgoingSaplingNote::value(&self) -> u64
+pub trait pepper_sync::wallet::OutputInterface: core::marker::Sized
+pub type pepper_sync::wallet::OutputInterface::Input: core::clone::Clone + core::fmt::Debug + core::cmp::PartialEq + core::cmp::Eq + core::cmp::PartialOrd + core::cmp::Ord
+pub type pepper_sync::wallet::OutputInterface::KeyId: pepper_sync::wallet::KeyIdInterface
+pub const pepper_sync::wallet::OutputInterface::POOL_TYPE: zcash_protocol::PoolType
+pub fn pepper_sync::wallet::OutputInterface::key_id(&self) -> Self::KeyId
+pub fn pepper_sync::wallet::OutputInterface::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OutputInterface::set_spending_transaction(&mut self, spending_transaction: core::option::Option<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::wallet::OutputInterface::spend_link(&self) -> core::option::Option<Self::Input>
+pub fn pepper_sync::wallet::OutputInterface::spending_transaction(&self) -> core::option::Option<zcash_protocol::txid::TxId>
+pub fn pepper_sync::wallet::OutputInterface::transaction_inputs(transaction: &pepper_sync::wallet::WalletTransaction) -> alloc::vec::Vec<&Self::Input>
+pub fn pepper_sync::wallet::OutputInterface::transaction_outputs(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::OutputInterface::value(&self) -> u64
+impl pepper_sync::wallet::OutputInterface for pepper_sync::wallet::IronwoodNote
+pub type pepper_sync::wallet::IronwoodNote::Input = orchard::note::nullifier::Nullifier
+pub type pepper_sync::wallet::IronwoodNote::KeyId = pepper_sync::keys::KeyId
+pub const pepper_sync::wallet::IronwoodNote::POOL_TYPE: zcash_protocol::PoolType
+pub fn pepper_sync::wallet::IronwoodNote::key_id(&self) -> pepper_sync::keys::KeyId
+pub fn pepper_sync::wallet::IronwoodNote::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::IronwoodNote::set_spending_transaction(&mut self, spending_transaction: core::option::Option<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::wallet::IronwoodNote::spend_link(&self) -> core::option::Option<Self::Input>
+pub fn pepper_sync::wallet::IronwoodNote::spending_transaction(&self) -> core::option::Option<zcash_protocol::txid::TxId>
+pub fn pepper_sync::wallet::IronwoodNote::transaction_inputs(transaction: &pepper_sync::wallet::WalletTransaction) -> alloc::vec::Vec<&Self::Input>
+pub fn pepper_sync::wallet::IronwoodNote::transaction_outputs(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::IronwoodNote::value(&self) -> u64
+impl pepper_sync::wallet::OutputInterface for pepper_sync::wallet::OrchardNote
+pub type pepper_sync::wallet::OrchardNote::Input = orchard::note::nullifier::Nullifier
+pub type pepper_sync::wallet::OrchardNote::KeyId = pepper_sync::keys::KeyId
+pub const pepper_sync::wallet::OrchardNote::POOL_TYPE: zcash_protocol::PoolType
+pub fn pepper_sync::wallet::OrchardNote::key_id(&self) -> pepper_sync::keys::KeyId
+pub fn pepper_sync::wallet::OrchardNote::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::OrchardNote::set_spending_transaction(&mut self, spending_transaction: core::option::Option<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::wallet::OrchardNote::spend_link(&self) -> core::option::Option<Self::Input>
+pub fn pepper_sync::wallet::OrchardNote::spending_transaction(&self) -> core::option::Option<zcash_protocol::txid::TxId>
+pub fn pepper_sync::wallet::OrchardNote::transaction_inputs(transaction: &pepper_sync::wallet::WalletTransaction) -> alloc::vec::Vec<&Self::Input>
+pub fn pepper_sync::wallet::OrchardNote::transaction_outputs(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::OrchardNote::value(&self) -> u64
+impl pepper_sync::wallet::OutputInterface for pepper_sync::wallet::SaplingNote
+pub type pepper_sync::wallet::SaplingNote::Input = sapling_crypto::note::nullifier::Nullifier
+pub type pepper_sync::wallet::SaplingNote::KeyId = pepper_sync::keys::KeyId
+pub const pepper_sync::wallet::SaplingNote::POOL_TYPE: zcash_protocol::PoolType
+pub fn pepper_sync::wallet::SaplingNote::key_id(&self) -> pepper_sync::keys::KeyId
+pub fn pepper_sync::wallet::SaplingNote::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::SaplingNote::set_spending_transaction(&mut self, spending_transaction: core::option::Option<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::wallet::SaplingNote::spend_link(&self) -> core::option::Option<Self::Input>
+pub fn pepper_sync::wallet::SaplingNote::spending_transaction(&self) -> core::option::Option<zcash_protocol::txid::TxId>
+pub fn pepper_sync::wallet::SaplingNote::transaction_inputs(transaction: &pepper_sync::wallet::WalletTransaction) -> alloc::vec::Vec<&Self::Input>
+pub fn pepper_sync::wallet::SaplingNote::transaction_outputs(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::SaplingNote::value(&self) -> u64
+impl pepper_sync::wallet::OutputInterface for pepper_sync::wallet::TransparentCoin
+pub type pepper_sync::wallet::TransparentCoin::Input = zcash_transparent::bundle::OutPoint
+pub type pepper_sync::wallet::TransparentCoin::KeyId = pepper_sync::keys::transparent::TransparentAddressId
+pub const pepper_sync::wallet::TransparentCoin::POOL_TYPE: zcash_protocol::PoolType
+pub fn pepper_sync::wallet::TransparentCoin::key_id(&self) -> Self::KeyId
+pub fn pepper_sync::wallet::TransparentCoin::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn pepper_sync::wallet::TransparentCoin::set_spending_transaction(&mut self, spending_transaction: core::option::Option<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::wallet::TransparentCoin::spend_link(&self) -> core::option::Option<Self::Input>
+pub fn pepper_sync::wallet::TransparentCoin::spending_transaction(&self) -> core::option::Option<zcash_protocol::txid::TxId>
+pub fn pepper_sync::wallet::TransparentCoin::transaction_inputs(transaction: &pepper_sync::wallet::WalletTransaction) -> alloc::vec::Vec<&Self::Input>
+pub fn pepper_sync::wallet::TransparentCoin::transaction_outputs(transaction: &pepper_sync::wallet::WalletTransaction) -> &[Self]
+pub fn pepper_sync::wallet::TransparentCoin::value(&self) -> u64
+pub fn pepper_sync::wallet::pool_upgrade(pool: zcash_protocol::ShieldedPool) -> zcash_protocol::consensus::NetworkUpgrade
+pub type pepper_sync::wallet::IronwoodNote = pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Ironwood>
+pub type pepper_sync::wallet::OrchardNote = pepper_sync::wallet::WalletNote<orchard::note::Note, orchard::note::nullifier::Nullifier, pepper_sync::wallet::Orchard>
+pub type pepper_sync::wallet::OrchardShardStore = shardtree::store::memory::MemoryShardStore<orchard::tree::MerkleHashOrchard, zcash_protocol::consensus::BlockHeight>
+pub type pepper_sync::wallet::OutgoingIronwoodNote = pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Ironwood>
+pub type pepper_sync::wallet::OutgoingOrchardNote = pepper_sync::wallet::OutgoingNote<orchard::note::Note, pepper_sync::wallet::Orchard>
+pub type pepper_sync::wallet::OutgoingSaplingNote = pepper_sync::wallet::OutgoingNote<sapling_crypto::note::Note, pepper_sync::wallet::Sapling>
+pub type pepper_sync::wallet::SaplingNote = pepper_sync::wallet::WalletNote<sapling_crypto::note::Note, sapling_crypto::note::nullifier::Nullifier, pepper_sync::wallet::Sapling>
+pub type pepper_sync::wallet::SaplingShardStore = shardtree::store::memory::MemoryShardStore<sapling_crypto::tree::Node, zcash_protocol::consensus::BlockHeight>
+pub fn pepper_sync::add_scan_targets(sync_state: &mut pepper_sync::wallet::SyncState, scan_targets: &[pepper_sync::wallet::ScanTarget])
+pub fn pepper_sync::reset_spends(wallet_transactions: &mut std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, invalid_txids: alloc::vec::Vec<zcash_protocol::txid::TxId>)
+pub fn pepper_sync::scan_pending_transaction<W>(consensus_parameters: &impl zcash_protocol::consensus::Parameters, ufvks: &std::collections::hash::map::HashMap<zip32::AccountId, zcash_keys::keys::UnifiedFullViewingKey>, wallet: &mut W, transaction: zcash_primitives::transaction::Transaction, status: zingo_status::confirmation_status::ConfirmationStatus, datetime: u32) -> core::result::Result<(), pepper_sync::error::SyncError<<W as pepper_sync::wallet::traits::SyncWallet>::Error>> where W: pepper_sync::wallet::traits::SyncWallet + pepper_sync::wallet::traits::SyncBlocks + pepper_sync::wallet::traits::SyncTransactions + pepper_sync::wallet::traits::SyncNullifiers + pepper_sync::wallet::traits::SyncOutPoints + pepper_sync::wallet::traits::SyncShardTrees
+pub fn pepper_sync::set_transactions_failed(wallet_transactions: &mut std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, failed_txids: alloc::vec::Vec<zcash_protocol::txid::TxId>)
+pub async fn pepper_sync::sync<C, P, W>(client: C, consensus_parameters: &P, wallet: alloc::sync::Arc<tokio::sync::rwlock::RwLock<W>>, sync_mode: alloc::sync::Arc<core::sync::atomic::AtomicU8>, config: pepper_sync::config::SyncConfig) -> core::result::Result<pepper_sync::sync::SyncResult, pepper_sync::error::SyncError<<W as pepper_sync::wallet::traits::SyncWallet>::Error>> where C: core::clone::Clone + zingo_netutils::Indexer + zingo_netutils::globally_public::TransparentIndexer + core::marker::Sync + core::marker::Send + 'static, P: zcash_protocol::consensus::Parameters + core::marker::Sync + core::marker::Send + 'static, W: pepper_sync::wallet::traits::SyncWallet + pepper_sync::wallet::traits::SyncBlocks + pepper_sync::wallet::traits::SyncTransactions + pepper_sync::wallet::traits::SyncNullifiers + pepper_sync::wallet::traits::SyncOutPoints + pepper_sync::wallet::traits::SyncShardTrees + core::marker::Send
+pub async fn pepper_sync::sync_status<W>(wallet: &W) -> core::result::Result<pepper_sync::sync::SyncStatus, pepper_sync::error::SyncStatusError<<W as pepper_sync::wallet::traits::SyncWallet>::Error>> where W: pepper_sync::wallet::traits::SyncWallet + pepper_sync::wallet::traits::SyncBlocks

--- a/tools/workbench/goldens/public-api/workbench.txt
+++ b/tools/workbench/goldens/public-api/workbench.txt
@@ -1,0 +1,6 @@
+pub mod workbench
+pub fn workbench::git(args: &[&str]) -> core::result::Result<alloc::string::String, alloc::vec::Vec<alloc::string::String>>
+pub fn workbench::read(path: &std::path::Path) -> core::result::Result<alloc::string::String, alloc::vec::Vec<alloc::string::String>>
+pub fn workbench::repo_root() -> core::result::Result<std::path::PathBuf, alloc::vec::Vec<alloc::string::String>>
+pub fn workbench::run<T>(prog: &str, body: impl core::ops::function::FnOnce() -> core::result::Result<T, alloc::vec::Vec<alloc::string::String>>, on_ok: impl core::ops::function::FnOnce(T)) -> never
+pub fn workbench::toolchain_channel(root: &std::path::Path) -> core::result::Result<alloc::string::String, alloc::vec::Vec<alloc::string::String>>

--- a/tools/workbench/goldens/public-api/zingo-cli.txt
+++ b/tools/workbench/goldens/public-api/zingo-cli.txt
@@ -1,0 +1,6 @@
+pub mod zingo_cli
+pub fn zingo_cli::build_clap_app() -> clap_builder::builder::command::Command
+pub fn zingo_cli::help_output(matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> core::option::Option<alloc::string::String>
+pub fn zingo_cli::is_interactive(matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> bool
+pub fn zingo_cli::log_file_path(matches: &clap_builder::parser::matches::arg_matches::ArgMatches) -> std::path::PathBuf
+pub fn zingo_cli::run_cli(matches: clap_builder::parser::matches::arg_matches::ArgMatches) -> std::io::error::Result<()>

--- a/tools/workbench/goldens/public-api/zingo-memo.txt
+++ b/tools/workbench/goldens/public-api/zingo-memo.txt
@@ -1,0 +1,12 @@
+pub mod zingo_memo
+pub enum zingo_memo::ParsedMemo
+pub zingo_memo::ParsedMemo::Version0
+pub zingo_memo::ParsedMemo::Version0::uas: alloc::vec::Vec<zcash_keys::address::UnifiedAddress>
+pub zingo_memo::ParsedMemo::Version1
+pub zingo_memo::ParsedMemo::Version1::rejection_address_indexes: alloc::vec::Vec<u32>
+pub zingo_memo::ParsedMemo::Version1::uas: alloc::vec::Vec<zcash_keys::address::UnifiedAddress>
+pub fn zingo_memo::create_wallet_internal_memo_version_0(consensus_parameters: &impl zcash_protocol::consensus::Parameters, uas: &[zcash_keys::address::UnifiedAddress]) -> std::io::error::Result<[u8; 511]>
+pub fn zingo_memo::create_wallet_internal_memo_version_1(consensus_parameters: &impl zcash_protocol::consensus::Parameters, uas: &[zcash_keys::address::UnifiedAddress], refund_address_indexes: &[u32]) -> std::io::error::Result<[u8; 511]>
+pub fn zingo_memo::parse_zingo_memo(memo: [u8; 511]) -> std::io::error::Result<zingo_memo::ParsedMemo>
+pub fn zingo_memo::read_unified_address_from_raw_encoding<R: std::io::Read>(reader: R) -> std::io::error::Result<zcash_keys::address::UnifiedAddress>
+pub fn zingo_memo::write_unified_address_to_raw_encoding<W: std::io::Write>(consensus_parameters: &impl zcash_protocol::consensus::Parameters, ua: &zcash_keys::address::UnifiedAddress, writer: W) -> std::io::error::Result<()>

--- a/tools/workbench/goldens/public-api/zingo-netutils.txt
+++ b/tools/workbench/goldens/public-api/zingo-netutils.txt
@@ -1,0 +1,104 @@
+pub mod zingo_netutils
+pub use zingo_netutils::Status
+pub use zingo_netutils::Streaming
+pub use zingo_netutils::lightwallet_protocol
+pub mod zingo_netutils::arm_race
+pub enum zingo_netutils::arm_race::LaunchPolicy
+pub zingo_netutils::arm_race::LaunchPolicy::EscalatingRounds
+pub zingo_netutils::arm_race::LaunchPolicy::Hedged
+pub zingo_netutils::arm_race::LaunchPolicy::Hedged::hedge_interval: core::time::Duration
+pub zingo_netutils::arm_race::LaunchPolicy::Hedged::max_parallel: usize
+pub enum zingo_netutils::arm_race::RaceAction
+pub zingo_netutils::arm_race::RaceAction::ArmHedgeTimer(core::time::Duration)
+pub zingo_netutils::arm_race::RaceAction::GiveUp
+pub zingo_netutils::arm_race::RaceAction::Launch
+pub zingo_netutils::arm_race::RaceAction::Launch::candidate: usize
+pub enum zingo_netutils::arm_race::RaceEvent
+pub zingo_netutils::arm_race::RaceEvent::ArmFailed
+pub zingo_netutils::arm_race::RaceEvent::ArmFailed::candidate: usize
+pub zingo_netutils::arm_race::RaceEvent::ArmFailed::error: alloc::string::String
+pub zingo_netutils::arm_race::RaceEvent::HedgeElapsed
+pub struct zingo_netutils::arm_race::ArmFailure
+pub zingo_netutils::arm_race::ArmFailure::candidate: usize
+pub zingo_netutils::arm_race::ArmFailure::error: alloc::string::String
+pub struct zingo_netutils::arm_race::RaceProgress
+pub zingo_netutils::arm_race::RaceProgress::failed: usize
+pub zingo_netutils::arm_race::RaceProgress::in_flight: usize
+pub zingo_netutils::arm_race::RaceProgress::launched: usize
+pub zingo_netutils::arm_race::RaceProgress::limit: usize
+impl core::fmt::Display for zingo_netutils::arm_race::RaceProgress
+pub fn zingo_netutils::arm_race::RaceProgress::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingo_netutils::arm_race::RaceState
+impl zingo_netutils::arm_race::RaceState
+pub fn zingo_netutils::arm_race::RaceState::failure_summary(&self, name: impl core::ops::function::Fn(usize) -> alloc::string::String) -> alloc::string::String
+pub fn zingo_netutils::arm_race::RaceState::failures(&self) -> &[zingo_netutils::arm_race::ArmFailure]
+pub fn zingo_netutils::arm_race::RaceState::launched(&self) -> usize
+pub fn zingo_netutils::arm_race::RaceState::new(candidates: usize, cap: usize, policy: zingo_netutils::arm_race::LaunchPolicy) -> Self
+pub fn zingo_netutils::arm_race::RaceState::on_event(&mut self, event: zingo_netutils::arm_race::RaceEvent) -> alloc::vec::Vec<zingo_netutils::arm_race::RaceAction>
+pub fn zingo_netutils::arm_race::RaceState::progress(&self) -> zingo_netutils::arm_race::RaceProgress
+pub fn zingo_netutils::arm_race::RaceState::start(&mut self) -> alloc::vec::Vec<zingo_netutils::arm_race::RaceAction>
+pub mod zingo_netutils::crypto
+pub fn zingo_netutils::crypto::ensure_default_crypto_provider()
+pub mod zingo_netutils::error
+pub enum zingo_netutils::error::GetClientError
+pub zingo_netutils::error::GetClientError::InvalidAuthority
+pub zingo_netutils::error::GetClientError::InvalidScheme
+pub zingo_netutils::error::GetClientError::Transport(tonic::transport::error::Error)
+pub enum zingo_netutils::GetClientError
+pub zingo_netutils::GetClientError::InvalidAuthority
+pub zingo_netutils::GetClientError::InvalidScheme
+pub zingo_netutils::GetClientError::Transport(tonic::transport::error::Error)
+pub struct zingo_netutils::GrpcIndexer
+impl zingo_netutils::GrpcIndexer
+pub async fn zingo_netutils::GrpcIndexer::get_clear_net_client(&self) -> lightwallet_protocol::cash::z::wallet::sdk::rpc::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transport::channel::Channel>
+pub async fn zingo_netutils::GrpcIndexer::new(uri: http::uri::Uri) -> core::result::Result<Self, zingo_netutils::GetClientError>
+pub fn zingo_netutils::GrpcIndexer::new_lazy(uri: http::uri::Uri) -> core::result::Result<Self, zingo_netutils::GetClientError>
+pub fn zingo_netutils::GrpcIndexer::uri(&self) -> &http::uri::Uri
+impl zingo_netutils::Indexer for zingo_netutils::GrpcIndexer
+pub async fn zingo_netutils::GrpcIndexer::get_block(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_block_nullifiers(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_block_range(&mut self, range: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockRange, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_block_range_nullifiers(&mut self, range: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockRange, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_latest_block(&mut self, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_latest_tree_state(&mut self, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::TreeState, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_lightd_info(&mut self, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::LightdInfo, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_mempool_stream(&mut self, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_mempool_tx(&mut self, request: lightwallet_protocol::cash::z::wallet::sdk::rpc::GetMempoolTxRequest, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactTx>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_subtree_roots(&mut self, arg: lightwallet_protocol::cash::z::wallet::sdk::rpc::GetSubtreeRootsArg, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::SubtreeRoot>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_transaction(&mut self, filter: lightwallet_protocol::cash::z::wallet::sdk::rpc::TxFilter, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_tree_state(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::TreeState, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::send_transaction(&mut self, tx: lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction, timeout: core::time::Duration) -> core::result::Result<alloc::string::String, tonic::status::Status>
+pub struct zingo_netutils::SendRejection
+pub zingo_netutils::SendRejection::code: i32
+pub zingo_netutils::SendRejection::message: alloc::string::String
+pub const zingo_netutils::NYM_STATUS_LINE_PREFIX: &str
+pub const zingo_netutils::SOCKS5_ADDR_LINE_PREFIX: &str
+pub trait zingo_netutils::Indexer
+pub fn zingo_netutils::Indexer::get_block(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_block_nullifiers(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_block_range(&mut self, range: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockRange, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock>, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_block_range_nullifiers(&mut self, range: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockRange, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock>, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_latest_block(&mut self, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_latest_tree_state(&mut self, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::TreeState, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_lightd_info(&mut self, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::LightdInfo, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_mempool_stream(&mut self, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction>, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_mempool_tx(&mut self, request: lightwallet_protocol::cash::z::wallet::sdk::rpc::GetMempoolTxRequest, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactTx>, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_subtree_roots(&mut self, arg: lightwallet_protocol::cash::z::wallet::sdk::rpc::GetSubtreeRootsArg, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::SubtreeRoot>, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_transaction(&mut self, filter: lightwallet_protocol::cash::z::wallet::sdk::rpc::TxFilter, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::get_tree_state(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::TreeState, tonic::status::Status>> + core::marker::Send
+pub fn zingo_netutils::Indexer::send_transaction(&mut self, tx: lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction, timeout: core::time::Duration) -> impl core::future::future::Future<Output = core::result::Result<alloc::string::String, tonic::status::Status>> + core::marker::Send
+impl zingo_netutils::Indexer for zingo_netutils::GrpcIndexer
+pub async fn zingo_netutils::GrpcIndexer::get_block(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_block_nullifiers(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_block_range(&mut self, range: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockRange, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_block_range_nullifiers(&mut self, range: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockRange, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactBlock>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_latest_block(&mut self, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_latest_tree_state(&mut self, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::TreeState, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_lightd_info(&mut self, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::LightdInfo, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_mempool_stream(&mut self, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_mempool_tx(&mut self, request: lightwallet_protocol::cash::z::wallet::sdk::rpc::GetMempoolTxRequest, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::CompactTx>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_subtree_roots(&mut self, arg: lightwallet_protocol::cash::z::wallet::sdk::rpc::GetSubtreeRootsArg, timeout: core::time::Duration) -> core::result::Result<tonic::codec::decode::Streaming<lightwallet_protocol::cash::z::wallet::sdk::rpc::SubtreeRoot>, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_transaction(&mut self, filter: lightwallet_protocol::cash::z::wallet::sdk::rpc::TxFilter, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::get_tree_state(&mut self, block_id: lightwallet_protocol::cash::z::wallet::sdk::rpc::BlockId, timeout: core::time::Duration) -> core::result::Result<lightwallet_protocol::cash::z::wallet::sdk::rpc::TreeState, tonic::status::Status>
+pub async fn zingo_netutils::GrpcIndexer::send_transaction(&mut self, tx: lightwallet_protocol::cash::z::wallet::sdk::rpc::RawTransaction, timeout: core::time::Duration) -> core::result::Result<alloc::string::String, tonic::status::Status>
+pub fn zingo_netutils::ensure_default_crypto_provider()

--- a/tools/workbench/goldens/public-api/zingo-price.txt
+++ b/tools/workbench/goldens/public-api/zingo-price.txt
@@ -1,0 +1,20 @@
+pub mod zingo_price
+pub enum zingo_price::PriceError
+pub zingo_price::PriceError::InvalidPrice
+pub zingo_price::PriceError::ParseError(core::num::float_parse::ParseFloatError)
+pub zingo_price::PriceError::PriceListNotInitialized
+pub struct zingo_price::Price
+pub zingo_price::Price::price_usd: f32
+pub zingo_price::Price::time: u32
+pub struct zingo_price::PriceList
+impl zingo_price::PriceList
+pub fn zingo_price::PriceList::current_price(&self) -> core::option::Option<zingo_price::Price>
+pub fn zingo_price::PriceList::daily_prices(&self) -> &[zingo_price::Price]
+pub fn zingo_price::PriceList::new() -> Self
+pub fn zingo_price::PriceList::prune(&mut self, transaction_times: alloc::vec::Vec<u32>, prune_below: u32)
+pub fn zingo_price::PriceList::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn zingo_price::PriceList::set_start_time(&mut self, time_of_birthday: u32)
+pub fn zingo_price::PriceList::time_historical_prices_last_updated(&self) -> core::option::Option<u32>
+pub fn zingo_price::PriceList::write<W: std::io::Write>(&self, writer: W) -> std::io::error::Result<()>
+impl core::default::Default for zingo_price::PriceList
+pub fn zingo_price::PriceList::default() -> Self

--- a/tools/workbench/goldens/public-api/zingo-status.txt
+++ b/tools/workbench/goldens/public-api/zingo-status.txt
@@ -1,0 +1,27 @@
+pub mod zingo_status
+pub mod zingo_status::confirmation_status
+pub enum zingo_status::confirmation_status::ConfirmationStatus
+pub zingo_status::confirmation_status::ConfirmationStatus::Calculated(zcash_protocol::consensus::BlockHeight)
+pub zingo_status::confirmation_status::ConfirmationStatus::Confirmed(zcash_protocol::consensus::BlockHeight)
+pub zingo_status::confirmation_status::ConfirmationStatus::Failed(zcash_protocol::consensus::BlockHeight)
+pub zingo_status::confirmation_status::ConfirmationStatus::Mempool(zcash_protocol::consensus::BlockHeight)
+pub zingo_status::confirmation_status::ConfirmationStatus::Transmitted(zcash_protocol::consensus::BlockHeight)
+impl zingo_status::confirmation_status::ConfirmationStatus
+pub fn zingo_status::confirmation_status::ConfirmationStatus::get_confirmed_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingo_status::confirmation_status::ConfirmationStatus::get_height(&self) -> zcash_protocol::consensus::BlockHeight
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_confirmed(&self) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_confirmed_after(&self, comparison_height: &zcash_protocol::consensus::BlockHeight) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_confirmed_after_or_at(&self, comparison_height: &zcash_protocol::consensus::BlockHeight) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_confirmed_before(&self, comparison_height: &zcash_protocol::consensus::BlockHeight) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_confirmed_before_or_at(&self, comparison_height: &zcash_protocol::consensus::BlockHeight) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_failed(&self) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_pending(&self) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::is_pending_before(&self, comparison_height: &zcash_protocol::consensus::BlockHeight) -> bool
+pub fn zingo_status::confirmation_status::ConfirmationStatus::read<R: std::io::Read>(reader: R) -> std::io::error::Result<Self>
+pub fn zingo_status::confirmation_status::ConfirmationStatus::write<W: std::io::Write>(&self, writer: &mut W) -> std::io::error::Result<()>
+impl core::convert::From<zingo_status::confirmation_status::ConfirmationStatus> for alloc::string::String
+pub fn alloc::string::String::from(value: zingo_status::confirmation_status::ConfirmationStatus) -> Self
+impl core::fmt::Debug for zingo_status::confirmation_status::ConfirmationStatus
+pub fn zingo_status::confirmation_status::ConfirmationStatus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for zingo_status::confirmation_status::ConfirmationStatus
+pub fn zingo_status::confirmation_status::ConfirmationStatus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result

--- a/tools/workbench/goldens/public-api/zingolib.txt
+++ b/tools/workbench/goldens/public-api/zingolib.txt
@@ -1,0 +1,1570 @@
+pub mod zingolib
+pub use zingolib::ActivationHeights
+pub use zingolib::ensure_default_crypto_provider
+pub mod zingolib::config
+pub enum zingolib::config::ChainType
+pub zingolib::config::ChainType::Mainnet
+pub zingolib::config::ChainType::Regtest(zingo_common_components::protocol::ActivationHeights)
+pub zingolib::config::ChainType::Testnet
+impl core::convert::TryFrom<&str> for zingolib::config::ChainType
+pub type zingolib::config::ChainType::Error = zingolib::config::InvalidChainType
+pub fn zingolib::config::ChainType::try_from(value: &str) -> core::result::Result<Self, Self::Error>
+impl core::fmt::Display for zingolib::config::ChainType
+pub fn zingolib::config::ChainType::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl zcash_protocol::consensus::Parameters for zingolib::config::ChainType
+pub fn zingolib::config::ChainType::activation_height(&self, nu: zcash_protocol::consensus::NetworkUpgrade) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::config::ChainType::network_type(&self) -> zcash_protocol::consensus::NetworkType
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zcash_keys::keys::UnifiedFullViewingKey
+pub const zcash_keys::keys::UnifiedFullViewingKey::VERSION: u8
+pub fn zcash_keys::keys::UnifiedFullViewingKey::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zcash_keys::keys::UnifiedFullViewingKey::write<W: std::io::Write>(&self, writer: W, input: zingolib::config::ChainType) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zingolib::wallet::keys::legacy::WalletCapability
+pub const zingolib::wallet::keys::legacy::WalletCapability::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::WalletCapability::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::WalletCapability::write<W: std::io::Write>(&self, _writer: W, _input: zingolib::config::ChainType) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zingolib::wallet::keys::unified::UnifiedKeyStore
+pub const zingolib::wallet::keys::unified::UnifiedKeyStore::VERSION: u8
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::write<W: std::io::Write>(&self, writer: W, input: zingolib::config::ChainType) -> std::io::error::Result<()>
+pub enum zingolib::config::ClientConfigError
+pub zingolib::config::ClientConfigError::FileError(alloc::string::String)
+pub zingolib::config::ClientConfigError::UsersDataDirNotFound
+pub zingolib::config::ClientConfigError::WalletDirNotSpecified
+pub enum zingolib::config::WalletConfig
+pub zingolib::config::WalletConfig::MnemonicPhrase
+pub zingolib::config::WalletConfig::MnemonicPhrase::birthday: u32
+pub zingolib::config::WalletConfig::MnemonicPhrase::mnemonic_phrase: alloc::string::String
+pub zingolib::config::WalletConfig::MnemonicPhrase::no_of_accounts: core::num::nonzero::NonZeroU32
+pub zingolib::config::WalletConfig::MnemonicPhrase::wallet_settings: zingolib::wallet::WalletSettings
+pub zingolib::config::WalletConfig::NewSeed
+pub zingolib::config::WalletConfig::NewSeed::chain_height: u32
+pub zingolib::config::WalletConfig::NewSeed::no_of_accounts: core::num::nonzero::NonZeroU32
+pub zingolib::config::WalletConfig::NewSeed::wallet_settings: zingolib::wallet::WalletSettings
+pub zingolib::config::WalletConfig::Read
+pub zingolib::config::WalletConfig::Ufvk
+pub zingolib::config::WalletConfig::Ufvk::birthday: u32
+pub zingolib::config::WalletConfig::Ufvk::ufvk: alloc::string::String
+pub zingolib::config::WalletConfig::Ufvk::wallet_settings: zingolib::wallet::WalletSettings
+pub zingolib::config::WalletConfig::Usk
+pub zingolib::config::WalletConfig::Usk::birthday: u32
+pub zingolib::config::WalletConfig::Usk::usk: alloc::vec::Vec<u8>
+pub zingolib::config::WalletConfig::Usk::wallet_settings: zingolib::wallet::WalletSettings
+pub struct zingolib::config::ClientConfig
+impl zingolib::config::ClientConfig
+pub fn zingolib::config::ClientConfig::builder() -> zingolib::config::ClientConfigBuilder
+pub fn zingolib::config::ClientConfig::chain_type(&self) -> zingolib::config::ChainType
+pub fn zingolib::config::ClientConfig::get_wallet_path(&self) -> alloc::boxed::Box<std::path::Path>
+pub fn zingolib::config::ClientConfig::indexer_uri(&self) -> core::option::Option<http::uri::Uri>
+pub fn zingolib::config::ClientConfig::migration_broadcast_uri(&self) -> core::option::Option<http::uri::Uri>
+pub fn zingolib::config::ClientConfig::wallet_config(&self) -> zingolib::config::WalletConfig
+pub fn zingolib::config::ClientConfig::wallet_dir(&self) -> std::path::PathBuf
+pub fn zingolib::config::ClientConfig::wallet_name(&self) -> &str
+pub struct zingolib::config::ClientConfigBuilder
+impl zingolib::config::ClientConfigBuilder
+pub fn zingolib::config::ClientConfigBuilder::build(self) -> core::result::Result<zingolib::config::ClientConfig, zingolib::config::ClientConfigError>
+pub fn zingolib::config::ClientConfigBuilder::new() -> Self
+pub fn zingolib::config::ClientConfigBuilder::set_chain_type(self, chain_type: zingolib::config::ChainType) -> Self
+pub fn zingolib::config::ClientConfigBuilder::set_indexer_uri(self, indexer_uri: http::uri::Uri) -> Self
+pub fn zingolib::config::ClientConfigBuilder::set_migration_broadcast_uri(self, migration_broadcast_uri: http::uri::Uri) -> Self
+pub fn zingolib::config::ClientConfigBuilder::set_wallet_config(self, wallet_config: zingolib::config::WalletConfig) -> Self
+pub fn zingolib::config::ClientConfigBuilder::set_wallet_dir(self, dir: std::path::PathBuf) -> Self
+pub fn zingolib::config::ClientConfigBuilder::set_wallet_name(self, wallet_name: alloc::string::String) -> Self
+impl core::default::Default for zingolib::config::ClientConfigBuilder
+pub fn zingolib::config::ClientConfigBuilder::default() -> Self
+pub struct zingolib::config::InvalidChainType(_)
+pub const zingolib::config::DEFAULT_INDEXER_URI: &str
+pub const zingolib::config::DEFAULT_INDEXER_URI_TESTNET: &str
+pub const zingolib::config::DEFAULT_WALLET_NAME: &str
+pub const zingolib::config::LIB_BIRTHDAY_MAINNET: u32
+pub const zingolib::config::LIB_BIRTHDAY_TESTNET: u32
+pub fn zingolib::config::construct_indexer_uri(server: core::option::Option<alloc::string::String>) -> core::result::Result<http::uri::Uri, http::uri::InvalidUri>
+pub fn zingolib::config::lib_birthday(chain: zingolib::config::ChainType) -> u32
+pub mod zingolib::data
+pub mod zingolib::data::proposal
+pub fn zingolib::data::proposal::total_fee(proposal: &zcash_client_backend::proposal::Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, zingolib::wallet::output::OutputRef>) -> core::result::Result<zcash_protocol::value::Zatoshis, zcash_protocol::value::BalanceError>
+pub fn zingolib::data::proposal::total_payment_amount(proposal: &zcash_client_backend::proposal::Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, zingolib::wallet::output::OutputRef>) -> core::result::Result<zcash_protocol::value::Zatoshis, zcash_protocol::value::BalanceError>
+pub mod zingolib::data::receivers
+pub struct zingolib::data::receivers::Receiver
+pub zingolib::data::receivers::Receiver::amount: zcash_protocol::value::Zatoshis
+pub zingolib::data::receivers::Receiver::memo: core::option::Option<zcash_protocol::memo::MemoBytes>
+pub zingolib::data::receivers::Receiver::recipient_address: zcash_address::ZcashAddress
+impl core::convert::TryFrom<zingolib::data::receivers::Receiver> for zip321::Payment
+pub type zip321::Payment::Error = zip321::PaymentError
+pub fn zip321::Payment::try_from(receiver: zingolib::data::receivers::Receiver) -> core::result::Result<Self, Self::Error>
+pub fn zingolib::data::receivers::transaction_request_from_receivers(receivers: zingolib::data::receivers::Receivers) -> core::result::Result<zip321::TransactionRequest, zip321::Zip321Error>
+pub type zingolib::data::receivers::Receivers = alloc::vec::Vec<zingolib::data::receivers::Receiver>
+pub enum zingolib::data::PollReport<T, E>
+pub zingolib::data::PollReport::NoHandle
+pub zingolib::data::PollReport::NotReady
+pub zingolib::data::PollReport::Ready(core::result::Result<T, E>)
+pub struct zingolib::data::ServerInfo
+pub zingolib::data::ServerInfo::chain_name: alloc::string::String
+pub zingolib::data::ServerInfo::consensus_branch_id: alloc::string::String
+pub zingolib::data::ServerInfo::git_commit: alloc::string::String
+pub zingolib::data::ServerInfo::latest_block_height: u64
+pub zingolib::data::ServerInfo::sapling_activation_height: u64
+pub zingolib::data::ServerInfo::server_uri: http::uri::Uri
+pub zingolib::data::ServerInfo::taddr_support: bool
+pub zingolib::data::ServerInfo::vendor: alloc::string::String
+pub zingolib::data::ServerInfo::version: alloc::string::String
+impl core::convert::From<zingolib::data::ServerInfo> for json::value::JsonValue
+pub fn json::value::JsonValue::from(info: zingolib::data::ServerInfo) -> Self
+pub mod zingolib::lightclient
+pub mod zingolib::lightclient::error
+pub enum zingolib::lightclient::error::LightClientError
+pub zingolib::lightclient::error::LightClientError::ClientError(zingo_netutils::error::GetClientError)
+pub zingolib::lightclient::error::LightClientError::FileError(std::io::error::Error)
+pub zingolib::lightclient::error::LightClientError::IndexerError(tonic::status::Status)
+pub zingolib::lightclient::error::LightClientError::MigrationError(zingolib::lightclient::error::MigrationError)
+pub zingolib::lightclient::error::LightClientError::Offline
+pub zingolib::lightclient::error::LightClientError::PriceError(zingolib::wallet::error::PriceError)
+pub zingolib::lightclient::error::LightClientError::PriceFetchUnsupported
+pub zingolib::lightclient::error::LightClientError::SendError(zingolib::lightclient::error::SendError)
+pub zingolib::lightclient::error::LightClientError::SyncError(pepper_sync::error::SyncError<zingolib::wallet::error::WalletError>)
+pub zingolib::lightclient::error::LightClientError::SyncLaunchError
+pub zingolib::lightclient::error::LightClientError::SyncModeError(pepper_sync::error::SyncModeError)
+pub zingolib::lightclient::error::LightClientError::SyncNotRunning
+pub zingolib::lightclient::error::LightClientError::WalletError(zingolib::wallet::error::WalletError)
+pub enum zingolib::lightclient::error::MigrationError
+pub zingolib::lightclient::error::MigrationError::ActivationBoundaryPending
+pub zingolib::lightclient::error::MigrationError::ActivationBoundaryPending::retry_after: zcash_protocol::consensus::BlockHeight
+pub zingolib::lightclient::error::MigrationError::AlreadyInProgress
+pub zingolib::lightclient::error::MigrationError::ConsentStale
+pub zingolib::lightclient::error::MigrationError::DifferentAccount
+pub zingolib::lightclient::error::MigrationError::NoMigration
+pub zingolib::lightclient::error::MigrationError::NoteSplittingRequired
+pub zingolib::lightclient::error::MigrationError::PreSignedUnavailable
+pub zingolib::lightclient::error::MigrationError::ScheduledMigrationExists
+pub zingolib::lightclient::error::MigrationError::SplitConfirmationTimeout
+pub zingolib::lightclient::error::MigrationError::SplitDidNotConverge(usize)
+pub zingolib::lightclient::error::MigrationError::SplitTransactionFailed(zcash_protocol::txid::TxId)
+pub enum zingolib::lightclient::error::SendError
+pub zingolib::lightclient::error::SendError::CalculateSendError(zingolib::wallet::error::CalculateTransactionError<zingolib::wallet::output::OutputRef>)
+pub zingolib::lightclient::error::SendError::CalculateShieldError(zingolib::wallet::error::CalculateTransactionError<core::convert::Infallible>)
+pub zingolib::lightclient::error::SendError::NoStoredProposal
+pub zingolib::lightclient::error::SendError::ProposeSendError(zingolib::wallet::error::ProposeSendError)
+pub zingolib::lightclient::error::SendError::ProposeShieldError(zingolib::wallet::error::ProposeShieldError)
+pub zingolib::lightclient::error::SendError::RetargetError(zcash_client_backend::proposal::ProposalError)
+pub zingolib::lightclient::error::SendError::TransmissionError(zingolib::lightclient::error::TransmissionError)
+pub enum zingolib::lightclient::error::TransmissionError
+pub zingolib::lightclient::error::TransmissionError::IncorrectTransactionStatus(zcash_protocol::txid::TxId)
+pub zingolib::lightclient::error::TransmissionError::IncorrectTxidFromServer(zcash_protocol::txid::TxId, zcash_protocol::txid::TxId)
+pub zingolib::lightclient::error::TransmissionError::TransmissionFailed(alloc::string::String)
+pub mod zingolib::lightclient::indexer_history
+pub enum zingolib::lightclient::indexer_history::AttemptKind
+pub zingolib::lightclient::indexer_history::AttemptKind::Probe
+pub zingolib::lightclient::indexer_history::AttemptKind::Send
+pub enum zingolib::lightclient::indexer_history::AttemptRoute
+pub zingolib::lightclient::indexer_history::AttemptRoute::Clearnet
+pub zingolib::lightclient::indexer_history::AttemptRoute::Mixnet
+pub enum zingolib::lightclient::indexer_history::FailureKind
+pub zingolib::lightclient::indexer_history::FailureKind::Other
+pub zingolib::lightclient::indexer_history::FailureKind::Queued
+pub zingolib::lightclient::indexer_history::FailureKind::Rejected
+pub zingolib::lightclient::indexer_history::FailureKind::Timeout
+pub zingolib::lightclient::indexer_history::FailureKind::Unreachable
+pub struct zingolib::lightclient::indexer_history::IndexerAttempt
+pub zingolib::lightclient::indexer_history::IndexerAttempt::host: alloc::string::String
+pub zingolib::lightclient::indexer_history::IndexerAttempt::kind: zingolib::lightclient::indexer_history::AttemptKind
+pub zingolib::lightclient::indexer_history::IndexerAttempt::millis: u64
+pub zingolib::lightclient::indexer_history::IndexerAttempt::outcome: core::result::Result<(), zingolib::lightclient::indexer_history::FailureKind>
+pub zingolib::lightclient::indexer_history::IndexerAttempt::route: zingolib::lightclient::indexer_history::AttemptRoute
+pub zingolib::lightclient::indexer_history::IndexerAttempt::unix_secs: u64
+pub struct zingolib::lightclient::indexer_history::IndexerHistoryHandle
+impl zingolib::lightclient::indexer_history::IndexerHistoryHandle
+pub fn zingolib::lightclient::indexer_history::IndexerHistoryHandle::is_recording(&self) -> bool
+pub fn zingolib::lightclient::indexer_history::IndexerHistoryHandle::load(&self) -> alloc::vec::Vec<zingolib::lightclient::indexer_history::IndexerAttempt>
+pub const zingolib::lightclient::indexer_history::MAX_DIARY_ATTEMPTS: usize
+pub mod zingolib::lightclient::migrate
+pub mod zingolib::lightclient::migrate::broadcast_grpc
+pub struct zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient
+impl zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient
+pub fn zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient::new(uri: http::uri::Uri) -> Self
+impl zingolib::wallet::migration::broadcast::BroadcastClient for zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient
+pub async fn zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>
+pub mod zingolib::lightclient::migrate::broadcast_route
+pub enum zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient
+pub zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient::Clearnet(zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient)
+impl zingolib::wallet::migration::broadcast::BroadcastClient for zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient
+pub async fn zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>
+pub enum zingolib::lightclient::migrate::DrainPhase
+pub zingolib::lightclient::migrate::DrainPhase::Building
+pub zingolib::lightclient::migrate::DrainPhase::Transmitting
+pub struct zingolib::lightclient::migrate::DrainProgressHandle(_)
+impl zingolib::lightclient::migrate::DrainProgressHandle
+pub fn zingolib::lightclient::migrate::DrainProgressHandle::status(&self) -> core::option::Option<zingolib::lightclient::migrate::DrainStatus>
+pub struct zingolib::lightclient::migrate::DrainStatus
+pub zingolib::lightclient::migrate::DrainStatus::built: u32
+pub zingolib::lightclient::migrate::DrainStatus::phase: zingolib::lightclient::migrate::DrainPhase
+pub zingolib::lightclient::migrate::DrainStatus::sent: u32
+pub zingolib::lightclient::migrate::DrainStatus::total: u32
+pub struct zingolib::lightclient::migrate::DrainSummary
+pub zingolib::lightclient::migrate::DrainSummary::fee: u64
+pub zingolib::lightclient::migrate::DrainSummary::migrated: u64
+pub zingolib::lightclient::migrate::DrainSummary::stranded: u64
+pub zingolib::lightclient::migrate::DrainSummary::txids: alloc::vec::Vec<zcash_protocol::txid::TxId>
+pub struct zingolib::lightclient::migrate::MigrationStatus
+pub zingolib::lightclient::migrate::MigrationStatus::next_wakes: alloc::vec::Vec<zingolib::wallet::migration::schedule::WakePoint>
+pub zingolib::lightclient::migrate::MigrationStatus::orchard_confirmed_spendable: u64
+pub zingolib::lightclient::migrate::MigrationStatus::parts_confirmed: u32
+pub zingolib::lightclient::migrate::MigrationStatus::parts_total: u32
+pub zingolib::lightclient::migrate::MigrationStatus::phase: core::option::Option<zingolib::wallet::migration::MigrationPhase>
+pub zingolib::lightclient::migrate::MigrationStatus::value_migrated: u64
+pub zingolib::lightclient::migrate::MigrationStatus::value_total: u64
+pub struct zingolib::lightclient::migrate::MigrationSummary
+pub zingolib::lightclient::migrate::MigrationSummary::part_txids: alloc::vec::Vec<zcash_protocol::txid::TxId>
+pub zingolib::lightclient::migrate::MigrationSummary::split_txids: alloc::vec::Vec<zcash_protocol::txid::TxId>
+pub zingolib::lightclient::migrate::MigrationSummary::stranded: u64
+pub mod zingolib::lightclient::offline
+pub mod zingolib::lightclient::propose
+pub mod zingolib::lightclient::save
+pub mod zingolib::lightclient::send
+pub mod zingolib::lightclient::sync
+pub struct zingolib::lightclient::sync::SyncPauseGuard
+impl core::ops::drop::Drop for zingolib::lightclient::sync::SyncPauseGuard
+pub fn zingolib::lightclient::sync::SyncPauseGuard::drop(&mut self)
+pub struct zingolib::lightclient::LightClient
+impl zingolib::lightclient::LightClient
+pub async fn zingolib::lightclient::LightClient::account_balance(&self, account_id: zip32::AccountId) -> core::result::Result<zingolib::wallet::balance::AccountBalance, zingolib::wallet::error::BalanceError>
+pub fn zingolib::lightclient::LightClient::backup_wallet_file(&self) -> core::result::Result<(), zingolib::lightclient::error::LightClientError>
+pub fn zingolib::lightclient::LightClient::birthday(&self) -> u32
+pub fn zingolib::lightclient::LightClient::chain_type(&self) -> zingolib::config::ChainType
+pub async fn zingolib::lightclient::LightClient::clear_proposal(&mut self)
+pub async fn zingolib::lightclient::LightClient::create_account(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub async fn zingolib::lightclient::LightClient::do_total_memobytes_to_address(&self) -> core::result::Result<zingolib::wallet::summary::data::finsight::TotalMemoBytesToAddress, zingolib::wallet::error::SummaryError>
+pub async fn zingolib::lightclient::LightClient::do_total_spends_to_address(&self) -> core::result::Result<zingolib::wallet::summary::data::finsight::TotalSendsToAddress, zingolib::wallet::error::SummaryError>
+pub async fn zingolib::lightclient::LightClient::do_total_value_to_address(&self) -> core::result::Result<zingolib::wallet::summary::data::finsight::TotalValueToAddress, zingolib::wallet::error::SummaryError>
+pub fn zingolib::lightclient::LightClient::drain_progress_handle(&self) -> zingolib::lightclient::migrate::DrainProgressHandle
+pub fn zingolib::lightclient::LightClient::drain_status(&self) -> core::option::Option<zingolib::lightclient::migrate::DrainStatus>
+pub async fn zingolib::lightclient::LightClient::from_bytes(bytes: alloc::vec::Vec<u8>, config: zingolib::config::ClientConfig) -> core::result::Result<Self, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::generate_transparent_address(&mut self, account_id: zip32::AccountId, enforce_no_gap: bool) -> core::result::Result<(pepper_sync::keys::transparent::TransparentAddressId, zcash_transparent::address::TransparentAddress), zingolib::wallet::error::KeyError>
+pub async fn zingolib::lightclient::LightClient::generate_unified_address(&mut self, receivers: zingolib::wallet::keys::unified::ReceiverSelection, account_id: zip32::AccountId) -> core::result::Result<(zingolib::wallet::keys::unified::UnifiedAddressId, zcash_keys::address::UnifiedAddress), zingolib::wallet::error::KeyError>
+pub fn zingolib::lightclient::LightClient::indexer_history_handle(&self) -> zingolib::lightclient::indexer_history::IndexerHistoryHandle
+pub fn zingolib::lightclient::LightClient::indexer_uri(&self) -> core::option::Option<http::uri::Uri>
+pub async fn zingolib::lightclient::LightClient::info(&mut self) -> core::result::Result<zingolib::data::ServerInfo, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::is_save_required(&self) -> bool
+pub async fn zingolib::lightclient::LightClient::messages_containing(&self, filter: core::option::Option<&str>) -> core::result::Result<zingolib::wallet::summary::data::ValueTransfers, zingolib::wallet::error::SummaryError>
+pub fn zingolib::lightclient::LightClient::mnemonic_phrase(&self) -> core::option::Option<alloc::string::String>
+pub async fn zingolib::lightclient::LightClient::new(config: zingolib::config::ClientConfig, overwrite: bool) -> core::result::Result<Self, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::recovery_info(&self) -> core::option::Option<zingolib::wallet::RecoveryInfo>
+pub async fn zingolib::lightclient::LightClient::set_indexer_uri(&mut self, server: http::uri::Uri) -> core::result::Result<(), zingo_netutils::error::GetClientError>
+pub async fn zingolib::lightclient::LightClient::transaction_summaries(&self, reverse_sort: bool) -> core::result::Result<zingolib::wallet::summary::data::TransactionSummaries, zingolib::wallet::error::SummaryError>
+pub fn zingolib::lightclient::LightClient::transmit_progress_handle(&self) -> zingolib::lightclient::TransmitProgressHandle
+pub async fn zingolib::lightclient::LightClient::transparent_addresses_json(&self) -> json::value::JsonValue
+pub async fn zingolib::lightclient::LightClient::unified_addresses_json(&self) -> json::value::JsonValue
+pub async fn zingolib::lightclient::LightClient::update_current_price(&self) -> core::result::Result<f32, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::update_wallet_settings(&mut self, settings: zingolib::wallet::WalletSettings)
+pub async fn zingolib::lightclient::LightClient::value_transfers(&self, sort_highest_to_lowest: bool) -> core::result::Result<zingolib::wallet::summary::data::ValueTransfers, zingolib::wallet::error::SummaryError>
+pub fn zingolib::lightclient::LightClient::wallet(&self) -> &alloc::sync::Arc<tokio::sync::rwlock::RwLock<zingolib::wallet::LightWallet>>
+pub fn zingolib::lightclient::LightClient::wallet_dir(&self) -> core::result::Result<std::path::PathBuf, zingolib::lightclient::error::LightClientError>
+pub fn zingolib::lightclient::LightClient::wallet_path(&self) -> std::path::PathBuf
+impl zingolib::lightclient::LightClient
+pub async fn zingolib::lightclient::LightClient::auto_broadcast_if_due(&mut self) -> core::result::Result<alloc::vec::Vec<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::broadcast_due_parts(&mut self) -> core::result::Result<alloc::vec::Vec<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::cancel_ironwood_migration(&mut self) -> core::result::Result<(), zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::catch_up_migration(&mut self, spacing: core::time::Duration) -> core::result::Result<alloc::vec::Vec<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::drain_orchard_to_ironwood(&mut self, account: zip32::AccountId) -> core::result::Result<zingolib::lightclient::migrate::DrainSummary, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::drain_orchard_to_ironwood_presynced(&mut self, account: zip32::AccountId, sync: &zingolib::lightclient::sync::SyncPauseGuard) -> core::result::Result<zingolib::lightclient::migrate::DrainSummary, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::migrate_to_ironwood(&mut self, account: zip32::AccountId) -> core::result::Result<zingolib::lightclient::migrate::MigrationSummary, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::migration_status(&self) -> core::result::Result<zingolib::lightclient::migrate::MigrationStatus, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::plan_ironwood_migration(&self, account: zip32::AccountId) -> core::result::Result<zingolib::wallet::migration::split::MigrationPlan, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::plan_orchard_drain(&self, account: zip32::AccountId) -> core::result::Result<zingolib::wallet::migration::drain::DrainPlan, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::reconcile_migration(&mut self) -> core::result::Result<zingolib::wallet::migration::reconcile::ReconcileReport, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::start_ironwood_migration(&mut self, account: zip32::AccountId, strategy: zingolib::wallet::migration::parts::SigningStrategy, consented_plan_hash: [u8; 32], per_bucket: core::option::Option<u32>) -> core::result::Result<(), zingolib::lightclient::error::LightClientError>
+impl zingolib::lightclient::LightClient
+pub async fn zingolib::lightclient::LightClient::await_sync(&mut self) -> core::result::Result<pepper_sync::sync::SyncResult, zingolib::lightclient::error::LightClientError>
+pub fn zingolib::lightclient::LightClient::pause_sync(&self) -> core::result::Result<(), pepper_sync::error::SyncModeError>
+pub fn zingolib::lightclient::LightClient::pause_sync_scoped(&self) -> core::result::Result<zingolib::lightclient::sync::SyncPauseGuard, pepper_sync::error::SyncModeError>
+pub fn zingolib::lightclient::LightClient::poll_sync(&mut self) -> zingolib::data::PollReport<pepper_sync::sync::SyncResult, pepper_sync::error::SyncError<zingolib::wallet::error::WalletError>>
+pub fn zingolib::lightclient::LightClient::poll_sync_recovery(&mut self) -> core::option::Option<(pepper_sync::error::SyncRecoveryObservables, alloc::string::String)>
+pub async fn zingolib::lightclient::LightClient::rescan(&mut self) -> core::result::Result<(), zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::rescan_and_await(&mut self) -> core::result::Result<pepper_sync::sync::SyncResult, zingolib::lightclient::error::LightClientError>
+pub fn zingolib::lightclient::LightClient::resume_sync(&self) -> core::result::Result<(), pepper_sync::error::SyncModeError>
+pub fn zingolib::lightclient::LightClient::stop_sync(&self) -> core::result::Result<(), pepper_sync::error::SyncModeError>
+pub async fn zingolib::lightclient::LightClient::sync(&mut self) -> core::result::Result<(), zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::sync_and_await(&mut self) -> core::result::Result<pepper_sync::sync::SyncResult, zingolib::lightclient::error::LightClientError>
+pub fn zingolib::lightclient::LightClient::sync_mode(&self) -> pepper_sync::wallet::SyncMode
+impl zingolib::lightclient::LightClient
+pub async fn zingolib::lightclient::LightClient::calculate_stored_proposal(&mut self) -> core::result::Result<nonempty::NonEmpty<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::quick_send(&mut self, request: zip321::TransactionRequest, account_id: zip32::AccountId, resume_sync: bool) -> core::result::Result<nonempty::NonEmpty<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::quick_shield(&mut self, account_id: zip32::AccountId) -> core::result::Result<nonempty::NonEmpty<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::send_stored_proposal(&mut self, resume_sync: bool) -> core::result::Result<nonempty::NonEmpty<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+pub async fn zingolib::lightclient::LightClient::transmit_calculated(&mut self, calculated_txids: nonempty::NonEmpty<zcash_protocol::txid::TxId>) -> core::result::Result<nonempty::NonEmpty<zcash_protocol::txid::TxId>, zingolib::lightclient::error::LightClientError>
+impl zingolib::lightclient::LightClient
+pub async fn zingolib::lightclient::LightClient::check_save_error(&mut self) -> std::io::error::Result<()>
+pub async fn zingolib::lightclient::LightClient::delete_wallet_file(&self) -> std::io::error::Result<()>
+pub async fn zingolib::lightclient::LightClient::flush(&mut self) -> std::io::error::Result<()>
+pub async fn zingolib::lightclient::LightClient::save_task(&mut self)
+pub async fn zingolib::lightclient::LightClient::shutdown_save_task(&mut self) -> std::io::error::Result<()>
+pub async fn zingolib::lightclient::LightClient::wait_for_save(&self)
+impl zingolib::lightclient::LightClient
+pub async fn zingolib::lightclient::LightClient::max_send_value(&self, address: zcash_address::ZcashAddress, zennies_for_zingo: bool, account_id: zip32::AccountId) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::ProposeSendError>
+pub async fn zingolib::lightclient::LightClient::propose_send(&mut self, request: zip321::TransactionRequest, account_id: zip32::AccountId) -> core::result::Result<zcash_client_backend::proposal::Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, zingolib::wallet::output::OutputRef>, zingolib::wallet::error::ProposeSendError>
+pub async fn zingolib::lightclient::LightClient::propose_send_all(&mut self, address: zcash_address::ZcashAddress, zennies_for_zingo: bool, memo: core::option::Option<zcash_protocol::memo::MemoBytes>, account_id: zip32::AccountId) -> core::result::Result<zcash_client_backend::proposal::Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, zingolib::wallet::output::OutputRef>, zingolib::wallet::error::ProposeSendError>
+pub async fn zingolib::lightclient::LightClient::propose_shield(&mut self, account_id: zip32::AccountId) -> core::result::Result<zcash_client_backend::proposal::Proposal<zcash_primitives::transaction::fees::zip317::FeeRule, core::convert::Infallible>, zingolib::wallet::error::ProposeShieldError>
+impl core::fmt::Debug for zingolib::lightclient::LightClient
+pub fn zingolib::lightclient::LightClient::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::lightclient::TransmitProgressHandle(_)
+impl zingolib::lightclient::TransmitProgressHandle
+pub fn zingolib::lightclient::TransmitProgressHandle::latest(&self) -> core::option::Option<alloc::string::String>
+pub const zingolib::lightclient::DEFAULT_REQUEST_TIMEOUT: core::time::Duration
+pub mod zingolib::utils
+pub mod zingolib::utils::conversion
+pub fn zingolib::utils::conversion::address_from_str(address: &str) -> core::result::Result<zcash_address::ZcashAddress, zingolib::utils::error::ConversionError>
+pub fn zingolib::utils::conversion::txid_from_hex_encoded_str(txid: &str) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::utils::error::ConversionError>
+pub fn zingolib::utils::conversion::zatoshis_from_u64(amount: u64) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::utils::error::ConversionError>
+pub mod zingolib::utils::error
+pub enum zingolib::utils::error::ConversionError
+pub zingolib::utils::error::ConversionError::DecodeHexFailed(hex::error::FromHexError)
+pub zingolib::utils::error::ConversionError::InvalidAddress(zcash_address::encoding::ParseError)
+pub zingolib::utils::error::ConversionError::InvalidTxidLength(usize)
+pub zingolib::utils::error::ConversionError::OutsideValidRange
+impl core::fmt::Display for zingolib::utils::error::ConversionError
+pub fn zingolib::utils::error::ConversionError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub mod zingolib::wallet
+pub use zingolib::wallet::PerformanceLevel
+pub use zingolib::wallet::SyncConfig
+pub use zingolib::wallet::TransparentAddressDiscovery
+pub use zingolib::wallet::TransparentAddressDiscoveryScopes
+pub mod zingolib::wallet::balance
+pub struct zingolib::wallet::balance::AccountBalance
+pub zingolib::wallet::balance::AccountBalance::confirmed_ironwood_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::confirmed_orchard_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::confirmed_sapling_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::confirmed_transparent_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::total_ironwood_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::total_orchard_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::total_sapling_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::total_transparent_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::unconfirmed_ironwood_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::unconfirmed_orchard_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::unconfirmed_sapling_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+pub zingolib::wallet::balance::AccountBalance::unconfirmed_transparent_balance: core::option::Option<zcash_protocol::value::Zatoshis>
+impl core::convert::From<zingolib::wallet::balance::AccountBalance> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value: zingolib::wallet::balance::AccountBalance) -> Self
+impl core::fmt::Display for zingolib::wallet::balance::AccountBalance
+pub fn zingolib::wallet::balance::AccountBalance::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub mod zingolib::wallet::disk
+pub mod zingolib::wallet::error
+pub enum zingolib::wallet::error::BalanceError
+pub zingolib::wallet::error::BalanceError::ConversionFailed(zingolib::utils::error::ConversionError)
+pub zingolib::wallet::error::BalanceError::KeyError(zingolib::wallet::error::KeyError)
+pub zingolib::wallet::error::BalanceError::Overflow
+pub enum zingolib::wallet::error::CalculateTransactionError<NoteRef>
+pub zingolib::wallet::error::CalculateTransactionError::Calculation(zcash_client_backend::data_api::error::Error<zingolib::wallet::error::WalletError, core::convert::Infallible, core::convert::Infallible, zcash_primitives::transaction::fees::zip317::FeeError, zcash_primitives::transaction::fees::zip317::FeeError, NoteRef>)
+pub zingolib::wallet::error::CalculateTransactionError::NoSpendingKey(zingolib::wallet::error::KeyError)
+pub zingolib::wallet::error::CalculateTransactionError::NonTexMultiStep
+pub zingolib::wallet::error::CalculateTransactionError::SaplingParams(alloc::string::String)
+pub enum zingolib::wallet::error::FeeError
+pub zingolib::wallet::error::FeeError::BalanceError(zcash_protocol::value::BalanceError)
+pub zingolib::wallet::error::FeeError::SpendNotFound
+pub zingolib::wallet::error::FeeError::SpendNotFound::spend: alloc::string::String
+pub zingolib::wallet::error::FeeError::SpendNotFound::txid: zcash_protocol::txid::TxId
+impl core::convert::From<zcash_protocol::value::BalanceError> for zingolib::wallet::error::FeeError
+pub fn zingolib::wallet::error::FeeError::from(value: zcash_protocol::value::BalanceError) -> Self
+impl core::error::Error for zingolib::wallet::error::FeeError
+impl core::fmt::Display for zingolib::wallet::error::FeeError
+pub fn zingolib::wallet::error::FeeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum zingolib::wallet::error::KeyError
+pub zingolib::wallet::error::KeyError::GapError
+pub zingolib::wallet::error::KeyError::InvalidAccountId(zip32::TryFromIntError)
+pub zingolib::wallet::error::KeyError::InvalidFormat
+pub zingolib::wallet::error::KeyError::InvalidMnemonicPhrase(bip0039::error::Error)
+pub zingolib::wallet::error::KeyError::InvalidNonHardenedChildIndex
+pub zingolib::wallet::error::KeyError::IoError(std::io::error::Error)
+pub zingolib::wallet::error::KeyError::KeyDecodingError
+pub zingolib::wallet::error::KeyError::KeyDerivationError(zcash_keys::keys::DerivationError)
+pub zingolib::wallet::error::KeyError::KeyParseError(zcash_address::kind::unified::ParseError)
+pub zingolib::wallet::error::KeyError::NetworkMismatch
+pub zingolib::wallet::error::KeyError::NoAccountKeys
+pub zingolib::wallet::error::KeyError::NoSpendCapability
+pub zingolib::wallet::error::KeyError::NoViewCapability
+pub zingolib::wallet::error::KeyError::UnifiedAddressError
+impl core::convert::From<bip32::error::Error> for zingolib::wallet::error::KeyError
+pub fn zingolib::wallet::error::KeyError::from(value: bip32::error::Error) -> Self
+pub enum zingolib::wallet::error::PriceError
+pub zingolib::wallet::error::PriceError::NotInitialised
+pub zingolib::wallet::error::PriceError::PriceError(zingo_price::PriceError)
+pub enum zingolib::wallet::error::ProposeSendError
+pub zingolib::wallet::error::ProposeSendError::BalanceError(zingolib::wallet::error::BalanceError)
+pub zingolib::wallet::error::ProposeSendError::Proposal(zcash_client_backend::data_api::error::Error<zingolib::wallet::error::WalletError, zingolib::wallet::error::WalletError, zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelectorError, zcash_primitives::transaction::fees::zip317::FeeError, zcash_primitives::transaction::fees::zip317::FeeError, zingolib::wallet::output::OutputRef>)
+pub zingolib::wallet::error::ProposeSendError::TransactionRequestFailed(zip321::Zip321Error)
+pub zingolib::wallet::error::ProposeSendError::ZeroValueSendAll
+pub enum zingolib::wallet::error::ProposeShieldError
+pub zingolib::wallet::error::ProposeShieldError::AddressParseError(zcash_address::encoding::ParseError)
+pub zingolib::wallet::error::ProposeShieldError::Component(zcash_client_backend::data_api::error::Error<zingolib::wallet::error::WalletError, zingolib::wallet::error::WalletError, zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelectorError, zcash_primitives::transaction::fees::zip317::FeeError, zcash_primitives::transaction::fees::zip317::FeeError, core::convert::Infallible>)
+pub zingolib::wallet::error::ProposeShieldError::InsufficientFunds
+pub enum zingolib::wallet::error::SpendError
+pub zingolib::wallet::error::SpendError::IncorrectSpendingTransaction
+pub zingolib::wallet::error::SpendError::IncorrectSpendingTransaction::output_id: pepper_sync::wallet::OutputId
+pub zingolib::wallet::error::SpendError::IncorrectSpendingTransaction::txid: zcash_protocol::txid::TxId
+pub zingolib::wallet::error::SpendError::SpendNotFound
+pub zingolib::wallet::error::SpendError::SpendNotFound::pool: zcash_protocol::PoolType
+pub zingolib::wallet::error::SpendError::SpendNotFound::spend: alloc::string::String
+pub zingolib::wallet::error::SpendError::SpendNotFound::txid: zcash_protocol::txid::TxId
+pub enum zingolib::wallet::error::SummaryError
+pub zingolib::wallet::error::SummaryError::KeyError(zingolib::wallet::error::KeyError)
+pub zingolib::wallet::error::SummaryError::ParseError(zcash_address::encoding::ParseError)
+pub zingolib::wallet::error::SummaryError::SpendError(zingolib::wallet::error::SpendError)
+pub enum zingolib::wallet::error::WalletError
+pub zingolib::wallet::error::WalletError::AccountCreationFailed
+pub zingolib::wallet::error::WalletError::AllFundsEverythingUnsupported
+pub zingolib::wallet::error::WalletError::BirthdayBelowSapling(u32, u32)
+pub zingolib::wallet::error::WalletError::BlockNotFound(zcash_protocol::consensus::BlockHeight)
+pub zingolib::wallet::error::WalletError::CalculatedTxScanError(pepper_sync::error::ScanError)
+pub zingolib::wallet::error::WalletError::CheckpointNotFound
+pub zingolib::wallet::error::WalletError::CheckpointNotFound::height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::error::WalletError::CheckpointNotFound::shielded_protocol: zcash_protocol::ShieldedPool
+pub zingolib::wallet::error::WalletError::ConversionFailed(zingolib::utils::error::ConversionError)
+pub zingolib::wallet::error::WalletError::InvalidValue(zcash_protocol::value::BalanceError)
+pub zingolib::wallet::error::WalletError::KeyError(zingolib::wallet::error::KeyError)
+pub zingolib::wallet::error::WalletError::MigrationBoundNoteMissing(pepper_sync::wallet::OutputId)
+pub zingolib::wallet::error::WalletError::MigrationBuild(alloc::string::String)
+pub zingolib::wallet::error::WalletError::MigrationDeviation(alloc::string::String)
+pub zingolib::wallet::error::WalletError::MigrationInvalidTransition
+pub zingolib::wallet::error::WalletError::MigrationInvalidTransition::from: &'static str
+pub zingolib::wallet::error::WalletError::MigrationInvalidTransition::to: &'static str
+pub zingolib::wallet::error::WalletError::MigrationNoteNotFound(u64)
+pub zingolib::wallet::error::WalletError::MigrationStateCorrupt(alloc::string::String)
+pub zingolib::wallet::error::WalletError::MinimumConfirmationError
+pub zingolib::wallet::error::WalletError::MnemonicError(bip0039::error::Error)
+pub zingolib::wallet::error::WalletError::MnemonicNotFound
+pub zingolib::wallet::error::WalletError::NoSyncData
+pub zingolib::wallet::error::WalletError::NothingToMigrate
+pub zingolib::wallet::error::WalletError::ParseError(zcash_address::encoding::ParseError)
+pub zingolib::wallet::error::WalletError::RemovalError
+pub zingolib::wallet::error::WalletError::ShardTreeError(shardtree::error::ShardTreeError<core::convert::Infallible>)
+pub zingolib::wallet::error::WalletError::TransactionNotFound(zcash_protocol::txid::TxId)
+pub zingolib::wallet::error::WalletError::TransactionRead(std::io::error::Error)
+pub zingolib::wallet::error::WalletError::TransactionWrite(std::io::error::Error)
+pub zingolib::wallet::error::WalletError::WalletAlreadyCreated
+pub mod zingolib::wallet::keys
+pub mod zingolib::wallet::keys::legacy
+pub mod zingolib::wallet::keys::legacy::extended_transparent
+pub enum zingolib::wallet::keys::legacy::extended_transparent::KeyIndex
+pub zingolib::wallet::keys::legacy::extended_transparent::KeyIndex::Hardened(u32)
+pub zingolib::wallet::keys::legacy::extended_transparent::KeyIndex::Normal(u32)
+impl zingolib::wallet::keys::legacy::extended_transparent::KeyIndex
+pub fn zingolib::wallet::keys::legacy::extended_transparent::KeyIndex::from_index(i: u32) -> Self
+pub fn zingolib::wallet::keys::legacy::extended_transparent::KeyIndex::hardened_from_normalize_index(i: u32) -> core::result::Result<zingolib::wallet::keys::legacy::extended_transparent::KeyIndex, secp256k1::Error>
+pub fn zingolib::wallet::keys::legacy::extended_transparent::KeyIndex::is_valid(self) -> bool
+impl core::convert::From<u32> for zingolib::wallet::keys::legacy::extended_transparent::KeyIndex
+pub fn zingolib::wallet::keys::legacy::extended_transparent::KeyIndex::from(index: u32) -> Self
+pub struct zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey
+pub zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::chain_code: alloc::vec::Vec<u8>
+pub zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::private_key: secp256k1::key::SecretKey
+impl zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::derive_private_key(&self, key_index: zingolib::wallet::keys::legacy::extended_transparent::KeyIndex) -> core::result::Result<zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey, secp256k1::Error>
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::get_ext_taddr_from_bip39seed(config: &zingolib::config::ClientConfig, bip39_seed: &[u8], position: u32) -> Self
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::with_seed(seed: &[u8]) -> core::result::Result<zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey, secp256k1::Error>
+impl core::convert::From<&zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey> for zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::from(sk: &zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey) -> Self
+impl zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey
+pub const zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::read<R: std::io::Read>(reader: R, (): ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+pub struct zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey
+pub zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::chain_code: alloc::vec::Vec<u8>
+pub zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::public_key: secp256k1::key::PublicKey
+impl zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::derive_public_key(&self, key_index: zingolib::wallet::keys::legacy::extended_transparent::KeyIndex) -> core::result::Result<zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey, secp256k1::Error>
+impl core::convert::From<&zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey> for zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::from(sk: &zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey) -> Self
+impl zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey
+pub const zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+#[non_exhaustive] pub enum zingolib::wallet::keys::legacy::Capability<ViewingKeyType, SpendKeyType>
+pub zingolib::wallet::keys::legacy::Capability::None
+pub zingolib::wallet::keys::legacy::Capability::Spend(SpendKeyType)
+pub zingolib::wallet::keys::legacy::Capability::View(ViewingKeyType)
+impl<V, S> zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::legacy::Capability<V, S> where V: zingolib::wallet::traits::ReadableWriteable<(), ()>, S: zingolib::wallet::traits::ReadableWriteable<(), ()>
+pub const zingolib::wallet::keys::legacy::Capability<V, S>::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::Capability<V, S>::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::Capability<V, S>::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+pub struct zingolib::wallet::keys::legacy::WalletCapability
+pub zingolib::wallet::keys::legacy::WalletCapability::unified_key_store: zingolib::wallet::keys::unified::UnifiedKeyStore
+impl zingolib::wallet::keys::legacy::WalletCapability
+pub fn zingolib::wallet::keys::legacy::WalletCapability::get_trees_witness_trees(&self) -> core::option::Option<zingolib::wallet::legacy::WitnessTrees>
+impl core::default::Default for zingolib::wallet::keys::legacy::WalletCapability
+pub fn zingolib::wallet::keys::legacy::WalletCapability::default() -> Self
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zingolib::wallet::keys::legacy::WalletCapability
+pub const zingolib::wallet::keys::legacy::WalletCapability::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::WalletCapability::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::WalletCapability::write<W: std::io::Write>(&self, _writer: W, _input: zingolib::config::ChainType) -> std::io::error::Result<()>
+pub mod zingolib::wallet::keys::unified
+pub enum zingolib::wallet::keys::unified::UnifiedKeyStore
+pub zingolib::wallet::keys::unified::UnifiedKeyStore::Empty
+pub zingolib::wallet::keys::unified::UnifiedKeyStore::Spend(alloc::boxed::Box<zcash_keys::keys::UnifiedSpendingKey>)
+pub zingolib::wallet::keys::unified::UnifiedKeyStore::View(alloc::boxed::Box<zcash_keys::keys::UnifiedFullViewingKey>)
+impl zingolib::wallet::keys::unified::UnifiedKeyStore
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::default_receivers(&self) -> core::option::Option<zingolib::wallet::keys::unified::ReceiverSelection>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::generate_transparent_address(&self, address_index: zcash_transparent::keys::NonHardenedChildIndex, scope: pepper_sync::keys::transparent::TransparentScope) -> core::result::Result<zcash_transparent::address::TransparentAddress, zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::generate_unified_address(&self, unified_address_index: u32, receivers: zingolib::wallet::keys::unified::ReceiverSelection) -> core::result::Result<zcash_keys::address::UnifiedAddress, zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::is_empty(&self) -> bool
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::is_spending_key(&self) -> bool
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::new_from_mnemonic(chain_type: zingolib::config::ChainType, mnemonic: &bip0039::mnemonic::Mnemonic, account_index: zip32::AccountId) -> core::result::Result<Self, zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::new_from_seed(chain_type: zingolib::config::ChainType, seed: &[u8; 64], account_index: zip32::AccountId) -> core::result::Result<Self, zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::new_from_ufvk(chain_type: zingolib::config::ChainType, ufvk_encoded: alloc::string::String) -> core::result::Result<Self, zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::new_from_usk(usk: &[u8]) -> core::result::Result<Self, zingolib::wallet::error::KeyError>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for orchard::keys::FullViewingKey
+pub type orchard::keys::FullViewingKey::Error = zingolib::wallet::error::KeyError
+pub fn orchard::keys::FullViewingKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for orchard::keys::SpendingKey
+pub type orchard::keys::SpendingKey::Error = zingolib::wallet::error::KeyError
+pub fn orchard::keys::SpendingKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for sapling_crypto::zip32::DiversifiableFullViewingKey
+pub type sapling_crypto::zip32::DiversifiableFullViewingKey::Error = zingolib::wallet::error::KeyError
+pub fn sapling_crypto::zip32::DiversifiableFullViewingKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for sapling_crypto::zip32::ExtendedSpendingKey
+pub type sapling_crypto::zip32::ExtendedSpendingKey::Error = zingolib::wallet::error::KeyError
+pub fn sapling_crypto::zip32::ExtendedSpendingKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for zcash_keys::keys::UnifiedFullViewingKey
+pub type zcash_keys::keys::UnifiedFullViewingKey::Error = zingolib::wallet::error::KeyError
+pub fn zcash_keys::keys::UnifiedFullViewingKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for zcash_keys::keys::UnifiedSpendingKey
+pub type zcash_keys::keys::UnifiedSpendingKey::Error = zingolib::wallet::error::KeyError
+pub fn zcash_keys::keys::UnifiedSpendingKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for zcash_transparent::keys::AccountPrivKey
+pub type zcash_transparent::keys::AccountPrivKey::Error = zingolib::wallet::error::KeyError
+pub fn zcash_transparent::keys::AccountPrivKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl core::convert::TryFrom<&zingolib::wallet::keys::unified::UnifiedKeyStore> for zcash_transparent::keys::AccountPubKey
+pub type zcash_transparent::keys::AccountPubKey::Error = zingolib::wallet::error::KeyError
+pub fn zcash_transparent::keys::AccountPubKey::try_from(unified_key_store: &zingolib::wallet::keys::unified::UnifiedKeyStore) -> core::result::Result<Self, Self::Error>
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zingolib::wallet::keys::unified::UnifiedKeyStore
+pub const zingolib::wallet::keys::unified::UnifiedKeyStore::VERSION: u8
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::write<W: std::io::Write>(&self, writer: W, input: zingolib::config::ChainType) -> std::io::error::Result<()>
+pub struct zingolib::wallet::keys::unified::ReceiverSelection
+pub zingolib::wallet::keys::unified::ReceiverSelection::orchard: bool
+pub zingolib::wallet::keys::unified::ReceiverSelection::sapling: bool
+impl zingolib::wallet::keys::unified::ReceiverSelection
+pub fn zingolib::wallet::keys::unified::ReceiverSelection::all_shielded() -> Self
+pub fn zingolib::wallet::keys::unified::ReceiverSelection::orchard_only() -> Self
+pub fn zingolib::wallet::keys::unified::ReceiverSelection::sapling_only() -> Self
+impl zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::unified::ReceiverSelection
+pub const zingolib::wallet::keys::unified::ReceiverSelection::VERSION: u8
+pub fn zingolib::wallet::keys::unified::ReceiverSelection::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::unified::ReceiverSelection::write<W: std::io::Write>(&self, writer: W, _input: ()) -> std::io::error::Result<()>
+pub struct zingolib::wallet::keys::unified::UnifiedAddressId
+pub zingolib::wallet::keys::unified::UnifiedAddressId::account_id: zip32::AccountId
+pub zingolib::wallet::keys::unified::UnifiedAddressId::address_index: u32
+pub enum zingolib::wallet::keys::WalletAddressRef
+pub zingolib::wallet::keys::WalletAddressRef::OrchardInternal
+pub zingolib::wallet::keys::WalletAddressRef::OrchardInternal::account_id: zip32::AccountId
+pub zingolib::wallet::keys::WalletAddressRef::OrchardInternal::diversifier_index: zip32::DiversifierIndex
+pub zingolib::wallet::keys::WalletAddressRef::OrchardInternal::encoded_address: alloc::string::String
+pub zingolib::wallet::keys::WalletAddressRef::SaplingExternal
+pub zingolib::wallet::keys::WalletAddressRef::SaplingExternal::account_id: zip32::AccountId
+pub zingolib::wallet::keys::WalletAddressRef::SaplingExternal::diversifier_index: zip32::DiversifierIndex
+pub zingolib::wallet::keys::WalletAddressRef::SaplingExternal::encoded_address: alloc::string::String
+pub zingolib::wallet::keys::WalletAddressRef::Transparent
+pub zingolib::wallet::keys::WalletAddressRef::Transparent::account_id: zip32::AccountId
+pub zingolib::wallet::keys::WalletAddressRef::Transparent::address_index: zcash_transparent::keys::NonHardenedChildIndex
+pub zingolib::wallet::keys::WalletAddressRef::Transparent::encoded_address: alloc::string::String
+pub zingolib::wallet::keys::WalletAddressRef::Transparent::scope: pepper_sync::keys::transparent::TransparentScope
+pub zingolib::wallet::keys::WalletAddressRef::Unified
+pub zingolib::wallet::keys::WalletAddressRef::Unified::account_id: zip32::AccountId
+pub zingolib::wallet::keys::WalletAddressRef::Unified::address_index: core::option::Option<u32>
+pub zingolib::wallet::keys::WalletAddressRef::Unified::encoded_address: alloc::string::String
+pub zingolib::wallet::keys::WalletAddressRef::Unified::has_orchard: bool
+pub zingolib::wallet::keys::WalletAddressRef::Unified::has_sapling: bool
+pub zingolib::wallet::keys::WalletAddressRef::Unified::has_transparent: bool
+pub mod zingolib::wallet::migration
+pub mod zingolib::wallet::migration::broadcast
+pub enum zingolib::wallet::migration::broadcast::BroadcastError
+pub zingolib::wallet::migration::broadcast::BroadcastError::Rejected(alloc::string::String)
+pub zingolib::wallet::migration::broadcast::BroadcastError::Transport(alloc::string::String)
+pub trait zingolib::wallet::migration::broadcast::BroadcastClient: core::marker::Send + core::marker::Sync
+pub fn zingolib::wallet::migration::broadcast::BroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> impl core::future::future::Future<Output = core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>> + core::marker::Send
+impl zingolib::wallet::migration::broadcast::BroadcastClient for zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient
+pub async fn zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>
+impl zingolib::wallet::migration::broadcast::BroadcastClient for zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient
+pub async fn zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>
+pub mod zingolib::wallet::migration::drain
+pub struct zingolib::wallet::migration::drain::DrainPlan
+pub zingolib::wallet::migration::drain::DrainPlan::fee: u64
+pub zingolib::wallet::migration::drain::DrainPlan::migrated: u64
+pub zingolib::wallet::migration::drain::DrainPlan::stranded: u64
+pub zingolib::wallet::migration::drain::DrainPlan::transactions: alloc::vec::Vec<zingolib::wallet::migration::drain::DrainTx>
+impl zingolib::wallet::migration::drain::DrainPlan
+pub fn zingolib::wallet::migration::drain::DrainPlan::is_empty(&self) -> bool
+pub struct zingolib::wallet::migration::drain::DrainTx
+pub zingolib::wallet::migration::drain::DrainTx::inputs: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::drain::DrainTx::output: u64
+impl zingolib::wallet::migration::drain::DrainTx
+pub fn zingolib::wallet::migration::drain::DrainTx::fee(&self) -> u64
+pub fn zingolib::wallet::migration::drain::drain_fee(n_in: usize) -> u64
+pub fn zingolib::wallet::migration::drain::plan_drain(note_values: &[u64], params: &zingolib::wallet::migration::params::MigrationParams) -> zingolib::wallet::migration::drain::DrainPlan
+pub mod zingolib::wallet::migration::params
+pub struct zingolib::wallet::migration::params::MigrationParams
+pub zingolib::wallet::migration::params::MigrationParams::bucket_modulus: u32
+pub zingolib::wallet::migration::params::MigrationParams::denom_cap: u64
+pub zingolib::wallet::migration::params::MigrationParams::denominations: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::params::MigrationParams::dust_floor: u64
+pub zingolib::wallet::migration::params::MigrationParams::expiry_delta: u32
+pub zingolib::wallet::migration::params::MigrationParams::k_max: u32
+pub zingolib::wallet::migration::params::MigrationParams::max_actions_per_split_tx: usize
+pub zingolib::wallet::migration::params::MigrationParams::part_fee: u64
+pub zingolib::wallet::migration::params::MigrationParams::sweep_min: u64
+pub zingolib::wallet::migration::params::MigrationParams::target_sessions: u32
+pub zingolib::wallet::migration::params::MigrationParams::version: u32
+impl zingolib::wallet::migration::params::MigrationParams
+pub fn zingolib::wallet::migration::params::MigrationParams::params_hash(&self) -> [u8; 32]
+pub fn zingolib::wallet::migration::params::MigrationParams::provisional(_chain: zingolib::config::ChainType) -> Self
+pub mod zingolib::wallet::migration::parts
+pub enum zingolib::wallet::migration::parts::MaterializeOutcome
+pub zingolib::wallet::migration::parts::MaterializeOutcome::Materialized
+pub zingolib::wallet::migration::parts::MaterializeOutcome::Materialized::raw_tx: alloc::vec::Vec<u8>
+pub zingolib::wallet::migration::parts::MaterializeOutcome::Materialized::txid: zcash_protocol::txid::TxId
+pub zingolib::wallet::migration::parts::MaterializeOutcome::Skip(zingolib::wallet::migration::parts::SkipReason)
+pub enum zingolib::wallet::migration::parts::PartState
+pub zingolib::wallet::migration::parts::PartState::Assigned
+pub zingolib::wallet::migration::parts::PartState::Bound
+pub zingolib::wallet::migration::parts::PartState::Broadcast
+pub zingolib::wallet::migration::parts::PartState::Confirmed
+pub zingolib::wallet::migration::parts::PartState::Confirmed::height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::parts::PartState::Expired
+pub zingolib::wallet::migration::parts::PartState::Invalidated
+pub zingolib::wallet::migration::parts::PartState::Signed
+pub enum zingolib::wallet::migration::parts::PrepareResult
+pub zingolib::wallet::migration::parts::PrepareResult::Ready
+pub zingolib::wallet::migration::parts::PrepareResult::Ready::expiry_height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::parts::PrepareResult::Ready::prove: zingolib::wallet::migration::parts::ProveOnce
+pub zingolib::wallet::migration::parts::PrepareResult::Ready::target_height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::parts::PrepareResult::Skip(zingolib::wallet::migration::parts::SkipReason)
+pub enum zingolib::wallet::migration::parts::SigningStrategy
+pub zingolib::wallet::migration::parts::SigningStrategy::LazyAtBoundary
+pub zingolib::wallet::migration::parts::SigningStrategy::PreSigned
+pub enum zingolib::wallet::migration::parts::SkipReason
+pub zingolib::wallet::migration::parts::SkipReason::BoundNoteMismatch
+pub zingolib::wallet::migration::parts::SkipReason::BoundNoteMismatch::bound: pepper_sync::wallet::OutputId
+pub zingolib::wallet::migration::parts::SkipReason::BoundNoteSpent
+pub zingolib::wallet::migration::parts::SkipReason::BoundNoteSpent::bound: pepper_sync::wallet::OutputId
+pub zingolib::wallet::migration::parts::SkipReason::BoundaryBeforeActivation
+pub zingolib::wallet::migration::parts::SkipReason::BoundaryBeforeActivation::activation: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::parts::SkipReason::BoundaryBeforeActivation::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::parts::SkipReason::MissedBoundary
+pub zingolib::wallet::migration::parts::SkipReason::MissedBoundary::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::parts::SkipReason::StaleTreeState
+pub zingolib::wallet::migration::parts::SkipReason::StaleTreeState::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::parts::SkipReason::StaleTreeState::tree_tip: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub struct zingolib::wallet::migration::parts::BoundNote
+pub zingolib::wallet::migration::parts::BoundNote::commitment: [u8; 32]
+pub zingolib::wallet::migration::parts::BoundNote::nullifier: [u8; 32]
+pub zingolib::wallet::migration::parts::BoundNote::output_id: pepper_sync::wallet::OutputId
+pub struct zingolib::wallet::migration::parts::BoundaryWitness
+pub zingolib::wallet::migration::parts::BoundaryWitness::anchor: [u8; 32]
+pub zingolib::wallet::migration::parts::BoundaryWitness::auth_path: alloc::vec::Vec<[u8; 32]>
+pub zingolib::wallet::migration::parts::BoundaryWitness::position: u64
+pub struct zingolib::wallet::migration::parts::PartId(pub u32)
+pub struct zingolib::wallet::migration::parts::PartRecord
+pub zingolib::wallet::migration::parts::PartRecord::anchor_witness: core::option::Option<zingolib::wallet::migration::parts::BoundaryWitness>
+pub zingolib::wallet::migration::parts::PartRecord::attempts: u8
+pub zingolib::wallet::migration::parts::PartRecord::bucket_index: core::option::Option<u64>
+pub zingolib::wallet::migration::parts::PartRecord::denomination: u64
+pub zingolib::wallet::migration::parts::PartRecord::expiry_height: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub zingolib::wallet::migration::parts::PartRecord::id: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::parts::PartRecord::note: core::option::Option<zingolib::wallet::migration::parts::BoundNote>
+pub zingolib::wallet::migration::parts::PartRecord::signed_blob: core::option::Option<alloc::vec::Vec<u8>>
+pub zingolib::wallet::migration::parts::PartRecord::state: zingolib::wallet::migration::parts::PartState
+pub zingolib::wallet::migration::parts::PartRecord::target_height: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub zingolib::wallet::migration::parts::PartRecord::txid: core::option::Option<zcash_protocol::txid::TxId>
+impl zingolib::wallet::migration::parts::PartRecord
+pub fn zingolib::wallet::migration::parts::PartRecord::assign(&mut self, bucket_index: u64) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_broadcast(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_confirmed(&mut self, height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_expired(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_invalidated(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_signed(&mut self, txid: zcash_protocol::txid::TxId, expiry_height: zcash_protocol::consensus::BlockHeight, signed_blob: core::option::Option<alloc::vec::Vec<u8>>) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::new(id: zingolib::wallet::migration::parts::PartId, denomination: u64, note: zingolib::wallet::migration::parts::BoundNote) -> Self
+pub fn zingolib::wallet::migration::parts::PartRecord::reassign(&mut self, bucket_index: u64) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::record_attempt(&mut self)
+pub fn zingolib::wallet::migration::parts::PartRecord::shift(&mut self, bucket_index: u64) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub type zingolib::wallet::migration::parts::ProveOnce = alloc::boxed::Box<(dyn core::ops::function::FnOnce() -> core::result::Result<(zcash_protocol::txid::TxId, alloc::vec::Vec<u8>), zingolib::wallet::error::WalletError> + core::marker::Send + 'static)>
+pub mod zingolib::wallet::migration::quantize
+pub struct zingolib::wallet::migration::quantize::Denominations
+impl zingolib::wallet::migration::quantize::Denominations
+pub fn zingolib::wallet::migration::quantize::Denominations::outputs(&self) -> &[zcash_protocol::value::Zatoshis]
+pub fn zingolib::wallet::migration::quantize::Denominations::remainder(&self) -> zcash_protocol::value::Zatoshis
+pub fn zingolib::wallet::migration::quantize::Denominations::total(&self) -> zcash_protocol::value::Zatoshis
+pub fn zingolib::wallet::migration::quantize::decompose(value: zcash_protocol::value::Zatoshis, params: &zingolib::wallet::migration::params::MigrationParams) -> zingolib::wallet::migration::quantize::Denominations
+pub mod zingolib::wallet::migration::reconcile
+pub enum zingolib::wallet::migration::reconcile::PartClass
+pub zingolib::wallet::migration::reconcile::PartClass::AwaitingExpiry
+pub zingolib::wallet::migration::reconcile::PartClass::AwaitingExpiry::expiry: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::reconcile::PartClass::Confirmed
+pub zingolib::wallet::migration::reconcile::PartClass::Expired
+pub zingolib::wallet::migration::reconcile::PartClass::Invalidated
+pub zingolib::wallet::migration::reconcile::PartClass::OnTrack
+pub zingolib::wallet::migration::reconcile::PartClass::Overdue
+pub zingolib::wallet::migration::reconcile::PartClass::SlippedWithinTolerance
+pub enum zingolib::wallet::migration::reconcile::RecommendedAction
+pub zingolib::wallet::migration::reconcile::RecommendedAction::AwaitSplitConfirmation
+pub zingolib::wallet::migration::reconcile::RecommendedAction::BindAndSchedule
+pub zingolib::wallet::migration::reconcile::RecommendedAction::ContinueNoteSplitting
+pub zingolib::wallet::migration::reconcile::RecommendedAction::MarkComplete
+pub zingolib::wallet::migration::reconcile::RecommendedAction::MarkComplete::residual: u64
+pub zingolib::wallet::migration::reconcile::RecommendedAction::MarkInvalidated
+pub zingolib::wallet::migration::reconcile::RecommendedAction::MarkInvalidated::part: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::reconcile::RecommendedAction::PromoteConfirmed
+pub zingolib::wallet::migration::reconcile::RecommendedAction::PromoteConfirmed::height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::reconcile::RecommendedAction::PromoteConfirmed::part: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::reconcile::RecommendedAction::PromptCatchUp
+pub zingolib::wallet::migration::reconcile::RecommendedAction::PromptCatchUp::disclosure_required: bool
+pub zingolib::wallet::migration::reconcile::RecommendedAction::PromptCatchUp::parts: alloc::vec::Vec<zingolib::wallet::migration::parts::PartId>
+pub zingolib::wallet::migration::reconcile::RecommendedAction::Rebuild
+pub zingolib::wallet::migration::reconcile::RecommendedAction::Rebuild::part: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::reconcile::RecommendedAction::ReplanRemainder
+pub zingolib::wallet::migration::reconcile::RecommendedAction::RetrySplit
+pub zingolib::wallet::migration::reconcile::RecommendedAction::RetrySplit::txid: zcash_protocol::txid::TxId
+pub struct zingolib::wallet::migration::reconcile::PartAssessment
+pub zingolib::wallet::migration::reconcile::PartAssessment::class: zingolib::wallet::migration::reconcile::PartClass
+pub zingolib::wallet::migration::reconcile::PartAssessment::id: zingolib::wallet::migration::parts::PartId
+pub struct zingolib::wallet::migration::reconcile::ReconcileReport
+pub zingolib::wallet::migration::reconcile::ReconcileReport::actions: alloc::vec::Vec<zingolib::wallet::migration::reconcile::RecommendedAction>
+pub zingolib::wallet::migration::reconcile::ReconcileReport::assessments: alloc::vec::Vec<zingolib::wallet::migration::reconcile::PartAssessment>
+pub trait zingolib::wallet::migration::reconcile::ChainView
+pub fn zingolib::wallet::migration::reconcile::ChainView::chain_tip(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::migration::reconcile::ChainView::note_spend(&self, output_id: pepper_sync::wallet::OutputId) -> core::option::Option<(zcash_protocol::txid::TxId, core::option::Option<zcash_protocol::consensus::BlockHeight>)>
+pub fn zingolib::wallet::migration::reconcile::ChainView::orchard_confirmed_spendable(&self, account: zip32::AccountId) -> u64
+pub fn zingolib::wallet::migration::reconcile::ChainView::spend_evidence_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::migration::reconcile::ChainView::transaction_confirmed_height(&self, txid: &zcash_protocol::txid::TxId) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::migration::reconcile::ChainView::transaction_failed(&self, txid: &zcash_protocol::txid::TxId) -> bool
+impl zingolib::wallet::migration::reconcile::ChainView for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::chain_tip(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::note_spend(&self, output_id: pepper_sync::wallet::OutputId) -> core::option::Option<(zcash_protocol::txid::TxId, core::option::Option<zcash_protocol::consensus::BlockHeight>)>
+pub fn zingolib::wallet::LightWallet::orchard_confirmed_spendable(&self, account: zip32::AccountId) -> u64
+pub fn zingolib::wallet::LightWallet::spend_evidence_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::transaction_confirmed_height(&self, txid: &zcash_protocol::txid::TxId) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::transaction_failed(&self, txid: &zcash_protocol::txid::TxId) -> bool
+pub fn zingolib::wallet::migration::reconcile::reconcile(state: &zingolib::wallet::migration::MigrationState, chain: &impl zingolib::wallet::migration::reconcile::ChainView) -> zingolib::wallet::migration::reconcile::ReconcileReport
+pub mod zingolib::wallet::migration::schedule
+pub struct zingolib::wallet::migration::schedule::WakePoint
+pub zingolib::wallet::migration::schedule::WakePoint::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::schedule::WakePoint::bucket_index: u64
+pub zingolib::wallet::migration::schedule::WakePoint::estimated_unix_time: u64
+pub zingolib::wallet::migration::schedule::WakePoint::part_ids: alloc::vec::Vec<zingolib::wallet::migration::parts::PartId>
+pub fn zingolib::wallet::migration::schedule::boundary_of(bucket_index: u64, bucket_modulus: u32) -> zcash_protocol::consensus::BlockHeight
+pub fn zingolib::wallet::migration::schedule::bucket_index(height: zcash_protocol::consensus::BlockHeight, bucket_modulus: u32) -> u64
+pub fn zingolib::wallet::migration::schedule::first_anchorable_boundary(activation: pepper_sync::wallet::PoolActivation, bucket_modulus: u32) -> zcash_protocol::consensus::BlockHeight
+pub fn zingolib::wallet::migration::schedule::first_permitted_bucket(now_height: zcash_protocol::consensus::BlockHeight, activation: pepper_sync::wallet::PoolActivation, params: &zingolib::wallet::migration::params::MigrationParams) -> u64
+pub fn zingolib::wallet::migration::schedule::next_wakes(parts: &[zingolib::wallet::migration::parts::PartRecord], now_height: zcash_protocol::consensus::BlockHeight, now_unix: u64, horizon: u64, params: &zingolib::wallet::migration::params::MigrationParams) -> alloc::vec::Vec<zingolib::wallet::migration::schedule::WakePoint>
+pub fn zingolib::wallet::migration::schedule::place(part: &mut zingolib::wallet::migration::parts::PartRecord, bucket: u64, rng: &mut impl rand::rng::Rng, params: &zingolib::wallet::migration::params::MigrationParams) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::schedule::place_immediate(part: &mut zingolib::wallet::migration::parts::PartRecord, bucket: u64) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::schedule::plan_schedule(parts: &mut [zingolib::wallet::migration::parts::PartRecord], now_height: zcash_protocol::consensus::BlockHeight, activation: pepper_sync::wallet::PoolActivation, params: &zingolib::wallet::migration::params::MigrationParams, rng: &mut impl rand::rng::Rng) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::schedule::previous_boundary(height: zcash_protocol::consensus::BlockHeight, bucket_modulus: u32) -> zcash_protocol::consensus::BlockHeight
+pub fn zingolib::wallet::migration::schedule::random_target_in_bucket(bucket: u64, rng: &mut impl rand::rng::Rng, params: &zingolib::wallet::migration::params::MigrationParams) -> zcash_protocol::consensus::BlockHeight
+pub mod zingolib::wallet::migration::split
+pub struct zingolib::wallet::migration::split::MigrationPlan
+pub zingolib::wallet::migration::split::MigrationPlan::parts: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::split::MigrationPlan::split_rounds: alloc::vec::Vec<alloc::vec::Vec<zingolib::wallet::migration::split::NoteSplitTx>>
+pub zingolib::wallet::migration::split::MigrationPlan::stranded: u64
+impl zingolib::wallet::migration::split::MigrationPlan
+pub fn zingolib::wallet::migration::split::MigrationPlan::is_split(&self) -> bool
+pub fn zingolib::wallet::migration::split::MigrationPlan::parts_fee(&self, params: &zingolib::wallet::migration::params::MigrationParams) -> u64
+pub fn zingolib::wallet::migration::split::MigrationPlan::split_fee(&self) -> u64
+pub struct zingolib::wallet::migration::split::NoteSplitTx
+pub zingolib::wallet::migration::split::NoteSplitTx::inputs: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::split::NoteSplitTx::outputs: alloc::vec::Vec<u64>
+impl zingolib::wallet::migration::split::NoteSplitTx
+pub fn zingolib::wallet::migration::split::NoteSplitTx::fee(&self) -> u64
+pub const zingolib::wallet::migration::split::CANONICAL_PART_FEE: u64
+pub fn zingolib::wallet::migration::split::note_split_fee(n_in: usize, n_out: usize, post_activation: bool) -> u64
+pub fn zingolib::wallet::migration::split::part_denomination(value: u64, params: &zingolib::wallet::migration::params::MigrationParams) -> core::option::Option<u64>
+pub fn zingolib::wallet::migration::split::plan_hash(plan: &zingolib::wallet::migration::split::MigrationPlan) -> [u8; 32]
+pub fn zingolib::wallet::migration::split::plan_migration(note_values: &[u64], post_activation: bool, params: &zingolib::wallet::migration::params::MigrationParams) -> zingolib::wallet::migration::split::MigrationPlan
+pub mod zingolib::wallet::migration::store
+pub fn zingolib::wallet::migration::store::read<R: std::io::Read>(reader: R) -> std::io::error::Result<zingolib::wallet::migration::MigrationState>
+pub fn zingolib::wallet::migration::store::write<W: std::io::Write>(writer: W, state: &zingolib::wallet::migration::MigrationState) -> std::io::error::Result<()>
+pub enum zingolib::wallet::migration::BroadcastError
+pub zingolib::wallet::migration::BroadcastError::Rejected(alloc::string::String)
+pub zingolib::wallet::migration::BroadcastError::Transport(alloc::string::String)
+pub enum zingolib::wallet::migration::MaterializeOutcome
+pub zingolib::wallet::migration::MaterializeOutcome::Materialized
+pub zingolib::wallet::migration::MaterializeOutcome::Materialized::raw_tx: alloc::vec::Vec<u8>
+pub zingolib::wallet::migration::MaterializeOutcome::Materialized::txid: zcash_protocol::txid::TxId
+pub zingolib::wallet::migration::MaterializeOutcome::Skip(zingolib::wallet::migration::parts::SkipReason)
+pub enum zingolib::wallet::migration::MigrationMode
+pub zingolib::wallet::migration::MigrationMode::Immediate
+pub zingolib::wallet::migration::MigrationMode::Scheduled
+pub enum zingolib::wallet::migration::MigrationPhase
+pub zingolib::wallet::migration::MigrationPhase::Complete
+pub zingolib::wallet::migration::MigrationPhase::Complete::residual: u64
+pub zingolib::wallet::migration::MigrationPhase::NoteSplitting
+pub zingolib::wallet::migration::MigrationPhase::NoteSplitting::pending_txids: alloc::vec::Vec<zcash_protocol::txid::TxId>
+pub zingolib::wallet::migration::MigrationPhase::NoteSplitting::round: u32
+pub zingolib::wallet::migration::MigrationPhase::PartsScheduled
+pub zingolib::wallet::migration::MigrationPhase::Planned
+pub enum zingolib::wallet::migration::PartClass
+pub zingolib::wallet::migration::PartClass::AwaitingExpiry
+pub zingolib::wallet::migration::PartClass::AwaitingExpiry::expiry: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::PartClass::Confirmed
+pub zingolib::wallet::migration::PartClass::Expired
+pub zingolib::wallet::migration::PartClass::Invalidated
+pub zingolib::wallet::migration::PartClass::OnTrack
+pub zingolib::wallet::migration::PartClass::Overdue
+pub zingolib::wallet::migration::PartClass::SlippedWithinTolerance
+pub enum zingolib::wallet::migration::PartState
+pub zingolib::wallet::migration::PartState::Assigned
+pub zingolib::wallet::migration::PartState::Bound
+pub zingolib::wallet::migration::PartState::Broadcast
+pub zingolib::wallet::migration::PartState::Confirmed
+pub zingolib::wallet::migration::PartState::Confirmed::height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::PartState::Expired
+pub zingolib::wallet::migration::PartState::Invalidated
+pub zingolib::wallet::migration::PartState::Signed
+pub enum zingolib::wallet::migration::PrepareResult
+pub zingolib::wallet::migration::PrepareResult::Ready
+pub zingolib::wallet::migration::PrepareResult::Ready::expiry_height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::PrepareResult::Ready::prove: zingolib::wallet::migration::parts::ProveOnce
+pub zingolib::wallet::migration::PrepareResult::Ready::target_height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::PrepareResult::Skip(zingolib::wallet::migration::parts::SkipReason)
+pub enum zingolib::wallet::migration::RecommendedAction
+pub zingolib::wallet::migration::RecommendedAction::AwaitSplitConfirmation
+pub zingolib::wallet::migration::RecommendedAction::BindAndSchedule
+pub zingolib::wallet::migration::RecommendedAction::ContinueNoteSplitting
+pub zingolib::wallet::migration::RecommendedAction::MarkComplete
+pub zingolib::wallet::migration::RecommendedAction::MarkComplete::residual: u64
+pub zingolib::wallet::migration::RecommendedAction::MarkInvalidated
+pub zingolib::wallet::migration::RecommendedAction::MarkInvalidated::part: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::RecommendedAction::PromoteConfirmed
+pub zingolib::wallet::migration::RecommendedAction::PromoteConfirmed::height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::RecommendedAction::PromoteConfirmed::part: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::RecommendedAction::PromptCatchUp
+pub zingolib::wallet::migration::RecommendedAction::PromptCatchUp::disclosure_required: bool
+pub zingolib::wallet::migration::RecommendedAction::PromptCatchUp::parts: alloc::vec::Vec<zingolib::wallet::migration::parts::PartId>
+pub zingolib::wallet::migration::RecommendedAction::Rebuild
+pub zingolib::wallet::migration::RecommendedAction::Rebuild::part: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::RecommendedAction::ReplanRemainder
+pub zingolib::wallet::migration::RecommendedAction::RetrySplit
+pub zingolib::wallet::migration::RecommendedAction::RetrySplit::txid: zcash_protocol::txid::TxId
+pub enum zingolib::wallet::migration::SigningStrategy
+pub zingolib::wallet::migration::SigningStrategy::LazyAtBoundary
+pub zingolib::wallet::migration::SigningStrategy::PreSigned
+pub enum zingolib::wallet::migration::SkipReason
+pub zingolib::wallet::migration::SkipReason::BoundNoteMismatch
+pub zingolib::wallet::migration::SkipReason::BoundNoteMismatch::bound: pepper_sync::wallet::OutputId
+pub zingolib::wallet::migration::SkipReason::BoundNoteSpent
+pub zingolib::wallet::migration::SkipReason::BoundNoteSpent::bound: pepper_sync::wallet::OutputId
+pub zingolib::wallet::migration::SkipReason::BoundaryBeforeActivation
+pub zingolib::wallet::migration::SkipReason::BoundaryBeforeActivation::activation: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::SkipReason::BoundaryBeforeActivation::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::SkipReason::MissedBoundary
+pub zingolib::wallet::migration::SkipReason::MissedBoundary::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::SkipReason::StaleTreeState
+pub zingolib::wallet::migration::SkipReason::StaleTreeState::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::SkipReason::StaleTreeState::tree_tip: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub struct zingolib::wallet::migration::BoundNote
+pub zingolib::wallet::migration::BoundNote::commitment: [u8; 32]
+pub zingolib::wallet::migration::BoundNote::nullifier: [u8; 32]
+pub zingolib::wallet::migration::BoundNote::output_id: pepper_sync::wallet::OutputId
+pub struct zingolib::wallet::migration::BoundaryWitness
+pub zingolib::wallet::migration::BoundaryWitness::anchor: [u8; 32]
+pub zingolib::wallet::migration::BoundaryWitness::auth_path: alloc::vec::Vec<[u8; 32]>
+pub zingolib::wallet::migration::BoundaryWitness::position: u64
+pub struct zingolib::wallet::migration::ConsentBinding
+pub zingolib::wallet::migration::ConsentBinding::consented_at: u64
+pub zingolib::wallet::migration::ConsentBinding::params_hash: [u8; 32]
+pub zingolib::wallet::migration::ConsentBinding::plan_hash: [u8; 32]
+pub struct zingolib::wallet::migration::Denominations
+impl zingolib::wallet::migration::quantize::Denominations
+pub fn zingolib::wallet::migration::quantize::Denominations::outputs(&self) -> &[zcash_protocol::value::Zatoshis]
+pub fn zingolib::wallet::migration::quantize::Denominations::remainder(&self) -> zcash_protocol::value::Zatoshis
+pub fn zingolib::wallet::migration::quantize::Denominations::total(&self) -> zcash_protocol::value::Zatoshis
+pub struct zingolib::wallet::migration::DrainPlan
+pub zingolib::wallet::migration::DrainPlan::fee: u64
+pub zingolib::wallet::migration::DrainPlan::migrated: u64
+pub zingolib::wallet::migration::DrainPlan::stranded: u64
+pub zingolib::wallet::migration::DrainPlan::transactions: alloc::vec::Vec<zingolib::wallet::migration::drain::DrainTx>
+impl zingolib::wallet::migration::drain::DrainPlan
+pub fn zingolib::wallet::migration::drain::DrainPlan::is_empty(&self) -> bool
+pub struct zingolib::wallet::migration::DrainTx
+pub zingolib::wallet::migration::DrainTx::inputs: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::DrainTx::output: u64
+impl zingolib::wallet::migration::drain::DrainTx
+pub fn zingolib::wallet::migration::drain::DrainTx::fee(&self) -> u64
+pub struct zingolib::wallet::migration::MigrationParams
+pub zingolib::wallet::migration::MigrationParams::bucket_modulus: u32
+pub zingolib::wallet::migration::MigrationParams::denom_cap: u64
+pub zingolib::wallet::migration::MigrationParams::denominations: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::MigrationParams::dust_floor: u64
+pub zingolib::wallet::migration::MigrationParams::expiry_delta: u32
+pub zingolib::wallet::migration::MigrationParams::k_max: u32
+pub zingolib::wallet::migration::MigrationParams::max_actions_per_split_tx: usize
+pub zingolib::wallet::migration::MigrationParams::part_fee: u64
+pub zingolib::wallet::migration::MigrationParams::sweep_min: u64
+pub zingolib::wallet::migration::MigrationParams::target_sessions: u32
+pub zingolib::wallet::migration::MigrationParams::version: u32
+impl zingolib::wallet::migration::params::MigrationParams
+pub fn zingolib::wallet::migration::params::MigrationParams::params_hash(&self) -> [u8; 32]
+pub fn zingolib::wallet::migration::params::MigrationParams::provisional(_chain: zingolib::config::ChainType) -> Self
+pub struct zingolib::wallet::migration::MigrationPlan
+pub zingolib::wallet::migration::MigrationPlan::parts: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::MigrationPlan::split_rounds: alloc::vec::Vec<alloc::vec::Vec<zingolib::wallet::migration::split::NoteSplitTx>>
+pub zingolib::wallet::migration::MigrationPlan::stranded: u64
+impl zingolib::wallet::migration::split::MigrationPlan
+pub fn zingolib::wallet::migration::split::MigrationPlan::is_split(&self) -> bool
+pub fn zingolib::wallet::migration::split::MigrationPlan::parts_fee(&self, params: &zingolib::wallet::migration::params::MigrationParams) -> u64
+pub fn zingolib::wallet::migration::split::MigrationPlan::split_fee(&self) -> u64
+pub struct zingolib::wallet::migration::MigrationState
+pub zingolib::wallet::migration::MigrationState::account: zip32::AccountId
+pub zingolib::wallet::migration::MigrationState::consent: zingolib::wallet::migration::ConsentBinding
+pub zingolib::wallet::migration::MigrationState::mode: zingolib::wallet::migration::MigrationMode
+pub zingolib::wallet::migration::MigrationState::params: zingolib::wallet::migration::params::MigrationParams
+pub zingolib::wallet::migration::MigrationState::parts: alloc::vec::Vec<zingolib::wallet::migration::parts::PartRecord>
+pub zingolib::wallet::migration::MigrationState::phase: zingolib::wallet::migration::MigrationPhase
+pub zingolib::wallet::migration::MigrationState::strategy: zingolib::wallet::migration::parts::SigningStrategy
+impl zingolib::wallet::migration::MigrationState
+pub fn zingolib::wallet::migration::MigrationState::reserved_output_ids(&self) -> alloc::vec::Vec<pepper_sync::wallet::OutputId>
+pub struct zingolib::wallet::migration::NoteSplitTx
+pub zingolib::wallet::migration::NoteSplitTx::inputs: alloc::vec::Vec<u64>
+pub zingolib::wallet::migration::NoteSplitTx::outputs: alloc::vec::Vec<u64>
+impl zingolib::wallet::migration::split::NoteSplitTx
+pub fn zingolib::wallet::migration::split::NoteSplitTx::fee(&self) -> u64
+pub struct zingolib::wallet::migration::PartId(pub u32)
+pub struct zingolib::wallet::migration::PartRecord
+pub zingolib::wallet::migration::PartRecord::anchor_witness: core::option::Option<zingolib::wallet::migration::parts::BoundaryWitness>
+pub zingolib::wallet::migration::PartRecord::attempts: u8
+pub zingolib::wallet::migration::PartRecord::bucket_index: core::option::Option<u64>
+pub zingolib::wallet::migration::PartRecord::denomination: u64
+pub zingolib::wallet::migration::PartRecord::expiry_height: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub zingolib::wallet::migration::PartRecord::id: zingolib::wallet::migration::parts::PartId
+pub zingolib::wallet::migration::PartRecord::note: core::option::Option<zingolib::wallet::migration::parts::BoundNote>
+pub zingolib::wallet::migration::PartRecord::signed_blob: core::option::Option<alloc::vec::Vec<u8>>
+pub zingolib::wallet::migration::PartRecord::state: zingolib::wallet::migration::parts::PartState
+pub zingolib::wallet::migration::PartRecord::target_height: core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub zingolib::wallet::migration::PartRecord::txid: core::option::Option<zcash_protocol::txid::TxId>
+impl zingolib::wallet::migration::parts::PartRecord
+pub fn zingolib::wallet::migration::parts::PartRecord::assign(&mut self, bucket_index: u64) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_broadcast(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_confirmed(&mut self, height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_expired(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_invalidated(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::mark_signed(&mut self, txid: zcash_protocol::txid::TxId, expiry_height: zcash_protocol::consensus::BlockHeight, signed_blob: core::option::Option<alloc::vec::Vec<u8>>) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::new(id: zingolib::wallet::migration::parts::PartId, denomination: u64, note: zingolib::wallet::migration::parts::BoundNote) -> Self
+pub fn zingolib::wallet::migration::parts::PartRecord::reassign(&mut self, bucket_index: u64) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::parts::PartRecord::record_attempt(&mut self)
+pub fn zingolib::wallet::migration::parts::PartRecord::shift(&mut self, bucket_index: u64) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub struct zingolib::wallet::migration::ReconcileReport
+pub zingolib::wallet::migration::ReconcileReport::actions: alloc::vec::Vec<zingolib::wallet::migration::reconcile::RecommendedAction>
+pub zingolib::wallet::migration::ReconcileReport::assessments: alloc::vec::Vec<zingolib::wallet::migration::reconcile::PartAssessment>
+pub struct zingolib::wallet::migration::WakePoint
+pub zingolib::wallet::migration::WakePoint::boundary: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::migration::WakePoint::bucket_index: u64
+pub zingolib::wallet::migration::WakePoint::estimated_unix_time: u64
+pub zingolib::wallet::migration::WakePoint::part_ids: alloc::vec::Vec<zingolib::wallet::migration::parts::PartId>
+pub const zingolib::wallet::migration::CANONICAL_PART_FEE: u64
+pub trait zingolib::wallet::migration::BroadcastClient: core::marker::Send + core::marker::Sync
+pub fn zingolib::wallet::migration::BroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> impl core::future::future::Future<Output = core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>> + core::marker::Send
+impl zingolib::wallet::migration::broadcast::BroadcastClient for zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient
+pub async fn zingolib::lightclient::migrate::broadcast_grpc::GrpcBroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>
+impl zingolib::wallet::migration::broadcast::BroadcastClient for zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient
+pub async fn zingolib::lightclient::migrate::broadcast_route::RoutedBroadcastClient::submit(&self, raw_tx: alloc::vec::Vec<u8>, expiry_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::migration::broadcast::BroadcastError>
+pub trait zingolib::wallet::migration::ChainView
+pub fn zingolib::wallet::migration::ChainView::chain_tip(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::migration::ChainView::note_spend(&self, output_id: pepper_sync::wallet::OutputId) -> core::option::Option<(zcash_protocol::txid::TxId, core::option::Option<zcash_protocol::consensus::BlockHeight>)>
+pub fn zingolib::wallet::migration::ChainView::orchard_confirmed_spendable(&self, account: zip32::AccountId) -> u64
+pub fn zingolib::wallet::migration::ChainView::spend_evidence_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::migration::ChainView::transaction_confirmed_height(&self, txid: &zcash_protocol::txid::TxId) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::migration::ChainView::transaction_failed(&self, txid: &zcash_protocol::txid::TxId) -> bool
+impl zingolib::wallet::migration::reconcile::ChainView for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::chain_tip(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::note_spend(&self, output_id: pepper_sync::wallet::OutputId) -> core::option::Option<(zcash_protocol::txid::TxId, core::option::Option<zcash_protocol::consensus::BlockHeight>)>
+pub fn zingolib::wallet::LightWallet::orchard_confirmed_spendable(&self, account: zip32::AccountId) -> u64
+pub fn zingolib::wallet::LightWallet::spend_evidence_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::transaction_confirmed_height(&self, txid: &zcash_protocol::txid::TxId) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::transaction_failed(&self, txid: &zcash_protocol::txid::TxId) -> bool
+pub fn zingolib::wallet::migration::decompose(value: zcash_protocol::value::Zatoshis, params: &zingolib::wallet::migration::params::MigrationParams) -> zingolib::wallet::migration::quantize::Denominations
+pub fn zingolib::wallet::migration::drain_fee(n_in: usize) -> u64
+pub fn zingolib::wallet::migration::next_wakes(parts: &[zingolib::wallet::migration::parts::PartRecord], now_height: zcash_protocol::consensus::BlockHeight, now_unix: u64, horizon: u64, params: &zingolib::wallet::migration::params::MigrationParams) -> alloc::vec::Vec<zingolib::wallet::migration::schedule::WakePoint>
+pub fn zingolib::wallet::migration::note_split_fee(n_in: usize, n_out: usize, post_activation: bool) -> u64
+pub fn zingolib::wallet::migration::part_denomination(value: u64, params: &zingolib::wallet::migration::params::MigrationParams) -> core::option::Option<u64>
+pub fn zingolib::wallet::migration::plan_hash(plan: &zingolib::wallet::migration::split::MigrationPlan) -> [u8; 32]
+pub fn zingolib::wallet::migration::plan_migration(note_values: &[u64], post_activation: bool, params: &zingolib::wallet::migration::params::MigrationParams) -> zingolib::wallet::migration::split::MigrationPlan
+pub fn zingolib::wallet::migration::plan_schedule(parts: &mut [zingolib::wallet::migration::parts::PartRecord], now_height: zcash_protocol::consensus::BlockHeight, activation: pepper_sync::wallet::PoolActivation, params: &zingolib::wallet::migration::params::MigrationParams, rng: &mut impl rand::rng::Rng) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::migration::reconcile(state: &zingolib::wallet::migration::MigrationState, chain: &impl zingolib::wallet::migration::reconcile::ChainView) -> zingolib::wallet::migration::reconcile::ReconcileReport
+pub mod zingolib::wallet::output
+pub mod zingolib::wallet::output::query
+pub struct zingolib::wallet::output::query::OutputPoolQuery
+pub zingolib::wallet::output::query::OutputPoolQuery::ironwood: bool
+pub zingolib::wallet::output::query::OutputPoolQuery::orchard: bool
+pub zingolib::wallet::output::query::OutputPoolQuery::sapling: bool
+pub zingolib::wallet::output::query::OutputPoolQuery::transparent: bool
+impl zingolib::wallet::output::query::OutputPoolQuery
+pub fn zingolib::wallet::output::query::OutputPoolQuery::any() -> Self
+pub fn zingolib::wallet::output::query::OutputPoolQuery::one_pool(pool_type: zcash_protocol::PoolType) -> Self
+pub fn zingolib::wallet::output::query::OutputPoolQuery::shielded() -> Self
+pub struct zingolib::wallet::output::query::OutputQuery
+pub zingolib::wallet::output::query::OutputQuery::pools: zingolib::wallet::output::query::OutputPoolQuery
+pub zingolib::wallet::output::query::OutputQuery::spend_status: zingolib::wallet::output::query::OutputSpendStatusQuery
+impl zingolib::wallet::output::query::OutputQuery
+pub fn zingolib::wallet::output::query::OutputQuery::any() -> Self
+pub fn zingolib::wallet::output::query::OutputQuery::ironwood(&self) -> bool
+pub fn zingolib::wallet::output::query::OutputQuery::only_unspent() -> Self
+pub fn zingolib::wallet::output::query::OutputQuery::orchard(&self) -> bool
+pub fn zingolib::wallet::output::query::OutputQuery::pending_spent(&self) -> bool
+pub fn zingolib::wallet::output::query::OutputQuery::sapling(&self) -> bool
+pub fn zingolib::wallet::output::query::OutputQuery::spent(&self) -> bool
+pub fn zingolib::wallet::output::query::OutputQuery::stipulations(unspent: bool, pending_spent: bool, spent: bool, transparent: bool, sapling: bool, orchard: bool, ironwood: bool) -> Self
+pub fn zingolib::wallet::output::query::OutputQuery::transparent(&self) -> bool
+pub fn zingolib::wallet::output::query::OutputQuery::unspent(&self) -> bool
+pub struct zingolib::wallet::output::query::OutputSpendStatusQuery
+pub zingolib::wallet::output::query::OutputSpendStatusQuery::pending_spent: bool
+pub zingolib::wallet::output::query::OutputSpendStatusQuery::spent: bool
+pub zingolib::wallet::output::query::OutputSpendStatusQuery::unspent: bool
+impl zingolib::wallet::output::query::OutputSpendStatusQuery
+pub fn zingolib::wallet::output::query::OutputSpendStatusQuery::any() -> Self
+pub fn zingolib::wallet::output::query::OutputSpendStatusQuery::only_pending_spent() -> Self
+pub fn zingolib::wallet::output::query::OutputSpendStatusQuery::only_spent() -> Self
+pub fn zingolib::wallet::output::query::OutputSpendStatusQuery::only_unspent() -> Self
+pub fn zingolib::wallet::output::query::OutputSpendStatusQuery::spentish() -> Self
+pub enum zingolib::wallet::output::SpendStatus
+pub zingolib::wallet::output::SpendStatus::CalculatedSpent(zcash_protocol::txid::TxId)
+pub zingolib::wallet::output::SpendStatus::MempoolSpent(zcash_protocol::txid::TxId)
+pub zingolib::wallet::output::SpendStatus::Spent(zcash_protocol::txid::TxId)
+pub zingolib::wallet::output::SpendStatus::TransmittedSpent(zcash_protocol::txid::TxId)
+pub zingolib::wallet::output::SpendStatus::Unspent
+impl zingolib::wallet::output::SpendStatus
+pub fn zingolib::wallet::output::SpendStatus::is_confirmed_spent(&self) -> bool
+pub fn zingolib::wallet::output::SpendStatus::is_pending_spent(&self) -> bool
+pub fn zingolib::wallet::output::SpendStatus::is_unspent(&self) -> bool
+impl core::fmt::Display for zingolib::wallet::output::SpendStatus
+pub fn zingolib::wallet::output::SpendStatus::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::output::OutputRef
+impl zingolib::wallet::output::OutputRef
+pub fn zingolib::wallet::output::OutputRef::new(output_id: pepper_sync::wallet::OutputId, pool_type: zcash_protocol::PoolType) -> Self
+pub fn zingolib::wallet::output::OutputRef::output_id(&self) -> pepper_sync::wallet::OutputId
+pub fn zingolib::wallet::output::OutputRef::output_index(&self) -> u32
+pub fn zingolib::wallet::output::OutputRef::pool_type(&self) -> zcash_protocol::PoolType
+pub fn zingolib::wallet::output::OutputRef::txid(&self) -> zcash_protocol::txid::TxId
+impl core::fmt::Display for zingolib::wallet::output::OutputRef
+pub fn zingolib::wallet::output::OutputRef::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub mod zingolib::wallet::propose
+pub mod zingolib::wallet::send
+pub mod zingolib::wallet::summary
+pub mod zingolib::wallet::summary::data
+pub mod zingolib::wallet::summary::data::finsight
+pub struct zingolib::wallet::summary::data::finsight::TotalMemoBytesToAddress(pub std::collections::hash::map::HashMap<alloc::string::String, usize>)
+impl core::convert::From<zingolib::wallet::summary::data::finsight::TotalMemoBytesToAddress> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value: zingolib::wallet::summary::data::finsight::TotalMemoBytesToAddress) -> Self
+pub struct zingolib::wallet::summary::data::finsight::TotalSendsToAddress(pub std::collections::hash::map::HashMap<alloc::string::String, u64>)
+impl core::convert::From<zingolib::wallet::summary::data::finsight::TotalSendsToAddress> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value: zingolib::wallet::summary::data::finsight::TotalSendsToAddress) -> Self
+pub struct zingolib::wallet::summary::data::finsight::TotalValueToAddress(pub std::collections::hash::map::HashMap<alloc::string::String, u64>)
+impl core::convert::From<zingolib::wallet::summary::data::finsight::TotalValueToAddress> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value: zingolib::wallet::summary::data::finsight::TotalValueToAddress) -> Self
+pub struct zingolib::wallet::summary::data::finsight::ValuesSentToAddress(pub std::collections::hash::map::HashMap<alloc::string::String, alloc::vec::Vec<u64>>)
+pub enum zingolib::wallet::summary::data::Scope
+pub zingolib::wallet::summary::data::Scope::External
+pub zingolib::wallet::summary::data::Scope::Internal
+impl core::convert::From<zip32::Scope> for zingolib::wallet::summary::data::Scope
+pub fn zingolib::wallet::summary::data::Scope::from(value: zip32::Scope) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::Scope
+pub fn zingolib::wallet::summary::data::Scope::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum zingolib::wallet::summary::data::SelfSendValueTransfer
+pub zingolib::wallet::summary::data::SelfSendValueTransfer::Basic
+pub zingolib::wallet::summary::data::SelfSendValueTransfer::MemoToSelf
+pub zingolib::wallet::summary::data::SelfSendValueTransfer::Refund
+pub zingolib::wallet::summary::data::SelfSendValueTransfer::Shield
+pub enum zingolib::wallet::summary::data::SendType
+pub zingolib::wallet::summary::data::SendType::Send
+pub zingolib::wallet::summary::data::SendType::SendToSelf
+pub zingolib::wallet::summary::data::SendType::Shield
+pub enum zingolib::wallet::summary::data::SentValueTransfer
+pub zingolib::wallet::summary::data::SentValueTransfer::Send
+pub zingolib::wallet::summary::data::SentValueTransfer::SendToSelf(zingolib::wallet::summary::data::SelfSendValueTransfer)
+pub enum zingolib::wallet::summary::data::TransactionKind
+pub zingolib::wallet::summary::data::TransactionKind::Received
+pub zingolib::wallet::summary::data::TransactionKind::Sent(zingolib::wallet::summary::data::SendType)
+impl core::fmt::Display for zingolib::wallet::summary::data::TransactionKind
+pub fn zingolib::wallet::summary::data::TransactionKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum zingolib::wallet::summary::data::ValueTransferKind
+pub zingolib::wallet::summary::data::ValueTransferKind::Received
+pub zingolib::wallet::summary::data::ValueTransferKind::Sent(zingolib::wallet::summary::data::SentValueTransfer)
+impl core::fmt::Display for zingolib::wallet::summary::data::ValueTransferKind
+pub fn zingolib::wallet::summary::data::ValueTransferKind::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::BasicCoinSummaries(_)
+impl core::fmt::Display for zingolib::wallet::summary::data::BasicCoinSummaries
+pub fn zingolib::wallet::summary::data::BasicCoinSummaries::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::BasicCoinSummary
+pub zingolib::wallet::summary::data::BasicCoinSummary::output_index: u32
+pub zingolib::wallet::summary::data::BasicCoinSummary::spend_summary: zingolib::wallet::output::SpendStatus
+pub zingolib::wallet::summary::data::BasicCoinSummary::value: u64
+impl zingolib::wallet::summary::data::BasicCoinSummary
+pub fn zingolib::wallet::summary::data::BasicCoinSummary::from_parts(value: u64, spend_status: zingolib::wallet::output::SpendStatus, output_index: u32) -> Self
+impl core::convert::From<zingolib::wallet::summary::data::BasicCoinSummary> for json::value::JsonValue
+pub fn json::value::JsonValue::from(note: zingolib::wallet::summary::data::BasicCoinSummary) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::BasicCoinSummary
+pub fn zingolib::wallet::summary::data::BasicCoinSummary::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::BasicNoteSummaries(_)
+impl core::fmt::Display for zingolib::wallet::summary::data::BasicNoteSummaries
+pub fn zingolib::wallet::summary::data::BasicNoteSummaries::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::BasicNoteSummary
+pub zingolib::wallet::summary::data::BasicNoteSummary::memo: core::option::Option<alloc::string::String>
+pub zingolib::wallet::summary::data::BasicNoteSummary::output_index: u32
+pub zingolib::wallet::summary::data::BasicNoteSummary::spend_status: zingolib::wallet::output::SpendStatus
+pub zingolib::wallet::summary::data::BasicNoteSummary::value: u64
+impl zingolib::wallet::summary::data::BasicNoteSummary
+pub fn zingolib::wallet::summary::data::BasicNoteSummary::from_parts(value: u64, spend_status: zingolib::wallet::output::SpendStatus, output_index: u32, memo: core::option::Option<alloc::string::String>) -> Self
+impl core::convert::From<zingolib::wallet::summary::data::BasicNoteSummary> for json::value::JsonValue
+pub fn json::value::JsonValue::from(note: zingolib::wallet::summary::data::BasicNoteSummary) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::BasicNoteSummary
+pub fn zingolib::wallet::summary::data::BasicNoteSummary::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::CoinSummary
+pub zingolib::wallet::summary::data::CoinSummary::account_id: zip32::AccountId
+pub zingolib::wallet::summary::data::CoinSummary::address_index: u32
+pub zingolib::wallet::summary::data::CoinSummary::block_height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::summary::data::CoinSummary::output_index: u32
+pub zingolib::wallet::summary::data::CoinSummary::scope: pepper_sync::keys::transparent::TransparentScope
+pub zingolib::wallet::summary::data::CoinSummary::spend_status: zingolib::wallet::output::SpendStatus
+pub zingolib::wallet::summary::data::CoinSummary::status: zingo_status::confirmation_status::ConfirmationStatus
+pub zingolib::wallet::summary::data::CoinSummary::time: u32
+pub zingolib::wallet::summary::data::CoinSummary::txid: zcash_protocol::txid::TxId
+pub zingolib::wallet::summary::data::CoinSummary::value: u64
+impl core::convert::From<zingolib::wallet::summary::data::CoinSummary> for json::value::JsonValue
+pub fn json::value::JsonValue::from(coin: zingolib::wallet::summary::data::CoinSummary) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::CoinSummary
+pub fn zingolib::wallet::summary::data::CoinSummary::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::NoteSummaries(_)
+impl zingolib::wallet::summary::data::NoteSummaries
+pub fn zingolib::wallet::summary::data::NoteSummaries::new(note_summaries: alloc::vec::Vec<zingolib::wallet::summary::data::NoteSummary>) -> Self
+impl core::convert::From<zingolib::wallet::summary::data::NoteSummaries> for json::value::JsonValue
+pub fn json::value::JsonValue::from(note_summaries: zingolib::wallet::summary::data::NoteSummaries) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::NoteSummaries
+pub fn zingolib::wallet::summary::data::NoteSummaries::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for zingolib::wallet::summary::data::NoteSummaries
+pub type zingolib::wallet::summary::data::NoteSummaries::Target = alloc::vec::Vec<zingolib::wallet::summary::data::NoteSummary>
+pub fn zingolib::wallet::summary::data::NoteSummaries::deref(&self) -> &Self::Target
+impl core::ops::deref::DerefMut for zingolib::wallet::summary::data::NoteSummaries
+pub fn zingolib::wallet::summary::data::NoteSummaries::deref_mut(&mut self) -> &mut Self::Target
+impl core::ops::index::Index<usize> for zingolib::wallet::summary::data::NoteSummaries
+pub type zingolib::wallet::summary::data::NoteSummaries::Output = zingolib::wallet::summary::data::NoteSummary
+pub fn zingolib::wallet::summary::data::NoteSummaries::index(&self, index: usize) -> &Self::Output
+impl<'a> core::iter::traits::collect::IntoIterator for &'a zingolib::wallet::summary::data::NoteSummaries
+pub type &'a zingolib::wallet::summary::data::NoteSummaries::IntoIter = core::slice::iter::Iter<'a, zingolib::wallet::summary::data::NoteSummary>
+pub type &'a zingolib::wallet::summary::data::NoteSummaries::Item = &'a zingolib::wallet::summary::data::NoteSummary
+pub fn &'a zingolib::wallet::summary::data::NoteSummaries::into_iter(self) -> Self::IntoIter
+pub struct zingolib::wallet::summary::data::NoteSummary
+pub zingolib::wallet::summary::data::NoteSummary::account_id: zip32::AccountId
+pub zingolib::wallet::summary::data::NoteSummary::block_height: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::summary::data::NoteSummary::memo: core::option::Option<alloc::string::String>
+pub zingolib::wallet::summary::data::NoteSummary::output_index: u32
+pub zingolib::wallet::summary::data::NoteSummary::scope: zingolib::wallet::summary::data::Scope
+pub zingolib::wallet::summary::data::NoteSummary::spend_status: zingolib::wallet::output::SpendStatus
+pub zingolib::wallet::summary::data::NoteSummary::status: zingo_status::confirmation_status::ConfirmationStatus
+pub zingolib::wallet::summary::data::NoteSummary::time: u32
+pub zingolib::wallet::summary::data::NoteSummary::txid: zcash_protocol::txid::TxId
+pub zingolib::wallet::summary::data::NoteSummary::value: u64
+impl core::convert::From<zingolib::wallet::summary::data::NoteSummary> for json::value::JsonValue
+pub fn json::value::JsonValue::from(note: zingolib::wallet::summary::data::NoteSummary) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::NoteSummary
+pub fn zingolib::wallet::summary::data::NoteSummary::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::OutgoingCoinSummaries(_)
+impl core::fmt::Display for zingolib::wallet::summary::data::OutgoingCoinSummaries
+pub fn zingolib::wallet::summary::data::OutgoingCoinSummaries::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::OutgoingCoinSummary
+pub zingolib::wallet::summary::data::OutgoingCoinSummary::output_index: u32
+pub zingolib::wallet::summary::data::OutgoingCoinSummary::recipient: alloc::string::String
+pub zingolib::wallet::summary::data::OutgoingCoinSummary::value: u64
+impl core::convert::From<zingolib::wallet::summary::data::OutgoingCoinSummary> for json::value::JsonValue
+pub fn json::value::JsonValue::from(note: zingolib::wallet::summary::data::OutgoingCoinSummary) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::OutgoingCoinSummary
+pub fn zingolib::wallet::summary::data::OutgoingCoinSummary::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::OutgoingNoteSummaries(_)
+impl core::fmt::Display for zingolib::wallet::summary::data::OutgoingNoteSummaries
+pub fn zingolib::wallet::summary::data::OutgoingNoteSummaries::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::OutgoingNoteSummary
+pub zingolib::wallet::summary::data::OutgoingNoteSummary::account_id: zip32::AccountId
+pub zingolib::wallet::summary::data::OutgoingNoteSummary::memo: core::option::Option<alloc::string::String>
+pub zingolib::wallet::summary::data::OutgoingNoteSummary::output_index: u32
+pub zingolib::wallet::summary::data::OutgoingNoteSummary::recipient: alloc::string::String
+pub zingolib::wallet::summary::data::OutgoingNoteSummary::recipient_unified_address: core::option::Option<alloc::string::String>
+pub zingolib::wallet::summary::data::OutgoingNoteSummary::scope: zingolib::wallet::summary::data::Scope
+pub zingolib::wallet::summary::data::OutgoingNoteSummary::value: u64
+impl core::convert::From<zingolib::wallet::summary::data::OutgoingNoteSummary> for json::value::JsonValue
+pub fn json::value::JsonValue::from(note: zingolib::wallet::summary::data::OutgoingNoteSummary) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::OutgoingNoteSummary
+pub fn zingolib::wallet::summary::data::OutgoingNoteSummary::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::TransactionSummaries(pub alloc::vec::Vec<zingolib::wallet::summary::data::TransactionSummary>)
+impl zingolib::wallet::summary::data::TransactionSummaries
+pub fn zingolib::wallet::summary::data::TransactionSummaries::iter(&self) -> core::slice::iter::Iter<'_, zingolib::wallet::summary::data::TransactionSummary>
+pub fn zingolib::wallet::summary::data::TransactionSummaries::new(transaction_summaries: alloc::vec::Vec<zingolib::wallet::summary::data::TransactionSummary>) -> Self
+pub fn zingolib::wallet::summary::data::TransactionSummaries::paid_fees(&self) -> u64
+pub fn zingolib::wallet::summary::data::TransactionSummaries::txids(&self) -> alloc::vec::Vec<zcash_protocol::txid::TxId>
+impl core::convert::From<zingolib::wallet::summary::data::TransactionSummaries> for json::value::JsonValue
+pub fn json::value::JsonValue::from(transaction_summaries: zingolib::wallet::summary::data::TransactionSummaries) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::TransactionSummaries
+pub fn zingolib::wallet::summary::data::TransactionSummaries::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::TransactionSummary
+pub zingolib::wallet::summary::data::TransactionSummary::blockheight: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::summary::data::TransactionSummary::datetime: u32
+pub zingolib::wallet::summary::data::TransactionSummary::fee: core::option::Option<u64>
+pub zingolib::wallet::summary::data::TransactionSummary::ironwood_notes: alloc::vec::Vec<zingolib::wallet::summary::data::BasicNoteSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::kind: zingolib::wallet::summary::data::TransactionKind
+pub zingolib::wallet::summary::data::TransactionSummary::orchard_notes: alloc::vec::Vec<zingolib::wallet::summary::data::BasicNoteSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::outgoing_ironwood_notes: alloc::vec::Vec<zingolib::wallet::summary::data::OutgoingNoteSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::outgoing_orchard_notes: alloc::vec::Vec<zingolib::wallet::summary::data::OutgoingNoteSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::outgoing_sapling_notes: alloc::vec::Vec<zingolib::wallet::summary::data::OutgoingNoteSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::outgoing_transparent_coins: alloc::vec::Vec<zingolib::wallet::summary::data::OutgoingCoinSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::pools_sent_from: alloc::vec::Vec<zcash_protocol::PoolType>
+pub zingolib::wallet::summary::data::TransactionSummary::sapling_notes: alloc::vec::Vec<zingolib::wallet::summary::data::BasicNoteSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::status: zingo_status::confirmation_status::ConfirmationStatus
+pub zingolib::wallet::summary::data::TransactionSummary::transparent_coins: alloc::vec::Vec<zingolib::wallet::summary::data::BasicCoinSummary>
+pub zingolib::wallet::summary::data::TransactionSummary::txid: zcash_protocol::txid::TxId
+pub zingolib::wallet::summary::data::TransactionSummary::value: u64
+pub zingolib::wallet::summary::data::TransactionSummary::zec_price: core::option::Option<f32>
+impl zingolib::wallet::summary::data::TransactionSummary
+pub fn zingolib::wallet::summary::data::TransactionSummary::balance_delta(&self) -> core::option::Option<i64>
+pub fn zingolib::wallet::summary::data::TransactionSummary::pools_received(&self) -> alloc::vec::Vec<zcash_protocol::PoolType>
+pub fn zingolib::wallet::summary::data::TransactionSummary::prepare_for_display(&self) -> (alloc::string::String, alloc::string::String, alloc::string::String, zingolib::wallet::summary::data::BasicNoteSummaries, zingolib::wallet::summary::data::BasicNoteSummaries, zingolib::wallet::summary::data::BasicNoteSummaries, zingolib::wallet::summary::data::BasicCoinSummaries, zingolib::wallet::summary::data::OutgoingNoteSummaries, zingolib::wallet::summary::data::OutgoingNoteSummaries, zingolib::wallet::summary::data::OutgoingNoteSummaries, zingolib::wallet::summary::data::OutgoingCoinSummaries)
+impl core::convert::From<zingolib::wallet::summary::data::TransactionSummary> for json::value::JsonValue
+pub fn json::value::JsonValue::from(transaction: zingolib::wallet::summary::data::TransactionSummary) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::TransactionSummary
+pub fn zingolib::wallet::summary::data::TransactionSummary::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::ValueTransfer
+pub zingolib::wallet::summary::data::ValueTransfer::blockheight: zcash_protocol::consensus::BlockHeight
+pub zingolib::wallet::summary::data::ValueTransfer::datetime: u32
+pub zingolib::wallet::summary::data::ValueTransfer::kind: zingolib::wallet::summary::data::ValueTransferKind
+pub zingolib::wallet::summary::data::ValueTransfer::memos: alloc::vec::Vec<alloc::string::String>
+pub zingolib::wallet::summary::data::ValueTransfer::pools_received: alloc::vec::Vec<zcash_protocol::PoolType>
+pub zingolib::wallet::summary::data::ValueTransfer::pools_sent_from: alloc::vec::Vec<zcash_protocol::PoolType>
+pub zingolib::wallet::summary::data::ValueTransfer::recipient_address: core::option::Option<alloc::string::String>
+pub zingolib::wallet::summary::data::ValueTransfer::status: zingo_status::confirmation_status::ConfirmationStatus
+pub zingolib::wallet::summary::data::ValueTransfer::transaction_fee: core::option::Option<u64>
+pub zingolib::wallet::summary::data::ValueTransfer::txid: zcash_protocol::txid::TxId
+pub zingolib::wallet::summary::data::ValueTransfer::value: u64
+pub zingolib::wallet::summary::data::ValueTransfer::zec_price: core::option::Option<f32>
+impl core::convert::From<zingolib::wallet::summary::data::ValueTransfer> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value_transfer: zingolib::wallet::summary::data::ValueTransfer) -> Self
+impl core::fmt::Debug for zingolib::wallet::summary::data::ValueTransfer
+pub fn zingolib::wallet::summary::data::ValueTransfer::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for zingolib::wallet::summary::data::ValueTransfer
+pub fn zingolib::wallet::summary::data::ValueTransfer::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::summary::data::ValueTransfers(_)
+impl zingolib::wallet::summary::data::ValueTransfers
+pub fn zingolib::wallet::summary::data::ValueTransfers::new(value_transfers: alloc::vec::Vec<zingolib::wallet::summary::data::ValueTransfer>) -> Self
+impl core::convert::From<zingolib::wallet::summary::data::ValueTransfers> for json::value::JsonValue
+pub fn json::value::JsonValue::from(value_transfers: zingolib::wallet::summary::data::ValueTransfers) -> Self
+impl core::fmt::Display for zingolib::wallet::summary::data::ValueTransfers
+pub fn zingolib::wallet::summary::data::ValueTransfers::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for zingolib::wallet::summary::data::ValueTransfers
+pub type zingolib::wallet::summary::data::ValueTransfers::Target = alloc::vec::Vec<zingolib::wallet::summary::data::ValueTransfer>
+pub fn zingolib::wallet::summary::data::ValueTransfers::deref(&self) -> &Self::Target
+impl core::ops::deref::DerefMut for zingolib::wallet::summary::data::ValueTransfers
+pub fn zingolib::wallet::summary::data::ValueTransfers::deref_mut(&mut self) -> &mut Self::Target
+impl core::ops::index::Index<usize> for zingolib::wallet::summary::data::ValueTransfers
+pub type zingolib::wallet::summary::data::ValueTransfers::Output = zingolib::wallet::summary::data::ValueTransfer
+pub fn zingolib::wallet::summary::data::ValueTransfers::index(&self, index: usize) -> &Self::Output
+impl<'a> core::iter::traits::collect::IntoIterator for &'a zingolib::wallet::summary::data::ValueTransfers
+pub type &'a zingolib::wallet::summary::data::ValueTransfers::IntoIter = core::slice::iter::Iter<'a, zingolib::wallet::summary::data::ValueTransfer>
+pub type &'a zingolib::wallet::summary::data::ValueTransfers::Item = &'a zingolib::wallet::summary::data::ValueTransfer
+pub fn &'a zingolib::wallet::summary::data::ValueTransfers::into_iter(self) -> Self::IntoIter
+pub mod zingolib::wallet::sync
+pub mod zingolib::wallet::traits
+pub trait zingolib::wallet::traits::ReadableWriteable<ReadInput, WriteInput>: core::marker::Sized
+pub const zingolib::wallet::traits::ReadableWriteable::VERSION: u8
+pub fn zingolib::wallet::traits::ReadableWriteable::get_version<R: std::io::Read>(reader: R) -> std::io::error::Result<u8>
+pub fn zingolib::wallet::traits::ReadableWriteable::read<R: std::io::Read>(reader: R, input: ReadInput) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::traits::ReadableWriteable::write<W: std::io::Write>(&self, writer: W, input: WriteInput) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for orchard::keys::FullViewingKey
+pub const orchard::keys::FullViewingKey::VERSION: u8
+pub fn orchard::keys::FullViewingKey::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn orchard::keys::FullViewingKey::write<W: std::io::Write>(&self, writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for orchard::keys::SpendingKey
+pub const orchard::keys::SpendingKey::VERSION: u8
+pub fn orchard::keys::SpendingKey::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn orchard::keys::SpendingKey::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for sapling_crypto::zip32::DiversifiableFullViewingKey
+pub const sapling_crypto::zip32::DiversifiableFullViewingKey::VERSION: u8
+pub fn sapling_crypto::zip32::DiversifiableFullViewingKey::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn sapling_crypto::zip32::DiversifiableFullViewingKey::write<W: std::io::Write>(&self, writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for sapling_crypto::zip32::ExtendedSpendingKey
+pub const sapling_crypto::zip32::ExtendedSpendingKey::VERSION: u8
+pub fn sapling_crypto::zip32::ExtendedSpendingKey::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn sapling_crypto::zip32::ExtendedSpendingKey::write<W: std::io::Write>(&self, writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for secp256k1::key::PublicKey
+pub const secp256k1::key::PublicKey::VERSION: u8
+pub fn secp256k1::key::PublicKey::read<R: std::io::Read>(reader: R, (): ()) -> std::io::error::Result<Self>
+pub fn secp256k1::key::PublicKey::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for secp256k1::key::SecretKey
+pub const secp256k1::key::SecretKey::VERSION: u8
+pub fn secp256k1::key::SecretKey::read<R: std::io::Read>(reader: R, (): ()) -> std::io::error::Result<Self>
+pub fn secp256k1::key::SecretKey::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for zcash_keys::keys::UnifiedSpendingKey
+pub const zcash_keys::keys::UnifiedSpendingKey::VERSION: u8
+pub fn zcash_keys::keys::UnifiedSpendingKey::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zcash_keys::keys::UnifiedSpendingKey::write<W: std::io::Write>(&self, writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for zingo_status::confirmation_status::ConfirmationStatus
+pub const zingo_status::confirmation_status::ConfirmationStatus::VERSION: u8
+pub fn zingo_status::confirmation_status::ConfirmationStatus::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zingo_status::confirmation_status::ConfirmationStatus::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey
+pub const zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::read<R: std::io::Read>(reader: R, (): ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPrivKey::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey
+pub const zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::extended_transparent::ExtendedPubKey::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::unified::ReceiverSelection
+pub const zingolib::wallet::keys::unified::ReceiverSelection::VERSION: u8
+pub fn zingolib::wallet::keys::unified::ReceiverSelection::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::unified::ReceiverSelection::write<W: std::io::Write>(&self, writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable<(orchard::keys::Diversifier, &zingolib::wallet::keys::legacy::WalletCapability)> for orchard::note::Note
+pub const orchard::note::Note::VERSION: u8
+pub fn orchard::note::Note::read<R: std::io::Read>(reader: R, (diversifier, wallet_capability): (orchard::keys::Diversifier, &zingolib::wallet::keys::legacy::WalletCapability)) -> std::io::error::Result<Self>
+pub fn orchard::note::Note::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable<(sapling_crypto::keys::Diversifier, &zingolib::wallet::keys::legacy::WalletCapability)> for sapling_crypto::note::Note
+pub const sapling_crypto::note::Note::VERSION: u8
+pub fn sapling_crypto::note::Note::read<R: std::io::Read>(reader: R, (diversifier, wallet_capability): (sapling_crypto::keys::Diversifier, &zingolib::wallet::keys::legacy::WalletCapability)) -> std::io::error::Result<Self>
+pub fn sapling_crypto::note::Note::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zcash_keys::keys::UnifiedFullViewingKey
+pub const zcash_keys::keys::UnifiedFullViewingKey::VERSION: u8
+pub fn zcash_keys::keys::UnifiedFullViewingKey::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zcash_keys::keys::UnifiedFullViewingKey::write<W: std::io::Write>(&self, writer: W, input: zingolib::config::ChainType) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zingolib::wallet::keys::legacy::WalletCapability
+pub const zingolib::wallet::keys::legacy::WalletCapability::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::WalletCapability::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::WalletCapability::write<W: std::io::Write>(&self, _writer: W, _input: zingolib::config::ChainType) -> std::io::error::Result<()>
+impl zingolib::wallet::traits::ReadableWriteable<zingolib::config::ChainType, zingolib::config::ChainType> for zingolib::wallet::keys::unified::UnifiedKeyStore
+pub const zingolib::wallet::keys::unified::UnifiedKeyStore::VERSION: u8
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::read<R: std::io::Read>(reader: R, input: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::unified::UnifiedKeyStore::write<W: std::io::Write>(&self, writer: W, input: zingolib::config::ChainType) -> std::io::error::Result<()>
+impl<V, S> zingolib::wallet::traits::ReadableWriteable for zingolib::wallet::keys::legacy::Capability<V, S> where V: zingolib::wallet::traits::ReadableWriteable<(), ()>, S: zingolib::wallet::traits::ReadableWriteable<(), ()>
+pub const zingolib::wallet::keys::legacy::Capability<V, S>::VERSION: u8
+pub fn zingolib::wallet::keys::legacy::Capability<V, S>::read<R: std::io::Read>(reader: R, _input: ()) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::keys::legacy::Capability<V, S>::write<W: std::io::Write>(&self, _writer: W, _input: ()) -> std::io::error::Result<()>
+pub mod zingolib::wallet::transaction
+pub mod zingolib::wallet::utils
+pub enum zingolib::wallet::utils::MemoError
+pub zingolib::wallet::utils::MemoError::TooLong(usize)
+pub fn zingolib::wallet::utils::get_zcash_params_path() -> std::io::error::Result<std::path::PathBuf>
+pub fn zingolib::wallet::utils::memo_bytes_from_string(memo_str: alloc::string::String) -> core::result::Result<zcash_protocol::memo::MemoBytes, zingolib::wallet::utils::MemoError>
+pub fn zingolib::wallet::utils::read_string<R: std::io::Read>(reader: R) -> std::io::error::Result<alloc::string::String>
+pub fn zingolib::wallet::utils::txid_from_slice(txid: &[u8]) -> zcash_protocol::txid::TxId
+pub fn zingolib::wallet::utils::write_string<W: std::io::Write>(writer: W, s: &alloc::string::String) -> std::io::error::Result<()>
+pub struct zingolib::wallet::LightWallet
+pub zingolib::wallet::LightWallet::migration: core::option::Option<zingolib::wallet::migration::MigrationState>
+pub zingolib::wallet::LightWallet::nullifier_map: pepper_sync::wallet::NullifierMap
+pub zingolib::wallet::LightWallet::outpoint_map: alloc::collections::btree::map::BTreeMap<pepper_sync::wallet::OutputId, pepper_sync::wallet::ScanTarget>
+pub zingolib::wallet::LightWallet::price_list: zingo_price::PriceList
+pub zingolib::wallet::LightWallet::shard_trees: pepper_sync::wallet::ShardTrees
+pub zingolib::wallet::LightWallet::sync_state: pepper_sync::wallet::SyncState
+pub zingolib::wallet::LightWallet::unified_key_store: alloc::collections::btree::map::BTreeMap<zip32::AccountId, zingolib::wallet::keys::unified::UnifiedKeyStore>
+pub zingolib::wallet::LightWallet::wallet_blocks: alloc::collections::btree::map::BTreeMap<zcash_protocol::consensus::BlockHeight, pepper_sync::wallet::WalletBlock>
+pub zingolib::wallet::LightWallet::wallet_settings: zingolib::wallet::WalletSettings
+pub zingolib::wallet::LightWallet::wallet_transactions: std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::account_balance(&self, account_id: zip32::AccountId) -> core::result::Result<zingolib::wallet::balance::AccountBalance, zingolib::wallet::error::BalanceError>
+pub fn zingolib::wallet::LightWallet::confirmed_balance<Op>(&self, account_id: zip32::AccountId) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError> where Op: pepper_sync::wallet::OutputInterface
+pub fn zingolib::wallet::LightWallet::confirmed_balance_excluding_dust<Op>(&self, account_id: zip32::AccountId) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError> where Op: pepper_sync::wallet::OutputInterface
+pub fn zingolib::wallet::LightWallet::get_filtered_balance<Op, F>(&self, filter_function: F, account_id: zip32::AccountId) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError> where Op: pepper_sync::wallet::OutputInterface, F: core::ops::function::Fn(&Op, &pepper_sync::wallet::WalletTransaction) -> bool
+pub fn zingolib::wallet::LightWallet::get_filtered_balance_mut<Op, F>(&self, filter_function: F, account_id: zip32::AccountId) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError> where Op: pepper_sync::wallet::OutputInterface, F: core::ops::function::FnMut(&Op, &pepper_sync::wallet::WalletTransaction) -> bool
+pub fn zingolib::wallet::LightWallet::shielded_spendable_balance(&self, account_id: zip32::AccountId, include_potentially_spent_notes: bool) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError>
+pub fn zingolib::wallet::LightWallet::spendable_balance<N>(&self, account_id: zip32::AccountId, include_potentially_spent_notes: bool) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError> where N: pepper_sync::wallet::NoteInterface
+pub fn zingolib::wallet::LightWallet::unconfirmed_balance<Op>(&self, account_id: zip32::AccountId) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError> where Op: pepper_sync::wallet::OutputInterface
+pub fn zingolib::wallet::LightWallet::unconfirmed_balance_excluding_dust<Op>(&self, account_id: zip32::AccountId) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::BalanceError> where Op: pepper_sync::wallet::OutputInterface
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::bind_parts_to_notes(&self, state: &mut zingolib::wallet::migration::MigrationState, account: zip32::AccountId) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::birthday(&self) -> zcash_protocol::consensus::BlockHeight
+pub fn zingolib::wallet::LightWallet::chain_type(&self) -> zingolib::config::ChainType
+pub fn zingolib::wallet::LightWallet::clear_all(&mut self)
+pub fn zingolib::wallet::LightWallet::clear_proposal(&mut self)
+pub fn zingolib::wallet::LightWallet::create_new_account(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::LightWallet::current_version(&self) -> u64
+pub fn zingolib::wallet::LightWallet::mark_dirty(&mut self)
+pub fn zingolib::wallet::LightWallet::mnemonic_phrase(&self) -> core::option::Option<alloc::string::String>
+pub fn zingolib::wallet::LightWallet::new(chain_type: zingolib::config::ChainType, wallet_config: zingolib::config::WalletConfig) -> core::result::Result<Self, zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::LightWallet::prune_price_list(&mut self)
+pub fn zingolib::wallet::LightWallet::read_version(&self) -> u64
+pub fn zingolib::wallet::LightWallet::recovery_info(&self) -> core::option::Option<zingolib::wallet::RecoveryInfo>
+pub fn zingolib::wallet::LightWallet::save(&mut self) -> std::io::error::Result<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn zingolib::wallet::LightWallet::transparent_addresses(&self) -> &alloc::collections::btree::map::BTreeMap<pepper_sync::keys::transparent::TransparentAddressId, alloc::string::String>
+pub fn zingolib::wallet::LightWallet::transparent_addresses_json(&self) -> json::value::JsonValue
+pub fn zingolib::wallet::LightWallet::unified_addresses(&self) -> &alloc::collections::btree::map::BTreeMap<zingolib::wallet::keys::unified::UnifiedAddressId, zcash_keys::address::UnifiedAddress>
+pub fn zingolib::wallet::LightWallet::unified_addresses_json(&self) -> json::value::JsonValue
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::build_drain_transaction(&mut self, account: zip32::AccountId, planned: &zingolib::wallet::migration::drain::DrainTx) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::LightWallet::plan_drain(&self, account: zip32::AccountId, params: &zingolib::wallet::migration::params::MigrationParams) -> core::result::Result<zingolib::wallet::migration::drain::DrainPlan, zingolib::wallet::error::WalletError>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::build_note_split_transaction(&mut self, account: zip32::AccountId, planned: &zingolib::wallet::migration::split::NoteSplitTx) -> core::result::Result<zcash_protocol::txid::TxId, zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::LightWallet::migration_note_values(&self, account: zip32::AccountId) -> core::result::Result<alloc::vec::Vec<u64>, zingolib::wallet::error::WalletError>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::calculate_transaction_fee(&self, transaction: &pepper_sync::wallet::WalletTransaction) -> core::result::Result<zcash_protocol::value::Zatoshis, zingolib::wallet::error::FeeError>
+pub fn zingolib::wallet::LightWallet::remove_failed_transaction(&mut self, txid: zcash_protocol::txid::TxId) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::coin_summaries(&self, include_spent_coins: bool) -> alloc::vec::Vec<zingolib::wallet::summary::data::CoinSummary>
+pub async fn zingolib::wallet::LightWallet::do_total_memobytes_to_address(&self) -> core::result::Result<zingolib::wallet::summary::data::finsight::TotalMemoBytesToAddress, zingolib::wallet::error::SummaryError>
+pub async fn zingolib::wallet::LightWallet::do_total_spends_to_address(&self) -> core::result::Result<zingolib::wallet::summary::data::finsight::TotalSendsToAddress, zingolib::wallet::error::SummaryError>
+pub async fn zingolib::wallet::LightWallet::do_total_value_to_address(&self) -> core::result::Result<zingolib::wallet::summary::data::finsight::TotalValueToAddress, zingolib::wallet::error::SummaryError>
+pub async fn zingolib::wallet::LightWallet::messages_containing(&self, filter: core::option::Option<&str>) -> core::result::Result<zingolib::wallet::summary::data::ValueTransfers, zingolib::wallet::error::SummaryError>
+pub fn zingolib::wallet::LightWallet::note_summaries<N>(&self, include_spent_notes: bool) -> zingolib::wallet::summary::data::NoteSummaries where N: pepper_sync::wallet::NoteInterface<KeyId = pepper_sync::keys::KeyId>
+pub async fn zingolib::wallet::LightWallet::transaction_summaries(&self, reverse_sort: bool) -> core::result::Result<zingolib::wallet::summary::data::TransactionSummaries, zingolib::wallet::error::SummaryError>
+pub async fn zingolib::wallet::LightWallet::value_transfers(&self, sort_highest_to_lowest: bool) -> core::result::Result<zingolib::wallet::summary::data::ValueTransfers, zingolib::wallet::error::SummaryError>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::generate_refund_addresses(&mut self, n: usize, account_id: zip32::AccountId) -> core::result::Result<alloc::vec::Vec<(pepper_sync::keys::transparent::TransparentAddressId, zcash_transparent::address::TransparentAddress)>, zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::LightWallet::generate_transparent_address(&mut self, account_id: zip32::AccountId, enforce_no_gap: bool) -> core::result::Result<(pepper_sync::keys::transparent::TransparentAddressId, zcash_transparent::address::TransparentAddress), zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::LightWallet::generate_unified_address(&mut self, receivers: zingolib::wallet::keys::unified::ReceiverSelection, account_id: zip32::AccountId) -> core::result::Result<(zingolib::wallet::keys::unified::UnifiedAddressId, zcash_keys::address::UnifiedAddress), zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::LightWallet::is_address_derived_by_keys(&self, encoded_address: &str) -> core::result::Result<core::option::Option<zingolib::wallet::keys::WalletAddressRef>, zingolib::wallet::error::KeyError>
+pub fn zingolib::wallet::LightWallet::is_orchard_address_derived_from_fvks(&self, address: &orchard::address::Address) -> core::option::Option<(zip32::AccountId, zip32::Scope, zip32::DiversifierIndex)>
+pub fn zingolib::wallet::LightWallet::is_orchard_address_in_unified_addresses(&self, address: &orchard::address::Address) -> core::option::Option<(zingolib::wallet::keys::unified::UnifiedAddressId, zcash_keys::address::UnifiedAddress)>
+pub fn zingolib::wallet::LightWallet::is_sapling_address_derived_from_fvks(&self, address: &sapling_crypto::address::PaymentAddress) -> core::option::Option<(zip32::AccountId, zip32::DiversifierIndex)>
+pub fn zingolib::wallet::LightWallet::is_sapling_address_in_unified_addresses(&self, address: &sapling_crypto::address::PaymentAddress) -> core::option::Option<(zingolib::wallet::keys::unified::UnifiedAddressId, zcash_keys::address::UnifiedAddress)>
+pub fn zingolib::wallet::LightWallet::is_transparent_wallet_address(&self, address: &zcash_transparent::address::TransparentAddress) -> core::option::Option<pepper_sync::keys::transparent::TransparentAddressId>
+pub fn zingolib::wallet::LightWallet::is_wallet_address(&self, encoded_address: &str) -> core::result::Result<core::option::Option<zingolib::wallet::keys::WalletAddressRef>, zingolib::wallet::error::KeyError>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::materialize_part(&mut self, account: zip32::AccountId, part: &mut zingolib::wallet::migration::parts::PartRecord, strategy: zingolib::wallet::migration::parts::SigningStrategy, params: &zingolib::wallet::migration::params::MigrationParams) -> core::result::Result<zingolib::wallet::migration::parts::MaterializeOutcome, zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::LightWallet::prepare_part(&mut self, account: zip32::AccountId, part: &mut zingolib::wallet::migration::parts::PartRecord, params: &zingolib::wallet::migration::params::MigrationParams) -> core::result::Result<zingolib::wallet::migration::parts::PrepareResult, zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::LightWallet::record_part_result(&mut self, part: &mut zingolib::wallet::migration::parts::PartRecord, txid: zcash_protocol::txid::TxId, raw_tx: &[u8], target_height: zcash_protocol::consensus::BlockHeight, expiry_height: zcash_protocol::consensus::BlockHeight, strategy: zingolib::wallet::migration::parts::SigningStrategy) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+pub fn zingolib::wallet::LightWallet::refresh_part_witnesses(&mut self) -> core::result::Result<(), zingolib::wallet::error::WalletError>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::output_spend_status(&self, output: &impl pepper_sync::wallet::OutputInterface) -> zingolib::wallet::output::SpendStatus
+pub fn zingolib::wallet::LightWallet::output_transaction(&self, output: &impl pepper_sync::wallet::OutputInterface) -> &pepper_sync::wallet::WalletTransaction
+pub fn zingolib::wallet::LightWallet::sum_queried_output_values(&self, query: zingolib::wallet::output::query::OutputQuery) -> u64
+pub fn zingolib::wallet::LightWallet::sum_queried_transaction_output_values(&self, transaction: &pepper_sync::wallet::WalletTransaction, query: zingolib::wallet::output::query::OutputQuery) -> u64
+pub fn zingolib::wallet::LightWallet::wallet_outputs<Op: pepper_sync::wallet::OutputInterface>(&self) -> alloc::vec::Vec<&Op>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::put_ironwood_subtree_roots(&mut self, start_index: u64, roots: &[zcash_client_backend::data_api::chain::CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>]) -> core::result::Result<(), shardtree::error::ShardTreeError<core::convert::Infallible>>
+pub fn zingolib::wallet::LightWallet::with_ironwood_tree_mut_inherent<F, A, E>(&mut self, callback: F) -> core::result::Result<A, E> where for<'a> F: core::ops::function::FnMut(&'a mut shardtree::ShardTree<pepper_sync::wallet::OrchardShardStore, { _ }, { ORCHARD_SHARD_HEIGHT }>) -> core::result::Result<A, E>, E: core::convert::From<shardtree::error::ShardTreeError<core::convert::Infallible>>
+impl zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::read<R: std::io::Read>(reader: R, chain_type: zingolib::config::ChainType) -> std::io::error::Result<Self>
+pub fn zingolib::wallet::LightWallet::read_recovery_info<R: std::io::Read>(reader: R) -> std::io::error::Result<zingolib::wallet::RecoveryInfo>
+pub const fn zingolib::wallet::LightWallet::serialized_version() -> u64
+pub fn zingolib::wallet::LightWallet::write<W: std::io::Write>(&mut self, writer: W, consensus_parameters: &impl zcash_protocol::consensus::Parameters) -> std::io::error::Result<()>
+impl pepper_sync::wallet::traits::SyncBlocks for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::get_wallet_block(&self, block_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<pepper_sync::wallet::WalletBlock, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_wallet_blocks_mut(&mut self) -> core::result::Result<&mut alloc::collections::btree::map::BTreeMap<zcash_protocol::consensus::BlockHeight, pepper_sync::wallet::WalletBlock>, Self::Error>
+impl pepper_sync::wallet::traits::SyncNullifiers for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::get_nullifiers(&self) -> core::result::Result<&pepper_sync::wallet::NullifierMap, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_nullifiers_mut(&mut self) -> core::result::Result<&mut pepper_sync::wallet::NullifierMap, Self::Error>
+impl pepper_sync::wallet::traits::SyncOutPoints for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::get_outpoints(&self) -> core::result::Result<&alloc::collections::btree::map::BTreeMap<pepper_sync::wallet::OutputId, pepper_sync::wallet::ScanTarget>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_outpoints_mut(&mut self) -> core::result::Result<&mut alloc::collections::btree::map::BTreeMap<pepper_sync::wallet::OutputId, pepper_sync::wallet::ScanTarget>, Self::Error>
+impl pepper_sync::wallet::traits::SyncShardTrees for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::get_shard_trees(&self) -> core::result::Result<&pepper_sync::wallet::ShardTrees, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_shard_trees_mut(&mut self) -> core::result::Result<&mut pepper_sync::wallet::ShardTrees, Self::Error>
+impl pepper_sync::wallet::traits::SyncTransactions for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::get_wallet_transactions(&self) -> core::result::Result<&std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_wallet_transactions_mut(&mut self) -> core::result::Result<&mut std::collections::hash::map::HashMap<zcash_protocol::txid::TxId, pepper_sync::wallet::WalletTransaction>, Self::Error>
+impl pepper_sync::wallet::traits::SyncWallet for zingolib::wallet::LightWallet
+pub type zingolib::wallet::LightWallet::Error = zingolib::wallet::error::WalletError
+pub fn zingolib::wallet::LightWallet::add_orchard_address(&mut self, account_id: zip32::AccountId, address: orchard::address::Address, diversifier_index: zip32::DiversifierIndex) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::add_sapling_address(&mut self, account_id: zip32::AccountId, address: sapling_crypto::address::PaymentAddress, diversifier_index: zip32::DiversifierIndex) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::get_birthday(&self) -> core::result::Result<zcash_protocol::consensus::BlockHeight, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_sync_state(&self) -> core::result::Result<&pepper_sync::wallet::SyncState, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_sync_state_mut(&mut self) -> core::result::Result<&mut pepper_sync::wallet::SyncState, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_transparent_addresses(&self) -> core::result::Result<&alloc::collections::btree::map::BTreeMap<pepper_sync::keys::transparent::TransparentAddressId, alloc::string::String>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_transparent_addresses_mut(&mut self) -> core::result::Result<&mut alloc::collections::btree::map::BTreeMap<pepper_sync::keys::transparent::TransparentAddressId, alloc::string::String>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_unified_full_viewing_keys(&self) -> core::result::Result<std::collections::hash::map::HashMap<zip32::AccountId, zcash_keys::keys::UnifiedFullViewingKey>, Self::Error>
+pub fn zingolib::wallet::LightWallet::set_save_flag(&mut self) -> core::result::Result<(), Self::Error>
+impl zcash_client_backend::data_api::InputSource for zingolib::wallet::LightWallet
+pub type zingolib::wallet::LightWallet::AccountId = zip32::AccountId
+pub type zingolib::wallet::LightWallet::Error = zingolib::wallet::error::WalletError
+pub type zingolib::wallet::LightWallet::NoteRef = zingolib::wallet::output::OutputRef
+pub fn zingolib::wallet::LightWallet::get_account_metadata(&self, _account: Self::AccountId, _selector: &zcash_client_backend::data_api::NoteFilter, _target_height: zcash_client_backend::data_api::wallet::TargetHeight, _exclude: &[Self::NoteRef]) -> core::result::Result<zcash_client_backend::data_api::AccountMeta, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_spendable_note(&self, _txid: &zcash_protocol::txid::TxId, _protocol: zcash_protocol::ShieldedPool, _index: u32, _target_height: zcash_client_backend::data_api::wallet::TargetHeight) -> core::result::Result<core::option::Option<zcash_client_backend::wallet::ReceivedNote<Self::NoteRef, zcash_client_backend::wallet::Note>>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_spendable_transparent_outputs(&self, address: &zcash_transparent::address::TransparentAddress, target_height: zcash_client_backend::data_api::wallet::TargetHeight, confirmations_policy: zcash_client_backend::data_api::wallet::ConfirmationsPolicy, _output_filter: zcash_client_backend::data_api::CoinbaseFilter) -> core::result::Result<alloc::vec::Vec<zcash_client_backend::wallet::WalletTransparentOutput<Self::AccountId>>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_unspent_transparent_output(&self, _outpoint: &zcash_transparent::bundle::OutPoint, _target_height: zcash_client_backend::data_api::wallet::TargetHeight) -> core::result::Result<core::option::Option<zcash_client_backend::wallet::WalletTransparentOutput<Self::AccountId>>, Self::Error>
+pub fn zingolib::wallet::LightWallet::select_spendable_notes(&self, account: Self::AccountId, target_value: zcash_client_backend::data_api::TargetValue, sources: &[zcash_protocol::ShieldedPool], _target_height: zcash_client_backend::data_api::wallet::TargetHeight, confirmations_policy: zcash_client_backend::data_api::wallet::ConfirmationsPolicy, exclude: &[Self::NoteRef]) -> core::result::Result<zcash_client_backend::data_api::ReceivedNotes<Self::NoteRef>, Self::Error>
+pub fn zingolib::wallet::LightWallet::select_unspent_notes(&self, _account: Self::AccountId, _sources: &[zcash_protocol::ShieldedPool], _target_height: zcash_client_backend::data_api::wallet::TargetHeight, _exclude: &[Self::NoteRef]) -> core::result::Result<zcash_client_backend::data_api::ReceivedNotes<Self::NoteRef>, Self::Error>
+impl zcash_client_backend::data_api::WalletCommitmentTrees for zingolib::wallet::LightWallet
+pub type zingolib::wallet::LightWallet::Error = core::convert::Infallible
+pub type zingolib::wallet::LightWallet::OrchardShardStore<'a> = shardtree::store::memory::MemoryShardStore<orchard::tree::MerkleHashOrchard, zcash_protocol::consensus::BlockHeight>
+pub type zingolib::wallet::LightWallet::SaplingShardStore<'a> = shardtree::store::memory::MemoryShardStore<sapling_crypto::tree::Node, zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::put_orchard_subtree_roots(&mut self, start_index: u64, roots: &[zcash_client_backend::data_api::chain::CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>]) -> core::result::Result<(), shardtree::error::ShardTreeError<Self::Error>>
+pub fn zingolib::wallet::LightWallet::put_sapling_subtree_roots(&mut self, start_index: u64, roots: &[zcash_client_backend::data_api::chain::CommitmentTreeRoot<sapling_crypto::tree::Node>]) -> core::result::Result<(), shardtree::error::ShardTreeError<Self::Error>>
+pub fn zingolib::wallet::LightWallet::with_ironwood_tree_mut<F, A, E>(&mut self, callback: F) -> core::result::Result<core::option::Option<A>, E> where for<'a> F: core::ops::function::FnMut(&'a mut shardtree::ShardTree<Self::OrchardShardStore, { _ }, ORCHARD_SHARD_HEIGHT>) -> core::result::Result<A, E>, E: core::convert::From<shardtree::error::ShardTreeError<Self::Error>>
+pub fn zingolib::wallet::LightWallet::with_orchard_tree_mut<F, A, E>(&mut self, callback: F) -> core::result::Result<A, E> where for<'a> F: core::ops::function::FnMut(&'a mut shardtree::ShardTree<Self::OrchardShardStore, { _ }, { ORCHARD_SHARD_HEIGHT }>) -> core::result::Result<A, E>, E: core::convert::From<shardtree::error::ShardTreeError<Self::Error>>
+pub fn zingolib::wallet::LightWallet::with_sapling_tree_mut<F, A, E>(&mut self, callback: F) -> core::result::Result<A, E> where for<'a> F: core::ops::function::FnMut(&'a mut shardtree::ShardTree<Self::SaplingShardStore, { sapling_crypto::NOTE_COMMITMENT_TREE_DEPTH }, { SAPLING_SHARD_HEIGHT }>) -> core::result::Result<A, E>, E: core::convert::From<shardtree::error::ShardTreeError<Self::Error>>
+impl zcash_client_backend::data_api::WalletRead for zingolib::wallet::LightWallet
+pub type zingolib::wallet::LightWallet::Account = zingolib::wallet::zcb_traits::ZingoAccount
+pub type zingolib::wallet::LightWallet::AccountId = zip32::AccountId
+pub type zingolib::wallet::LightWallet::Error = zingolib::wallet::error::WalletError
+pub fn zingolib::wallet::LightWallet::block_fully_scanned(&self) -> core::result::Result<core::option::Option<zcash_client_backend::data_api::BlockMetadata>, Self::Error>
+pub fn zingolib::wallet::LightWallet::block_max_scanned(&self) -> core::result::Result<core::option::Option<zcash_client_backend::data_api::BlockMetadata>, Self::Error>
+pub fn zingolib::wallet::LightWallet::block_metadata(&self, _height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<core::option::Option<zcash_client_backend::data_api::BlockMetadata>, Self::Error>
+pub fn zingolib::wallet::LightWallet::chain_height(&self) -> core::result::Result<core::option::Option<zcash_protocol::consensus::BlockHeight>, Self::Error>
+pub fn zingolib::wallet::LightWallet::find_account_for_address<P: zcash_protocol::consensus::Parameters>(&self, _params: &P, _address: &zcash_keys::address::Address) -> core::result::Result<core::option::Option<Self::AccountId>, zcash_client_backend::data_api::error::FindAccountForAddressError<Self::Error>>
+pub fn zingolib::wallet::LightWallet::get_account(&self, _account_id: Self::AccountId) -> core::result::Result<core::option::Option<Self::Account>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_account_birthday(&self, _account: Self::AccountId) -> core::result::Result<zcash_protocol::consensus::BlockHeight, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_account_for_ufvk(&self, ufvk: &zcash_keys::keys::UnifiedFullViewingKey) -> core::result::Result<core::option::Option<Self::Account>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_account_ids(&self) -> core::result::Result<alloc::vec::Vec<Self::AccountId>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_block_hash(&self, _block_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<core::option::Option<zcash_primitives::block::BlockHash>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_derived_account(&self, _account_id: &zcash_client_backend::data_api::Zip32Derivation) -> core::result::Result<core::option::Option<Self::Account>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_ephemeral_transparent_receivers(&self, account: Self::AccountId, _exposure_depth: u32, _exclude_used: bool) -> core::result::Result<std::collections::hash::map::HashMap<zcash_transparent::address::TransparentAddress, zcash_client_backend::wallet::TransparentAddressMetadata>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_ironwood_nullifiers(&self, _query: zcash_client_backend::data_api::NullifierQuery) -> core::result::Result<alloc::vec::Vec<(Self::AccountId, orchard::note::nullifier::Nullifier)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_last_generated_address_matching(&self, _account: Self::AccountId, _address_filter: zcash_keys::keys::UnifiedAddressRequest) -> core::result::Result<core::option::Option<zcash_keys::address::UnifiedAddress>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_max_height_hash(&self) -> core::result::Result<core::option::Option<(zcash_protocol::consensus::BlockHeight, zcash_primitives::block::BlockHash)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_memo(&self, _note_id: zcash_client_backend::wallet::NoteId) -> core::result::Result<core::option::Option<zcash_protocol::memo::Memo>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_orchard_nullifiers(&self, _query: zcash_client_backend::data_api::NullifierQuery) -> core::result::Result<alloc::vec::Vec<(Self::AccountId, orchard::note::nullifier::Nullifier)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_received_outputs(&self, _txid: zcash_protocol::txid::TxId, _target_height: zcash_client_backend::data_api::wallet::TargetHeight, _confirmations_policy: zcash_client_backend::data_api::wallet::ConfirmationsPolicy) -> core::result::Result<alloc::vec::Vec<zcash_client_backend::data_api::ReceivedTransactionOutput>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_sapling_nullifiers(&self, _query: zcash_client_backend::data_api::NullifierQuery) -> core::result::Result<alloc::vec::Vec<(Self::AccountId, sapling_crypto::note::nullifier::Nullifier)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_target_and_anchor_heights(&self, min_confirmations: core::num::nonzero::NonZeroU32) -> core::result::Result<core::option::Option<(zcash_client_backend::data_api::wallet::TargetHeight, zcash_protocol::consensus::BlockHeight)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_transaction(&self, _txid: zcash_protocol::txid::TxId) -> core::result::Result<core::option::Option<zcash_primitives::transaction::Transaction>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_transparent_address_metadata(&self, account: Self::AccountId, address: &zcash_transparent::address::TransparentAddress) -> core::result::Result<core::option::Option<zcash_client_backend::wallet::TransparentAddressMetadata>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_transparent_balances(&self, _account: Self::AccountId, _max_height: zcash_client_backend::data_api::wallet::TargetHeight, _confirmations_policy: zcash_client_backend::data_api::wallet::ConfirmationsPolicy) -> core::result::Result<std::collections::hash::map::HashMap<zcash_transparent::address::TransparentAddress, (zcash_client_backend::data_api::TransparentKeyOrigin, zcash_client_backend::data_api::Balance)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_transparent_receivers(&self, account: Self::AccountId, _include_change: bool, _include_standalone_receivers: bool) -> core::result::Result<std::collections::hash::map::HashMap<zcash_transparent::address::TransparentAddress, zcash_client_backend::wallet::TransparentAddressMetadata>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_tx_height(&self, txid: zcash_protocol::txid::TxId) -> core::result::Result<core::option::Option<zcash_protocol::consensus::BlockHeight>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_unified_full_viewing_keys(&self) -> core::result::Result<std::collections::hash::map::HashMap<Self::AccountId, zcash_keys::keys::UnifiedFullViewingKey>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_wallet_birthday(&self) -> core::result::Result<core::option::Option<zcash_protocol::consensus::BlockHeight>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_wallet_summary(&self, _min_confirmations: zcash_client_backend::data_api::wallet::ConfirmationsPolicy) -> core::result::Result<core::option::Option<zcash_client_backend::data_api::WalletSummary<Self::AccountId>>, Self::Error>
+pub fn zingolib::wallet::LightWallet::list_addresses(&self, _account: Self::AccountId) -> core::result::Result<alloc::vec::Vec<zcash_client_backend::data_api::AddressInfo>, Self::Error>
+pub fn zingolib::wallet::LightWallet::seed_relevance_to_derived_accounts(&self, _seed: &secrecy::vec::SecretVec<u8>) -> core::result::Result<zcash_client_backend::data_api::SeedRelevance<Self::AccountId>, Self::Error>
+pub fn zingolib::wallet::LightWallet::suggest_scan_ranges(&self) -> core::result::Result<alloc::vec::Vec<zcash_client_backend::data_api::scanning::ScanRange>, Self::Error>
+pub fn zingolib::wallet::LightWallet::transaction_data_requests(&self) -> core::result::Result<alloc::vec::Vec<zcash_client_backend::data_api::TransactionDataRequest>, Self::Error>
+pub fn zingolib::wallet::LightWallet::utxo_query_height(&self, _account: Self::AccountId) -> core::result::Result<zcash_protocol::consensus::BlockHeight, Self::Error>
+pub fn zingolib::wallet::LightWallet::validate_seed(&self, _account_id: Self::AccountId, _seed: &secrecy::vec::SecretVec<u8>) -> core::result::Result<bool, Self::Error>
+impl zcash_client_backend::data_api::WalletWrite for zingolib::wallet::LightWallet
+pub type zingolib::wallet::LightWallet::UtxoRef = u32
+pub fn zingolib::wallet::LightWallet::create_account(&mut self, _account_name: &str, _seed: &secrecy::vec::SecretVec<u8>, _birthday: &zcash_client_backend::data_api::AccountBirthday, _key_source: core::option::Option<&str>) -> core::result::Result<(Self::AccountId, zcash_keys::keys::UnifiedSpendingKey), Self::Error>
+pub fn zingolib::wallet::LightWallet::delete_account(&mut self, _account: Self::AccountId) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::get_address_for_index(&mut self, _account: Self::AccountId, _diversifier_index: zip32::DiversifierIndex, _request: zcash_keys::keys::UnifiedAddressRequest) -> core::result::Result<core::option::Option<zcash_keys::address::UnifiedAddress>, Self::Error>
+pub fn zingolib::wallet::LightWallet::get_next_available_address(&mut self, _account: Self::AccountId, _request: zcash_keys::keys::UnifiedAddressRequest) -> core::result::Result<core::option::Option<(zcash_keys::address::UnifiedAddress, zip32::DiversifierIndex)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::import_account_hd(&mut self, _account_name: &str, _seed: &secrecy::vec::SecretVec<u8>, _account_index: zip32::AccountId, _birthday: &zcash_client_backend::data_api::AccountBirthday, _key_source: core::option::Option<&str>) -> core::result::Result<(Self::Account, zcash_keys::keys::UnifiedSpendingKey), Self::Error>
+pub fn zingolib::wallet::LightWallet::import_account_ufvk(&mut self, _account_name: &str, _unified_key: &zcash_keys::keys::UnifiedFullViewingKey, _birthday: &zcash_client_backend::data_api::AccountBirthday, _purpose: zcash_client_backend::data_api::AccountPurpose, _key_source: core::option::Option<&str>) -> core::result::Result<Self::Account, Self::Error>
+pub fn zingolib::wallet::LightWallet::notify_address_checked(&mut self, _request: zcash_client_backend::data_api::TransactionsInvolvingAddress, _as_of_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::put_blocks(&mut self, _from_state: &zcash_client_backend::data_api::chain::ChainState, _blocks: alloc::vec::Vec<zcash_client_backend::data_api::ScannedBlock<Self::AccountId>>) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::put_received_transparent_utxo(&mut self, _output: &zcash_client_backend::wallet::WalletTransparentOutput<Self::AccountId>) -> core::result::Result<Self::UtxoRef, Self::Error>
+pub fn zingolib::wallet::LightWallet::reserve_next_n_ephemeral_addresses(&mut self, account_id: Self::AccountId, n: usize) -> core::result::Result<alloc::vec::Vec<(zcash_transparent::address::TransparentAddress, zcash_client_backend::wallet::TransparentAddressMetadata)>, Self::Error>
+pub fn zingolib::wallet::LightWallet::rewind_to_chain_state(&mut self, _chain_state: zcash_client_backend::data_api::chain::ChainState, _reset_account_birthdays: std::collections::hash::set::HashSet<Self::AccountId>) -> core::result::Result<(), zcash_client_backend::data_api::error::RewindError<Self::AccountId, Self::Error>>
+pub fn zingolib::wallet::LightWallet::set_transaction_status(&mut self, _txid: zcash_protocol::txid::TxId, _status: zcash_client_backend::data_api::TransactionStatus) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::set_tx_trust(&mut self, _txid: zcash_protocol::txid::TxId, _trusted: bool) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::store_decrypted_tx(&mut self, _received_tx: zcash_client_backend::data_api::DecryptedTransaction<'_, zcash_primitives::transaction::Transaction, Self::AccountId>) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::store_transactions_to_be_sent(&mut self, transactions: &[zcash_client_backend::data_api::SentTransaction<'_, Self::AccountId>]) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::truncate_to_chain_state(&mut self, _chain_state: zcash_client_backend::data_api::chain::ChainState) -> core::result::Result<(), Self::Error>
+pub fn zingolib::wallet::LightWallet::truncate_to_height(&mut self, _max_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<zcash_protocol::consensus::BlockHeight, Self::Error>
+pub fn zingolib::wallet::LightWallet::update_chain_tip(&mut self, _tip_height: zcash_protocol::consensus::BlockHeight) -> core::result::Result<(), Self::Error>
+impl zingolib::wallet::migration::reconcile::ChainView for zingolib::wallet::LightWallet
+pub fn zingolib::wallet::LightWallet::chain_tip(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::note_spend(&self, output_id: pepper_sync::wallet::OutputId) -> core::option::Option<(zcash_protocol::txid::TxId, core::option::Option<zcash_protocol::consensus::BlockHeight>)>
+pub fn zingolib::wallet::LightWallet::orchard_confirmed_spendable(&self, account: zip32::AccountId) -> u64
+pub fn zingolib::wallet::LightWallet::spend_evidence_height(&self) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::transaction_confirmed_height(&self, txid: &zcash_protocol::txid::TxId) -> core::option::Option<zcash_protocol::consensus::BlockHeight>
+pub fn zingolib::wallet::LightWallet::transaction_failed(&self, txid: &zcash_protocol::txid::TxId) -> bool
+pub struct zingolib::wallet::RecoveryInfo
+pub zingolib::wallet::RecoveryInfo::birthday: u64
+pub zingolib::wallet::RecoveryInfo::no_of_accounts: u32
+pub zingolib::wallet::RecoveryInfo::seed_phrase: alloc::string::String
+impl core::fmt::Display for zingolib::wallet::RecoveryInfo
+pub fn zingolib::wallet::RecoveryInfo::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct zingolib::wallet::WalletSettings
+pub zingolib::wallet::WalletSettings::min_confirmations: core::num::nonzero::NonZeroU32
+pub zingolib::wallet::WalletSettings::sync_config: pepper_sync::config::SyncConfig
+impl core::default::Default for zingolib::wallet::WalletSettings
+pub fn zingolib::wallet::WalletSettings::default() -> Self
+pub struct zingolib::SaplingParams
+impl zingolib::SaplingParams
+pub fn zingolib::SaplingParams::get(file_path: &str) -> core::option::Option<rust_embed_utils::EmbeddedFile>
+pub fn zingolib::SaplingParams::iter() -> impl core::iter::traits::iterator::Iterator<Item = alloc::borrow::Cow<'static, str>> + 'static
+impl rust_embed::RustEmbed for zingolib::SaplingParams
+pub fn zingolib::SaplingParams::get(file_path: &str) -> core::option::Option<rust_embed_utils::EmbeddedFile>
+pub fn zingolib::SaplingParams::iter() -> rust_embed::Filenames
+pub const zingolib::DEVELOPER_DONATION_ADDRESS: &str
+pub const zingolib::ZENNIES_FOR_ZINGO_AMOUNT: u64
+pub const zingolib::ZENNIES_FOR_ZINGO_DONATION_ADDRESS: &str
+pub const zingolib::ZENNIES_FOR_ZINGO_REGTEST_ADDRESS: &str
+pub const zingolib::ZENNIES_FOR_ZINGO_TESTNET_ADDRESS: &str
+pub fn zingolib::get_zennies_for_zingo_address(chain_type: zingolib::config::ChainType) -> &'static str
+pub fn zingolib::git_description() -> &'static str

--- a/tools/workbench/goldens/public-api/zingolib_testutils.txt
+++ b/tools/workbench/goldens/public-api/zingolib_testutils.txt
@@ -1,0 +1,181 @@
+pub mod zingolib_testutils
+pub mod zingolib_testutils::attribution
+pub enum zingolib_testutils::attribution::SendFailureAttribution
+pub zingolib_testutils::attribution::SendFailureAttribution::IndexerTransformed
+pub zingolib_testutils::attribution::SendFailureAttribution::IndexerTransformed::direct_txid: alloc::string::String
+pub zingolib_testutils::attribution::SendFailureAttribution::ValidatorWrongAtBoundary
+pub zingolib_testutils::attribution::SendFailureAttribution::ValidatorWrongAtBoundary::boundary_error: alloc::string::String
+pub zingolib_testutils::attribution::SendFailureAttribution::ValidatorWrongAtBoundary::later_txid: alloc::string::String
+pub zingolib_testutils::attribution::SendFailureAttribution::WalletBuiltInvalid
+pub zingolib_testutils::attribution::SendFailureAttribution::WalletBuiltInvalid::boundary_error: alloc::string::String
+pub zingolib_testutils::attribution::SendFailureAttribution::WalletBuiltInvalid::later_error: alloc::string::String
+impl zingolib_testutils::attribution::SendFailureAttribution
+pub fn zingolib_testutils::attribution::SendFailureAttribution::boundary_error(&self) -> core::option::Option<&str>
+impl core::fmt::Display for zingolib_testutils::attribution::SendFailureAttribution
+pub fn zingolib_testutils::attribution::SendFailureAttribution::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub async fn zingolib_testutils::attribution::attribute_send_failure(local_net: &zingolib_testutils::setup_metrics::MeteredNet, client: &zingolib::lightclient::LightClient, distance_blocks: u32) -> zingolib_testutils::attribution::SendFailureAttribution
+pub async fn zingolib_testutils::attribution::failed_transaction_bytes(client: &zingolib::lightclient::LightClient) -> alloc::vec::Vec<u8>
+pub mod zingolib_testutils::chain_cache
+pub enum zingolib_testutils::chain_cache::ChainCachePolicy
+pub zingolib_testutils::chain_cache::ChainCachePolicy::Disabled
+pub zingolib_testutils::chain_cache::ChainCachePolicy::LoadRaw(std::path::PathBuf)
+pub zingolib_testutils::chain_cache::ChainCachePolicy::PerTest
+pub const zingolib_testutils::chain_cache::REGENERATE_ENV: &str
+pub async fn zingolib_testutils::chain_cache::export_raw(local_net: &zingolib_testutils::setup_metrics::MeteredNet, path: &std::path::Path)
+pub mod zingolib_testutils::observability
+pub struct zingolib_testutils::observability::FrontRecord
+impl zingolib_testutils::observability::FrontRecord
+pub fn zingolib_testutils::observability::FrontRecord::events(&self) -> alloc::vec::Vec<zingolib_testutils::observability::TapEvent>
+pub fn zingolib_testutils::observability::FrontRecord::prime(label: &'static str) -> alloc::sync::Arc<Self>
+pub fn zingolib_testutils::observability::FrontRecord::render(&self) -> alloc::string::String
+pub fn zingolib_testutils::observability::FrontRecord::summary(&self) -> alloc::string::String
+impl zcash_local_net::front::FrontObserver for zingolib_testutils::observability::FrontRecord
+pub fn zingolib_testutils::observability::FrontRecord::on_chunk(&self, event: &zcash_local_net::front::ChunkEvent)
+pub struct zingolib_testutils::observability::LinkTap
+impl zingolib_testutils::observability::LinkTap
+pub fn zingolib_testutils::observability::LinkTap::events(&self) -> alloc::vec::Vec<zingolib_testutils::observability::TapEvent>
+pub async fn zingolib_testutils::observability::LinkTap::open(label: &'static str, upstream_port: u16) -> Self
+pub fn zingolib_testutils::observability::LinkTap::port(&self) -> u16
+pub fn zingolib_testutils::observability::LinkTap::render(&self) -> alloc::string::String
+pub fn zingolib_testutils::observability::LinkTap::summary(&self) -> alloc::string::String
+impl core::ops::drop::Drop for zingolib_testutils::observability::LinkTap
+pub fn zingolib_testutils::observability::LinkTap::drop(&mut self)
+pub struct zingolib_testutils::observability::StateEvent
+pub zingolib_testutils::observability::StateEvent::at: core::time::Duration
+pub zingolib_testutils::observability::StateEvent::fingerprint: alloc::string::String
+pub struct zingolib_testutils::observability::StateWatch<O: zingolib_testutils::observability::Observable>
+impl<O: zingolib_testutils::observability::Observable> zingolib_testutils::observability::StateWatch<O>
+pub fn zingolib_testutils::observability::StateWatch<O>::elapsed(&self) -> core::time::Duration
+pub fn zingolib_testutils::observability::StateWatch<O>::events(&self) -> alloc::vec::Vec<zingolib_testutils::observability::StateEvent>
+pub fn zingolib_testutils::observability::StateWatch<O>::last(&self) -> core::option::Option<zingolib_testutils::observability::StateEvent>
+pub fn zingolib_testutils::observability::StateWatch<O>::prime(observer: O) -> Self
+pub fn zingolib_testutils::observability::StateWatch<O>::render(&self) -> alloc::string::String
+pub fn zingolib_testutils::observability::StateWatch<O>::summary(&self) -> alloc::string::String
+impl<O: zingolib_testutils::observability::Observable> core::ops::drop::Drop for zingolib_testutils::observability::StateWatch<O>
+pub fn zingolib_testutils::observability::StateWatch<O>::drop(&mut self)
+pub struct zingolib_testutils::observability::TapEvent
+pub zingolib_testutils::observability::TapEvent::at: core::time::Duration
+pub zingolib_testutils::observability::TapEvent::bytes: usize
+pub zingolib_testutils::observability::TapEvent::connection: usize
+pub zingolib_testutils::observability::TapEvent::direction: &'static str
+pub zingolib_testutils::observability::TapEvent::note: alloc::string::String
+pub struct zingolib_testutils::observability::WalletState
+pub zingolib_testutils::observability::WalletState::label: &'static str
+pub zingolib_testutils::observability::WalletState::wallet: alloc::sync::Arc<tokio::sync::rwlock::RwLock<zingolib::wallet::LightWallet>>
+impl zingolib_testutils::observability::Observable for zingolib_testutils::observability::WalletState
+pub const zingolib_testutils::observability::WalletState::NODE: &'static str
+pub const zingolib_testutils::observability::WalletState::POLL_INTERVAL: core::time::Duration
+pub async fn zingolib_testutils::observability::WalletState::fingerprint(&self) -> core::option::Option<alloc::string::String>
+pub struct zingolib_testutils::observability::ZainodState
+pub zingolib_testutils::observability::ZainodState::uri: http::uri::Uri
+impl zingolib_testutils::observability::Observable for zingolib_testutils::observability::ZainodState
+pub const zingolib_testutils::observability::ZainodState::NODE: &'static str
+pub const zingolib_testutils::observability::ZainodState::POLL_INTERVAL: core::time::Duration
+pub async fn zingolib_testutils::observability::ZainodState::fingerprint(&self) -> core::option::Option<alloc::string::String>
+pub struct zingolib_testutils::observability::ZebradState
+pub zingolib_testutils::observability::ZebradState::rpc_port: u16
+impl zingolib_testutils::observability::Observable for zingolib_testutils::observability::ZebradState
+pub const zingolib_testutils::observability::ZebradState::NODE: &'static str
+pub async fn zingolib_testutils::observability::ZebradState::fingerprint(&self) -> core::option::Option<alloc::string::String>
+pub trait zingolib_testutils::observability::Observable: core::marker::Send + 'static
+pub const zingolib_testutils::observability::Observable::NODE: &'static str
+pub const zingolib_testutils::observability::Observable::POLL_INTERVAL: core::time::Duration
+pub fn zingolib_testutils::observability::Observable::fingerprint(&self) -> impl core::future::future::Future<Output = core::option::Option<alloc::string::String>> + core::marker::Send
+impl zingolib_testutils::observability::Observable for zingolib_testutils::observability::WalletState
+pub const zingolib_testutils::observability::WalletState::NODE: &'static str
+pub const zingolib_testutils::observability::WalletState::POLL_INTERVAL: core::time::Duration
+pub async fn zingolib_testutils::observability::WalletState::fingerprint(&self) -> core::option::Option<alloc::string::String>
+impl zingolib_testutils::observability::Observable for zingolib_testutils::observability::ZainodState
+pub const zingolib_testutils::observability::ZainodState::NODE: &'static str
+pub const zingolib_testutils::observability::ZainodState::POLL_INTERVAL: core::time::Duration
+pub async fn zingolib_testutils::observability::ZainodState::fingerprint(&self) -> core::option::Option<alloc::string::String>
+impl zingolib_testutils::observability::Observable for zingolib_testutils::observability::ZebradState
+pub const zingolib_testutils::observability::ZebradState::NODE: &'static str
+pub async fn zingolib_testutils::observability::ZebradState::fingerprint(&self) -> core::option::Option<alloc::string::String>
+pub mod zingolib_testutils::scenarios
+pub mod zingolib_testutils::scenarios::network_combo
+pub type zingolib_testutils::scenarios::network_combo::DefaultIndexer = zcash_local_net::indexer::zainod::Zainod
+pub type zingolib_testutils::scenarios::network_combo::DefaultValidator = zcash_local_net::validator::zebrad::Zebrad
+pub enum zingolib_testutils::scenarios::ChainCachePolicy
+pub zingolib_testutils::scenarios::ChainCachePolicy::Disabled
+pub zingolib_testutils::scenarios::ChainCachePolicy::LoadRaw(std::path::PathBuf)
+pub zingolib_testutils::scenarios::ChainCachePolicy::PerTest
+pub struct zingolib_testutils::scenarios::ClientBuilder
+pub zingolib_testutils::scenarios::ClientBuilder::server_id: http::uri::Uri
+pub zingolib_testutils::scenarios::ClientBuilder::zingo_datadir: tempfile::dir::TempDir
+impl zingolib_testutils::scenarios::ClientBuilder
+pub async fn zingolib_testutils::scenarios::ClientBuilder::build_client(&mut self, wallet_config: zingolib::config::WalletConfig, overwrite: bool) -> zingolib::lightclient::LightClient
+pub async fn zingolib_testutils::scenarios::ClientBuilder::build_faucet(&mut self, overwrite: bool) -> zingolib::lightclient::LightClient
+pub fn zingolib_testutils::scenarios::ClientBuilder::create_clientconfig(&self, conf_path: std::path::PathBuf, configured_activation_heights: zingo_common_components::protocol::ActivationHeights, wallet_config: zingolib::config::WalletConfig) -> zingolib::config::ClientConfig
+pub fn zingolib_testutils::scenarios::ClientBuilder::make_unique_data_dir_and_create_config(&mut self, wallet_config: zingolib::config::WalletConfig) -> zingolib::config::ClientConfig
+pub fn zingolib_testutils::scenarios::ClientBuilder::new(server_id: http::uri::Uri, zingo_datadir: tempfile::dir::TempDir, activation_heights: zingo_common_components::protocol::ActivationHeights) -> Self
+pub const zingolib_testutils::scenarios::BLOCK_ONE_SAPLING_COINBASE: u64
+pub const zingolib_testutils::scenarios::DEFERRED_STREAM_SKIM: u64
+pub const zingolib_testutils::scenarios::FUNDED_FAUCET_SETUP_HEIGHT: u32
+pub const zingolib_testutils::scenarios::FUND_OFFLOAD_AMOUNT: u64
+pub const zingolib_testutils::scenarios::IRONWOOD_COINBASE_START_HEIGHT: u32
+pub const zingolib_testutils::scenarios::ORCHARD_COINBASE_START_HEIGHT: u32
+pub const zingolib_testutils::scenarios::POST_STREAM_BLOCK_REWARD: u64
+pub trait zingolib_testutils::scenarios::IndexerConvergence
+pub fn zingolib_testutils::scenarios::IndexerConvergence::converge(&self, target: u32) -> impl core::future::future::Future<Output = ()> + core::marker::Send
+impl<V> zingolib_testutils::scenarios::IndexerConvergence for zcash_local_net::LocalNet<V, zcash_local_net::indexer::zainod::Zainod> where V: zcash_local_net::validator::Validator + zcash_local_net::logs::LogsToStdoutAndStderr + core::marker::Send, <V as zcash_local_net::process::Process>::Config: core::marker::Send
+pub async fn zcash_local_net::LocalNet<V, zcash_local_net::indexer::zainod::Zainod>::converge(&self, target: u32)
+pub async fn zingolib_testutils::scenarios::custom_clients(mine_to_pool: zcash_protocol::PoolType, configured_activation_heights: zingo_common_components::protocol::ActivationHeights, cache: zingolib_testutils::chain_cache::ChainCachePolicy) -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib_testutils::scenarios::ClientBuilder)
+pub async fn zingolib_testutils::scenarios::custom_clients_default() -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib_testutils::scenarios::ClientBuilder)
+pub fn zingolib_testutils::scenarios::default_net_activation_heights() -> zingo_consensus::ActivationHeights
+pub fn zingolib_testutils::scenarios::default_test_activation_heights() -> zingo_common_components::protocol::ActivationHeights
+pub async fn zingolib_testutils::scenarios::faucet(mine_to_pool: zcash_protocol::PoolType, configured_activation_heights: zingo_common_components::protocol::ActivationHeights, cache: zingolib_testutils::chain_cache::ChainCachePolicy) -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient)
+pub async fn zingolib_testutils::scenarios::faucet_default() -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient)
+pub async fn zingolib_testutils::scenarios::faucet_funded_recipient(orchard_funds: core::option::Option<u64>, sapling_funds: core::option::Option<u64>, transparent_funds: core::option::Option<u64>, mine_to_pool: zcash_protocol::PoolType, configured_activation_heights: zingo_common_components::protocol::ActivationHeights, cache: zingolib_testutils::chain_cache::ChainCachePolicy) -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient, zingolib::lightclient::LightClient, core::option::Option<alloc::string::String>, core::option::Option<alloc::string::String>, core::option::Option<alloc::string::String>)
+pub async fn zingolib_testutils::scenarios::faucet_funded_recipient_default(orchard_funds: u64) -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient, zingolib::lightclient::LightClient, alloc::string::String)
+pub async fn zingolib_testutils::scenarios::faucet_recipient(mine_to_pool: zcash_protocol::PoolType, configured_activation_heights: zingo_common_components::protocol::ActivationHeights, cache: zingolib_testutils::chain_cache::ChainCachePolicy) -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient, zingolib::lightclient::LightClient)
+pub async fn zingolib_testutils::scenarios::faucet_recipient_default() -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient, zingolib::lightclient::LightClient)
+pub const fn zingolib_testutils::scenarios::funded_faucet_ironwood_balance() -> u64
+pub async fn zingolib_testutils::scenarios::funded_orchard_mobileclient(value: u64) -> zcash_local_net::LocalNet<zingolib_testutils::scenarios::network_combo::DefaultValidator, zingolib_testutils::scenarios::network_combo::DefaultIndexer>
+pub async fn zingolib_testutils::scenarios::funded_orchard_sapling_transparent_shielded_mobileclient(value: u64) -> zcash_local_net::LocalNet<zingolib_testutils::scenarios::network_combo::DefaultValidator, zingolib_testutils::scenarios::network_combo::DefaultIndexer>
+pub async fn zingolib_testutils::scenarios::funded_orchard_with_3_txs_mobileclient(value: u64) -> zcash_local_net::LocalNet<zingolib_testutils::scenarios::network_combo::DefaultValidator, zingolib_testutils::scenarios::network_combo::DefaultIndexer>
+pub async fn zingolib_testutils::scenarios::funded_transparent_mobileclient(value: u64) -> zcash_local_net::LocalNet<zingolib_testutils::scenarios::network_combo::DefaultValidator, zingolib_testutils::scenarios::network_combo::DefaultIndexer>
+pub async fn zingolib_testutils::scenarios::generate_n_blocks_return_new_height<V, I>(local_net: &zcash_local_net::LocalNet<V, I>, n: u32) -> u32 where V: zcash_local_net::validator::Validator + zcash_local_net::logs::LogsToStdoutAndStderr + core::marker::Send, <V as zcash_local_net::process::Process>::Config: core::marker::Send, I: zcash_local_net::indexer::Indexer + zcash_local_net::logs::LogsToStdoutAndStderr, <I as zcash_local_net::process::Process>::Config: core::marker::Send
+pub async fn zingolib_testutils::scenarios::increase_height_and_wait_for_client<V, I>(local_net: &zcash_local_net::LocalNet<V, I>, client: &mut zingolib::lightclient::LightClient, n: u32) -> core::result::Result<(), zingolib::lightclient::error::LightClientError> where V: zcash_local_net::validator::Validator + zcash_local_net::logs::LogsToStdoutAndStderr + core::marker::Send, <V as zcash_local_net::process::Process>::Config: core::marker::Send, I: zcash_local_net::indexer::Indexer + zcash_local_net::logs::LogsToStdoutAndStderr, <I as zcash_local_net::process::Process>::Config: core::marker::Send, zcash_local_net::LocalNet<V, I>: zingolib_testutils::scenarios::IndexerConvergence
+pub async fn zingolib_testutils::scenarios::launch_test<V, I>(indexer_listen_port: core::option::Option<portpicker::Port>, mine_to_pool: zcash_protocol::PoolType, configured_activation_heights: zingo_common_components::protocol::ActivationHeights, chain_cache: core::option::Option<std::path::PathBuf>) -> zcash_local_net::LocalNet<V, I> where V: zcash_local_net::validator::Validator + zcash_local_net::logs::LogsToStdoutAndStderr + core::marker::Send, <V as zcash_local_net::process::Process>::Config: core::marker::Send + zcash_local_net::validator::ValidatorConfig + core::default::Default, I: zcash_local_net::indexer::Indexer + zcash_local_net::logs::LogsToStdoutAndStderr, <I as zcash_local_net::process::Process>::Config: core::marker::Send + zcash_local_net::indexer::IndexerConfig + core::default::Default
+pub const fn zingolib_testutils::scenarios::mined_block_rewards_total(count: u64) -> u64
+pub fn zingolib_testutils::scenarios::mobileclient_activation_heights() -> zingo_common_components::protocol::ActivationHeights
+pub const fn zingolib_testutils::scenarios::orchard_coinbase_total(tip: u32) -> u64
+pub async fn zingolib_testutils::scenarios::send_and_bump<V, I>(local_net: &zcash_local_net::LocalNet<V, I>, sender: &mut zingolib::lightclient::LightClient, receivers: alloc::vec::Vec<(&str, u64, core::option::Option<&str>)>) -> nonempty::NonEmpty<zcash_protocol::txid::TxId> where V: zcash_local_net::validator::Validator + zcash_local_net::logs::LogsToStdoutAndStderr + core::marker::Send, <V as zcash_local_net::process::Process>::Config: core::marker::Send, I: zcash_local_net::indexer::Indexer + zcash_local_net::logs::LogsToStdoutAndStderr, <I as zcash_local_net::process::Process>::Config: core::marker::Send, zcash_local_net::LocalNet<V, I>: zingolib_testutils::scenarios::IndexerConvergence
+pub async fn zingolib_testutils::scenarios::send_value_between_clients_and_sync<V, I>(local_net: &zcash_local_net::LocalNet<V, I>, sender: &mut zingolib::lightclient::LightClient, recipient: &mut zingolib::lightclient::LightClient, value: u64, address_pool: zcash_protocol::PoolType) -> core::result::Result<alloc::string::String, zingolib::lightclient::error::LightClientError> where V: zcash_local_net::validator::Validator + zcash_local_net::logs::LogsToStdoutAndStderr + core::marker::Send, <V as zcash_local_net::process::Process>::Config: core::marker::Send, I: zcash_local_net::indexer::Indexer + zcash_local_net::logs::LogsToStdoutAndStderr, <I as zcash_local_net::process::Process>::Config: core::marker::Send, zcash_local_net::LocalNet<V, I>: zingolib_testutils::scenarios::IndexerConvergence
+pub async fn zingolib_testutils::scenarios::sync_client_to_validator_tip<V, I>(local_net: &zcash_local_net::LocalNet<V, I>, client: &mut zingolib::lightclient::LightClient) where I: zcash_local_net::indexer::Indexer + zcash_local_net::logs::LogsToStdoutAndStderr, V: zcash_local_net::validator::Validator + zcash_local_net::logs::LogsToStdoutAndStderr + core::marker::Send, <I as zcash_local_net::process::Process>::Config: core::marker::Send, <V as zcash_local_net::process::Process>::Config: core::marker::Send, zcash_local_net::LocalNet<V, I>: zingolib_testutils::scenarios::IndexerConvergence
+pub async fn zingolib_testutils::scenarios::unfunded_client(configured_activation_heights: zingo_common_components::protocol::ActivationHeights, cache: zingolib_testutils::chain_cache::ChainCachePolicy) -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient)
+pub async fn zingolib_testutils::scenarios::unfunded_client_default() -> (zingolib_testutils::setup_metrics::MeteredNet, zingolib::lightclient::LightClient)
+pub async fn zingolib_testutils::scenarios::unfunded_mobileclient() -> zcash_local_net::LocalNet<zingolib_testutils::scenarios::network_combo::DefaultValidator, zingolib_testutils::scenarios::network_combo::DefaultIndexer>
+pub fn zingolib_testutils::scenarios::wallet_activation_heights(heights: &zingo_consensus::ActivationHeights) -> zingo_common_components::protocol::ActivationHeights
+pub mod zingolib_testutils::setup_metrics
+pub struct zingolib_testutils::setup_metrics::MeteredNet
+impl zingolib_testutils::setup_metrics::MeteredNet
+pub fn zingolib_testutils::setup_metrics::MeteredNet::mark_setup_complete(&mut self, scenario: &'static str)
+pub fn zingolib_testutils::setup_metrics::MeteredNet::new(net: zcash_local_net::LocalNet<zingolib_testutils::scenarios::network_combo::DefaultValidator, zingolib_testutils::scenarios::network_combo::DefaultIndexer>, zebrad_front: alloc::sync::Arc<zingolib_testutils::observability::FrontRecord>, zainod_front: alloc::sync::Arc<zingolib_testutils::observability::FrontRecord>, setup_started: std::time::Instant) -> Self
+pub fn zingolib_testutils::setup_metrics::MeteredNet::zainod_front(&self) -> &zingolib_testutils::observability::FrontRecord
+pub fn zingolib_testutils::setup_metrics::MeteredNet::zainod_watch(&self) -> &zingolib_testutils::observability::StateWatch<zingolib_testutils::observability::ZainodState>
+pub fn zingolib_testutils::setup_metrics::MeteredNet::zebrad_front(&self) -> &zingolib_testutils::observability::FrontRecord
+pub fn zingolib_testutils::setup_metrics::MeteredNet::zebrad_watch(&self) -> &zingolib_testutils::observability::StateWatch<zingolib_testutils::observability::ZebradState>
+impl core::ops::deref::Deref for zingolib_testutils::setup_metrics::MeteredNet
+pub type zingolib_testutils::setup_metrics::MeteredNet::Target = zcash_local_net::LocalNet<zcash_local_net::validator::zebrad::Zebrad, zcash_local_net::indexer::zainod::Zainod>
+pub fn zingolib_testutils::setup_metrics::MeteredNet::deref(&self) -> &Self::Target
+impl core::ops::deref::DerefMut for zingolib_testutils::setup_metrics::MeteredNet
+pub fn zingolib_testutils::setup_metrics::MeteredNet::deref_mut(&mut self) -> &mut Self::Target
+impl core::ops::drop::Drop for zingolib_testutils::setup_metrics::MeteredNet
+pub fn zingolib_testutils::setup_metrics::MeteredNet::drop(&mut self)
+pub mod zingolib_testutils::validator_rpc
+pub enum zingolib_testutils::validator_rpc::RawTransactionVerdict
+pub zingolib_testutils::validator_rpc::RawTransactionVerdict::Accepted(alloc::string::String)
+pub zingolib_testutils::validator_rpc::RawTransactionVerdict::Rejected(alloc::string::String)
+pub struct zingolib_testutils::validator_rpc::LedgerEntry
+pub zingolib_testutils::validator_rpc::LedgerEntry::at: std::time::Instant
+pub zingolib_testutils::validator_rpc::LedgerEntry::method: alloc::string::String
+pub async fn zingolib_testutils::validator_rpc::get_block_hex(rpc_port: u16, height: u32) -> alloc::string::String
+pub async fn zingolib_testutils::validator_rpc::get_raw_mempool(rpc_port: u16) -> alloc::vec::Vec<alloc::string::String>
+pub fn zingolib_testutils::validator_rpc::is_write_method(method: &str) -> bool
+pub fn zingolib_testutils::validator_rpc::ledger_snapshot() -> alloc::vec::Vec<zingolib_testutils::validator_rpc::LedgerEntry>
+pub async fn zingolib_testutils::validator_rpc::send_raw_transaction(rpc_port: u16, transaction_bytes: &[u8]) -> zingolib_testutils::validator_rpc::RawTransactionVerdict
+pub async fn zingolib_testutils::validator_rpc::submit_block(rpc_port: u16, block_hex: &str)
+pub async fn zingolib_testutils::validator_rpc::try_get_chain_info(rpc_port: u16) -> core::option::Option<(u32, alloc::string::String)>
+pub async fn zingolib_testutils::validator_rpc::try_get_peer_count(rpc_port: u16) -> core::option::Option<usize>

--- a/tools/workbench/src/bin/decent-exposure.rs
+++ b/tools/workbench/src/bin/decent-exposure.rs
@@ -1,0 +1,285 @@
+//! The `decent_exposure` CI gate: enforce maximum Rust item privacy across
+//! every package in the repository.
+//!
+//! Three layers run in order, and a failing layer stops the run before the
+//! next begins:
+//!
+//! 1. rustc's `unreachable_pub` lint, at deny: a `pub` item the crate root
+//!    does not re-export must shrink to `pub(crate)` or below, so nothing is
+//!    public by accident.
+//! 2. rustc's `missing_docs` lint, at deny: every item that earns `pub`
+//!    carries documentation, so publicity always costs a written sentence.
+//! 3. `cargo public-api`: each package's public surface must match its
+//!    checked-in golden under `tools/workbench/goldens/public-api/`. A surface
+//!    change lands by regenerating the goldens with `--bless` and reviewing
+//!    the diff like any other code.
+//!
+//! The package list is derived rather than declared: the root workspace
+//! members are parsed from `<root>/Cargo.toml`, and the two standalone
+//! workspaces (`zingo-netutils`, `tools/workbench`) are appended. A package
+//! added to the root workspace is therefore gated automatically. Each lint
+//! layer runs against the package's lib target, where the public surface
+//! lives; goldens pin the default-feature surface (the `nym` surface rides
+//! the nym-feature job's `-D warnings` clippy instead).
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+use workbench::{read, repo_root, run};
+
+/// Workspaces that resolve outside the root lockfile. Their packages are
+/// gated exactly like root members but addressed by manifest path.
+const STANDALONE_WORKSPACES: &[&str] = &["zingo-netutils", "tools/workbench"];
+
+fn main() {
+    let bless = std::env::args().any(|arg| arg == "--bless");
+    run(
+        "decent-exposure",
+        || {
+            let root = repo_root()?;
+            let packages = packages(&root)?;
+            rustc_lint_layer(&root, &packages, "unreachable_pub")?;
+            rustc_lint_layer(&root, &packages, "missing_docs")?;
+            public_api_layer(&root, &packages, bless)
+        },
+        |()| println!("decent-exposure: every package is minimally public, documented, and pinned"),
+    )
+}
+
+/// One gated package and how cargo addresses it from the repo root.
+struct Package {
+    /// The `[package] name`, read from the member's own manifest.
+    name: String,
+    /// `Some(dir)` for a standalone-workspace package (own lockfile),
+    /// addressed with `--manifest-path`; `None` for a root member, addressed
+    /// with `-p`.
+    standalone_dir: Option<&'static str>,
+}
+
+impl Package {
+    /// Start a `cargo <subcommand>` invocation addressed at this package.
+    fn cargo(&self, root: &Path, subcommand: &str) -> Command {
+        let mut cmd = Command::new("cargo");
+        cmd.current_dir(root);
+        cmd.arg(subcommand);
+        match self.standalone_dir {
+            Some(dir) => {
+                cmd.arg("--manifest-path");
+                cmd.arg(format!("{dir}/Cargo.toml"));
+            }
+            None => {
+                cmd.args(["-p", &self.name]);
+            }
+        }
+        cmd
+    }
+}
+
+/// Every package in the repository: root workspace members plus the
+/// standalone workspaces.
+fn packages(root: &Path) -> Result<Vec<Package>, Vec<String>> {
+    let root_manifest = read(&root.join("Cargo.toml"))?;
+    let mut packages = Vec::new();
+    for dir in member_dirs(&root_manifest) {
+        packages.push(Package {
+            name: package_name(root, &dir)?,
+            standalone_dir: None,
+        });
+    }
+    if packages.is_empty() {
+        return Err(vec![
+            "no members parsed from the root Cargo.toml".to_string()
+        ]);
+    }
+    for dir in STANDALONE_WORKSPACES {
+        packages.push(Package {
+            name: package_name(root, dir)?,
+            standalone_dir: Some(dir),
+        });
+    }
+    Ok(packages)
+}
+
+/// Member directories of the root workspace, from its multi-line
+/// `members = [ ... ]` array. The repo writes one quoted directory per line;
+/// glob members would need a richer parser and are rejected by
+/// [`package_name`] failing to find their manifest.
+fn member_dirs(root_manifest: &str) -> Vec<String> {
+    let mut dirs = Vec::new();
+    let mut in_members = false;
+    for line in root_manifest.lines() {
+        let line = line.trim();
+        if !in_members {
+            in_members = line
+                .strip_prefix("members")
+                .map(|rest| rest.trim_start().starts_with('='))
+                .unwrap_or(false);
+            continue;
+        }
+        if line.starts_with(']') {
+            break;
+        }
+        if let Some(dir) = quoted_value(line) {
+            dirs.push(dir);
+        }
+    }
+    dirs
+}
+
+/// The first double-quoted string in a line: `"zingolib",` → `zingolib`.
+fn quoted_value(line: &str) -> Option<String> {
+    let start = line.find('"')? + 1;
+    let end = start + line[start..].find('"')?;
+    Some(line[start..end].to_string())
+}
+
+/// The `[package] name` of the crate at `<root>/<dir>/Cargo.toml`. The first
+/// `name = "..."` assignment wins, which is the `[package]` one in every
+/// manifest here (`[[bin]]` tables, when present, come later).
+fn package_name(root: &Path, dir: &str) -> Result<String, Vec<String>> {
+    let path = root.join(dir).join("Cargo.toml");
+    let manifest = read(&path)?;
+    manifest
+        .lines()
+        .find_map(|line| {
+            let rest = line.trim().strip_prefix("name")?.trim_start();
+            quoted_value(rest.strip_prefix('=')?)
+        })
+        .ok_or_else(|| vec![format!("no package name in {}", path.display())])
+}
+
+/// Run one rustc lint at deny over every package's lib target. Every package
+/// is checked before the layer fails, so one CI run shows the layer's whole
+/// backlog. Findings stream straight to the log.
+fn rustc_lint_layer(root: &Path, packages: &[Package], lint: &str) -> Result<(), Vec<String>> {
+    println!("== decent-exposure layer: -D {lint} ==");
+    let mut failed = Vec::new();
+    for package in packages {
+        let mut cmd = package.cargo(root, "rustc");
+        cmd.args(["--lib", "--profile", "check", "--", "-D", lint]);
+        let status = cmd
+            .status()
+            .map_err(|e| vec![format!("failed to run cargo rustc: {e}")])?;
+        if !status.success() {
+            failed.push(package.name.clone());
+        }
+    }
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(vec![format!("-D {lint} failed in: {}", failed.join(", "))])
+    }
+}
+
+/// Diff every package's public API against its golden, or rewrite the goldens
+/// under `--bless`. Runs `cargo public-api -sss` (blanket, auto-trait, and
+/// auto-derived impls omitted) so a golden line is always a deliberate item.
+fn public_api_layer(root: &Path, packages: &[Package], bless: bool) -> Result<(), Vec<String>> {
+    println!("== decent-exposure layer: public API goldens ==");
+    let goldens_dir = root.join("tools/workbench/goldens/public-api");
+    let mut diagnostics = Vec::new();
+    for package in packages {
+        let mut cmd = package.cargo(root, "public-api");
+        cmd.args(["--color", "never", "-sss"]);
+        let output = cmd
+            .output()
+            .map_err(|e| vec![format!("failed to run cargo public-api: {e}")])?;
+        if !output.status.success() {
+            diagnostics.push(format!(
+                "{}: cargo public-api failed:\n{}",
+                package.name,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+            continue;
+        }
+        let current = String::from_utf8(output.stdout)
+            .map_err(|e| vec![format!("{}: output not utf-8: {e}", package.name)])?;
+        let golden_path = goldens_dir.join(format!("{}.txt", package.name));
+        if bless {
+            std::fs::create_dir_all(&goldens_dir)
+                .map_err(|e| vec![format!("cannot create {}: {e}", goldens_dir.display())])?;
+            std::fs::write(&golden_path, &current)
+                .map_err(|e| vec![format!("cannot write {}: {e}", golden_path.display())])?;
+            println!("blessed {}", golden_path.display());
+            continue;
+        }
+        match read(&golden_path) {
+            Err(_) => diagnostics.push(format!(
+                "{}: no golden at {}; run `cargo run --manifest-path \
+                 tools/workbench/Cargo.toml --bin decent-exposure -- --bless` \
+                 and commit the result",
+                package.name,
+                golden_path.display()
+            )),
+            Ok(golden) if golden != current => {
+                diagnostics.extend(surface_diff(&package.name, &golden, &current));
+            }
+            Ok(_) => {}
+        }
+    }
+    if diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(diagnostics)
+    }
+}
+
+/// Order-insensitive line diff of a package's public surface: which items
+/// left the golden and which joined it, each on its own diagnostic line.
+fn surface_diff(name: &str, golden: &str, current: &str) -> Vec<String> {
+    let golden_lines: BTreeSet<&str> = golden.lines().collect();
+    let current_lines: BTreeSet<&str> = current.lines().collect();
+    let mut lines = vec![format!(
+        "{name}: public API differs from its golden; if intended, re-bless and review"
+    )];
+    for gone in golden_lines.difference(&current_lines) {
+        lines.push(format!("{name}: - {gone}"));
+    }
+    for joined in current_lines.difference(&golden_lines) {
+        lines.push(format!("{name}: + {joined}"));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn member_dirs_reads_the_multiline_array() {
+        let manifest = r#"
+[workspace]
+members = [
+    "libtonode-tests",
+    "zingolib",
+]
+# trailing comment
+"#;
+        assert_eq!(member_dirs(manifest), vec!["libtonode-tests", "zingolib"]);
+    }
+
+    #[test]
+    fn member_dirs_ignores_manifests_without_members() {
+        assert!(member_dirs("[package]\nname = \"solo\"\n").is_empty());
+    }
+
+    #[test]
+    fn quoted_value_takes_the_first_quoted_string() {
+        assert_eq!(quoted_value("\"zingolib\",").as_deref(), Some("zingolib"));
+        assert_eq!(quoted_value("no quotes"), None);
+    }
+
+    #[test]
+    fn surface_diff_reports_departures_and_arrivals() {
+        let diff = surface_diff(
+            "pkg",
+            "pub fn a()\npub fn b()\n",
+            "pub fn b()\npub fn c()\n",
+        );
+        assert!(diff[1].contains("- pub fn a()"));
+        assert!(diff[2].contains("+ pub fn c()"));
+    }
+}

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -34,7 +34,7 @@ use zingolib::wallet::keys::WalletAddressRef;
 use zingolib::wallet::keys::unified::{ReceiverSelection, UnifiedKeyStore};
 use zingolib::wallet::migration::{self, MigrationPhase};
 
-pub static RT: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
+pub(crate) static RT: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
 
 /// The cadence of the transmit heartbeat. A transmission can legitimately run
 /// for minutes (mixnet round trips, per-arm retries, serially gated fan-out
@@ -82,7 +82,7 @@ async fn with_transmit_heartbeat<T>(
 /// site that renders these to prose for string frontends; typed
 /// frontends consume them directly via `do_user_command_result`.
 #[derive(Debug, thiserror::Error)]
-pub enum CommandError {
+enum CommandError {
     #[error(transparent)]
     Migration(#[from] MigrationCommandError),
     #[error(transparent)]
@@ -96,7 +96,7 @@ pub enum CommandError {
 }
 
 /// This command interface is used both by cli and also consumers.
-pub trait Command {
+trait Command {
     /// display command help (in cli)
     fn help(&self) -> &'static str;
 
@@ -117,7 +117,7 @@ pub trait Command {
 /// This is used for commands like `help` that must run before the wallet
 /// is loaded — for example when the user passes `help` as the COMMAND
 /// argument on the command line.
-pub trait ShortCircuitedCommand {
+pub(crate) trait ShortCircuitedCommand {
     /// Execute the command without a [`LightClient`], returning the
     /// output string that will be printed to the console.
     fn exec_without_lc(args: Vec<String>) -> String;
@@ -574,7 +574,7 @@ impl Command for ClearCommand {
 }
 
 /// Lists all available commands or shows detailed help for a specific command.
-pub struct HelpCommand {}
+pub(crate) struct HelpCommand {}
 impl Command for HelpCommand {
     fn help(&self) -> &'static str {
         indoc! {r#"
@@ -799,7 +799,7 @@ fn bundled_proxy_path() -> Option<String> {
 /// Typed failure of the `nym` command family. Each variant exists only in
 /// the build that can produce it, so the enum's shape follows the feature.
 #[derive(Debug, thiserror::Error)]
-pub enum NymCommandError {
+enum NymCommandError {
     #[cfg(feature = "nym")]
     #[error(
         "unknown nym subcommand '{0}'. Use: nym status | nym on [path] | nym off | \
@@ -2617,7 +2617,7 @@ fn render_migration_phase(phase: &MigrationPhase) -> String {
 /// message is byte-identical to the in-band string it replaced, so no
 /// frontend observes the change.
 #[derive(Debug, thiserror::Error)]
-pub enum MigrationCommandError {
+enum MigrationCommandError {
     #[error("migrate command expects no arguments. Type \"help migrate\" for usage.")]
     UnexpectedArguments,
     #[error("migration command expects a sub-command. Type \"help migration\" for usage.")]
@@ -2923,7 +2923,7 @@ impl Command for MigrationCommand {
 }
 
 /// Commands that do not require a wallet connection.
-pub fn get_standalone_commands() -> HashMap<&'static str, Box<dyn Command>> {
+fn get_standalone_commands() -> HashMap<&'static str, Box<dyn Command>> {
     vec![
         ("help", Box::new(HelpCommand {}) as Box<dyn Command>),
         ("parse_address", Box::new(ParseAddressCommand {})),
@@ -2935,7 +2935,7 @@ pub fn get_standalone_commands() -> HashMap<&'static str, Box<dyn Command>> {
 }
 
 /// Commands that require a wallet connection.
-pub fn get_wallet_commands() -> HashMap<&'static str, Box<dyn Command>> {
+fn get_wallet_commands() -> HashMap<&'static str, Box<dyn Command>> {
     vec![
         (
             "addresses",
@@ -2996,7 +2996,7 @@ pub fn get_wallet_commands() -> HashMap<&'static str, Box<dyn Command>> {
 }
 
 /// All commands (standalone + wallet). Used for dispatch and `help <command>`.
-pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
+fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
     let mut all = get_standalone_commands();
     all.extend(get_wallet_commands());
     all
@@ -3007,7 +3007,7 @@ pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
 ///
 /// An unknown command returns its "Unknown command" prose via `Ok`, mirroring
 /// the string entry point's historical behavior of not treating it as an error.
-pub fn do_user_command_result(
+fn do_user_command_result(
     cmd: &str,
     args: &[&str],
     lightclient: &mut LightClient,
@@ -3025,7 +3025,7 @@ pub fn do_user_command_result(
 /// Returns the command's output string, or an "Unknown command" message
 /// if no command with the given name exists. This is the single site that
 /// renders [`CommandError`] to prose for string frontends.
-pub fn do_user_command(cmd: &str, args: &[&str], lightclient: &mut LightClient) -> String {
+pub(crate) fn do_user_command(cmd: &str, args: &[&str], lightclient: &mut LightClient) -> String {
     match do_user_command_result(cmd, args, lightclient) {
         Ok(output) => output,
         Err(e) => format!("Error: {e}"),

--- a/zingo-cli/src/version.rs
+++ b/zingo-cli/src/version.rs
@@ -2,4 +2,4 @@
 
 /// The current version of the `zingo-cli` crate, used in `--version` output
 /// and the clap `Command` definition.
-pub const VERSION: &str = "0.1.1";
+pub(crate) const VERSION: &str = "0.1.1";

--- a/zingo-netutils/src/error.rs
+++ b/zingo-netutils/src/error.rs
@@ -21,12 +21,16 @@
 /// ```
 #[derive(Debug, thiserror::Error)]
 pub enum GetClientError {
+    /// The URI carries no scheme, or a scheme other than `http` or `https`.
     #[error("bad uri: invalid scheme")]
     InvalidScheme,
 
+    /// The URI carries no authority, so it names no host to connect to.
     #[error("bad uri: invalid authority")]
     InvalidAuthority,
 
+    /// The transport layer failed while building the endpoint, configuring
+    /// TLS, or connecting to the indexer.
     #[error(transparent)]
     Transport(#[from] tonic::transport::Error),
 }

--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -273,6 +273,17 @@ pub struct GrpcIndexer {
 }
 
 impl GrpcIndexer {
+    /// Connects to the indexer at `uri` and returns a client ready to issue
+    /// RPCs.
+    ///
+    /// The URI must carry an `http` or `https` scheme and an authority.
+    /// Anything else fails with [`GetClientError::InvalidScheme`] or
+    /// [`GetClientError::InvalidAuthority`] before the network is touched.
+    /// An `https` URI negotiates TLS with this crate's client configuration.
+    ///
+    /// The channel connects eagerly, so an unreachable indexer fails here
+    /// rather than at the first RPC. Use [`Self::new_lazy`] to defer the
+    /// connection to first use.
     pub async fn new(uri: http::Uri) -> Result<Self, GetClientError> {
         let scheme = uri
             .scheme_str()

--- a/zingolib/src/wallet/legacy.rs
+++ b/zingolib/src/wallet/legacy.rs
@@ -30,7 +30,7 @@ use super::{keys::legacy::WalletCapability, traits::ReadableWriteable};
 
 /// TODO: Add Doc Comment Here!
 #[derive(Clone, PartialEq)]
-pub struct BlockData {
+pub(crate) struct BlockData {
     /// TODO: Add Doc Comment Here!
     pub(crate) ecb: Vec<u8>,
     /// TODO: Add Doc Comment Here!
@@ -53,7 +53,7 @@ impl BlockData {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+    pub(crate) fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let height = reader.read_i32::<LittleEndian>()? as u64;
 
         let mut hash_bytes = [0; 32];
@@ -84,19 +84,19 @@ impl BlockData {
 /// `HashMap` of all transactions in a wallet, keyed by txid.
 /// Note that the parent is expected to hold a `RwLock`, so we will assume that all accesses to
 /// this struct are threadsafe/locked properly.
-pub struct TxMap {
+pub(crate) struct TxMap {
     /// TODO: Doc-comment!
-    pub transaction_records_by_id: TransactionRecordsById,
+    pub(crate) transaction_records_by_id: TransactionRecordsById,
 }
 
 impl TxMap {
     /// TODO: Doc-comment!
-    pub fn serialized_version() -> u64 {
+    fn serialized_version() -> u64 {
         23
     }
 
     /// TODO: Doc-comment!
-    pub fn read_old<R: Read>(
+    pub(crate) fn read_old<R: Read>(
         mut reader: R,
         wallet_capability: &WalletCapability,
     ) -> io::Result<Self> {
@@ -154,7 +154,10 @@ impl TxMap {
 
     /// TODO: Doc-comment!
     #[allow(unused_assignments)]
-    pub fn read<R: Read>(mut reader: R, wallet_capability: &WalletCapability) -> io::Result<Self> {
+    pub(crate) fn read<R: Read>(
+        mut reader: R,
+        wallet_capability: &WalletCapability,
+    ) -> io::Result<Self> {
         let version = reader.read_u64::<LittleEndian>()?;
         if version > Self::serialized_version() {
             return Err(io::Error::new(
@@ -226,18 +229,18 @@ impl TxMap {
 }
 
 /// A convenience wrapper, to impl behavior on.
-pub struct TransactionRecordsById(pub HashMap<TxId, TransactionRecord>);
+pub(crate) struct TransactionRecordsById(pub(crate) HashMap<TxId, TransactionRecord>);
 
 impl TransactionRecordsById {
     /// Constructs a `TransactionRecordsById` from a `HashMap`
-    pub fn from_map(map: HashMap<TxId, TransactionRecord>) -> Self {
+    fn from_map(map: HashMap<TxId, TransactionRecord>) -> Self {
         TransactionRecordsById(map)
     }
 }
 
 ///  Everything (SOMETHING) about a transaction
 #[allow(dead_code)]
-pub struct TransactionRecord {
+pub(crate) struct TransactionRecord {
     /// the relationship of the transaction to the blockchain. can be either Broadcast (to mempool}, or Confirmed.
     pub status: zingo_status::confirmation_status::ConfirmationStatus,
     /// Timestamp of Tx. Added in v4
@@ -270,7 +273,7 @@ pub struct TransactionRecord {
 impl TransactionRecord {
     /// TODO: Add Doc Comment Here!
     #[allow(clippy::type_complexity)]
-    pub fn read<R: Read>(
+    fn read<R: Read>(
         mut reader: R,
         (wallet_capability, mut trees): (
             &WalletCapability,
@@ -475,7 +478,7 @@ impl ReadableWriteable<(orchard::keys::Diversifier, &WalletCapability)> for orch
 
 /// TODO: Add Doc Comment Here!
 #[derive(Clone, PartialEq)]
-pub struct TransparentOutput {
+pub(crate) struct TransparentOutput {
     /// TODO: Add Doc Comment Here!
     pub address: String,
     /// TODO: Add Doc Comment Here!
@@ -494,7 +497,7 @@ pub struct TransparentOutput {
 
 impl TransparentOutput {
     /// TODO: Add Doc Comment Here!
-    pub fn read<R: std::io::Read>(mut reader: R) -> std::io::Result<Self> {
+    fn read<R: std::io::Read>(mut reader: R) -> std::io::Result<Self> {
         let version = reader.read_u64::<byteorder::LittleEndian>()?;
 
         let address_len = reader.read_i32::<byteorder::LittleEndian>()?;
@@ -576,7 +579,7 @@ impl TransparentOutput {
 /// TODO: Add Doc Comment Here!
 #[derive(Clone)]
 #[allow(dead_code)]
-pub struct SaplingNote {
+pub(crate) struct SaplingNote {
     /// TODO: Add Doc Comment Here!
     pub diversifier: sapling_crypto::Diversifier,
     /// TODO: Add Doc Comment Here!
@@ -749,7 +752,7 @@ impl
 
 /// TODO: Add Doc Comment Here!
 #[derive(Clone, PartialEq)]
-pub struct OrchardNote {
+pub(crate) struct OrchardNote {
     /// TODO: Add Doc Comment Here!
     pub diversifier: orchard::keys::Diversifier,
     /// TODO: Add Doc Comment Here!
@@ -921,7 +924,7 @@ impl
 /// Only for `TransactionRecords` *from* "this" capability
 #[derive(Clone)]
 #[allow(dead_code)]
-pub struct OutgoingTxData {
+pub(crate) struct OutgoingTxData {
     /// TODO: Add Doc Comment Here!
     pub recipient_address: String,
     /// Amount to this receiver
@@ -937,7 +940,7 @@ pub struct OutgoingTxData {
 
 impl OutgoingTxData {
     /// Before version 0, `OutgoingTxData` didn't have a version field
-    pub fn read_old<R: Read>(mut reader: R) -> io::Result<Self> {
+    fn read_old<R: Read>(mut reader: R) -> io::Result<Self> {
         let address_len = reader.read_u64::<LittleEndian>()?;
         let mut address_bytes = vec![0; address_len as usize];
         reader.read_exact(&mut address_bytes)?;
@@ -969,7 +972,7 @@ impl OutgoingTxData {
 
     /// Read an `OutgoingTxData` from its serialized
     /// representation
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+    fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let _external_version = CompactSize::read(&mut reader)?;
         let address_len = reader.read_u64::<LittleEndian>()?;
         let mut address_bytes = vec![0; address_len as usize];
@@ -1003,13 +1006,13 @@ impl OutgoingTxData {
 }
 
 /// TODO: Add Doc Comment Here!
-pub const COMMITMENT_TREE_LEVELS: u8 = 32;
+pub(crate) const COMMITMENT_TREE_LEVELS: u8 = 32;
 /// TODO: Add Doc Comment Here!
-pub const MAX_SHARD_LEVEL: u8 = 16;
+pub(crate) const MAX_SHARD_LEVEL: u8 = 16;
 /// Witness-tree checkpoint retention depth, derived from the
 /// repository's single max-reorg truth (which in turn mirrors zebra's
 /// finalization boundary — see the source constant's docs).
-pub const MAX_REORG: usize = pepper_sync::sync::MAX_REORG_ALLOWANCE as usize;
+const MAX_REORG: usize = pepper_sync::sync::MAX_REORG_ALLOWANCE as usize;
 
 /// TODO: Add Doc Comment Here!
 #[derive(Debug)]
@@ -1102,16 +1105,16 @@ pub(crate) type OrchStore = MemoryShardStore<MerkleHashOrchard, BlockHeight>;
 /// TODO: Add Doc Comment Here!
 #[allow(dead_code)]
 #[derive(Clone)]
-pub struct WitnessCache<Node: Hashable> {
+struct WitnessCache<Node: Hashable> {
     /// TODO: Add Doc Comment Here!
-    pub(crate) witnesses: Vec<IncrementalWitness<Node, 32>>,
+    witnesses: Vec<IncrementalWitness<Node, 32>>,
     /// TODO: Add Doc Comment Here!
-    pub top_height: u64,
+    top_height: u64,
 }
 
 impl<Node: Hashable> WitnessCache<Node> {
     /// TODO: Add Doc Comment Here!
-    pub fn new(witnesses: Vec<IncrementalWitness<Node, 32>>, top_height: u64) -> Self {
+    fn new(witnesses: Vec<IncrementalWitness<Node, 32>>, top_height: u64) -> Self {
         Self {
             witnesses,
             top_height,
@@ -1119,7 +1122,7 @@ impl<Node: Hashable> WitnessCache<Node> {
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn last(&self) -> Option<&IncrementalWitness<Node, 32>> {
+    fn last(&self) -> Option<&IncrementalWitness<Node, 32>> {
         self.witnesses.last()
     }
 }
@@ -1151,7 +1154,7 @@ impl ReadableWriteable for ConfirmationStatus {
 /// TODO: Add Doc Comment Here!
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MemoDownloadOption {
+pub(crate) enum MemoDownloadOption {
     /// TODO: Add Doc Comment Here!
     NoMemos,
     /// TODO: Add Doc Comment Here!
@@ -1163,14 +1166,14 @@ pub enum MemoDownloadOption {
 /// TODO: Add Doc Comment Here!
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
-pub struct WalletOptions {
+pub(crate) struct WalletOptions {
     pub(crate) download_memos: MemoDownloadOption,
     /// TODO: Add Doc Comment Here!
-    pub transaction_size_filter: Option<u32>,
+    pub(crate) transaction_size_filter: Option<u32>,
 }
 
 /// TODO: Add Doc Comment Here!
-pub const MAX_TRANSACTION_SIZE_DEFAULT: u32 = 500;
+const MAX_TRANSACTION_SIZE_DEFAULT: u32 = 500;
 
 impl Default for WalletOptions {
     fn default() -> Self {
@@ -1183,7 +1186,7 @@ impl Default for WalletOptions {
 
 impl WalletOptions {
     /// TODO: Add Doc Comment Here!
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+    pub(crate) fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let external_version = reader.read_u64::<LittleEndian>()?;
 
         let download_memos = match reader.read_u8()? {
@@ -1214,7 +1217,7 @@ impl WalletOptions {
 /// Struct that tracks the latest and historical price of ZEC in the wallet
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
-pub struct WalletZecPriceInfo {
+pub(crate) struct WalletZecPriceInfo {
     /// Latest price of ZEC and when it was fetched
     pub zec_price: Option<(u64, f64)>,
 
@@ -1241,12 +1244,12 @@ impl Default for WalletZecPriceInfo {
 
 impl WalletZecPriceInfo {
     /// TODO: Add Doc Comment Here!
-    pub fn serialized_version() -> u64 {
+    fn serialized_version() -> u64 {
         20
     }
 
     /// TODO: Add Doc Comment Here!
-    pub fn read<R: Read>(mut reader: R) -> io::Result<Self> {
+    pub(crate) fn read<R: Read>(mut reader: R) -> io::Result<Self> {
         let version = reader.read_u64::<LittleEndian>()?;
         if version > Self::serialized_version() {
             return Err(io::Error::new(

--- a/zingolib_testutils/src/lib.rs
+++ b/zingolib_testutils/src/lib.rs
@@ -1,3 +1,18 @@
+//! Test infrastructure shared by the crates that exercise `zingolib` against
+//! a live regtest network.
+//!
+//! These modules build and observe that network; they do not test it.
+//! [`scenarios`] assembles the clients and funding a test starts from, and
+//! [`chain_cache`] records the blocks a setup generated so a later run
+//! replays them instead of regenerating them. [`setup_metrics`] meters what
+//! each setup costs in time and disk.
+//!
+//! The remaining modules answer questions the wallet's own view cannot.
+//! [`validator_rpc`] speaks JSON-RPC to the Validator directly, bypassing the
+//! Indexer; [`attribution`] uses that direct channel to charge a send failure
+//! to the wallet, the Indexer, or the Validator; and [`observability`] taps
+//! the whole pipeline so every change to the chain can be accounted for.
+
 #![forbid(unsafe_code)]
 
 pub mod attribution;


### PR DESCRIPTION
**Source crates — code**

| Package | Change type | Files | Lines +/− |
|---|---|---|---|
| zingolib | visibility demotions (`wallet/legacy.rs`) | 1 | +37 / −34 |
| zingo-cli | visibility demotions | 2 | +13 / −13 |
| libtonode-tests | `forbid(unsafe_code)` attribute | shares lib.rs below | +2 / −0 |
| *Subtotal* | | *3* | *+52 / −47* |

**Source crates — documentation**

| Package | Change type | Files | Lines +/− |
|---|---|---|---|
| zingolib_testutils | crate documentation | 1 | +15 / −0 |
| zingo-netutils | item documentation | 2 | +15 / −0 |
| libtonode-tests | crate documentation | 1 | +11 / −0 |
| *Subtotal* | | *4* | *+41 / −0* |

**Tooling and CI**

| Package | Change type | Files | Lines +/− |
|---|---|---|---|
| tools/workbench | public-api goldens (generated pins) | 10 | +2581 / −0 |
| tools/workbench | gate driver, `decent-exposure` (new binary) | 1 | +285 / −0 |
| CI workflows | `decent_exposure` job in ci-pr.yaml | 1 | +60 / −0 |
| *Subtotal* | | *12* | *+2926 / −0* |

**Grand total: 19 files, +3019 / −47.**

The source crates change by a hundred-odd hand-written lines; the volume is the generated golden files and the new driver in the tooling section.

This PR makes maximum Rust item privacy a hard CI condition. A new job named `decent_exposure` joins the PR workflow as its privacy authority. The other jobs start optimistically in parallel with it and share warm build caches, but when it fails, its final step cancels the entire run: every in-flight job is reaped and its runner returns to the pool. The job carries `actions: write` for exactly that cancellation, and the nightly workflow inherits the arrangement because it calls ci-pr.yaml.

The job enforces three layers, in order, over every Rust package — the eight root workspace members plus the standalone `zingo-netutils` and `tools/workbench` workspaces. First, rustc's `unreachable_pub` at deny: a `pub` item the crate root does not export must shrink, so nothing is public by accident. Second, rustc's `missing_docs` at deny: every item that earns `pub` carries documentation. Third, `cargo public-api` against per-package goldens under `tools/workbench/goldens/public-api/`: any change to a public surface fails the gate until the goldens are regenerated with `--bless` and the diff is reviewed like code.

The driver is a workbench binary, `decent-exposure`. It derives the package list from the root workspace manifest and appends the standalone workspaces, so a new root member is gated automatically. Each layer runs against lib targets, where the public surface lives, and the goldens pin the default-feature surface; the `nym` surface keeps riding the nym-feature job's `-D warnings` clippy. CI pins cargo-public-api 0.50.2, the version the goldens were generated with.

Two preparatory commits make the gate pass on contact. The first demotes all 43 items `unreachable_pub` flagged — 30 in `zingolib/src/wallet/legacy.rs`, decided by their one consumer, the wallet-file readers in disk.rs, and 13 in zingo-cli, decided by what main.rs and lib.rs actually import. No demotion surfaced dead code. The second documents the six items `missing_docs` flagged and gives libtonode-tests the `forbid(unsafe_code)` attribute its siblings already carry. The other six packages were already clean, which speaks well of the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
