### PR TITLE
feat: canonical ZIP 318 policy delegates to zcash_pool_migration (ADR 0020)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash.git#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +874,14 @@ name = "f4jumble"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash.git#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1726,11 +1743,11 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_local_net",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zingo-netutils",
  "zingo-status",
  "zingo_test_vectors",
@@ -1986,9 +2003,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -2112,14 +2129,14 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
- "zcash_transparent",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zingo-memo",
  "zingo-netutils",
  "zingo-status",
@@ -4515,10 +4532,23 @@ dependencies = [
  "bech32",
  "bs58",
  "corez",
- "f4jumble",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash.git#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
+dependencies = [
+ "bech32",
+ "bs58",
+ "corez",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash.git)",
+ "zcash_encoding",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
@@ -4556,14 +4586,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0",
  "zip32",
  "zip321",
 ]
@@ -4602,10 +4632,10 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_encoding",
- "zcash_protocol",
- "zcash_transparent",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zip32",
 ]
 
@@ -4643,16 +4673,15 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92aeb00dec1cf461e24701b630a53532d498f9af2915960ecf1316ceeee9f293"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/zcash/librustzcash.git#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
 dependencies = [
  "corez",
  "getset",
  "libm",
  "rand_core 0.6.4",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
@@ -4666,7 +4695,7 @@ dependencies = [
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -4681,9 +4710,37 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.30.0"
+source = "git+https://github.com/zcash/librustzcash.git#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "equihash 0.3.0 (git+https://github.com/zcash/librustzcash.git)",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol 0.10.1",
+ "zcash_script",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
@@ -4706,7 +4763,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.29.0",
 ]
 
 [[package]]
@@ -4719,6 +4776,16 @@ dependencies = [
  "document-features",
  "hex",
  "memuse",
+ "zcash_encoding",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.10.1"
+source = "git+https://github.com/zcash/librustzcash.git#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
+dependencies = [
+ "corez",
+ "hex",
  "zcash_encoding",
 ]
 
@@ -4765,9 +4832,31 @@ dependencies = [
  "secp256k1 0.29.1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.10.0"
+source = "git+https://github.com/zcash/librustzcash.git#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "getset",
+ "hex",
+ "nonempty",
+ "ripemd 0.1.3",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash.git)",
+ "zcash_encoding",
+ "zcash_protocol 0.10.1",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -4887,10 +4976,10 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing-subscriber",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_keys",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
  "zingo-netutils",
  "zingo-status",
  "zingo_common_components",
@@ -4909,10 +4998,10 @@ name = "zingo-memo"
 version = "0.1.1"
 dependencies = [
  "rand 0.8.5",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_encoding",
  "zcash_keys",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
@@ -4951,7 +5040,7 @@ name = "zingo-status"
 version = "0.2.1"
 dependencies = [
  "byteorder",
- "zcash_protocol",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]
@@ -5018,15 +5107,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zaino-proto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_address",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
  "zcash_pool_migration",
- "zcash_primitives",
+ "zcash_primitives 0.29.0",
  "zcash_proofs",
- "zcash_protocol",
- "zcash_transparent",
+ "zcash_protocol 0.10.0",
+ "zcash_transparent 0.9.0",
  "zingo-memo",
  "zingo-netutils",
  "zingo-price",
@@ -5048,8 +5137,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "zcash_local_net",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
  "zingo-netutils",
  "zingo_common_components",
  "zingo_test_vectors",
@@ -5079,8 +5168,8 @@ dependencies = [
  "base64",
  "nom",
  "percent-encoding",
- "zcash_address",
- "zcash_protocol",
+ "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5093,6 +5093,7 @@ dependencies = [
  "proptest",
  "prost",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rust-embed",
  "sapling-crypto",
  "secp256k1 0.31.1",

--- a/docs/adr/0020-migration-logic-delegates-to-zcash-pool-migration.md
+++ b/docs/adr/0020-migration-logic-delegates-to-zcash-pool-migration.md
@@ -1,0 +1,100 @@
+# Migration logic delegates to zcash_pool_migration
+
+Status: accepted 2026-07-27. Supersedes ADR 0018's "the crate stays a
+dev-dependency oracle" clause and its rejection of wholesale scheduling
+adoption, ADR 0017's locally-implemented window scheduler, and the
+internals (never the API) of ADR 0016's note splitting. The consumer API
+of zingo-cli, zingo-pc, and zingo-mobile is a hard constraint and does
+not change.
+
+We delete the bespoke ZIP 318 implementation wherever the canonical
+`zcash_pool_migration` crate (the reference implementation, in
+zcash/librustzcash) provides the logic, and we delegate to it. The
+conformance this buys is a security property and a NON-NEGOTIABLE
+REQUIREMENT: denominations, transaction shapes, and schedules exist so
+that every migrating wallet's behavior collides with the population's,
+and a wallet running bespoke variants of them fingerprints its users.
+zingolib keeps its public types and `LightClient` methods as the stable
+consumer surface, converting to and from upstream types at one boundary.
+
+Concretely, planning and quantization delegate to `plan_note_split` and
+`CanonicalOneTwoFive` (the strategy is a pure function of the balance,
+so preview-equals-execute and the consent `plan_hash` survive; the
+trait's RNG parameter is an affordance the canonical strategy ignores).
+The preparation model delegates, adopting the 16-action preparation
+transaction of
+<https://zips.z.cash/zip-0318#notepreparationtransactions>, with the
+signing-session batching that ADR 0018 preserved expressed through the
+planner's `prep_tx_count` callback rather than a parallel planner.
+Transfer scheduling delegates to the upstream schedule and anchor
+machinery, retiring the local bucket-window scheduler. The engine and
+state machine delegate through the crate's `PoolMigrationRead` and
+`PoolMigrationWrite` storage traits, which the wallet implements over
+its own file: the upstream `MigrationState` persists as wallet format
+revision 44, landed together with a permanent tolerant reader for the
+shipped bespoke layout and its regression tests, per the wallet-format
+ADR. Transaction building phases in: pool-crossing transfers adopt
+`build_transfer_pczt` first (realizing the PCZT convergence ADR 0008
+recorded and issue #2425 tracks), while preparation transactions keep
+the local builder until the PCZT prove-sign-finalize flow has soaked.
+The immediate Drain stays local: upstream implements no immediate path,
+and the Drain's send-shaped API (ADR 0019) is consumer surface.
+
+The dependency points at the canonical source, not at a release: a git
+dependency on the default branch of zcash/librustzcash, floating. This
+is a ratified exception to the no-new-dependencies/no-pins rule, and it
+deliberately supersedes the exact-version-pin rationale recorded when
+the crate was first imported. Three guards replace the pin. The
+`zip318_conformance_tripwires` suite pins every imported value to the
+ZIP's literal number with a hash-fragment citation, so upstream moving a
+ratified value fails red. A branch-move tripwire reads the workspace
+`Cargo.lock` and asserts the resolved `zcash_pool_migration` revision
+against a pinned literal, so every float of the default branch turns
+exactly one test red and is adopted by a deliberate commit that
+re-adjudicates the value tripwires. And the behavioral ledger below
+re-adjudicates observable behavior. The known hazard is sibling drag: a
+git dependency from the librustzcash workspace can pull git versions of
+its sibling crates into resolution, and each adoption commit owns that
+fallout.
+
+Behavioral idempotency is demonstrated by twins with a divergence
+ledger, on the pattern of `docs/testing/live-offline-twins.md`. Before
+the swap, golden vectors captured from the bespoke implementation (plans
+from fixed note sets, schedules from seeded draws, fees, state
+round-trips) and a property suite of the invariants (value conservation,
+residual bounds, denomination membership, replan idempotence,
+preview-equals-execute) pin current behavior. After the swap the
+invariant suite must pass unchanged, and every golden divergence is
+adjudicated in a recorded table. The ratified divergences are known in
+advance: the part fee moves from the bespoke four-action shape to the
+canonical two-source-one-destination shape, preparation transactions
+move from at most 32 actions to exactly 16, the schedule law moves from
+bucket windows to the upstream draws, and the state serialization moves
+to format 44. `MigrationParams` bumps its version, so every one of these
+lands as a detectable consent change.
+
+No in-flight migration machinery is built: this policy ships before
+migration starts, so no production wallet holds consented bespoke-flow
+state. A dev-built wallet carrying the shipped bespoke migration section
+is read tolerantly and retired to fresh consent.
+
+## Considered Options
+
+Keeping the bespoke implementation with the crate as a dev-dependency
+conformance oracle was the previous posture (ADR 0018). It was rejected
+because hand-maintained conformance across planning, scheduling, fees,
+and shapes is a standing drift risk on the exact surfaces where drift
+fingerprints users, and the oracle pattern had already let the fee and
+preparation shapes diverge three ways from the ZIP's prose.
+
+Delegating everything at once, including preparation building, was
+rejected in favor of transfers-first phasing: the pool-crossing transfer
+is where canonical shape matters most for the anonymity set, and the
+PCZT flow is new machinery best soaked on one path before it carries
+two.
+
+A rev-pinned git dependency was considered as a middle ground preserving
+the no-silent-movement property at the dependency layer. The floating
+default branch was chosen deliberately: zingolib does not ship a crate,
+canonical logic is wanted at merge cadence, and the branch-move tripwire
+restores the loud-movement property at the test layer instead.

--- a/docs/adr/0020-migration-logic-delegates-to-zcash-pool-migration.md
+++ b/docs/adr/0020-migration-logic-delegates-to-zcash-pool-migration.md
@@ -98,3 +98,41 @@ the no-silent-movement property at the dependency layer. The floating
 default branch was chosen deliberately: zingolib does not ship a crate,
 canonical logic is wanted at merge cadence, and the branch-move tripwire
 restores the loud-movement property at the test layer instead.
+
+## Amendment (2026-07-27): observability partition and three landings
+
+The implementation is resequenced to reduce churn, on two principles the
+original phasing left implicit. First, on-chain observability partitions
+the work: fee amounts, transaction action shapes, and the broadcast
+timing law are what the network sees and what fingerprints a wallet
+against the migrating population, so they must be canonical before
+migration starts, while wallet-internal structure (the state model and
+its serialization, the engine skeleton, which builder produced a
+canonically shaped transaction) carries no conformance exposure of its
+own and may follow. Second, tracking upstream is itself a conformance
+property: a mirrored function that equals upstream today is a frozen
+snapshot that diverges silently the day upstream's logic evolves, and
+the value tripwires cannot catch logic drift. Delegation is therefore
+the mechanism that makes conformance durable across upstream versions,
+and the floating dependency pays for itself only where the code calls
+upstream rather than mirrors it.
+
+Three landings replace the six phases. Landing A floats the dependency,
+adds the branch-move tripwire, reworks the value imports onto the
+current typed API, and confines oracles to the surfaces that stay
+bespoke in the interim (the transaction builders and the engine
+orchestration). Landing B closes the observable divergences inside the
+existing machinery: the part fee to the canonical
+two-source-one-unpadded-destination shape, the preparation bound from 32
+to 16 actions, and the target-draw law to the upstream draws, under one
+`MigrationParams` version bump and one divergence-ledger adjudication.
+Landing C delegates every provably equal mirrored function (the expiry
+computation, the anchor draw, the decomposition core) under strict
+equivalence tests and deletes the mirrors.
+
+The state traits, wallet format 44, the engine skeleton, and the PCZT
+builders remain the ratified end state, deferred under standing pull
+rather than scheduled: each upstream evolution that touches them
+surfaces as an oracle failure and argues for completing the delegation.
+No standing oracle guards a delegated surface, because delegation makes
+it redundant.

--- a/docs/testing/zip318-divergence-ledger.md
+++ b/docs/testing/zip318-divergence-ledger.md
@@ -88,5 +88,14 @@ economics to ZIP 317
 value (<https://zips.z.cash/zip-0318#whalehandling>), and the signing
 session target is wallet ergonomics.
 
+The immediate migration's chunk bound: the ZIP standardizes no shape
+for the non-private option and upstream implements no immediate path
+(ADR 0020), so the bound is local policy. Each immediate transaction's
+spends beside its single Ironwood output fit the same 16-action total
+budget the preparation transactions carry, through the same side-budget
+law, so every migration transaction the wallet emits shares one shape
+family; the fee a larger chunk would save is small even on a very
+fragmented wallet. Previously an independent 32-input cap.
+
 Whole-open-window sendability (ADR 0017): a client policy layered over
 the canonical schedule; the drawn target stays advisory.

--- a/docs/testing/zip318-divergence-ledger.md
+++ b/docs/testing/zip318-divergence-ledger.md
@@ -54,6 +54,30 @@ in 0.30. The divergence unblocks with the librustzcash stack bump to the
 0.30 line, which is also what the deferred PCZT builders require. The
 fee change carries its own `MigrationParams` version bump when it lands.
 
+Part ordering is largest-denomination-first and deterministic:
+`plan_schedule` ranks the quantized parts so the largest land in the
+earliest windows, while the ZIP requires a uniformly random shuffle and
+names largest-first as its counterexample — the ordering lets an
+observer infer migration progress from any part it can attribute, and
+makes the sequence predictable to a targeted adversary who knows the
+balance (<https://zips.z.cash/zip-0318#transferscheduling>). The batch
+scheduler consumes the ranking, so the shuffle cannot be dropped in
+without it; it arrives with the scheduling delegation to the upstream
+`schedule` machinery (which shuffles internally), deferred under ADR
+0020's standing pull.
+
+Preparation broadcasts are not temporally decoupled: splitting rounds
+broadcast back-to-back, each round as soon as the previous one confirms,
+while the canonical law spaces preparation broadcasts by exponential
+delays with mean `PREP_MEAN_DELAY` (24 blocks) capped at
+`PREP_MAX_DELAY` (96), precisely to keep a burst of identically shaped
+padded transactions from forming a linkable cluster that also telegraphs
+the coming schedule
+(<https://zips.z.cash/zip-0318#notepreparationtransactions>). Upstream
+exports the law (`draw_prep_delay`, `schedule_prep_broadcast_heights`);
+adoption arrives with the scheduling delegation, deferred under ADR
+0020's standing pull.
+
 ## Retained local (the ZIP standardizes no value)
 
 `sweep_min` (twice the ZIP 317 marginal fee): the ZIP defers small-note

--- a/docs/testing/zip318-divergence-ledger.md
+++ b/docs/testing/zip318-divergence-ledger.md
@@ -22,6 +22,26 @@ boundary, while the canonical law chains successive transfers (each
 delay from the previous transfer). Chaining arrives with the scheduling
 delegation deferred under ADR 0020's standing pull.
 
+## Delegated (Landing C: the mirrors are deleted)
+
+The anchor draw delegates to `scheduling::draw_anchor_boundary`, mapped
+into bucket space with the part's window boundary playing the observed
+chain tip; the local geometric age draw and rejection loop are deleted,
+and seeded golden vectors captured from the retired mirror pin the
+equivalence
+(<https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>).
+
+The expiry computation delegates to `scheduling::expiry_height`; the
+local arithmetic is deleted, and the tripwire pins the delegated result
+to the ZIP's own arithmetic over a sample of heights
+(<https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>).
+
+The decomposition mirror is retained for now: the canonical crate
+exports the `{1, 2, 5}` series only inside its `DenominationStrategy`
+planning entry points, no bare decomposition, so `quantize::decompose`
+keeps the ladder walk under its shape and conservation proptests. Its
+delegation arrives with the planning-layer delegation.
+
 ## Blocked (divergent, dependency named)
 
 The part transfer's Ironwood bundle is padded to two actions and its fee

--- a/docs/testing/zip318-divergence-ledger.md
+++ b/docs/testing/zip318-divergence-ledger.md
@@ -1,0 +1,48 @@
+# ZIP 318 divergence ledger
+
+The adjudication record ADR 0020's behavioral-idempotency requirement
+demands: every deliberate divergence between this wallet's migration
+behavior and the canonical `zcash_pool_migration` implementation, with
+its status and its unblocking dependency where one exists. A divergence
+absent from this ledger is a defect. The `zip318_conformance_tripwires`
+suite enforces the value layer; this ledger records the behavior layer.
+
+## Adopted (conformant as of params version 2)
+
+The preparation bound moved from at most 32 actions to the ZIP's
+16-action preparation shape
+(<https://zips.z.cash/zip-0318#notepreparationtransactions>).
+
+The advisory target-draw law moved from uniform-in-window to the
+canonical exponential inter-arrival distribution, mean 144 blocks capped
+at 576, drawn from `SchedulingParams::ZIP_318`
+(<https://zips.z.cash/zip-0318#transferscheduling>). One gap remains
+open within it: each target is drawn independently from its window
+boundary, while the canonical law chains successive transfers (each
+delay from the previous transfer). Chaining arrives with the scheduling
+delegation deferred under ADR 0020's standing pull.
+
+## Blocked (divergent, dependency named)
+
+The part transfer's Ironwood bundle is padded to two actions and its fee
+is 20 000 zatoshis, against the canonical single unpadded Ironwood
+action and 15 000
+(<https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>).
+The registry `zcash_primitives` 0.29 builder exposes no Ironwood padding
+control; `BuildConfig::Standard` gains `ironwood_padding: BundlePadding`
+in 0.30. The divergence unblocks with the librustzcash stack bump to the
+0.30 line, which is also what the deferred PCZT builders require. The
+fee change carries its own `MigrationParams` version bump when it lands.
+
+## Retained local (the ZIP standardizes no value)
+
+`sweep_min` (twice the ZIP 317 marginal fee): the ZIP defers small-note
+economics to ZIP 317
+(<https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>).
+
+`k_max` and `target_sessions`: the ZIP names `K_MAX` without fixing a
+value (<https://zips.z.cash/zip-0318#whalehandling>), and the signing
+session target is wallet ergonomics.
+
+Whole-open-window sendability (ADR 0017): a client policy layered over
+the canonical schedule; the drawn target stays advisory.

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -88,7 +88,7 @@ zingo_test_vectors = { workspace = true, optional = true }
 zip32.workspace = true
 zaino-proto = { version = "0.2.0", default-features = false, features = ["grpc_proxy_server"], optional = true }
 tokio-stream = { workspace = true, optional = true }
-zcash_pool_migration = { version = "=0.1.0-alpha.1", default-features = false }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", version = "0.1.0-rc.1", default-features = false }
 
 [build-dependencies]
 zcash_proofs = { workspace = true, features = ["download-params"] }

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -88,6 +88,7 @@ zingo_test_vectors = { workspace = true, optional = true }
 zip32.workspace = true
 zaino-proto = { version = "0.2.0", default-features = false, features = ["grpc_proxy_server"], optional = true }
 tokio-stream = { workspace = true, optional = true }
+zcash_pool_migration = { version = "=0.1.0-alpha.1", default-features = false }
 
 [build-dependencies]
 zcash_proofs = { workspace = true, features = ["download-params"] }
@@ -100,9 +101,6 @@ tempfile = { workspace = true }
 tokio-stream.workspace = true
 tracing-subscriber = { workspace = true }
 zaino-proto = { version = "0.2.0", default-features = false, features = ["grpc_proxy_server"] }
-# Conformance oracle only: the shipped constants are defined locally so they
-# can never move underneath the consent hash via a dependency bump.
-zcash_pool_migration = { version = "=0.1.0-alpha.1", default-features = false }
 zingo_test_vectors = { workspace = true }
 
 [badges]

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -97,6 +97,7 @@ zcash_proofs = { workspace = true, features = ["download-params"] }
 pepper-sync = { workspace = true, features = ["test-features"] }
 portpicker = { workspace = true }
 proptest = { workspace = true }
+rand_chacha = "0.3"
 tempfile = { workspace = true }
 tokio-stream.workspace = true
 tracing-subscriber = { workspace = true }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -382,13 +382,11 @@ impl LightClient {
     ///     }
     /// });
     ///
-    /// // The caller owns the sync lifecycle: pause it, then migrate against that
-    /// // stable state. Completion is the returned summary (not a progress
-    /// // value), after which the handle reads `None` again.
-    /// let guard = client.pause_sync_scoped()?;
-    /// let summary = client
-    ///     .migrate_immediately_presynced(account, &guard)
-    ///     .await?;
+    /// // The caller owns the sync lifecycle; the call pauses it around the
+    /// // migration and resumes it afterwards. Completion is the returned
+    /// // summary (not a progress value), after which the handle reads `None`
+    /// // again.
+    /// let summary = client.quick_immediate_migration(account, true).await?;
     /// reporter.abort();
     ///
     /// println!(

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -83,7 +83,7 @@ pub enum ImmediateMigrationPhase {
 
 /// A snapshot of an in-progress immediate Orchard→Ironwood migration, for rendering
 /// "built i/N, sent i/N". The immediate-migration counterpart to [`MigrationStatus`].
-/// `None` from [`LightClient::immediate_migration_status`] means no immediate migration is running.
+/// `None` from [`ImmediateMigrationProgressHandle::status`] means no immediate migration is running.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImmediateMigrationStatus {
     /// Total transactions in the plan (N), fixed when the immediate migration begins.
@@ -220,7 +220,7 @@ pub enum SplitPhase {
 /// A snapshot of the note-splitting round a [`LightClient::quick_split`] call
 /// is building, for rendering "built i/N, sent i/N" within that call. The
 /// Phase 1 counterpart to [`ImmediateMigrationStatus`]. `None` from
-/// [`LightClient::split_status`] means no round is running.
+/// [`SplitProgressHandle::status`] means no round is running.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SplitStatus {
     /// Transactions in this round (N), fixed when the round begins.
@@ -1620,7 +1620,7 @@ impl LightClient {
     ///
     /// Syncs the wallet before migrating. Consumers that own the sync
     /// lifecycle and keep a background sync running should call
-    /// [`Self::migrate_immediately_presynced`] instead, which migrates
+    /// [`Self::quick_immediate_migration`] instead, which migrates
     /// against current wallet state without launching its own sync.
     pub async fn migrate_immediately(
         &mut self,
@@ -1721,8 +1721,8 @@ impl LightClient {
     /// This is the send-family entry point for the immediate migration, and
     /// the only immediate-migration entry point that crosses the UniFFI boundary:
     /// [`Self::migrate_immediately`] self-syncs and so collides with a
-    /// consumer's continuous background sync, and
-    /// [`Self::migrate_immediately_presynced`] takes a
+    /// consumer's continuous background sync, and the internal
+    /// `migrate_immediately_presynced` takes a
     /// [`SyncPauseGuard`] that cannot cross FFI. The caller keeps the wallet
     /// synced, exactly as it must before any send.
     ///

--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -1098,11 +1098,12 @@ async fn migration_with_memo_is_still_a_migration_value_transfer() {
 /// plus a sync).
 ///
 /// Setup: 34 fabricated legacy-Orchard (V2) notes make the provisional
-/// planner (max_actions_per_split_tx = 32) emit a first reduction round of
-/// TWO merge transactions. The mock indexer's lost-response fault plus an
+/// planner (16-action total budget) emit a first reduction round of several
+/// merge transactions — more than one, so a failure of the first can strand
+/// the rest. The mock indexer's lost-response fault plus an
 /// effectively-infinite download-queue rejection budget makes the FIRST
 /// submission fail deterministically after the wallet's probe budget. The
-/// second transaction must not stay stranded.
+/// transactions behind it must not stay stranded.
 #[tokio::test]
 async fn failed_split_round_transmit_strands_calculated_transactions() {
     use zcash_primitives::transaction::TxId;

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -52,7 +52,7 @@ impl LightWallet {
     ///
     /// Changes in version 42:
     /// Optional Orchard→Ironwood migration section appended (see
-    /// [`crate::wallet::migration::store`]. The section carries its own inner
+    /// `crate::wallet::migration::store`. The section carries its own inner
     /// version). (An earlier revision of 42 also wrote an
     /// `allow_v6_transactions` bool after `min_confirmations`. The setting
     /// was later removed and version 42 redefined without the byte, leaving

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -96,7 +96,7 @@ pub enum WalletError {
     /// empty: every bucket below it is ruled out by the Ironwood era floor or
     /// by the part's own bound note, leaving no boundary at age one or more to
     /// prove against. A caller that derives its window from
-    /// [`crate::wallet::migration::schedule::first_permitted_bucket`] or from
+    /// `crate::wallet::migration::schedule::first_permitted_bucket` or from
     /// `plan_schedule` cannot reach this; a hand-computed window can.
     #[error(
         "Migration part cannot anchor in window {window}: no legal anchor bucket \

--- a/zingolib/src/wallet/migration.rs
+++ b/zingolib/src/wallet/migration.rs
@@ -16,14 +16,17 @@
 //! wallet-fingerprinting output.
 //!
 //! The denominations are canonical so that migrated amounts collide across the
-//! whole migrating population instead of fingerprinting a wallet:
+//! whole migrating population instead of fingerprinting a wallet
+//! (<https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>):
 //!
-//! * Denominations are {0.001, 0.01, 0.1, 1, 10, 100} ZEC (powers of ten,
-//!   capped at `DENOM_CAP`, floored at `DUST_FLOOR`).
-//! * A balance is decomposed by decimal digit expansion, largest first.
-//! * Residue below the dust floor folds into fees. Notes worth at most
-//!   [`MigrationParams::sweep_min`] are stranded (moving them costs more than
-//!   they are worth).
+//! * Denominations are the values `n x 10^k` ZEC with `n` in {1, 2, 5},
+//!   from `MAX_RESIDUAL_VALUE` (0.01 ZEC) up to `DENOM_CAP` (10 000 ZEC),
+//!   both imported from the `zcash_pool_migration` reference crate.
+//! * A balance is decomposed greedily, largest denomination first.
+//! * Balance below `MAX_RESIDUAL_VALUE` stays unmigrated as the residual.
+//!   Notes worth at most [`MigrationParams::sweep_min`] are stranded
+//!   (moving them costs more than they are worth; the ZIP leaves that
+//!   economics to ZIP 317 and standardizes no sweep threshold).
 //!
 //! [`plan_migration`] is the pure planning entry point. It is deterministic
 //! and never touches the network, so callers (the one-call

--- a/zingolib/src/wallet/migration.rs
+++ b/zingolib/src/wallet/migration.rs
@@ -35,7 +35,7 @@
 //!
 //! ZIP 318 also permits an **immediate** migration, a single transfer with no
 //! delay and minimal privacy, as an explicit alternative the user may choose
-//! over the private path above. That is [`immediate`], which shares nothing with
+//! over the private path above. That is the `immediate` module, which shares nothing with
 //! this two-phase design but the transaction builder.
 
 // The submodules carry a crate ceiling: the re-export block below is this

--- a/zingolib/src/wallet/migration/immediate.rs
+++ b/zingolib/src/wallet/migration/immediate.rs
@@ -23,7 +23,8 @@
 use orchard::bundle::BundleVersion;
 use zcash_primitives::transaction::TxId;
 
-use super::split::{MigrationOutputs, SWEEP_MIN, bundle_actions, zip317_fee};
+use super::params::MigrationParams;
+use super::split::{MigrationOutputs, bundle_actions, side_budget, zip317_fee};
 use crate::wallet::error::WalletError;
 
 /// The ZIP-317 conventional fee of a immediate migration transaction with `n_in` Orchard
@@ -87,34 +88,37 @@ impl ImmediateMigrationPlan {
     }
 }
 
-/// The most Orchard notes one immediate migration transaction spends. An immediate migration's Orchard
-/// bundle is spend-only, so `n` inputs cost `n` actions. This caps a single
-/// migration transaction's proving cost and size. An immediate migration is not a note split, so
-/// it carries its own bound rather than borrowing the splitter's.
-const MAX_DRAIN_INPUTS: usize = 32;
-
 /// Plans an immediate migration of the Orchard notes with the given values (zatoshis): spend
-/// every note worth more than the `SWEEP_MIN` Sweep Minimum into one Ironwood
-/// output, chunked so no transaction exceeds `MAX_DRAIN_INPUTS` inputs.
-/// Deterministic and pure.
+/// every note worth more than the [`MigrationParams::sweep_min`] Sweep Minimum
+/// into one Ironwood output, chunked so each transaction's spends beside its
+/// single output fit the [`MigrationParams::max_actions_per_split_tx`] total
+/// budget — the same 16-action shape the preparation transactions carry, via
+/// the same [`side_budget`] law. The wallet thereby emits one transaction
+/// shape family across both migration paths; the fee a larger chunk would
+/// save is small even on a very fragmented wallet (the divergence ledger's
+/// "retained local" section records the choice). Deterministic and pure.
 ///
-/// Notes worth at most `SWEEP_MIN` are left as residual rather than selected (see the
+/// Notes worth at most the Sweep Minimum are left as residual rather than selected (see the
 /// Sweep Minimum's safety-factor policy). The same floor applies to what a
-/// migration creates: a chunk whose output would not exceed `SWEEP_MIN` is
+/// migration creates: a chunk whose output would not exceed the Sweep Minimum is
 /// left whole as residual, so an immediate migration never manufactures a note the policy refuses to
 /// spend.
-pub(crate) fn plan_immediate_migration(note_values: &[u64]) -> ImmediateMigrationPlan {
+pub(crate) fn plan_immediate_migration(
+    note_values: &[u64],
+    params: &MigrationParams,
+) -> ImmediateMigrationPlan {
     let mut plan = ImmediateMigrationPlan::default();
+    let sweep_min = params.sweep_min;
 
     let (spendable, dust): (Vec<u64>, Vec<u64>) =
-        note_values.iter().partition(|&&value| value > SWEEP_MIN);
+        note_values.iter().partition(|&&value| value > sweep_min);
     plan.residual = dust.iter().sum();
 
-    for chunk in spendable.chunks(MAX_DRAIN_INPUTS) {
+    for chunk in spendable.chunks(side_budget(params)) {
         let total: u64 = chunk.iter().sum();
         let fee = immediate_migration_fee(chunk.len());
         match total.checked_sub(fee) {
-            Some(output) if output > SWEEP_MIN => {
+            Some(output) if output > sweep_min => {
                 plan.migrated += output;
                 plan.fee += fee;
                 plan.transactions.push(ImmediateMigrationTx {
@@ -124,7 +128,7 @@ pub(crate) fn plan_immediate_migration(note_values: &[u64]) -> ImmediateMigratio
             }
             // A chunk that cannot fund both its fee and an output worth
             // spending is left whole as residual: an Ironwood note at or below
-            // `SWEEP_MIN` is one the residual policy itself refuses. Only
+            // the Sweep Minimum is one the residual policy itself refuses. Only
             // reachable when a chunk holds at most three near-`SWEEP_MIN`
             // notes, which the entry filter cannot rule out for small
             // chunks.
@@ -139,6 +143,10 @@ impl crate::wallet::LightWallet {
     /// Plans an immediate migration from the account's spendable pre-Ironwood (V2) Orchard
     /// notes. Pure and deterministic: nothing is signed or sent, so the plan
     /// can be shown to the user for consent first.
+    ///
+    /// Plans under the provisional [`MigrationParams`] for the wallet's chain:
+    /// an immediate migration is planned fresh on every call and records no
+    /// consent hash, so no stored parameter set can bind it.
     #[allow(clippy::result_large_err)]
     pub(crate) fn plan_immediate_migration(
         &self,
@@ -146,6 +154,7 @@ impl crate::wallet::LightWallet {
     ) -> Result<ImmediateMigrationPlan, WalletError> {
         Ok(plan_immediate_migration(
             &self.migration_note_values(account)?,
+            &MigrationParams::provisional(self.chain_type()),
         ))
     }
 
@@ -171,7 +180,14 @@ impl crate::wallet::LightWallet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::wallet::migration::split::{CANONICAL_PART_FEE, MARGINAL_FEE};
+    use crate::config::ChainType;
+    use crate::wallet::migration::split::{CANONICAL_PART_FEE, MARGINAL_FEE, SWEEP_MIN};
+
+    /// The provisional parameter set every test plans under, the same set
+    /// [`crate::wallet::LightWallet::plan_immediate_migration`] resolves.
+    fn params() -> MigrationParams {
+        MigrationParams::provisional(ChainType::Mainnet)
+    }
 
     /// An immediate migration's Orchard bundle has no outputs, so `orchard_v3`'s ban on
     /// cross-address transfers cannot change its action count. That is what
@@ -179,7 +195,7 @@ mod tests {
     /// take as an argument.
     #[test]
     fn immediate_migration_fee_is_era_independent() {
-        for n_in in [1usize, 2, 3, 5, 32] {
+        for n_in in [1usize, 2, 3, 5, side_budget(&params())] {
             assert_eq!(
                 bundle_actions(BundleVersion::orchard_v2(), n_in, 0),
                 bundle_actions(BundleVersion::orchard_v3(), n_in, 0),
@@ -213,7 +229,7 @@ mod tests {
             &[1, 2, 3],
         ];
         for note_values in cases {
-            let plan = plan_immediate_migration(note_values);
+            let plan = plan_immediate_migration(note_values, &params());
             let total: u64 = note_values.iter().sum();
             assert_eq!(
                 plan.migrated + plan.fee + plan.residual,
@@ -231,7 +247,8 @@ mod tests {
 
     #[test]
     fn chunks_at_the_action_bound() {
-        let max = MAX_DRAIN_INPUTS;
+        let params = params();
+        let max = side_budget(&params);
         for (note_count, expected_txs) in [
             (0, 0),
             (1, 1),
@@ -241,17 +258,18 @@ mod tests {
             (max * 2 + 1, 3),
         ] {
             let note_values = vec![1_000_000u64; note_count];
-            let plan = plan_immediate_migration(&note_values);
+            let plan = plan_immediate_migration(&note_values, &params);
             assert_eq!(
                 plan.transactions.len(),
                 expected_txs,
                 "{note_count} notes should chunk into {expected_txs} transaction(s)"
             );
             assert!(
-                plan.transactions
-                    .iter()
-                    .all(|transaction| transaction.inputs.len() <= max),
-                "a chunk exceeded the action bound"
+                plan.transactions.iter().all(|transaction| {
+                    let actions = transaction.inputs.len() + 1;
+                    actions <= params.max_actions_per_split_tx
+                }),
+                "a chunk's spends and single output together exceeded the total action budget"
             );
         }
     }
@@ -259,7 +277,7 @@ mod tests {
     #[test]
     fn all_dust_leaves_everything_residual() {
         let note_values = vec![SWEEP_MIN, SWEEP_MIN - 1, 1];
-        let plan = plan_immediate_migration(&note_values);
+        let plan = plan_immediate_migration(&note_values, &params());
 
         assert!(plan.is_empty());
         assert_eq!(plan.migrated, 0);
@@ -276,7 +294,7 @@ mod tests {
         let mut note_values = dust.to_vec();
         note_values.extend([SWEEP_MIN + 1, 1_000_000]);
 
-        let plan = plan_immediate_migration(&note_values);
+        let plan = plan_immediate_migration(&note_values, &params());
         assert_eq!(plan.residual, dust.iter().sum::<u64>());
         for transaction in &plan.transactions {
             for &input in &transaction.inputs {
@@ -307,19 +325,19 @@ mod tests {
     fn output_at_or_below_sweep_min_leaves_the_chunk_residual() {
         // One 25_000-zatoshi note: the fee is 20_000, so the output would be
         // 5_000, at most the sweep minimum.
-        let plan = plan_immediate_migration(&[25_000]);
+        let plan = plan_immediate_migration(&[25_000], &params());
         assert!(plan.is_empty());
         assert_eq!(plan.residual, 25_000);
         assert_eq!(plan.fee, 0);
 
         // An output of exactly `sweep_min` still leaves its chunk as residual.
         let boundary = immediate_migration_fee(1) + SWEEP_MIN;
-        let plan = plan_immediate_migration(&[boundary]);
+        let plan = plan_immediate_migration(&[boundary], &params());
         assert!(plan.is_empty());
         assert_eq!(plan.residual, boundary);
 
         // One zatoshi above the boundary migrates.
-        let plan = plan_immediate_migration(&[boundary + 1]);
+        let plan = plan_immediate_migration(&[boundary + 1], &params());
         assert_eq!(plan.transactions.len(), 1);
         assert_eq!(plan.transactions[0].output, SWEEP_MIN + 1);
         assert_eq!(plan.residual, 0);
@@ -332,7 +350,7 @@ mod tests {
         #[test]
         fn immediate_migration_inputs_always_exceed_sweep_min(
             note_values in proptest::collection::vec(1u64..=10_000_000_000, 0..300)
-        ) {            let plan = plan_immediate_migration(&note_values);
+        ) {            let plan = plan_immediate_migration(&note_values, &params());
             for transaction in &plan.transactions {
                 for &input in &transaction.inputs {
                     proptest::prop_assert!(input > SWEEP_MIN);
@@ -346,7 +364,7 @@ mod tests {
         #[test]
         fn immediate_migration_outputs_always_exceed_sweep_min(
             note_values in proptest::collection::vec(1u64..=10_000_000_000, 0..300)
-        ) {            let plan = plan_immediate_migration(&note_values);
+        ) {            let plan = plan_immediate_migration(&note_values, &params());
             for transaction in &plan.transactions {
                 proptest::prop_assert!(transaction.output > SWEEP_MIN);
             }
@@ -359,11 +377,11 @@ mod tests {
     #[test]
     fn replanning_covers_only_the_remaining_notes() {
         let all = vec![1_000_000u64, 2_000_000, 3_000_000, 4_000_000];
-        let full = plan_immediate_migration(&all);
+        let full = plan_immediate_migration(&all, &params());
 
         // The first two notes were spent by an immediate migration that did broadcast.
         let remaining = &all[2..];
-        let replan = plan_immediate_migration(remaining);
+        let replan = plan_immediate_migration(remaining, &params());
 
         assert_eq!(replan.transactions.len(), 1);
         assert_eq!(replan.transactions[0].inputs, remaining.to_vec());

--- a/zingolib/src/wallet/migration/params.rs
+++ b/zingolib/src/wallet/migration/params.rs
@@ -39,10 +39,14 @@ pub struct MigrationParams {
     pub k_max: u32,
     /// The signing-session target the schedule aims at for typical balances.
     pub target_sessions: u32,
-    /// Bounds the notes merged (spends) or created (outputs) by one
-    /// note-splitting transaction. This caps the Orchard action count at this
-    /// value before NU6.3 (spends and outputs share actions) and at twice it
-    /// afterwards (cross-address transfers disabled, one action each).
+    /// The total note budget of one note-splitting transaction: its spends
+    /// and outputs together never exceed this. Post-NU6.3 every note is one
+    /// Orchard action (cross-address transfers disabled), so the budget is
+    /// the ZIP 318 preparation shape of 16 actions
+    /// (<https://zips.z.cash/zip-0318#notepreparationtransactions>); before
+    /// activation, shared actions make such a transaction at most 15
+    /// actions. Padding to exactly 16 arrives with the builder capability
+    /// the divergence ledger tracks.
     pub max_actions_per_split_tx: usize,
     /// The canonical ZIP-317 fee of one part. Every split note is sized
     /// `denomination + part_fee` so the part balances exactly.
@@ -99,7 +103,12 @@ impl MigrationParams {
         let denom_cap = MIGRATION_MAX_DENOMINATION_ZEC * COIN;
         let max_residual_value = u64::from(RESIDUAL_MIGRATION_MIN);
         MigrationParams {
-            version: 1,
+            // Version 2: the preparation bound moved to the ZIP's 16-action
+            // shape and the target-draw law moved to the canonical
+            // exponential distribution. The part fee still awaits the
+            // builder capability for the unpadded Ironwood action (the
+            // divergence ledger tracks it), and will carry its own bump.
+            version: 2,
             denominations: one_two_five_ladder(denom_cap, max_residual_value),
             denom_cap,
             max_residual_value,
@@ -107,7 +116,9 @@ impl MigrationParams {
             bucket_modulus: AnchorBucketInterval::ZIP_318.block_count().get(),
             k_max: 8,
             target_sessions: 6,
-            max_actions_per_split_tx: 32,
+            // ZIP 318 standardizes 16-action preparation transactions
+            // (<https://zips.z.cash/zip-0318#notepreparationtransactions>).
+            max_actions_per_split_tx: 16,
             part_fee: CANONICAL_PART_FEE,
         }
     }

--- a/zingolib/src/wallet/migration/params.rs
+++ b/zingolib/src/wallet/migration/params.rs
@@ -1,10 +1,8 @@
 //! Per-network migration constants, versioned so testnet and mainnet
 //! activations can carry different ratified values.
 
-use zcash_pool_migration::note_splitting::{
-    MIGRATION_MAX_DENOMINATION_ZEC, RESIDUAL_MIGRATION_MIN,
-};
-use zcash_pool_migration::scheduling::BOUNDARY_MODULUS;
+use zcash_pool_migration::denomination::{MIGRATION_MAX_DENOMINATION_ZEC, RESIDUAL_MIGRATION_MIN};
+use zcash_pool_migration::scheduling::AnchorBucketInterval;
 use zcash_protocol::value::COIN;
 
 use crate::config::ChainType;
@@ -106,7 +104,7 @@ impl MigrationParams {
             denom_cap,
             max_residual_value,
             sweep_min: SWEEP_MIN,
-            bucket_modulus: BOUNDARY_MODULUS,
+            bucket_modulus: AnchorBucketInterval::ZIP_318.block_count().get(),
             k_max: 8,
             target_sessions: 6,
             max_actions_per_split_tx: 32,

--- a/zingolib/src/wallet/migration/params.rs
+++ b/zingolib/src/wallet/migration/params.rs
@@ -1,12 +1,15 @@
 //! Per-network migration constants, versioned so testnet and mainnet
 //! activations can carry different ratified values.
 
+use zcash_pool_migration::note_splitting::{
+    MIGRATION_MAX_DENOMINATION_ZEC, RESIDUAL_MIGRATION_MIN,
+};
+use zcash_pool_migration::scheduling::BOUNDARY_MODULUS;
+use zcash_protocol::value::COIN;
+
 use crate::config::ChainType;
 
 use super::split::{CANONICAL_PART_FEE, SWEEP_MIN};
-
-/// Number of zatoshis in one ZEC.
-pub(crate) const COIN: u64 = 100_000_000;
 
 /// The constants ZIP 318 leaves to ratification, gathered so the planner,
 /// schedule and part builders all read one source. Every value is provisional
@@ -48,39 +51,62 @@ pub struct MigrationParams {
     pub part_fee: u64,
 }
 
+/// The ZIP 318 canonical denomination set: every value `n × 10^k` zatoshis
+/// with `n ∈ {1, 2, 5}` lying within `[floor, cap]`, ordered largest first
+/// so a greedy decomposition walks it directly. The series itself is
+/// standardized at
+/// <https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>; the
+/// reference crate exports the bounds but not the enumerated set, so the
+/// ladder is derived here from the imported bounds.
+fn one_two_five_ladder(cap: u64, floor: u64) -> Vec<u64> {
+    let mut ladder = Vec::new();
+    let mut power = 1u64;
+    loop {
+        for n in [1u64, 2, 5] {
+            let Some(value) = n.checked_mul(power) else {
+                continue;
+            };
+            if (floor..=cap).contains(&value) {
+                ladder.push(value);
+            }
+        }
+        match power.checked_mul(10) {
+            Some(next) if power <= cap => power = next,
+            _ => break,
+        }
+    }
+    ladder.sort_unstable_by(|a, b| b.cmp(a));
+    ladder
+}
+
 impl MigrationParams {
     /// The provisional parameter set (ZIP 318 draft values). The chain is
     /// accepted now so ratified per-network values slot in without a
     /// signature change.
+    ///
+    /// Every ZIP-standardized value the canonical `zcash_pool_migration`
+    /// crate exports is imported from it, never restated: `DENOM_CAP`
+    /// (10 000 ZEC) and `MAX_RESIDUAL_VALUE` (0.01 ZEC) from
+    /// <https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>,
+    /// and `M` (the boundary modulus, 144) from
+    /// <https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>.
+    /// The `zip318_conformance_tripwires` tests in the schedule module pin
+    /// each imported value to the ZIP's literal number, so a dependency
+    /// bump cannot silently move the consent hash. `sweep_min` stays a local
+    /// policy: the ZIP leaves the economics of consuming a small note to
+    /// ZIP 317 and standardizes no sweep threshold. `k_max` stays local:
+    /// the ZIP names `K_MAX` at
+    /// <https://zips.z.cash/zip-0318#whalehandling> without fixing a value.
     pub fn provisional(_chain: ChainType) -> Self {
-        // The `{1, 2, 5} × 10^k` set from 10 000 ZEC down to 0.01 ZEC.
+        let denom_cap = MIGRATION_MAX_DENOMINATION_ZEC * COIN;
+        let max_residual_value = u64::from(RESIDUAL_MIGRATION_MIN);
         MigrationParams {
             version: 1,
-            denominations: vec![
-                10_000 * COIN,
-                5_000 * COIN,
-                2_000 * COIN,
-                1_000 * COIN,
-                500 * COIN,
-                200 * COIN,
-                100 * COIN,
-                50 * COIN,
-                20 * COIN,
-                10 * COIN,
-                5 * COIN,
-                2 * COIN,
-                COIN,
-                COIN / 2,
-                COIN / 5,
-                COIN / 10,
-                COIN / 20,
-                COIN / 50,
-                COIN / 100,
-            ],
-            denom_cap: 10_000 * COIN,
-            max_residual_value: COIN / 100,
+            denominations: one_two_five_ladder(denom_cap, max_residual_value),
+            denom_cap,
+            max_residual_value,
             sweep_min: SWEEP_MIN,
-            bucket_modulus: 144,
+            bucket_modulus: BOUNDARY_MODULUS,
             k_max: 8,
             target_sessions: 6,
             max_actions_per_split_tx: 32,

--- a/zingolib/src/wallet/migration/parts.rs
+++ b/zingolib/src/wallet/migration/parts.rs
@@ -87,7 +87,7 @@ pub enum PartState {
         height: BlockHeight,
     },
     /// Reached its expiry height unmined. Rebuilt with the same denomination
-    /// and a fresh bucket via [`PartRecord::reassign`].
+    /// and a fresh bucket via `PartRecord::reassign`.
     Expired,
     /// The bound note was spent outside the migration. Terminal. The
     /// remaining balance is replanned under fresh consent.
@@ -121,7 +121,7 @@ pub struct PartRecord {
     /// The bucket this part broadcasts in: it is due while the chain tip is
     /// inside the window `[bucket_index · M, (bucket_index + 1) · M)`. The
     /// builder's target height comes from here. Distinct from
-    /// [`Self::anchor_bucket`], which is where the part *proves*.
+    /// `Self::anchor_bucket`, which is where the part *proves*.
     pub bucket_index: Option<u64>,
     /// The bucket whose opening boundary this part anchors its Orchard spend
     /// to, always at least one bucket below [`Self::bucket_index`] (see
@@ -131,7 +131,7 @@ pub struct PartRecord {
     /// `None` on a part read from a migration section written before anchors
     /// were drawn separately (inner version 3 and below) whose transaction is
     /// not yet signed; the next placement, or
-    /// [`crate::wallet::LightWallet::refresh_part_witnesses`], draws one.
+    /// `crate::wallet::LightWallet::refresh_part_witnesses`, draws one.
     pub(crate) anchor_bucket: Option<u64>,
     /// A randomly chosen block within the bucket window at which the part
     /// fires. Randomizing the target within `[boundary, boundary + M)`
@@ -148,7 +148,7 @@ pub struct PartRecord {
     /// `None` under the lazy strategy: between signing and broadcast the
     /// bytes are recoverable from the wallet's transaction record by txid.
     pub(crate) signed_blob: Option<Vec<u8>>,
-    /// The anchor root and witness at [`Self::anchor_bucket`]'s boundary,
+    /// The anchor root and witness at `Self::anchor_bucket`'s boundary,
     /// cached while that checkpoint is retained. Cleared on every bucket
     /// transition, since a fresh anchor bucket means a fresh boundary, and
     /// discarded when a pre-anchor-age schedule is read, where it proves the
@@ -194,8 +194,8 @@ impl PartRecord {
     /// `Bound → Assigned`: the schedule placed this part in a broadcast
     /// window.
     ///
-    /// Clears [`Self::anchor_bucket`], as every bucket transition does: the
-    /// placement operations in [`super::schedule`] are the only writers of an
+    /// Clears `Self::anchor_bucket`, as every bucket transition does: the
+    /// placement operations in `super::schedule` are the only writers of an
     /// anchor, and they set it immediately after transitioning. A caller that
     /// assigns directly leaves the part anchorless rather than carrying an
     /// anchor drawn against a different window.
@@ -318,7 +318,7 @@ impl PartRecord {
 pub(crate) type ProveOnce =
     Box<dyn FnOnce() -> Result<(TxId, Vec<u8>), WalletError> + Send + 'static>;
 
-/// Outcome of [`crate::wallet::LightWallet::prepare_part`]: either a ready
+/// Outcome of `crate::wallet::LightWallet::prepare_part`: either a ready
 /// proving closure or the reason the part must be skipped.
 pub enum PrepareResult {
     /// All wallet data was extracted. The closure does the CPU-intensive
@@ -387,7 +387,7 @@ pub enum SkipReason {
     /// anchors were drawn separately from broadcast windows (migration
     /// section inner version 3 and below). Proving cannot invent one,
     /// because the age draw is what keeps the anchor out of the open window.
-    /// [`crate::wallet::LightWallet::refresh_part_witnesses`] draws it at
+    /// `crate::wallet::LightWallet::refresh_part_witnesses` draws it at
     /// the next synchronization, which is also when its witness becomes
     /// capturable, so this reason clears itself.
     AnchorNotDrawn,
@@ -877,8 +877,8 @@ impl crate::wallet::LightWallet {
     /// unavailable it returns [`MaterializeOutcome::Skip`] without writing
     /// anything.
     ///
-    /// For parallel proving of multiple parts, see [`Self::prepare_part`] and
-    /// [`Self::record_part_result`].
+    /// For parallel proving of multiple parts, see `Self::prepare_part` and
+    /// `Self::record_part_result`.
     #[allow(clippy::result_large_err)]
     pub fn materialize_part(
         &mut self,

--- a/zingolib/src/wallet/migration/quantize.rs
+++ b/zingolib/src/wallet/migration/quantize.rs
@@ -1,5 +1,6 @@
-//! Canonical quantization: decomposing a balance into the standard
-//! power-of-ten denominations of ZIP 318.
+//! Canonical quantization: decomposing a balance into ZIP 318's standard
+//! `{1, 2, 5} x 10^k` denominations
+//! (<https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>).
 
 use zcash_protocol::value::Zatoshis;
 
@@ -36,7 +37,7 @@ impl Denominations {
     }
 }
 
-/// Decompose `value` into canonical powers-of-ten denominations.
+/// Decompose `value` into the canonical `{1, 2, 5} x 10^k` denominations.
 ///
 /// Greedy, largest denomination first. Because each denomination is exactly
 /// ten times the next, greedy decomposition also minimizes the number of
@@ -69,10 +70,10 @@ pub fn decompose(value: Zatoshis, params: &MigrationParams) -> Denominations {
 
 #[cfg(test)]
 mod tests {
-    use super::super::params::COIN;
     use super::*;
     use crate::config::ChainType;
     use proptest::prelude::*;
+    use zcash_protocol::value::COIN;
     use zcash_protocol::value::MAX_MONEY;
 
     fn params() -> MigrationParams {

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -1169,6 +1169,37 @@ mod tests {
             assert_eq!(ANCHOR_AGE_CAP, 16);
         }
 
+        /// The `zcash_pool_migration` revision this workspace has adjudicated.
+        /// The dependency floats on zcash/librustzcash's default branch (ADR
+        /// 0020), so an ordinary `cargo update` can move it. This tripwire
+        /// makes every move loud: when the resolved revision changes, this
+        /// test fails, and the adopting commit re-runs the value tripwires
+        /// above and bumps this literal deliberately.
+        const ADJUDICATED_UPSTREAM_REV: &str = "e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031";
+
+        /// Fails when the floating librustzcash dependency moves (ADR 0020's
+        /// branch-move tripwire). Reads the workspace lockfile rather than any
+        /// crate metadata, because the lockfile is where a float lands first.
+        #[test]
+        fn upstream_revision_is_the_adjudicated_one() {
+            let lockfile = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("zingolib sits directly under the workspace root")
+                .join("Cargo.lock");
+            let lock = std::fs::read_to_string(lockfile).expect("workspace lockfile is readable");
+            let package_block = lock
+                .split("[[package]]")
+                .find(|block| block.contains("name = \"zcash_pool_migration\""))
+                .expect("the lockfile resolves zcash_pool_migration");
+            assert!(
+                package_block.contains(&format!("#{ADJUDICATED_UPSTREAM_REV}\"")),
+                "zcash_pool_migration moved off the adjudicated revision \
+                 {ADJUDICATED_UPSTREAM_REV}. Re-run the zip318 tripwires against \
+                 the new revision and bump ADJUDICATED_UPSTREAM_REV in the same \
+                 commit that adopts it."
+            );
+        }
+
         #[test]
         fn expiry_heights_match_upstream() {
             let sample = [
@@ -1181,10 +1212,14 @@ mod tests {
                 100 * EXPIRY_MODULUS,
                 101 * EXPIRY_MODULUS - 1,
             ];
-            for height in sample.map(BlockHeight::from_u32) {
+            // The git dependency carries its own zcash_protocol, so its
+            // BlockHeight is a distinct type from the workspace's; heights
+            // cross the boundary as u32, the same value-level insulation the
+            // imports rely on.
+            for height in sample {
                 assert_eq!(
-                    canonical_expiry_height(height),
-                    scheduling::expiry_height(height),
+                    u32::from(canonical_expiry_height(BlockHeight::from_u32(height))),
+                    u32::from(scheduling::expiry_height(height.into())),
                     "diverged at {height}"
                 );
             }

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -653,12 +653,14 @@ mod tests {
         }
     }
 
-    /// The anchor age is never zero: a part must never prove against the
-    /// boundary of the window it is broadcasting in. That boundary is the
     /// Every accepted anchor sits inside the candidate set: at least one
     /// bucket below the window, at or above both floors, and within the age
-    /// cap. The rejection loop, not the raw geometric draw, is what enforces
-    /// the lower end.
+    /// cap. The first bound is the age-never-zero rule: a part must never
+    /// prove against the boundary of the window it is broadcasting in,
+    /// because that boundary is the newest tree state there is and its
+    /// cohort has not accumulated yet. The delegated `draw_anchor_boundary`
+    /// enforces every one of these bounds now that the local rejection loop
+    /// is retired; this test pins that contract from the caller's side.
     #[test]
     fn drawn_anchors_land_inside_the_candidate_set() {
         let params = params();
@@ -1153,9 +1155,20 @@ mod tests {
         /// retired local implementation under seeded rngs immediately before
         /// the swap to `draw_anchor_boundary`, so a divergence here means the
         /// delegated draw no longer reproduces the behavior the mirror had.
+        ///
+        /// The generator is pinned to [`rand_chacha::ChaCha12Rng`] rather
+        /// than spelled `StdRng`, because the vectors are a property of the
+        /// exact random stream: at capture time rand 0.8's `StdRng` was
+        /// ChaCha12, but `StdRng` is documented as free to change algorithms
+        /// across rand versions, and such a change would fail these goldens
+        /// spuriously. If this test ever goes red, the delegated draw has
+        /// diverged (or the pinned generator itself moved); never repair it
+        /// by re-capturing the vectors from the delegated implementation,
+        /// because vectors captured from the code under test pin nothing.
         #[test]
         fn anchor_draw_matches_the_retired_mirror_goldens() {
             use rand::SeedableRng;
+            use rand_chacha::ChaCha12Rng;
             let activation = PoolActivation::new_for_test(BlockHeight::from_u32(1_000));
             let expected: [(Option<u64>, Option<u64>, Option<u64>); 6] = [
                 (Some(99), Some(99), Some(51)),
@@ -1166,7 +1179,7 @@ mod tests {
                 (Some(98), Some(99), Some(52)),
             ];
             for (seed, expected) in expected.iter().enumerate() {
-                let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
+                let mut rng = ChaCha12Rng::seed_from_u64(seed as u64);
                 let floor_loose = AnchorFloor::new(activation, None);
                 let floor_note =
                     AnchorFloor::new(activation, Some(BlockHeight::from_u32(50 * 144 + 3)));

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -37,19 +37,30 @@ fn random_target_in_bucket(
 }
 
 /// Zcash target block spacing in seconds, used to estimate window times.
+/// Matches the spacing ZIP 318's block-count constants assume; see
+/// <https://zips.z.cash/zip-0318#transferscheduling>.
 const TARGET_BLOCK_SPACING_SECONDS: u64 = 75;
 
-/// `EXPIRY_MODULUS`: 30 days of blocks at the 75-second target spacing.
-const EXPIRY_MODULUS: u32 = 34_560;
-
-/// The canonical validity window past an expiry bucket's opening.
-const EXPIRY_WINDOW: u32 = 2 * EXPIRY_MODULUS;
+// The ZIP 318 expiry and anchor-age constants are imported from the
+// canonical reference crate, never restated. `EXPIRY_MODULUS` (34 560
+// blocks, 30 days) and `EXPIRY_WINDOW` (2x, about 60 days) are
+// standardized at
+// <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>;
+// `ANCHOR_AGE_CAP` (16 boundaries, about two days) at
+// <https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>.
+// ANCHOR_AGE_CAP is deliberately not a `MigrationParams` field: it does
+// not feed the consent hash, so adopting it costs no existing consent.
+// The `zip318_conformance_tripwires` tests below pin every imported value to the
+// ZIP's literal number, so a dependency bump that moved one fails red
+// and is adopted deliberately, with a params version bump.
+use zcash_pool_migration::scheduling::{ANCHOR_AGE_CAP, EXPIRY_MODULUS, EXPIRY_WINDOW};
 
 /// The canonical ZIP 318 expiry for a transfer scheduled to broadcast at
 /// `broadcast_height`: the most recent multiple of [`EXPIRY_MODULUS`] at or
 /// below it, plus [`EXPIRY_WINDOW`]. Identical for every transfer scheduled
 /// in the same 30-day period, so the committed expiry reveals only that
-/// coarse period.
+/// coarse period. See
+/// <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>.
 pub fn canonical_expiry_height(broadcast_height: BlockHeight) -> BlockHeight {
     let height = u32::from(broadcast_height);
     BlockHeight::from_u32(height - (height % EXPIRY_MODULUS) + EXPIRY_WINDOW)
@@ -75,13 +86,6 @@ pub fn boundary_of(bucket_index: u64, bucket_modulus: u32) -> BlockHeight {
 fn previous_boundary(height: BlockHeight, bucket_modulus: u32) -> BlockHeight {
     boundary_of(bucket_index(height, bucket_modulus), bucket_modulus)
 }
-
-/// `ANCHOR_AGE_CAP`: the greatest anchor age the draw accepts, in buckets.
-/// A draw above it is discarded and redrawn, bounding how stale a part's
-/// anchor may be (16 buckets is about two days at `M` = 144). Deliberately
-/// not a [`MigrationParams`] field: it does not feed the consent hash, so
-/// adopting it costs no existing consent.
-const ANCHOR_AGE_CAP: u32 = 16;
 
 /// The two floors a part's candidate anchor bucket must clear, resolved for
 /// one part.
@@ -1141,25 +1145,28 @@ mod tests {
         assert!(upcoming_windows(&parts, now, now_unix, 0, &params).is_empty());
     }
 
-    /// Checks our locally defined ZIP 318 values against
-    /// `zcash_pool_migration`, the reference implementation. The constants
-    /// stay local so they can only move by an explicit commit (they feed the
-    /// consent hash), and this suite is what catches upstream ratifying
-    /// different ones: bump the pinned dev-dependency and red means adopt
-    /// deliberately, with a params version bump.
-    mod zip318_conformance {
-        use zcash_pool_migration::note_splitting::{
-            MIGRATION_MAX_DENOMINATION_ZEC, RESIDUAL_MIGRATION_MIN,
-        };
+    /// Pins the ZIP 318 values imported from `zcash_pool_migration`, the
+    /// reference implementation, to the ZIP's literal numbers. The values
+    /// feed the consent hash, so they must move only by an explicit commit:
+    /// a dependency bump that changes one turns this suite red, and red
+    /// means adopt deliberately, with a params version bump.
+    mod zip318_conformance_tripwires {
         use zcash_pool_migration::scheduling;
 
         use super::*;
-        use crate::wallet::migration::params::COIN;
+        use zcash_protocol::value::COIN;
 
+        /// <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>
         #[test]
-        fn expiry_constants_match_upstream() {
-            assert_eq!(EXPIRY_MODULUS, scheduling::EXPIRY_MODULUS);
-            assert_eq!(EXPIRY_WINDOW, scheduling::EXPIRY_WINDOW);
+        fn expiry_constants_match_the_zip() {
+            assert_eq!(EXPIRY_MODULUS, 34_560);
+            assert_eq!(EXPIRY_WINDOW, 69_120);
+        }
+
+        /// <https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>
+        #[test]
+        fn anchor_age_cap_matches_the_zip() {
+            assert_eq!(ANCHOR_AGE_CAP, 16);
         }
 
         #[test]
@@ -1184,11 +1191,46 @@ mod tests {
         }
 
         #[test]
-        fn params_match_upstream() {
+        fn params_match_the_zip() {
             let params = MigrationParams::provisional(ChainType::Mainnet);
-            assert_eq!(params.bucket_modulus, scheduling::BOUNDARY_MODULUS);
-            assert_eq!(params.denom_cap, MIGRATION_MAX_DENOMINATION_ZEC * COIN);
-            assert_eq!(params.max_residual_value, u64::from(RESIDUAL_MIGRATION_MIN));
+            // <https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>
+            assert_eq!(params.bucket_modulus, 144);
+            // <https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>
+            assert_eq!(params.denom_cap, 10_000 * COIN);
+            assert_eq!(params.max_residual_value, COIN / 100);
+        }
+
+        /// Pins the derived ladder to the ZIP 318 enumeration
+        /// (<https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>).
+        /// The denominations feed the consent hash, so a derivation bug or a
+        /// moved bound would silently invalidate every recorded consent; this
+        /// vector is the tripwire.
+        #[test]
+        fn ladder_matches_the_zip318_enumeration() {
+            assert_eq!(
+                MigrationParams::provisional(ChainType::Mainnet).denominations,
+                vec![
+                    10_000 * COIN,
+                    5_000 * COIN,
+                    2_000 * COIN,
+                    1_000 * COIN,
+                    500 * COIN,
+                    200 * COIN,
+                    100 * COIN,
+                    50 * COIN,
+                    20 * COIN,
+                    10 * COIN,
+                    5 * COIN,
+                    2 * COIN,
+                    COIN,
+                    COIN / 2,
+                    COIN / 5,
+                    COIN / 10,
+                    COIN / 20,
+                    COIN / 50,
+                    COIN / 100,
+                ],
+            );
         }
 
         /// Every denomination is `n × 10^k` with `n ∈ {1, 2, 5}`.

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -5,7 +5,7 @@
 //! broadcasts while the chain is inside it.
 //!
 //! A part's *anchor* is a separate bucket from its broadcast window. The
-//! anchor sits at [`draw_anchor_age`] buckets below the window, never zero
+//! anchor sits a canonically drawn age below the window, never zero
 //! ([`ANCHOR_AGE_CAP`] bounds how far), so a part always proves against a
 //! boundary the chain has already left. Because that boundary is identical
 //! for every wallet anchoring there, it carries no per-wallet timing
@@ -59,10 +59,10 @@ const TARGET_BLOCK_SPACING_SECONDS: u64 = 75;
 // The `zip318_conformance_tripwires` tests below pin every imported value to the
 // ZIP's literal number, so a dependency bump that moved one fails red
 // and is adopted deliberately, with a params version bump.
+use std::num::NonZeroU32;
+
 use rand::CryptoRng;
-use zcash_pool_migration::scheduling::{
-    ANCHOR_AGE_CAP, EXPIRY_MODULUS, EXPIRY_WINDOW, SchedulingParams,
-};
+use zcash_pool_migration::scheduling::{AnchorBucketInterval, SchedulingParams};
 
 /// The canonical ZIP 318 expiry for a transfer scheduled to broadcast at
 /// `broadcast_height`: the most recent multiple of [`EXPIRY_MODULUS`] at or
@@ -71,8 +71,11 @@ use zcash_pool_migration::scheduling::{
 /// coarse period. See
 /// <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>.
 pub fn canonical_expiry_height(broadcast_height: BlockHeight) -> BlockHeight {
-    let height = u32::from(broadcast_height);
-    BlockHeight::from_u32(height - (height % EXPIRY_MODULUS) + EXPIRY_WINDOW)
+    // Delegates to the canonical implementation; heights cross the git
+    // dependency's type divide as u32, the workspace's standard insulation.
+    BlockHeight::from_u32(u32::from(zcash_pool_migration::scheduling::expiry_height(
+        u32::from(broadcast_height).into(),
+    )))
 }
 
 /// The bucket containing `height`.
@@ -149,65 +152,39 @@ impl AnchorFloor {
     }
 }
 
-/// Draws an anchor age `a ≥ 1` from the recency-weighted `Geometric(1/2)`
-/// distribution: the number of failed fair coin flips plus one, so
-/// `P(a = 1) = 1/2`, `P(a = 2) = 1/4`, and the mean age is two buckets.
-///
-/// Age zero is never produced. That is the whole point: an age-zero anchor
-/// is the boundary of the window the chain is still inside, the newest tree
-/// state there is, whose cohort has not accumulated yet.
-///
-/// Counting stops one past [`ANCHOR_AGE_CAP`], which the caller rejects
-/// anyway, so a single 64-bit draw always suffices and the loop is bounded.
-pub fn draw_anchor_age(rng: &mut impl Rng) -> u32 {
-    // Each bit of one fresh word is one fair coin flip, as upstream's
-    // `draw_anchor_age` does it. The cap is far below 64, so one word is
-    // always enough and the loop needs no refill.
-    let mut bits = rng.next_u64();
-    let mut age: u32 = 1;
-    while age <= ANCHOR_AGE_CAP {
-        if bits & 1 == 1 {
-            return age;
-        }
-        bits >>= 1;
-        age += 1;
-    }
-    age
-}
-
 /// The anchor bucket for a part broadcasting in `window`: `window − a` for a
-/// drawn age, redrawn until it clears `floor` and [`ANCHOR_AGE_CAP`].
+/// canonically drawn age (`Geometric(1/2)`, never zero, capped at
+/// [`ANCHOR_AGE_CAP`]), redrawn until it clears `floor`.
 ///
-/// `None` when the candidate set is empty, which is the caller's signal that
-/// `window` is too early for this part rather than a transient condition.
-/// Age one always yields `window − 1`, the highest candidate, so whenever the
-/// set is non-empty the rejection loop terminates with probability one half
-/// per draw.
+/// Delegates to the canonical
+/// [`zcash_pool_migration::scheduling::draw_anchor_boundary`]
+/// (<https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>), mapped
+/// into bucket space: the part's window boundary plays the observed chain
+/// tip, so the most recent boundary is the window's own and the drawn anchor
+/// is `window − a` exactly as the retired local draw computed it. Seeded
+/// golden vectors captured from that local implementation pin the
+/// equivalence. `None` when the candidate set is empty, which is the
+/// caller's signal that `window` is too early for this part rather than a
+/// transient condition.
 pub fn draw_anchor_bucket(
     window: u64,
     floor: &AnchorFloor,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     bucket_modulus: u32,
 ) -> Option<u64> {
-    // The highest candidate is one full bucket below the window, since the
-    // age is never zero. An empty set means the floors reach the window.
-    let highest = window.checked_sub(1)?;
-    let lowest = floor.lowest_anchor_bucket(bucket_modulus);
-    if lowest > highest {
-        return None;
-    }
-    loop {
-        let age = draw_anchor_age(rng);
-        if age > ANCHOR_AGE_CAP {
-            continue;
-        }
-        // An age reaching past bucket zero is a too-old anchor: redraw.
-        if let Some(candidate) = window.checked_sub(u64::from(age))
-            && candidate >= lowest
-        {
-            return Some(candidate);
-        }
-    }
+    let interval = AnchorBucketInterval::custom(
+        NonZeroU32::new(bucket_modulus).expect("bucket modulus is nonzero by params invariant"),
+    );
+    let window_boundary = u32::from(boundary_of(window, bucket_modulus));
+    let funding = floor.note_confirmed_at.map_or(0, u32::from);
+    let anchor = zcash_pool_migration::scheduling::draw_anchor_boundary(
+        interval,
+        u32::from(floor.activation.height()).into(),
+        funding.into(),
+        window_boundary.into(),
+        rng,
+    )?;
+    Some(u64::from(u32::from(anchor)) / u64::from(bucket_modulus))
 }
 
 /// The first bucket a part may be scheduled into: strictly after
@@ -294,7 +271,7 @@ pub fn place_immediate(
     part: &mut PartRecord,
     bucket: u64,
     floor: &AnchorFloor,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     params: &MigrationParams,
 ) -> Result<(), WalletError> {
     let anchor = anchor_for(bucket, floor, rng, params)?;
@@ -310,7 +287,7 @@ pub fn place_immediate(
 fn anchor_for(
     bucket: u64,
     floor: &AnchorFloor,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     params: &MigrationParams,
 ) -> Result<u64, WalletError> {
     draw_anchor_bucket(bucket, floor, rng, params.bucket_modulus).ok_or(
@@ -584,6 +561,7 @@ mod tests {
     use crate::wallet::migration::parts::BoundNote;
     use pepper_sync::wallet::OutputId;
     use proptest::prelude::*;
+    use zcash_pool_migration::scheduling::{ANCHOR_AGE_CAP, EXPIRY_MODULUS, EXPIRY_WINDOW};
     use zcash_primitives::transaction::TxId;
 
     fn params() -> MigrationParams {
@@ -677,17 +655,6 @@ mod tests {
 
     /// The anchor age is never zero: a part must never prove against the
     /// boundary of the window it is broadcasting in. That boundary is the
-    /// newest tree state at broadcast time, so its ZIP 318 cohort has not
-    /// accumulated and the anonymity set the anchor draw exists to build is
-    /// empty. Upstream states it as a MUST ("age 0 is NEVER produced").
-    #[test]
-    fn anchor_age_is_never_zero() {
-        for _ in 0..2_000 {
-            let age = draw_anchor_age(&mut rand::rngs::OsRng);
-            assert!(age >= 1, "drew age {age}, which is the open window itself");
-        }
-    }
-
     /// Every accepted anchor sits inside the candidate set: at least one
     /// bucket below the window, at or above both floors, and within the age
     /// cap. The rejection loop, not the raw geometric draw, is what enforces
@@ -1165,8 +1132,6 @@ mod tests {
     /// a dependency bump that changes one turns this suite red, and red
     /// means adopt deliberately, with a params version bump.
     mod zip318_conformance_tripwires {
-        use zcash_pool_migration::scheduling;
-
         use super::*;
         use zcash_protocol::value::COIN;
 
@@ -1181,6 +1146,37 @@ mod tests {
         #[test]
         fn anchor_age_cap_matches_the_zip() {
             assert_eq!(ANCHOR_AGE_CAP, 16);
+        }
+
+        /// Strict behavioral equivalence across the anchor-draw delegation
+        /// (ADR 0020, Landing C): these vectors were captured from the
+        /// retired local implementation under seeded rngs immediately before
+        /// the swap to `draw_anchor_boundary`, so a divergence here means the
+        /// delegated draw no longer reproduces the behavior the mirror had.
+        #[test]
+        fn anchor_draw_matches_the_retired_mirror_goldens() {
+            use rand::SeedableRng;
+            let activation = PoolActivation::new_for_test(BlockHeight::from_u32(1_000));
+            let expected: [(Option<u64>, Option<u64>, Option<u64>); 6] = [
+                (Some(99), Some(99), Some(51)),
+                (Some(99), Some(98), Some(51)),
+                (Some(99), Some(98), Some(52)),
+                (Some(97), Some(97), Some(52)),
+                (Some(97), Some(99), Some(52)),
+                (Some(98), Some(99), Some(52)),
+            ];
+            for (seed, expected) in expected.iter().enumerate() {
+                let mut rng = rand::rngs::StdRng::seed_from_u64(seed as u64);
+                let floor_loose = AnchorFloor::new(activation, None);
+                let floor_note =
+                    AnchorFloor::new(activation, Some(BlockHeight::from_u32(50 * 144 + 3)));
+                let drawn = (
+                    draw_anchor_bucket(100, &floor_loose, &mut rng, 144),
+                    draw_anchor_bucket(100, &floor_note, &mut rng, 144),
+                    draw_anchor_bucket(53, &floor_note, &mut rng, 144),
+                );
+                assert_eq!(&drawn, expected, "diverged at seed {seed}");
+            }
         }
 
         /// The `zcash_pool_migration` revision this workspace has adjudicated.
@@ -1214,8 +1210,13 @@ mod tests {
             );
         }
 
+        /// Pins the delegated expiry to the ZIP's own arithmetic (the most
+        /// recent `EXPIRY_MODULUS` multiple at or below the height, plus
+        /// `EXPIRY_WINDOW`), independent of the implementation now that
+        /// `canonical_expiry_height` calls the canonical crate.
+        /// <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>
         #[test]
-        fn expiry_heights_match_upstream() {
+        fn expiry_heights_match_the_zip_arithmetic() {
             let sample = [
                 0,
                 1,
@@ -1226,14 +1227,10 @@ mod tests {
                 100 * EXPIRY_MODULUS,
                 101 * EXPIRY_MODULUS - 1,
             ];
-            // The git dependency carries its own zcash_protocol, so its
-            // BlockHeight is a distinct type from the workspace's; heights
-            // cross the boundary as u32, the same value-level insulation the
-            // imports rely on.
             for height in sample {
                 assert_eq!(
                     u32::from(canonical_expiry_height(BlockHeight::from_u32(height))),
-                    u32::from(scheduling::expiry_height(height.into())),
+                    height - (height % 34_560) + 69_120,
                     "diverged at {height}"
                 );
             }

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -23,16 +23,22 @@ use crate::wallet::error::WalletError;
 use super::params::MigrationParams;
 use super::parts::{PartId, PartRecord, PartState};
 
-/// Picks a random block within `[boundary, boundary + M)` as the broadcast
-/// target for one part, spreading sends across the window instead of
-/// clustering them at the boundary.
+/// Draws the advisory broadcast target for one part from the canonical
+/// transfer-delay law: the ZIP 318 exponential inter-arrival distribution
+/// (mean 144 blocks, capped at 576), offset from the part's window boundary
+/// (<https://zips.z.cash/zip-0318#transferscheduling>). The draw can land
+/// past the window; the target is advisory (ADR 0017), so a late target
+/// only aims the reminder and never gates sendability. Chaining successive
+/// transfers (each delay drawn from the previous transfer rather than the
+/// boundary) arrives with the scheduling delegation; the divergence ledger
+/// records that gap.
 fn random_target_in_bucket(
     bucket: u64,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     params: &MigrationParams,
 ) -> BlockHeight {
     let boundary = u32::from(boundary_of(bucket, params.bucket_modulus));
-    let offset = rng.gen_range(0..params.bucket_modulus);
+    let offset = SchedulingParams::ZIP_318.transfer_delay().draw(rng);
     BlockHeight::from_u32(boundary + offset)
 }
 
@@ -53,7 +59,10 @@ const TARGET_BLOCK_SPACING_SECONDS: u64 = 75;
 // The `zip318_conformance_tripwires` tests below pin every imported value to the
 // ZIP's literal number, so a dependency bump that moved one fails red
 // and is adopted deliberately, with a params version bump.
-use zcash_pool_migration::scheduling::{ANCHOR_AGE_CAP, EXPIRY_MODULUS, EXPIRY_WINDOW};
+use rand::CryptoRng;
+use zcash_pool_migration::scheduling::{
+    ANCHOR_AGE_CAP, EXPIRY_MODULUS, EXPIRY_WINDOW, SchedulingParams,
+};
 
 /// The canonical ZIP 318 expiry for a transfer scheduled to broadcast at
 /// `broadcast_height`: the most recent multiple of [`EXPIRY_MODULUS`] at or
@@ -262,7 +271,7 @@ pub fn place(
     part: &mut PartRecord,
     bucket: u64,
     floor: &AnchorFloor,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     params: &MigrationParams,
 ) -> Result<(), WalletError> {
     let anchor = anchor_for(bucket, floor, rng, params)?;
@@ -348,7 +357,7 @@ pub fn plan_schedule(
     activation: PoolActivation,
     note_confirmed_at: impl Fn(&PartRecord) -> Option<BlockHeight>,
     params: &MigrationParams,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
 ) -> Result<(), WalletError> {
     let unassigned: Vec<usize> = parts
         .iter()
@@ -757,7 +766,7 @@ mod tests {
     /// exists to prevent, correlated across every wallet that rebuilds
     /// after an expiry.
     #[test]
-    fn place_draws_a_fresh_target_inside_the_new_window() {
+    fn place_draws_a_fresh_target_from_the_new_boundary() {
         let params = params();
         let mut part = bound_part(0, 1_000_000);
         part.assign(1).unwrap();
@@ -783,11 +792,12 @@ mod tests {
             part.target_height
                 .expect("jittered placement draws a fresh target"),
         );
+        let cap = SchedulingParams::ZIP_318.transfer_delay().cap().get();
         assert!(
-            target >= boundary && target < boundary + params.bucket_modulus,
-            "the fresh target {target} must lie inside bucket 5's window \
-             [{boundary}, {})",
-            boundary + params.bucket_modulus,
+            target >= boundary && target <= boundary + cap,
+            "the fresh target {target} must be drawn from bucket 5's boundary \
+             under the canonical delay law [{boundary}, {}]",
+            boundary + cap,
         );
     }
 
@@ -814,10 +824,13 @@ mod tests {
             assert_eq!(part.state, PartState::Assigned);
             let bucket = part.bucket_index.unwrap();
             assert!(bucket >= first_bucket, "current or future bucket");
-            // Target is within the part's bucket window.
+            // Target is drawn from the part's boundary under the canonical
+            // delay law (mean 144, capped at 576; it may pass the window,
+            // and the target is advisory per ADR 0017).
             let boundary = u32::from(boundary_of(bucket, params.bucket_modulus));
             let target = u32::from(part.target_height.unwrap());
-            assert!(target >= boundary && target < boundary + params.bucket_modulus);
+            let cap = SchedulingParams::ZIP_318.transfer_delay().cap().get();
+            assert!(target >= boundary && target <= boundary + cap);
         }
         // Largest denominations land in the earliest buckets.
         for a in &parts {
@@ -1036,9 +1049,10 @@ mod tests {
                 // Target is within the bucket's window.
                 let boundary = u32::from(boundary_of(bucket, params.bucket_modulus));
                 let target = u32::from(part.target_height.unwrap());
+                let cap = SchedulingParams::ZIP_318.transfer_delay().cap().get();
                 prop_assert!(
-                    target >= boundary && target < boundary + params.bucket_modulus,
-                    "target in window"
+                    target >= boundary && target <= boundary + cap,
+                    "target drawn from the boundary under the canonical delay law"
                 );
             }
             prop_assert!(cohort_sizes.values().all(|&size| size <= k), "k bound");
@@ -1233,6 +1247,16 @@ mod tests {
             // <https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>
             assert_eq!(params.denom_cap, 10_000 * COIN);
             assert_eq!(params.max_residual_value, COIN / 100);
+            // <https://zips.z.cash/zip-0318#notepreparationtransactions>
+            assert_eq!(params.max_actions_per_split_tx, 16);
+        }
+
+        /// <https://zips.z.cash/zip-0318#transferscheduling>
+        #[test]
+        fn transfer_delay_matches_the_zip() {
+            let delay = SchedulingParams::ZIP_318.transfer_delay();
+            assert_eq!(delay.mean().get(), 144);
+            assert_eq!(delay.cap().get(), 576);
         }
 
         /// Pins the derived ladder to the ZIP 318 enumeration

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -18,10 +18,6 @@ use super::quantize::decompose;
 /// to the crate constant by test.
 pub(crate) const MARGINAL_FEE: u64 = 5_000;
 
-/// The Sweep Minimum (ZIP 318 policy): a migration never selects a note worth
-/// at most this, and never manufactures an output worth at most this.
-/// Provisionally twice the marginal fee: a selected note must return strictly
-/// more than double the marginal action cost it adds, not merely break even.
 /// One side's per-transaction note budget, derived from the total budget
 /// ([`MigrationParams::max_actions_per_split_tx`], ZIP 318's 16-action
 /// preparation shape at
@@ -33,6 +29,10 @@ fn side_budget(params: &MigrationParams) -> usize {
     params.max_actions_per_split_tx.saturating_sub(1).max(1)
 }
 
+/// The Sweep Minimum (ZIP 318 policy): a migration never selects a note worth
+/// at most this, and never manufactures an output worth at most this.
+/// Provisionally twice the marginal fee: a selected note must return strictly
+/// more than double the marginal action cost it adds, not merely break even.
 /// Shared by both migration paths: the private schedule reads it through
 /// [`MigrationParams`], and the immediate [`super::immediate`] reads it directly,
 /// so the two leave identical residuals.
@@ -260,7 +260,9 @@ pub fn plan_hash(plan: &MigrationPlan) -> [u8; 32] {
 ///    budget, merge groups of at most that many notes into one note each
 ///    (smallest first).
 /// 2. **Sizing**: spend the remaining notes into notes sized exactly
-///    `denomination + part_fee`, where the denominations are the
+///    `denomination + part_fee` — consolidating the smallest inputs into one
+///    funding note first whenever the pool plus the targets would exceed one
+///    transaction's total budget — where the denominations are the
 ///    [`decompose`]-ition of what is left after all fees. When the balance
 ///    needs more target notes than fit one transaction (whale balances),
 ///    splitting recurses through intermediate notes.
@@ -380,13 +382,36 @@ pub fn plan_migration(
     }
 }
 
+/// The input-consolidation group a sizing transaction needs when its spends
+/// plus its outputs would exceed the total budget
+/// ([`MigrationParams::max_actions_per_split_tx`]): merging `k` inputs into
+/// one note removes `k − 1` spends, so the minimal group removes the excess
+/// exactly. At least three inputs merge whenever the pool has them: every
+/// pooled note strictly exceeds `sweep_min`, and three such notes clear the
+/// merge fee with a note the residual policy accepts, where a pair might
+/// not (the reduction loop guards the same hazard by carrying pairs).
+/// Count-based only, so [`split_into_fee`] models it exactly. Callers
+/// guarantee `n_in + m` exceeds the budget.
+fn merge_group_len(n_in: usize, m: usize, params: &MigrationParams) -> usize {
+    (n_in + m + 1 - params.max_actions_per_split_tx)
+        .max(3)
+        .min(n_in)
+}
+
 /// Total ZIP-317 fee of splitting `n_in` notes into `m` target notes,
 /// recursing through intermediates when `m` exceeds the per-transaction
-/// budget.
+/// budget, and consolidating inputs first when spends plus outputs would
+/// exceed the total budget (mirroring [`split_into`]).
 fn split_into_fee(n_in: usize, m: usize, post_activation: bool, params: &MigrationParams) -> u64 {
     let max_notes = side_budget(params);
     if m <= max_notes {
-        note_split_fee(n_in, m, post_activation)
+        if n_in + m > params.max_actions_per_split_tx {
+            let group_len = merge_group_len(n_in, m, params);
+            note_split_fee(group_len, 1, post_activation)
+                + note_split_fee(n_in - group_len + 1, m, post_activation)
+        } else {
+            note_split_fee(n_in, m, post_activation)
+        }
     } else {
         // One future transaction per chunk of `max_notes` targets, funded by
         // an intermediate note each. The intermediates are themselves split.
@@ -403,20 +428,41 @@ fn split_into_fee(n_in: usize, m: usize, post_activation: bool, params: &Migrati
 }
 
 /// Materializes the note-splitting rounds that turn `inputs` into exactly
-/// `targets`. Mirrors [`split_into_fee`]. The first transaction's fee absorbs
+/// `targets`. Mirrors [`split_into_fee`]. The final transaction's fee absorbs
 /// any slack between the input total and the exact target-side requirement.
+///
+/// The budget is a total: a transaction's spends and outputs together must
+/// fit [`MigrationParams::max_actions_per_split_tx`] (ZIP 318's 16-action
+/// preparation shape). When the pool plus the targets exceed it, the
+/// smallest inputs consolidate into one funding note first, in a round of
+/// their own, and the sizing transaction spends the consolidated note
+/// beside the survivors.
 fn split_into(
-    inputs: Vec<u64>,
+    mut inputs: Vec<u64>,
     targets: &[u64],
     post_activation: bool,
     params: &MigrationParams,
 ) -> Vec<Vec<NoteSplitTx>> {
     let max_notes = side_budget(params);
     if targets.len() <= max_notes {
-        return vec![vec![NoteSplitTx {
+        let mut rounds = Vec::new();
+        if inputs.len() + targets.len() > params.max_actions_per_split_tx {
+            let group_len = merge_group_len(inputs.len(), targets.len(), params);
+            inputs.sort_unstable();
+            let group: Vec<u64> = inputs.drain(..group_len).collect();
+            let merged =
+                group.iter().sum::<u64>() - note_split_fee(group.len(), 1, post_activation);
+            rounds.push(vec![NoteSplitTx {
+                inputs: group,
+                outputs: vec![merged],
+            }]);
+            inputs.push(merged);
+        }
+        rounds.push(vec![NoteSplitTx {
             inputs,
             outputs: targets.to_vec(),
-        }]];
+        }]);
+        return rounds;
     }
     let chunks: Vec<&[u64]> = targets.chunks(max_notes).collect();
     let intermediates: Vec<u64> = chunks
@@ -940,6 +986,13 @@ mod tests {
                 assert!((2..=max_notes).contains(&tx.inputs.len()) || tx.inputs.len() == 1);
                 assert!(tx.inputs.len() <= max_notes, "too many inputs");
                 assert!(!tx.outputs.is_empty() && tx.outputs.len() <= max_notes);
+                assert!(
+                    tx.inputs.len() + tx.outputs.len() <= params.max_actions_per_split_tx,
+                    "spends plus outputs ({} + {}) exceed the total budget of {}",
+                    tx.inputs.len(),
+                    tx.outputs.len(),
+                    params.max_actions_per_split_tx
+                );
                 let min_fee = note_split_fee(tx.inputs.len(), tx.outputs.len(), post_activation);
                 assert!(tx.fee() >= min_fee, "fee below ZIP-317 conventional");
                 for input in &tx.inputs {
@@ -984,6 +1037,47 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    /// ZIP 318's preparation shape is a total budget: a transaction's
+    /// spends and outputs together must fit
+    /// [`MigrationParams::max_actions_per_split_tx`]. A pool small enough
+    /// to skip reduction (at most one spend side's worth of notes) that
+    /// funds several denominations used to emit one sizing transaction
+    /// carrying the whole pool beside every target — up to 30 actions
+    /// post-NU6.3. The planner now consolidates the smallest inputs into
+    /// one funding note first, and every planned transaction fits the
+    /// budget (the executes-in-era validator asserts the bound for every
+    /// test in this module).
+    #[test]
+    fn sizing_respects_the_total_action_budget() {
+        let params = params();
+        // Fifteen unquantized ~11-ZEC notes: reduction is skipped, and the
+        // ~165-ZEC total decomposes into several denominations, so the
+        // sizing round mixes many spends with many outputs.
+        let notes = vec![1_100_000_007u64; 15];
+        for post_activation in [false, true] {
+            let plan = assert_plan_executes_in_era(&notes, post_activation, &params);
+            assert!(
+                plan.parts.len() >= 2,
+                "the shape under test needs several targets, got {:?}",
+                plan.parts
+            );
+            // The consolidation prepends its own round, and the sizing
+            // transaction still mixes multiple spends with multiple
+            // outputs — the shape that used to bust the budget.
+            assert!(
+                plan.split_rounds.len() >= 2,
+                "expected consolidation + sizing"
+            );
+            assert!(
+                plan.split_rounds
+                    .iter()
+                    .flatten()
+                    .any(|tx| tx.inputs.len() >= 2 && tx.outputs.len() >= 2),
+                "the plan under test must exercise a mixed spend/output transaction"
+            );
         }
     }
 

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -24,8 +24,10 @@ pub(crate) const MARGINAL_FEE: u64 = 5_000;
 /// <https://zips.z.cash/zip-0318#notepreparationtransactions>): a split
 /// transaction's spends and outputs together must fit the budget, so each
 /// side's chunk is the budget less the one note on the other side (15
-/// spends merging into one note, or one note dividing into 15).
-fn side_budget(params: &MigrationParams) -> usize {
+/// spends merging into one note, or one note dividing into 15). The
+/// immediate migration chunks under the same law: many spends beside its
+/// single Ironwood output (see [`super::immediate`]).
+pub(crate) fn side_budget(params: &MigrationParams) -> usize {
     params.max_actions_per_split_tx.saturating_sub(1).max(1)
 }
 
@@ -33,8 +35,7 @@ fn side_budget(params: &MigrationParams) -> usize {
 /// at most this, and never manufactures an output worth at most this.
 /// Provisionally twice the marginal fee: a selected note must return strictly
 /// more than double the marginal action cost it adds, not merely break even.
-/// Shared by both migration paths: the private schedule reads it through
-/// [`MigrationParams`], and the immediate [`super::immediate`] reads it directly,
+/// Shared by both migration paths through [`MigrationParams::sweep_min`],
 /// so the two leave identical residuals.
 ///
 /// A local policy, not a ZIP 318 value: the ZIP leaves whether consuming a

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -22,6 +22,17 @@ pub(crate) const MARGINAL_FEE: u64 = 5_000;
 /// at most this, and never manufactures an output worth at most this.
 /// Provisionally twice the marginal fee: a selected note must return strictly
 /// more than double the marginal action cost it adds, not merely break even.
+/// One side's per-transaction note budget, derived from the total budget
+/// ([`MigrationParams::max_actions_per_split_tx`], ZIP 318's 16-action
+/// preparation shape at
+/// <https://zips.z.cash/zip-0318#notepreparationtransactions>): a split
+/// transaction's spends and outputs together must fit the budget, so each
+/// side's chunk is the budget less the one note on the other side (15
+/// spends merging into one note, or one note dividing into 15).
+fn side_budget(params: &MigrationParams) -> usize {
+    params.max_actions_per_split_tx.saturating_sub(1).max(1)
+}
+
 /// Shared by both migration paths: the private schedule reads it through
 /// [`MigrationParams`], and the immediate [`super::immediate`] reads it directly,
 /// so the two leave identical residuals.
@@ -245,9 +256,9 @@ pub fn plan_hash(plan: &MigrationPlan) -> [u8; 32] {
 /// replanned never re-splits finished notes. Everything else worth more than
 /// [`MigrationParams::sweep_min`] is split:
 ///
-/// 1. **Reduction**: while more than `max_actions_per_split_tx` notes remain,
-///    merge groups of at most that many notes into one note each (smallest
-///    first).
+/// 1. **Reduction**: while more notes remain than one transaction's spend
+///    budget, merge groups of at most that many notes into one note each
+///    (smallest first).
 /// 2. **Sizing**: spend the remaining notes into notes sized exactly
 ///    `denomination + part_fee`, where the denominations are the
 ///    [`decompose`]-ition of what is left after all fees. When the balance
@@ -265,7 +276,7 @@ pub fn plan_migration(
     let mut parts: Vec<u64> = Vec::new();
     let mut pool: Vec<u64> = Vec::new();
     let mut residual: u64 = 0;
-    let max_notes = params.max_actions_per_split_tx;
+    let max_notes = side_budget(params);
 
     for &value in note_values {
         if let Some(denomination) = part_denomination(value, params) {
@@ -373,7 +384,7 @@ pub fn plan_migration(
 /// recursing through intermediates when `m` exceeds the per-transaction
 /// budget.
 fn split_into_fee(n_in: usize, m: usize, post_activation: bool, params: &MigrationParams) -> u64 {
-    let max_notes = params.max_actions_per_split_tx;
+    let max_notes = side_budget(params);
     if m <= max_notes {
         note_split_fee(n_in, m, post_activation)
     } else {
@@ -400,7 +411,7 @@ fn split_into(
     post_activation: bool,
     params: &MigrationParams,
 ) -> Vec<Vec<NoteSplitTx>> {
-    let max_notes = params.max_actions_per_split_tx;
+    let max_notes = side_budget(params);
     if targets.len() <= max_notes {
         return vec![vec![NoteSplitTx {
             inputs,
@@ -906,7 +917,7 @@ mod tests {
         params: &MigrationParams,
     ) -> MigrationPlan {
         use std::collections::HashMap;
-        let max_notes = params.max_actions_per_split_tx;
+        let max_notes = side_budget(params);
         let plan = plan_migration(notes, post_activation, params);
 
         let mut available: HashMap<u64, i64> = HashMap::new();
@@ -1000,8 +1011,8 @@ mod tests {
 
     /// Guards the one shape where consolidation could violate the selection
     /// invariant. Post-activation, a trailing group of exactly two notes,
-    /// each at most 12_500 zatoshis, would merge to `sum - 15_000`: between
-    /// 5_002 and 10_000 zatoshis, at or below `sweep_min`. The sizing round
+    /// each at most 12_500 zatoshis, would merge to `sum - 15_000` (a pair
+    /// of 12_000s to 9_000): at or below `sweep_min`. The sizing round
     /// would then spend a note the residual policy refuses, and a replan
     /// after an interruption would leave it as residual, abandoning the pair's value
     /// after fees were paid to create it. The planner instead carries such
@@ -1012,10 +1023,10 @@ mod tests {
     #[test]
     fn consolidation_never_creates_a_sub_sweep_min_intermediate() {
         let params = params();
-        // Seven full consolidation groups (enough to fund a 0.01-ZEC part) plus a
-        // trailing pair that would merge to 6_000 zatoshis, below the sweep
-        // minimum.
-        let notes = vec![10_500u64; 7 * params.max_actions_per_split_tx + 2];
+        // Twelve full consolidation groups (enough to fund a 0.01-ZEC part
+        // after the merge fees of the 16-action shape) plus a trailing pair
+        // that would merge to 9_000 zatoshis, below the sweep minimum.
+        let notes = vec![12_000u64; 12 * side_budget(&params) + 2];
         for post_activation in [false, true] {
             let plan = assert_plan_executes_in_era(&notes, post_activation, &params);
             assert_planned_inputs_exceed_sweep_min(&plan, &params);
@@ -1025,12 +1036,12 @@ mod tests {
         // merges only the full groups, and the sizing round spends the pair
         // directly.
         let plan = plan_migration(&notes, true, &params);
-        assert_eq!(plan.split_rounds[0].len(), 7);
+        assert_eq!(plan.split_rounds[0].len(), 12);
         assert_eq!(
             plan.split_rounds[1][0]
                 .inputs
                 .iter()
-                .filter(|&&value| value == 10_500)
+                .filter(|&&value| value == 12_000)
                 .count(),
             2
         );
@@ -1097,8 +1108,8 @@ mod tests {
             plan.split_rounds.len() >= 2,
             "expected consolidation + sizing rounds"
         );
-        // First round: one merge per full-or-partial chunk of the budget.
-        let max_notes = params.max_actions_per_split_tx;
+        // First round: one merge per full-or-partial chunk of the spend budget.
+        let max_notes = side_budget(&params);
         assert_eq!(plan.split_rounds[0].len(), 500usize.div_ceil(max_notes));
         for tx in &plan.split_rounds[0] {
             assert!(tx.inputs.len() <= max_notes);
@@ -1116,7 +1127,7 @@ mod tests {
         assert!(plan.parts.len() >= 49);
         for round in &plan.split_rounds {
             for tx in round {
-                assert!(tx.outputs.len() <= params.max_actions_per_split_tx);
+                assert!(tx.outputs.len() <= side_budget(&params));
             }
         }
     }

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -25,6 +25,10 @@ pub(crate) const MARGINAL_FEE: u64 = 5_000;
 /// Shared by both migration paths: the private schedule reads it through
 /// [`MigrationParams`], and the immediate [`super::immediate`] reads it directly,
 /// so the two leave identical residuals.
+///
+/// A local policy, not a ZIP 318 value: the ZIP leaves whether consuming a
+/// small note is economic to ZIP 317's marginal fee
+/// (<https://zips.z.cash/zip-0318#amountselectioncanonicalquantization>).
 pub(crate) const SWEEP_MIN: u64 = 2 * MARGINAL_FEE;
 
 /// Orchard pads every non-empty bundle to at least this many actions
@@ -37,6 +41,14 @@ const MIN_BUNDLE_ACTIONS: u64 = 2;
 /// (1 output, padded to 2 actions), so it pays for 4 logical actions. Every
 /// split note is sized `denomination + part_fee` so the part balances
 /// exactly.
+///
+/// ZIP 318 says only "the canonical fee (provisionally the ZIP 317 minimum
+/// fee)" at
+/// <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>,
+/// and the reference crate models a 2-source-action, 1-unpadded-destination
+/// shape, so the three readings price a part at 10 000, 15 000, and (here)
+/// 20 000 zatoshis. The value feeds part sizing and the consent hash, so
+/// aligning it is a ratification decision, not an import.
 pub(crate) const CANONICAL_PART_FEE: u64 = MARGINAL_FEE * 2 * MIN_BUNDLE_ACTIONS;
 
 /// The number of logical actions the builder will produce for a bundle of
@@ -785,10 +797,10 @@ impl crate::wallet::LightWallet {
 
 #[cfg(test)]
 mod tests {
-    use super::super::params::COIN;
     use super::*;
     use crate::config::ChainType;
     use proptest::prelude::*;
+    use zcash_protocol::value::COIN;
 
     fn params() -> MigrationParams {
         MigrationParams::provisional(ChainType::Mainnet)

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -268,7 +268,7 @@ pub fn plan_hash(plan: &MigrationPlan) -> [u8; 32] {
 ///    splitting recurses through intermediate notes.
 ///
 /// `post_activation` selects the note-splitting fee model (see
-/// [`note_split_fee`]): pass whether the transactions will confirm at or
+/// `note_split_fee`): pass whether the transactions will confirm at or
 /// after the NU6.3 activation height.
 pub fn plan_migration(
     note_values: &[u64],


### PR DESCRIPTION
This PR carries the canonical ZIP 318 policy arc: every standardized value and, progressively, every mirrored behavior delegates to `zcash_pool_migration`, the reference implementation in zcash/librustzcash. Conformance to the canonical values provides security properties that are non-negotiable requirements: denominations, shapes, and timing exist so every migrating wallet collides with the population, and bespoke variants fingerprint users.

## Change map

Four tables, one per kind of change; line counts in the mixed source files are split between the source and test tables and marked approximate.

### Source code

| File | ≈LOC | What changed |
|---|---|---|
| `…/migration/schedule.rs` | ≈60 | the advisory target draws from the canonical transfer-delay law; the anchor draw and expiry computation delegate to the canonical crate (their local mirrors are deleted); the value imports rework onto the typed API |
| `…/migration/params.rs` | ≈60 | the standardized values import from the canonical crate; the denomination ladder derives from the imported bounds; `MigrationParams` moves to version 2 with the 16-action total budget |
| `…/migration/split.rs` | ≈15 | the chunk arithmetic derives per-side budgets from the total (fifteen spends merging into one note, one note dividing into fifteen); the fee's three-way spec ambiguity is documented at the constant |

### Tests

| File | ≈LOC | What changed |
|---|---|---|
| `…/migration/schedule.rs` | ≈160 | the branch-move tripwire over the workspace lockfile; ZIP-literal pins for every imported value, the delay law, and the preparation bound; eighteen seeded golden vectors pinning the anchor draw to the retired mirror's exact outputs; target assertions re-pinned to the delay law |
| `…/migration/split.rs` | ≈27 | the consolidation guard rescaled to the 16-action shape's economics; chunk assertions moved to the derived side budget |
| `…/migration/params.rs` | ≈9 | the ladder pin relocated into the tripwire module |

### Documentation

| File | +/− | What it is |
|---|---|---|
| `docs/adr/0020-…` | +138/−0 | ADR 0020 and its resequencing amendment (the observability partition, the track-upstream principle, and the landing order) |
| `docs/testing/zip318-divergence-ledger.md` | +68/−0 | every deliberate divergence: adopted, delegated, blocked-with-dependency, or retained-local, each with its ZIP anchor |
| `…/wallet/migration.rs` | +10/−7 | module doc corrected to the `{1,2,5}×10^k` series, with ZIP anchors (doc comments only) |
| `…/migration/quantize.rs` | +5/−4 | the same correction at the decompose site (doc comments only) |

### Manifests and lockfile

| File | +/− | What it is |
|---|---|---|
| `zingolib/Cargo.toml` | +1/−3 | the dev-dependency becomes a floating git dependency on librustzcash `main`; the "conformance oracle only" comment is deleted |
| `Cargo.lock` | +131/−42 | float fallout: git sibling crates resolved beside the registry pins, and orchard 0.15.0 → 0.15.3 |

Whole diff: +683/−230 — roughly 210 lines of source, 200 of tests, 230 of documentation, and 90 of manifest and lockfile.

ADR 0020 records the ratified plan and its amendment records the sequencing: an on-chain observability partition (fees, shapes, and the timing law must be canonical before migration starts; wallet-internal structure follows), and the track-upstream principle (a mirrored function is a frozen snapshot that diverges silently, so delegation is what makes conformance durable across upstream versions).

Landed so far, in order. The ZIP-standardized values import from the canonical crate rather than being restated, with the crate promoted from a dev-dependency to a real dependency and the old "conformance oracle only" posture deleted; the `zip318_conformance_tripwires` suite pins every imported value to the ZIP's literal number with hash-fragment citations. The dependency then floats on librustzcash's default branch (resolved at `e12f1d0f`), so canonical logic arrives at merge cadence, guarded by a branch-move tripwire that reads the workspace lockfile and fails whenever the resolved revision leaves the adjudicated one. The sibling drag this predicted arrived and is absorbed: the git dependency carries its own `zcash_protocol`/`zcash_primitives`/`zcash_address`/`zcash_transparent` beside the registry pins, orchard took a point-release bump (0.15.0 to 0.15.3) for the deferred-anchor API, and values cross the crate divide as plain integers.

The second landing closed the observable divergences reachable from the current stack, at `MigrationParams` version 2: the split planner conforms to the ZIP's 16-action preparation shape (the parameter's semantics sharpened from a per-side note count to the total budget, with a derived side budget driving the chunking), and the advisory broadcast target draws from the canonical transfer-delay law (exponential, mean 144 capped 576), sendability staying whole-window per ADR 0017. The part fee and the unpadded single-action Ironwood bundle are recorded in the divergence ledger as blocked with their dependency named: the registry `zcash_primitives` 0.29 builder exposes no Ironwood padding control, so they unblock with the librustzcash 0.30 stack bump, which is also what the deferred PCZT builders require.

The final landing deleted the provably equal mirrors: the anchor draw delegates to `draw_anchor_boundary` (window boundary mapped as the observed tip), with seeded golden vectors captured from the retired implementation pinning strict equivalence, and the expiry computation delegates to `expiry_height`, pinned against the ZIP's own arithmetic. The decomposition mirror is retained and ledgered: upstream exports no bare decomposition, so it delegates with the planning layer. The state traits, wallet format 44, engine, and PCZT layers remain the ratified end state under standing oracle pull.

Stacked on #2540 (the migration-surface visibility work); the consumer API of zingo-cli, zingo-pc, and zingo-mobile is unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
