### PR TITLE
error when ironwood data is missing from compact block scanning

### DIFF
--- a/pepper-sync/src/scan/transactions.rs
+++ b/pepper-sync/src/scan/transactions.rs
@@ -326,12 +326,6 @@ pub(crate) fn scan_transaction(
             .map(|action| (IronwoodDomain::for_action(action), action.clone()))
             .collect();
 
-        // The decrypted-note-data lookup is deliberately lenient here, unlike
-        // the sapling and orchard passes: an ironwood output can decrypt in a
-        // confirmed transaction the compact scan never saw (a server that
-        // does not serve ironwood actions yet), so a missing entry falls back
-        // to deriving the nullifier from the full viewing key and leaving the
-        // position unset until a compact scan supplies it.
         scan_incoming_notes::<
             IronwoodDomain,
             Action<Signature<SpendAuth>>,
@@ -343,21 +337,8 @@ pub(crate) fn scan_transaction(
             txid,
             ironwood_ivks,
             &ironwood_actions,
-            None,
+            decrypted_note_data.map(|d| &d.ironwood_nullifiers_and_positions),
         )?;
-        for note in &mut ironwood_notes {
-            if let Some((nullifier, position)) = decrypted_note_data
-                .and_then(|d| d.ironwood_nullifiers_and_positions.get(&note.output_id))
-            {
-                note.nullifier = Some(*nullifier);
-                note.position = Some(*position);
-            } else if let Some(fvk) = ufvks
-                .get(&note.key_id.account_id)
-                .and_then(zcash_keys::keys::UnifiedFullViewingKey::orchard)
-            {
-                note.nullifier = Some(note.note.nullifier(fvk));
-            }
-        }
 
         scan_outgoing_notes(
             &mut outgoing_ironwood_notes,

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -584,8 +584,6 @@ impl LightWallet {
         account_id: zip32::AccountId,
         include_potentially_spent_notes: bool,
     ) -> Result<Zatoshis, BalanceError> {
-        // Zero while ironwood notes carry no positions, which is right
-        // because those notes are not witnessable.
         let ironwood_balance = match self
             .spendable_balance::<IronwoodNote>(account_id, include_potentially_spent_notes)
         {


### PR DESCRIPTION
currently, the user may be left with unspendable ironwood notes when a server only paritally serves ironwood data. this PR prefers an error is returned so the user cannot progress in scanning until the server is switched to serve all the necessary ironwood data