### PR TITLE
refactor: gather every temporal parameter into zingo_netutils::time

### DIFF
--- a/libtonode-tests/Cargo.toml
+++ b/libtonode-tests/Cargo.toml
@@ -44,7 +44,8 @@ zcash_address = { workspace = true, features = ["test-dependencies"] }
 zcash_client_backend = { workspace = true }
 zcash_primitives = { workspace = true }
 zcash_protocol = { workspace = true }
-zingo-netutils = { workspace = true }
+# `testutils` exposes `time::test`, the tests' temporal parameters.
+zingo-netutils = { workspace = true, features = ["testutils"] }
 zingo-status = { workspace = true }
 zingo_test_vectors = { workspace = true }
 zip32 = { workspace = true }

--- a/libtonode-tests/tests/mempool_attribution.rs
+++ b/libtonode-tests/tests/mempool_attribution.rs
@@ -129,7 +129,7 @@ async fn indexer_mempool_view_trails_validator_acceptance() {
     )
     .await
     .unwrap();
-    let bound = Duration::from_secs(10);
+    let bound = zingo_netutils::time::test::MEMPOOL_INGEST_BOUND;
     let indexer_lag = loop {
         let mut mempool_stream = grpc_client
             .get_mempool_tx(
@@ -137,7 +137,7 @@ async fn indexer_mempool_view_trails_validator_acceptance() {
                     exclude_txid_suffixes: vec![],
                     pool_types: vec![],
                 },
-                Duration::from_secs(5),
+                zingo_netutils::time::test::MEMPOOL_STREAM_BOUND,
             )
             .await
             .unwrap();
@@ -195,7 +195,7 @@ async fn wallet_mempool_record_trails_validator_acceptance() {
     recipient.sync_and_await().await.unwrap();
     let sync_returned = accepted_at.elapsed();
 
-    let bound = Duration::from_secs(15);
+    let bound = zingo_netutils::time::test::WALLET_RECORD_LAG_BOUND;
     let wallet_record_lag = loop {
         let in_mempool = {
             let wallet = recipient.wallet();

--- a/libtonode-tests/tests/sentinels.rs
+++ b/libtonode-tests/tests/sentinels.rs
@@ -69,7 +69,7 @@ async fn launch_mines_exactly_one_block_and_nothing_else_mines() {
         "this test issued writes itself, so it cannot attribute block 1: {writes:?}"
     );
 
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    tokio::time::sleep(zingo_netutils::time::test::IDLE_OBSERVATION_WINDOW).await;
     let (idle_height, idle_tip) = validator_rpc::try_get_chain_info(rpc_port)
         .await
         .expect("idle zebrad must still answer");
@@ -145,7 +145,7 @@ async fn suppressed_launch_generate_leaves_genesis() {
          state persists on disk after all, or something other than the launch generate mines"
     );
 
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    tokio::time::sleep(zingo_netutils::time::test::IDLE_OBSERVATION_WINDOW).await;
     let (idle_height, idle_tip) = validator_rpc::try_get_chain_info(rpc_port)
         .await
         .expect("idle cache-loaded zebrad must still answer");

--- a/libtonode-tests/tests/sentinels.rs
+++ b/libtonode-tests/tests/sentinels.rs
@@ -15,7 +15,6 @@
 #![cfg(feature = "sentinels")]
 
 use std::path::PathBuf;
-use std::time::Duration;
 
 use zcash_local_net::MinerPool;
 use zcash_local_net::process::Process;

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -48,7 +48,7 @@ async fn sync_mainnet_test() {
     let mut lightclient = LightClient::new(config, true).await.unwrap();
 
     lightclient.sync().await.unwrap();
-    let mut interval = tokio::time::interval(Duration::from_secs(5));
+    let mut interval = tokio::time::interval(zingo_netutils::time::test::SETTLE_POLL_INTERVAL);
     loop {
         interval.tick().await;
         {

--- a/pepper-sync/src/client.rs
+++ b/pepper-sync/src/client.rs
@@ -32,7 +32,7 @@ pub(crate) mod fetch;
 
 const MAX_RETRIES: u8 = 3;
 
-const STREAM_MSG_TIMEOUT: Duration = Duration::from_secs(15);
+use zingo_netutils::time::STREAM_MSG_TIMEOUT;
 
 async fn next_stream_item<T>(
     stream: &mut tonic::Streaming<T>,

--- a/pepper-sync/src/client/fetch.rs
+++ b/pepper-sync/src/client/fetch.rs
@@ -1,6 +1,6 @@
 //! Queue and prioritise fetch requests to fetch data from the server
 
-use std::{ops::Range, time::Duration};
+use std::ops::Range;
 
 use tokio::sync::mpsc::UnboundedReceiver;
 
@@ -17,8 +17,7 @@ use zingo_netutils::{
 
 use crate::client::FetchRequest;
 
-const UNARY_RPC_TIMEOUT: Duration = Duration::from_secs(10);
-const HEAVY_UNARY_TIMEOUT: Duration = Duration::from_secs(20);
+use zingo_netutils::time::{HEAVY_UNARY_TIMEOUT, UNARY_RPC_TIMEOUT};
 
 use zingo_netutils::lightwallet_protocol::{GetSubtreeRootsArg, SubtreeRoot};
 

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -38,8 +38,7 @@ use super::{ScanResults, scan};
 const MAX_WORKER_POOLSIZE: usize = 2;
 const MAX_BATCH_NULLIFIERS: usize = 2usize.pow(14);
 
-const STREAM_MSG_TIMEOUT: Duration = Duration::from_secs(15);
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+use zingo_netutils::time::{SCANNER_SHUTDOWN_TIMEOUT, STREAM_MSG_TIMEOUT};
 
 pub(crate) enum ScannerState {
     Verification,
@@ -619,7 +618,7 @@ where
             .take()
             .expect("batcher should always have a handle to take!");
 
-        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut handle).await {
+        match tokio::time::timeout(SCANNER_SHUTDOWN_TIMEOUT, &mut handle).await {
             Ok(join_res) => join_res.expect("task panicked")?,
             Err(_) => {
                 handle.abort();
@@ -729,7 +728,7 @@ where
             .take()
             .expect("worker should always have a handle to take!");
 
-        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut handle).await {
+        match tokio::time::timeout(SCANNER_SHUTDOWN_TIMEOUT, &mut handle).await {
             Ok(res) => res,
             Err(_) => {
                 handle.abort();

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1206,16 +1206,12 @@ fn drain_verdict(
     connected_for: Option<Duration>,
     poll_elapsed: Duration,
 ) -> DrainVerdict {
-    /// The pre-c90f8d309 unconditional sleep, demoted to worst case: a
-    /// stream that never connects must not hold the session open.
-    const CEILING: Duration = Duration::from_secs(1);
-    /// One settle window after subscription.
-    const SETTLE: Duration = Duration::from_millis(200);
+    use zingo_netutils::time::{MEMPOOL_DRAIN_CEILING, MEMPOOL_DRAIN_SETTLE};
 
     if unprocessed_mempool_transactions > 0 {
         return DrainVerdict::Reenter;
     }
-    if poll_elapsed >= CEILING {
+    if poll_elapsed >= MEMPOOL_DRAIN_CEILING {
         return if scan_workers == 0 {
             DrainVerdict::Shutdown
         } else {
@@ -1223,7 +1219,7 @@ fn drain_verdict(
         };
     }
     match connected_for {
-        Some(age) if age >= SETTLE && scan_workers == 0 => DrainVerdict::Shutdown,
+        Some(age) if age >= MEMPOOL_DRAIN_SETTLE && scan_workers == 0 => DrainVerdict::Shutdown,
         _ => DrainVerdict::KeepPolling,
     }
 }

--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -42,6 +42,9 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# The heartbeat and log-file tests read their temporal parameters from
+# `time::test`.
+zingo-netutils = { workspace = true, features = ["testutils"] }
 # test-util powers the paused-clock heartbeat tests.
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros", "test-util"] }
 tokio-stream = "0.1"

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -40,12 +40,7 @@ use zingolib::wallet::migration::{self, MigrationPhase};
 
 pub static RT: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
 
-/// The cadence of the transmit heartbeat. A transmission can legitimately run
-/// for minutes (mixnet round trips, per-arm retries, serially gated fan-out
-/// rounds, queued-verdict probes), so every transmitting command prints the
-/// transmission's latest progress line at this interval while it waits. A send
-/// that completes before the first tick stays silent.
-const TRANSMIT_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+use zingo_netutils::time::TRANSMIT_HEARTBEAT_INTERVAL;
 
 /// Awaits `operation`, emitting a heartbeat every
 /// [`TRANSMIT_HEARTBEAT_INTERVAL`]: the latest line from `latest` (the
@@ -843,10 +838,8 @@ fn parse_nym_args(args: &[&str]) -> Result<NymSubCommand, NymCommandError> {
     }
 }
 
-/// How long each probe leg may take. Generous for the mixnet leg's tunnel
-/// establishment. A hanging exit is reported as a timeout, not waited out.
 #[cfg(feature = "nym")]
-const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+use zingo_netutils::time::PROBE_LEG_TIMEOUT;
 
 /// Render one paired probe: the two legs side by side, so a mixnet-specific
 /// failure (clearnet ok, mixnet failed) reads at a glance. Pure, pinned by
@@ -1057,7 +1050,7 @@ fn nym_command(args: &[&str], lightclient: &mut LightClient) -> Result<String, N
             }
             NymSubCommand::Probe { target } => {
                 let probes = lightclient
-                    .probe_broadcast_indexers(target, PROBE_TIMEOUT)
+                    .probe_broadcast_indexers(target, PROBE_LEG_TIMEOUT)
                     .await;
                 Ok(probes
                     .iter()
@@ -3314,7 +3307,7 @@ mod transmit_heartbeat {
             "confirm",
             || Some("submitting".to_string()),
             move |line| sink.lock().expect("line sink poisoned").push(line),
-            tokio::time::sleep(Duration::from_secs(5)),
+            tokio::time::sleep(zingo_netutils::time::test::SIMULATED_TRANSMIT),
         )
         .await;
         let () = out;

--- a/zingo-cli/src/server_select.rs
+++ b/zingo-cli/src/server_select.rs
@@ -23,7 +23,7 @@ pub(crate) struct RankedServer {
 ///
 /// Uses a per-server timeout so one slow server doesn't block the rest.
 pub(crate) fn select_servers() -> Vec<RankedServer> {
-    const GET_INFO_TIMEOUT: Duration = Duration::from_secs(5);
+    use zingo_netutils::time::SERVER_RANKING_TIMEOUT;
 
     let uris: Vec<http::Uri> = MOST_UP_INDEXER_URIS
         .iter()
@@ -42,7 +42,7 @@ pub(crate) fn select_servers() -> Vec<RankedServer> {
                     Ok(i) => i,
                     Err(_) => return None,
                 };
-                match indexer.get_lightd_info(GET_INFO_TIMEOUT).await {
+                match indexer.get_lightd_info(SERVER_RANKING_TIMEOUT).await {
                     Ok(_info) => Some(RankedServer {
                         uri,
                         latency: start.elapsed(),

--- a/zingo-cli/tests/log_file.rs
+++ b/zingo-cli/tests/log_file.rs
@@ -65,7 +65,7 @@ fn interactive_mode_redirects_tracing_to_log_file() {
     // Wait for the startup INFO lines to reach the log file, polling
     // instead of sleeping a fixed interval; the ceiling only bounds the
     // pathological case.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + zingo_netutils::time::test::LOG_FLUSH_DEADLINE;
     loop {
         if std::fs::read_to_string(&log_path)
             .unwrap_or_default()
@@ -75,7 +75,8 @@ fn interactive_mode_redirects_tracing_to_log_file() {
         }
         assert!(
             std::time::Instant::now() < deadline,
-            "no INFO line reached the log file within 15s"
+            "no INFO line reached the log file within {:?}",
+            zingo_netutils::time::test::LOG_FLUSH_DEADLINE
         );
         std::thread::sleep(std::time::Duration::from_millis(100));
     }

--- a/zingo-netutils/Cargo.toml
+++ b/zingo-netutils/Cargo.toml
@@ -54,6 +54,9 @@ zingo-net-diag = { version = "0.1.0", path = "../zingo-net-diag", optional = tru
 [features]
 globally-public-transparent = ["dep:tokio-stream"]
 ping-very-insecure = []
+# Exposes `time::test`, the temporal parameters owned by tests. Enabled by
+# downstream crates' dev-dependencies only, never by a production build.
+testutils = []
 # Wallet-side SOCKS5-dialing transmit (ADR 0011, consumption model A). Light —
 # no nym-sdk, so it resolves in the main workspace's lockfile. The wallet
 # enables this to route a transaction through the spawned nym-proxy's local

--- a/zingo-netutils/nym-proxy-ffi/Cargo.toml
+++ b/zingo-netutils/nym-proxy-ffi/Cargo.toml
@@ -23,3 +23,5 @@ thiserror = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+# The tests read their temporal parameters from `time::test`.
+zingo-netutils = { path = "..", features = ["testutils"] }

--- a/zingo-netutils/nym-proxy-ffi/src/lib.rs
+++ b/zingo-netutils/nym-proxy-ffi/src/lib.rs
@@ -21,12 +21,9 @@
 use std::{net::SocketAddr, sync::Mutex, time::Duration};
 
 use tokio::runtime::Runtime;
+use zingo_netutils::time::{LIVENESS_PROBE_INTERVAL, LOOPBACK_DIAL_BOUND};
 use zingo_netutils::NymProxy;
 
-/// How often the liveness monitor probes the local SOCKS5 listener.
-const LIVENESS_PROBE_INTERVAL: Duration = Duration::from_secs(15);
-/// How long one probe may take before it counts as a failure.
-const LIVENESS_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Consecutive probe failures required before the proxy is declared dead,
 /// so one transient hiccup does not kill an attached session.
 const LIVENESS_PROBE_STRIKES: u32 = 2;
@@ -208,7 +205,7 @@ impl MixnetProxyHandle {
                     endpoint.clone(),
                     observer,
                     LIVENESS_PROBE_INTERVAL,
-                    LIVENESS_PROBE_TIMEOUT,
+                    LOOPBACK_DIAL_BOUND,
                     LIVENESS_PROBE_STRIKES,
                 ))
                 .abort_handle()
@@ -292,12 +289,12 @@ mod tests {
         (endpoint, serving)
     }
 
-    const TEST_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+    use zingo_netutils::time::test::MONITOR_PROBE_TIMEOUT;
 
     #[tokio::test]
     async fn probe_passes_a_listener_that_completes_the_handshake() {
         let (endpoint, serving) = mock_socks5_listener([0x05, 0x00]).await;
-        socks5_handshake_probe(&endpoint, TEST_PROBE_TIMEOUT)
+        socks5_handshake_probe(&endpoint, MONITOR_PROBE_TIMEOUT)
             .await
             .expect("healthy handshake must pass the probe");
         serving.abort();
@@ -308,7 +305,7 @@ mod tests {
         // 0xff is SOCKS5 for "no acceptable method" — the listener is alive
         // but no longer serving, which must read as dead.
         let (endpoint, serving) = mock_socks5_listener([0x05, 0xff]).await;
-        socks5_handshake_probe(&endpoint, TEST_PROBE_TIMEOUT)
+        socks5_handshake_probe(&endpoint, MONITOR_PROBE_TIMEOUT)
             .await
             .expect_err("a refusing listener must fail the probe");
         serving.abort();
@@ -320,7 +317,7 @@ mod tests {
         serving.abort();
         // The port is now free again; connecting must be refused.
         tokio::time::sleep(Duration::from_millis(50)).await;
-        socks5_handshake_probe(&endpoint, TEST_PROBE_TIMEOUT)
+        socks5_handshake_probe(&endpoint, MONITOR_PROBE_TIMEOUT)
             .await
             .expect_err("a dead listener must fail the probe");
     }
@@ -336,7 +333,7 @@ mod tests {
         }
     }
 
-    const TEST_PROBE_INTERVAL: Duration = Duration::from_millis(30);
+    use zingo_netutils::time::test::MONITOR_PROBE_INTERVAL;
 
     #[tokio::test]
     async fn monitor_reports_death_exactly_once_after_the_listener_dies() {
@@ -345,18 +342,18 @@ mod tests {
         let monitor = tokio::spawn(monitor_liveness(
             endpoint,
             Box::new(Arc::clone(&observer)),
-            TEST_PROBE_INTERVAL,
-            TEST_PROBE_TIMEOUT,
+            MONITOR_PROBE_INTERVAL,
+            MONITOR_PROBE_TIMEOUT,
             LIVENESS_PROBE_STRIKES,
         ));
         // Several healthy intervals pass without a death report.
-        tokio::time::sleep(TEST_PROBE_INTERVAL * 4).await;
+        tokio::time::sleep(MONITOR_PROBE_INTERVAL * 4).await;
         assert!(observer.deaths.lock().unwrap().is_empty());
 
         serving.abort();
         // The monitor ends itself after reporting; that is the at-most-once
         // guarantee, and joining it proves the report happened.
-        tokio::time::timeout(Duration::from_secs(5), monitor)
+        tokio::time::timeout(zingo_netutils::time::test::MOCK_OP_BOUND, monitor)
             .await
             .expect("monitor must report within the strike window")
             .expect("monitor task must end cleanly");

--- a/zingo-netutils/src/arm_race.rs
+++ b/zingo-netutils/src/arm_race.rs
@@ -238,12 +238,12 @@ impl RaceState {
 mod tests {
     use super::*;
 
-    const HEDGE: Duration = Duration::from_secs(5);
+    use crate::time::test::PLANNER_HEDGE;
 
     fn hedged(max_parallel: usize) -> LaunchPolicy {
         LaunchPolicy::Hedged {
             max_parallel,
-            hedge_interval: HEDGE,
+            hedge_interval: PLANNER_HEDGE,
         }
     }
 
@@ -261,7 +261,7 @@ mod tests {
             race.start(),
             vec![
                 RaceAction::Launch { candidate: 0 },
-                RaceAction::ArmHedgeTimer(HEDGE)
+                RaceAction::ArmHedgeTimer(PLANNER_HEDGE)
             ]
         );
     }
@@ -274,7 +274,7 @@ mod tests {
             race.on_event(RaceEvent::HedgeElapsed),
             vec![
                 RaceAction::Launch { candidate: 1 },
-                RaceAction::ArmHedgeTimer(HEDGE)
+                RaceAction::ArmHedgeTimer(PLANNER_HEDGE)
             ]
         );
         // The third arm fills max_parallel, so no further timer is armed.
@@ -295,7 +295,7 @@ mod tests {
             actions,
             vec![
                 RaceAction::Launch { candidate: 1 },
-                RaceAction::ArmHedgeTimer(HEDGE)
+                RaceAction::ArmHedgeTimer(PLANNER_HEDGE)
             ],
             "a failure is a signal to try elsewhere at once, not to wait"
         );

--- a/zingo-netutils/src/bin/nym-proxy.rs
+++ b/zingo-netutils/src/bin/nym-proxy.rs
@@ -35,11 +35,10 @@
 #![forbid(unsafe_code)]
 
 use std::io::Write as _;
-use std::time::Duration;
-
 use tokio::io::AsyncReadExt as _;
 use zingo_netutils::{
     NYM_STATUS_LINE_PREFIX, NymProxy, SOCKS5_ADDR_LINE_PREFIX, get_lightd_info_via_socks5,
+    time::MIXNET_ROUND_TRIP_BOUND,
 };
 
 /// The indexer contacted to prove the mixnet actually carries data before the
@@ -48,10 +47,6 @@ use zingo_netutils::{
 /// deployed, reliable mainnet endpoint. Contacting it is a health probe, not a
 /// wallet operation. (A future refinement could rotate this across a set.)
 const HEALTH_CHECK_INDEXER: &str = "https://zec.rocks:443";
-
-/// Per-attempt bound on the health round trip. A dead path stalls the TLS
-/// handshake, so this must fire well within the mixnet's own lifecycle cap.
-const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// How many draws to try before giving up. Each failure redraws a fresh set of
 /// gateways, so this is the number of distinct mixnet paths attempted.
@@ -111,7 +106,8 @@ async fn health_gate(proxy: &mut NymProxy) -> Result<(), Box<dyn std::error::Err
         report(format!(
             "verifying the mixnet path (attempt {attempt}/{MAX_HEALTH_ATTEMPTS})"
         ));
-        match get_lightd_info_via_socks5(&proxy.socks5_addr(), &indexer, HEALTH_CHECK_TIMEOUT).await
+        match get_lightd_info_via_socks5(&proxy.socks5_addr(), &indexer, MIXNET_ROUND_TRIP_BOUND)
+            .await
         {
             Ok(_) => {
                 report("mixnet path verified".to_string());

--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -56,6 +56,10 @@ pub const SOCKS5_ADDR_LINE_PREFIX: &str = "SOCKS5_ADDR=";
 /// definition. The full line is e.g.
 /// `NYM_STATUS=attempt 4/10: 2 in flight, 2 failed`.
 pub const NYM_STATUS_LINE_PREFIX: &str = "NYM_STATUS=";
+
+// The temporal parameters of every crate that can see this one, including
+// the values owned by tests (`time::test`). See the module's registry.
+pub mod time;
 pub use error::*;
 pub use lightwallet_protocol;
 pub use tonic::{Status, Streaming};
@@ -629,8 +633,6 @@ mod tests {
     //! - We explicitly install a rustls crypto provider to avoid
     //!   provider-selection panics in test binaries.
 
-    use std::time::Duration;
-
     use http::{Request, Response};
     use hyper::{
         body::{Bytes, Incoming},
@@ -644,7 +646,7 @@ mod tests {
 
     use tokio_rustls::rustls::RootCertStore;
 
-    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+    use crate::time::test::LOCAL_TLS_TEST_BOUND;
 
     fn add_test_cert_to_roots(roots: &mut RootCertStore) {
         use tonic::transport::CertificateDer;
@@ -959,7 +961,7 @@ mod tests {
         let response = GrpcIndexer::new(uri)
             .await
             .expect("URI to be valid.")
-            .get_lightd_info(DEFAULT_TIMEOUT)
+            .get_lightd_info(LOCAL_TLS_TEST_BOUND)
             .await
             .expect("to get info");
         assert!(
@@ -995,7 +997,7 @@ mod tests {
         let mut indexer = GrpcIndexer::new(uri).await.expect("valid URI");
 
         let tip = indexer
-            .get_latest_block(DEFAULT_TIMEOUT)
+            .get_latest_block(LOCAL_TLS_TEST_BOUND)
             .await
             .expect("get_latest_block");
         let start_height = tip.height;
@@ -1015,7 +1017,7 @@ mod tests {
         };
 
         let mut stream = indexer
-            .get_block_range(range, DEFAULT_TIMEOUT)
+            .get_block_range(range, LOCAL_TLS_TEST_BOUND)
             .await
             .expect("get_block_range");
 

--- a/zingo-netutils/src/nym_proxy.rs
+++ b/zingo-netutils/src/nym_proxy.rs
@@ -38,7 +38,6 @@ use std::{
     collections::HashMap,
     future::Future,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    time::Duration,
 };
 
 use nym_sdk::mixnet::{MixnetClientBuilder, Socks5, Socks5MixnetClient};
@@ -59,31 +58,9 @@ const MAX_PROVIDER_ATTEMPTS: usize = 10;
 /// parallelism is deliberately narrow.
 const MAX_PARALLEL_CONNECTS: usize = 3;
 
-/// How long the hedged bootstrap stays quiet before launching another
-/// provider in parallel. A responsive provider typically connects in well
-/// under ten seconds, so an attempt this old is worth hedging against
-/// without yet giving up on it.
-const HEDGE_INTERVAL: Duration = Duration::from_secs(5);
-
-/// Overall timeout for `start()` and `reconnect()` to prevent infinite hangs.
-///
-/// Nym SDK connection attempts can block indefinitely if a gateway is
-/// unresponsive. This timeout caps total wall-clock time for the entire
-/// retry loop. [`PER_ATTEMPT_CONNECT_TIMEOUT`] caps individual attempts.
-const NYM_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(120);
-
-/// Timeout for a single provider connect attempt.
-///
-/// Without this bound, one unresponsive provider hangs
-/// `connect_to_mixnet_via_socks5` until the whole [`NYM_LIFECYCLE_TIMEOUT`]
-/// budget burns, and the retry engine never reaches the next provider. A
-/// responsive provider bootstraps in well under ten seconds. Six full
-/// attempts fit inside the lifecycle budget.
-const PER_ATTEMPT_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
-
-/// Timeout for the provider-discovery API query, which is otherwise
-/// unbounded for the same reason as the connect attempts.
-const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(15);
+use crate::time::{
+    DISCOVERY_TIMEOUT, HEDGE_INTERVAL, NYM_LIFECYCLE_TIMEOUT, PER_ATTEMPT_CONNECT_TIMEOUT,
+};
 
 /// Embedded Nym SOCKS5 proxy that routes traffic through the Nym mixnet.
 ///
@@ -581,6 +558,8 @@ fn time_entropy_seed() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     // The scheme-stripping and retry-engine logic is tested in

--- a/zingo-netutils/src/socks5_transmit.rs
+++ b/zingo-netutils/src/socks5_transmit.rs
@@ -435,6 +435,8 @@ pub async fn transaction_known_via_socks5(
 mod tests {
     use super::*;
 
+    use crate::time::test::MOCK_OP_BOUND;
+
     fn an_indexer() -> Uri {
         "https://indexer.example:443".parse().expect("static uri")
     }
@@ -567,10 +569,9 @@ mod tests {
     #[tokio::test]
     async fn a_non_https_indexer_is_refused() {
         let http = "http://indexer.example:9067".parse().expect("static uri");
-        let err =
-            send_transaction_via_socks5("127.0.0.1:1", &http, b"tx", 1, Duration::from_secs(5))
-                .await
-                .expect_err("http must be refused");
+        let err = send_transaction_via_socks5("127.0.0.1:1", &http, b"tx", 1, MOCK_OP_BOUND)
+            .await
+            .expect_err("http must be refused");
         assert!(
             matches!(err, Socks5TransmitError::InsecureScheme { .. }),
             "expected InsecureScheme, got: {err}"
@@ -588,10 +589,9 @@ mod tests {
         let addr = listener.local_addr().expect("local addr").to_string();
         drop(listener);
 
-        let err =
-            send_transaction_via_socks5(&addr, &an_indexer(), b"tx", 1, Duration::from_secs(5))
-                .await
-                .expect_err("no proxy is listening");
+        let err = send_transaction_via_socks5(&addr, &an_indexer(), b"tx", 1, MOCK_OP_BOUND)
+            .await
+            .expect_err("no proxy is listening");
         assert!(
             matches!(err, Socks5TransmitError::ProxyUnreachable { .. }),
             "expected ProxyUnreachable, got: {err}"
@@ -616,10 +616,9 @@ mod tests {
             }
         });
 
-        let err =
-            send_transaction_via_socks5(&addr, &an_indexer(), b"tx", 1, Duration::from_secs(5))
-                .await
-                .expect_err("the handshake dies");
+        let err = send_transaction_via_socks5(&addr, &an_indexer(), b"tx", 1, MOCK_OP_BOUND)
+            .await
+            .expect_err("the handshake dies");
         assert!(
             matches!(err, Socks5TransmitError::TunnelRefused { .. }),
             "expected TunnelRefused, got: {err}"

--- a/zingo-netutils/src/time.rs
+++ b/zingo-netutils/src/time.rs
@@ -8,8 +8,8 @@
 //! two call sites share a constant only when they bound the *same*
 //! quantity, never because their numbers coincide — the census behind this
 //! module adjudicated every coincidence. Values that exist only for tests
-//! live in [`test`], compiled unconditionally so downstream test code can
-//! import them.
+//! live in the `test` submodule, which `cfg(test)` exposes to this crate's
+//! own tests and the `testutils` feature exposes to downstream test code.
 //!
 //! The one production exception dependency direction forces: `zingo-price`
 //! sits below the wallet with no dependency on this crate, so

--- a/zingo-netutils/src/time.rs
+++ b/zingo-netutils/src/time.rs
@@ -1,0 +1,220 @@
+//! The temporal parameters of every crate that can see this one, in one
+//! place.
+//!
+//! Every timeout, cadence, pause, and window that tunes a mechanism in a
+//! crate depending on `zingo-netutils` lives here, so a retune moves one
+//! number per physical fact and a reader surveys every knob on one page
+//! (issue #2565). Each constant documents the physical quantity it names;
+//! two call sites share a constant only when they bound the *same*
+//! quantity, never because their numbers coincide — the census behind this
+//! module adjudicated every coincidence. Values that exist only for tests
+//! live in [`test`], compiled unconditionally so downstream test code can
+//! import them.
+//!
+//! The one production exception dependency direction forces: `zingo-price`
+//! sits below the wallet with no dependency on this crate, so
+//! `zingo_price::REQUEST_TIMEOUT` (20 s) and `zingo_price::CONNECT_TIMEOUT`
+//! (10 s) stay there, role-tuned to a decorative datum under the mobile
+//! UI's 25-second watchdog.
+#![forbid(unsafe_code)]
+
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// The mixnet transport (ADR 0011 and its mobile amendment)
+// ---------------------------------------------------------------------------
+
+/// Bound on one data round trip through the mixnet tunnel: the health
+/// round trip the spawnable `nym-proxy` binary gates readiness on, and the
+/// identical round trip the wallet's attach readiness gate runs (ADR 0011's
+/// mobile amendment). One physical quantity, defined once so the two gates
+/// cannot be retuned apart (issue #2565). A dead path stalls the TLS
+/// handshake, so this must fire well within [`NYM_LIFECYCLE_TIMEOUT`].
+pub const MIXNET_ROUND_TRIP_BOUND: Duration = Duration::from_secs(15);
+
+/// Bound on one loopback exchange with the local SOCKS5 listener: the wallet
+/// supervisor's liveness probe (a bare TCP dial) and the mobile shim's
+/// liveness monitor (a SOCKS5 method-selection round trip) both address the
+/// same in-process listener, so they share one bound (issue #2565). Generous
+/// for a loopback exchange — its job is to notice a torn-down host, not to
+/// measure the mixnet, which no local exchange can see.
+pub const LOOPBACK_DIAL_BOUND: Duration = Duration::from_secs(5);
+
+/// Overall timeout for the mixnet bootstrap (`start()` and `reconnect()`),
+/// preventing infinite hangs.
+///
+/// Nym SDK connection attempts can block indefinitely if a gateway is
+/// unresponsive. This timeout caps total wall-clock time for the entire
+/// retry loop. [`PER_ATTEMPT_CONNECT_TIMEOUT`] caps individual attempts.
+pub const NYM_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Timeout for a single provider connect attempt.
+///
+/// Without this bound, one unresponsive provider hangs
+/// `connect_to_mixnet_via_socks5` until the whole [`NYM_LIFECYCLE_TIMEOUT`]
+/// budget burns, and the retry engine never reaches the next provider. A
+/// responsive provider bootstraps in well under ten seconds. Six full
+/// attempts fit inside the lifecycle budget.
+pub const PER_ATTEMPT_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Timeout for the provider-discovery API query, which is otherwise
+/// unbounded for the same reason as the connect attempts.
+pub const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// How long the hedged bootstrap stays quiet before launching another
+/// provider in parallel. A responsive provider typically connects in well
+/// under ten seconds, so an attempt this old is worth hedging against
+/// without yet giving up on it.
+pub const HEDGE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How often the mobile shim's liveness monitor probes the local SOCKS5
+/// listener. Faster than [`ATTACH_PROBE_INTERVAL`] because the shim's host
+/// (the app) is the remediation owner: it must notice a lost proxy and
+/// re-attach before the wallet's backstop declares death. Whether that
+/// ordering is a hard constraint is an open question on issue #2565.
+pub const LIVENESS_PROBE_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Cadence of the wallet supervisor's liveness probe against an attached
+/// endpoint — the backstop for hosts that pass no death observer.
+pub const ATTACH_PROBE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Pause between the attach readiness gate's round-trip attempts, letting a
+/// transient blip pass. Spacing, not a bound: the attempts themselves are
+/// bounded by [`MIXNET_ROUND_TRIP_BOUND`].
+pub const ATTACH_HEALTH_RETRY_PAUSE: Duration = Duration::from_secs(1);
+
+// ---------------------------------------------------------------------------
+// The gRPC data path (sync and send)
+// ---------------------------------------------------------------------------
+
+/// Bound on one ordinary unary indexer request: the wallet's default
+/// patience for a single gRPC call on the send and query paths.
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Bound on waiting for the next message on a gRPC stream, so a stalled
+/// server ends the wait as a typed timeout rather than hanging the consumer.
+/// Shared by pepper-sync's client and scanner, which formerly each carried
+/// their own identical copy (issue #2565).
+pub const STREAM_MSG_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Bound on one light unary RPC issued by pepper-sync's fetcher.
+pub const UNARY_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Bound on one heavy unary RPC issued by pepper-sync's fetcher, whose
+/// responses are large enough to deserve more patience than
+/// [`UNARY_RPC_TIMEOUT`].
+pub const HEAVY_UNARY_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long pepper-sync's scanner waits for its workers to wind down before
+/// abandoning a clean shutdown.
+pub const SCANNER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The mempool drain's worst-case wait: the pre-c90f8d309 unconditional
+/// sleep, demoted to a ceiling so a stream that never connects cannot hold
+/// the session open.
+pub const MEMPOOL_DRAIN_CEILING: Duration = Duration::from_secs(1);
+
+/// One settle window after the mempool subscription, inside
+/// [`MEMPOOL_DRAIN_CEILING`].
+pub const MEMPOOL_DRAIN_SETTLE: Duration = Duration::from_millis(200);
+
+/// Bound on waiting for the sync engine to acknowledge a start request.
+pub const SYNC_START_TIMEOUT: Duration = Duration::from_secs(3);
+
+// ---------------------------------------------------------------------------
+// The send pipeline and its narration
+// ---------------------------------------------------------------------------
+
+/// The interval between transmit retries and queued-verdict probes.
+pub const TRANSMIT_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Bound on one migration-broadcast submission through the tunnel. More
+/// patient than [`DEFAULT_REQUEST_TIMEOUT`] because a migration broadcast
+/// tolerates latency better than an interactive send.
+pub const MIGRATION_SUBMIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long to wait between sync polls while a note-splitting migration
+/// round confirms.
+pub const CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Mixnet transmissions can wait for minutes (mixnet round trips, per-arm
+/// retries, serially gated fan-out rounds, queued-verdict probes), so every
+/// transmitting CLI command prints the transmission's latest progress line
+/// at this interval while it waits. A send that completes before the first
+/// tick stays silent.
+pub const TRANSMIT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Diagnostics and server selection
+// ---------------------------------------------------------------------------
+
+/// How long each paired-probe leg may take. Generous for the mixnet leg's
+/// tunnel establishment. A hanging exit is reported as a timeout, not
+/// waited out.
+pub const PROBE_LEG_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Per-server bound on the ranking `get_info` sweep, deliberately tight so
+/// one slow server cannot block the fastest-first ordering.
+pub const SERVER_RANKING_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Temporal parameters owned by tests. Gated so production code cannot
+/// reference it: this crate's own unit tests see it via `cfg(test)`, and
+/// downstream crates' test code opts in through the `testutils` feature
+/// (declared in their dev-dependencies, so the gate never leaks into a
+/// production build).
+#[cfg(any(test, feature = "testutils"))]
+pub mod test {
+    use std::time::Duration;
+
+    /// Generous bound for an operation against a local mock that should
+    /// complete in milliseconds; expiry means the code under test hung.
+    pub const MOCK_OP_BOUND: Duration = Duration::from_secs(5);
+
+    /// Bound for the TLS-handshake tests' requests against their local
+    /// listener.
+    pub const LOCAL_TLS_TEST_BOUND: Duration = Duration::from_secs(10);
+
+    /// Idle window after which a quiet chain is declared genuinely quiet:
+    /// the sentinel tests sleep this long, re-query, and assert nothing
+    /// moved.
+    pub const IDLE_OBSERVATION_WINDOW: Duration = Duration::from_secs(5);
+
+    /// Deadline for a log line to reach the log file on disk.
+    pub const LOG_FLUSH_DEADLINE: Duration = Duration::from_secs(15);
+
+    /// Poll cadence while an integration test waits for chain state to
+    /// settle.
+    pub const SETTLE_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+    /// Per-stage bound for the hand-run live staged probe against a public
+    /// indexer over clearnet.
+    pub const LIVE_STAGE_BOUND: Duration = Duration::from_secs(15);
+
+    /// Bound on the indexer ingesting a submitted transaction into its
+    /// mempool view.
+    pub const MEMPOOL_INGEST_BOUND: Duration = Duration::from_secs(10);
+
+    /// Bound on one mempool stream request while polling for a transaction.
+    pub const MEMPOOL_STREAM_BOUND: Duration = Duration::from_secs(5);
+
+    /// Bound on the wallet record leaving Transmitted status after a sync.
+    pub const WALLET_RECORD_LAG_BOUND: Duration = Duration::from_secs(15);
+
+    /// The simulated duration of a transmission in the CLI heartbeat tests.
+    pub const SIMULATED_TRANSMIT: Duration = Duration::from_secs(5);
+
+    /// The hedge interval the pure racing planner's paused-time tests use;
+    /// deliberately independent of the production [`super::HEDGE_INTERVAL`]
+    /// so planner tests never retune with production.
+    pub const PLANNER_HEDGE: Duration = Duration::from_secs(5);
+
+    /// A stage bound short enough to prove staged-probe timeouts on paused
+    /// time.
+    pub const FAST_STAGE_BOUND: Duration = Duration::from_millis(800);
+
+    /// Cadence of the FFI liveness monitor under paused-time tests.
+    pub const MONITOR_PROBE_INTERVAL: Duration = Duration::from_millis(30);
+
+    /// Per-probe bound of the FFI liveness monitor under paused-time tests.
+    pub const MONITOR_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+}

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -93,6 +93,8 @@ zcash_proofs = { workspace = true, features = ["download-params"] }
 
 [dev-dependencies]
 pepper-sync = { workspace = true, features = ["test-features"] }
+# The nym tests read their temporal parameters from `time::test`.
+zingo-netutils = { workspace = true, features = ["testutils"] }
 # `test-util` enables paused-time tests (`start_paused`) for the attached-
 # transport falsifiers; dev-only, so the shipped graph is unchanged.
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -8,7 +8,6 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicU8},
     },
-    time::Duration,
 };
 
 use json::JsonValue;
@@ -58,7 +57,7 @@ mod darkside;
 #[cfg(test)]
 mod mock_chain_tests;
 
-pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub use zingo_netutils::time::DEFAULT_REQUEST_TIMEOUT;
 
 /// Wallet struct owned by a [`crate::lightclient::LightClient`], with metadata and immutable wallet data stored outside
 /// the read/write lock.

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -46,8 +46,7 @@ use crate::wallet::migration::{
 pub mod broadcast_grpc;
 pub mod broadcast_route;
 
-/// How long to wait between sync polls while a note-splitting round confirms.
-const CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
+use zingo_netutils::time::CONFIRMATION_POLL_INTERVAL;
 /// Give up waiting for a note-splitting round after this many polls.
 const MAX_CONFIRMATION_POLLS: usize = 720;
 /// A migration replans after every round. A real plan converges in

--- a/zingolib/src/lightclient/migrate/broadcast_grpc.rs
+++ b/zingolib/src/lightclient/migrate/broadcast_grpc.rs
@@ -5,8 +5,6 @@
 //! not depend on the network stack. Each submit builds a fresh connection to
 //! its own URI, so parts never travel over the synchronization channel.
 
-use std::time::Duration;
-
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_netutils::Indexer as _;
@@ -14,7 +12,7 @@ use zingo_netutils::lightwallet_protocol::RawTransaction;
 
 use crate::wallet::migration::broadcast::{BroadcastClient, BroadcastError};
 
-pub(super) const SUBMIT_TIMEOUT: Duration = Duration::from_secs(30);
+pub(super) use zingo_netutils::time::MIGRATION_SUBMIT_TIMEOUT;
 
 /// Submits parts over gRPC and can do nothing else.
 pub struct GrpcBroadcastClient {
@@ -44,7 +42,7 @@ impl BroadcastClient for GrpcBroadcastClient {
                     data: raw_tx,
                     height: u64::from(u32::from(expiry_height)),
                 },
-                SUBMIT_TIMEOUT,
+                MIGRATION_SUBMIT_TIMEOUT,
             )
             .await
             .map_err(|status| BroadcastError::Rejected(status.to_string()))?;

--- a/zingolib/src/lightclient/migrate/broadcast_route.rs
+++ b/zingolib/src/lightclient/migrate/broadcast_route.rs
@@ -94,7 +94,7 @@ impl BroadcastClient for MixnetBroadcastClient {
             indexer,
             &raw_tx,
             u64::from(u32::from(expiry_height)),
-            super::broadcast_grpc::SUBMIT_TIMEOUT,
+            super::broadcast_grpc::MIGRATION_SUBMIT_TIMEOUT,
         )
         .await
         .map_err(|error| {

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -19,7 +19,7 @@ use super::LightClient;
 use super::SyncResult;
 use super::error::LightClientError;
 
-const SYNC_START_TIMEOUT: Duration = Duration::from_secs(3);
+use zingo_netutils::time::SYNC_START_TIMEOUT;
 
 impl LightClient {
     /// Launches a task for syncing the wallet to the latest state of the block chain, storing the handle in the

--- a/zingolib/src/lightclient/transmit.rs
+++ b/zingolib/src/lightclient/transmit.rs
@@ -25,8 +25,7 @@ pub(crate) const MAX_RETRIES: u8 = 3;
 /// cadence, for the verdict to become storage-backed (issue #2450).
 pub(crate) const MAX_QUEUED_PROBES: u8 = 30;
 
-/// The interval between retries and queued-probes.
-const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+use zingo_netutils::time::TRANSMIT_RETRY_INTERVAL;
 
 /// A shareable snapshot of the in-flight Transmission's latest progress line,
 /// or `None` when no transmission is running. A consumer holding a clone (the
@@ -209,7 +208,7 @@ where
                 report(format!(
                     "delivered, awaiting the server's verdict (probe {queued_probes}/{MAX_QUEUED_PROBES})"
                 ));
-                sleep(RETRY_INTERVAL).await;
+                sleep(TRANSMIT_RETRY_INTERVAL).await;
             }
             RejectionClass::Transient => {
                 if retry_count >= MAX_RETRIES {
@@ -228,7 +227,7 @@ where
                 report(format!(
                     "retrying after a transient error (retry {retry_count}/{MAX_RETRIES})"
                 ));
-                sleep(RETRY_INTERVAL).await;
+                sleep(TRANSMIT_RETRY_INTERVAL).await;
             }
         }
     }

--- a/zingolib/src/nym/probe.rs
+++ b/zingolib/src/nym/probe.rs
@@ -400,7 +400,7 @@ pub async fn probe_sync_server(server: &Uri, stage_timeout: Duration) -> SyncSer
 mod tests {
     use super::*;
 
-    const FAST: Duration = Duration::from_millis(800);
+    use zingo_netutils::time::test::FAST_STAGE_BOUND;
 
     fn uri(text: &str) -> Uri {
         text.parse().expect("static uri")
@@ -415,7 +415,7 @@ mod tests {
             let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
             listener.local_addr().unwrap()
         };
-        let probe = probe_sync_server(&uri(&format!("https://{closed}")), FAST).await;
+        let probe = probe_sync_server(&uri(&format!("https://{closed}")), FAST_STAGE_BOUND).await;
         assert_eq!(probe.stages.len(), 1, "the run stops at the first failure");
         assert_eq!(probe.stages[0].step, SyncProbeStep::TcpConnect);
         let failure = probe.stages[0].failure.as_ref().expect("stage failed");
@@ -439,7 +439,7 @@ mod tests {
             }
         });
 
-        let probe = probe_sync_server(&uri(&format!("https://{addr}")), FAST).await;
+        let probe = probe_sync_server(&uri(&format!("https://{addr}")), FAST_STAGE_BOUND).await;
         assert_eq!(probe.stages.len(), 2);
         assert!(probe.stages[0].failure.is_none(), "TCP is reachable");
         let failure = probe.stages[1].failure.as_ref().expect("channel must fail");
@@ -466,7 +466,11 @@ mod tests {
     #[tokio::test]
     #[ignore = "contacts a live public indexer over clearnet"]
     async fn live_staged_probe_smoke() {
-        let probe = probe_sync_server(&uri("https://zec.rocks:443"), Duration::from_secs(15)).await;
+        let probe = probe_sync_server(
+            &uri("https://zec.rocks:443"),
+            zingo_netutils::time::test::LIVE_STAGE_BOUND,
+        )
+        .await;
         assert_eq!(probe.stages.len(), 3, "all stages ran: {probe:?}");
         assert!(probe.info.is_some(), "a live indexer answers: {probe:?}");
     }

--- a/zingolib/src/nym/supervisor.rs
+++ b/zingolib/src/nym/supervisor.rs
@@ -51,6 +51,9 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::task::JoinHandle;
+use zingo_netutils::time::{
+    ATTACH_HEALTH_RETRY_PAUSE, ATTACH_PROBE_INTERVAL, LOOPBACK_DIAL_BOUND, MIXNET_ROUND_TRIP_BOUND,
+};
 use zingo_netutils::{NYM_STATUS_LINE_PREFIX, SOCKS5_ADDR_LINE_PREFIX};
 
 use crate::nym::MixnetMode;
@@ -60,23 +63,11 @@ use crate::nym::MixnetMode;
 /// binary's health-check indexer.
 const ATTACH_HEALTH_INDEXER: &str = "https://zec.rocks:443";
 
-/// Bound on one attach readiness round trip.
-const ATTACH_HEALTH_TIMEOUT: Duration = Duration::from_secs(15);
-
 /// Readiness attempts against the attached endpoint before declaring it
 /// dead. Unlike the spawned binary's health gate, attach cannot redraw a
 /// mixnet path — the platform owns the endpoint — so retrying buys recovery
 /// only from a transient blip, and two attempts suffice.
 const ATTACH_HEALTH_ATTEMPTS: usize = 2;
-
-/// Pause between attach readiness attempts.
-const ATTACH_HEALTH_RETRY_PAUSE: Duration = Duration::from_secs(1);
-
-/// Cadence of the liveness probe against an attached endpoint.
-const ATTACH_PROBE_INTERVAL: Duration = Duration::from_secs(30);
-
-/// Bound on one liveness probe connect.
-const ATTACH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A failure starting the mixnet proxy child process or attaching to a
 /// platform-hosted endpoint.
@@ -300,7 +291,7 @@ async fn attach_readiness(socks5_addr: String) -> Result<(), zingo_net_diag::Net
         match zingo_netutils::get_lightd_info_via_socks5(
             &socks5_addr,
             &indexer,
-            ATTACH_HEALTH_TIMEOUT,
+            MIXNET_ROUND_TRIP_BOUND,
         )
         .await
         {
@@ -327,7 +318,7 @@ async fn attach_readiness(socks5_addr: String) -> Result<(), zingo_net_diag::Net
 async fn endpoint_alive(socks5_addr: String) -> bool {
     matches!(
         tokio::time::timeout(
-            ATTACH_PROBE_TIMEOUT,
+            LOOPBACK_DIAL_BOUND,
             tokio::net::TcpStream::connect(&socks5_addr),
         )
         .await,


### PR DESCRIPTION
## Summary

This PR does one thing: it defines `zingo_netutils::time` (with its feature-gated `time::test` submodule) and moves every temporal parameter the dependency graph can reach into it. No values change; every constant keeps its prior duration. It executes the consolidation ratified on #2565 and does nothing else.

## What moves where

The module collapses the three duplicated quantities the #2565 census exposed: the tunnel round-trip bound (`HEALTH_CHECK_TIMEOUT` in the `nym-proxy` binary and `ATTACH_HEALTH_TIMEOUT` in the supervisor become one `MIXNET_ROUND_TRIP_BOUND`), the loopback dial bound (`ATTACH_PROBE_TIMEOUT` and `LIVENESS_PROBE_TIMEOUT` become `LOOPBACK_DIAL_BOUND`), and pepper-sync's twin `STREAM_MSG_TIMEOUT` definitions. The remaining production constants move in unchanged, several gaining contextual names because their old names were too generic for a shared registry (`RETRY_INTERVAL` → `TRANSMIT_RETRY_INTERVAL`, `SUBMIT_TIMEOUT` → `MIGRATION_SUBMIT_TIMEOUT`, `PROBE_TIMEOUT` → `PROBE_LEG_TIMEOUT`, `GET_INFO_TIMEOUT` → `SERVER_RANKING_TIMEOUT`, `SHUTDOWN_TIMEOUT` → `SCANNER_SHUTDOWN_TIMEOUT`, `CEILING`/`SETTLE` → `MEMPOOL_DRAIN_CEILING`/`MEMPOOL_DRAIN_SETTLE`). `zingolib` re-exports `DEFAULT_REQUEST_TIMEOUT` at its old path, so its public API is unchanged.

Test-owned values (mock-op bounds, idle observation windows, paused-time monitor knobs, container-test measurement bounds) live in `time::test`, gated behind a new `testutils` feature: the crate's own unit tests see the submodule via `cfg(test)`, downstream crates enable the feature in dev-dependencies only, and no production build can reach it.

The module's rustdoc carries the complete registry, including the two constants dependency direction keeps at home: `zingo_price::REQUEST_TIMEOUT` and `CONNECT_TIMEOUT`, since zingo-price cannot depend on zingo-netutils.

## Verification

Both workspaces compile clean under check, clippy, and fmt. The netutils workspace's 59 tests, zingolib's 41 nym tests, zingo-cli's heartbeat tests, and pepper-sync's 86 unit tests all pass; the libtonode integration tests compile.

## Stacking

This PR is based on `net_diag_taxonomy`, so its diff is exactly the single refactor commit 73ed12af7. It stacks on #2561; when that PR merges, GitHub retargets this one to `dev` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
