### PR TITLE
refactor!: answer the #2428 review threads that were still live in code

### DIFF
--- a/zingolib/src/lightclient/error.rs
+++ b/zingolib/src/lightclient/error.rs
@@ -120,10 +120,10 @@ pub enum MigrationError {
     /// A migration transaction (a note split or a part) failed or
     /// disappeared from the wallet.
     #[error("Migration transaction {0} failed or disappeared.")]
-    MigrationTransactionFailed(TxId),
+    TransactionFailed(TxId),
     /// Migration transactions were not confirmed within the polling window.
     #[error("Timed out waiting for migration transactions to confirm.")]
-    MigrationConfirmationTimeout,
+    ConfirmationTimeout,
     /// The scheduled flow was asked to start over a plan that still needs
     /// note splitting, which no scheduled-flow driver executes yet.
     #[error(

--- a/zingolib/src/lightclient/error.rs
+++ b/zingolib/src/lightclient/error.rs
@@ -117,13 +117,13 @@ pub enum MigrationError {
     /// Note splitting kept producing new rounds past the round bound.
     #[error("Migration did not converge within {0} rounds.")]
     SplitDidNotConverge(usize),
-    /// A note-splitting transaction failed or disappeared from the wallet.
-    #[error("Note-splitting transaction {0} failed or disappeared.")]
-    SplitTransactionFailed(TxId),
-    /// Note-splitting transactions were not confirmed within the polling
-    /// window.
-    #[error("Timed out waiting for note-splitting transactions to confirm.")]
-    SplitConfirmationTimeout,
+    /// A migration transaction (a note split or a part) failed or
+    /// disappeared from the wallet.
+    #[error("Migration transaction {0} failed or disappeared.")]
+    MigrationTransactionFailed(TxId),
+    /// Migration transactions were not confirmed within the polling window.
+    #[error("Timed out waiting for migration transactions to confirm.")]
+    MigrationConfirmationTimeout,
     /// The scheduled flow was asked to start over a plan that still needs
     /// note splitting, which no scheduled-flow driver executes yet.
     #[error(

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -584,8 +584,10 @@ impl LightClient {
         &self,
         account: zip32::AccountId,
     ) -> Result<MigrationPlan, LightClientError> {
-        let wallet = self.wallet().read().await;
-        Ok(wallet.plan_ironwood_migration_now(account)?)
+        self.wallet()
+            .read()
+            .await
+            .plan_ironwood_migration_now(account)
     }
 
     /// Records the user's consent to a proposed migration plan and persists
@@ -1517,7 +1519,7 @@ impl LightClient {
                     MigrationPhase::Planned | MigrationPhase::NoteSplitting { .. } => {
                         let plan = crate::wallet::migration::plan_migration(
                             &wallet.live_v2_note_values(state.account),
-                            wallet.splits_confirm_post_activation(),
+                            wallet.splits_confirm_post_activation()?,
                             &state.params,
                         );
                         (plan.parts.len() as u32, plan.parts.iter().sum())
@@ -2200,11 +2202,11 @@ impl crate::wallet::LightWallet {
     pub(crate) fn plan_ironwood_migration_now(
         &self,
         account: zip32::AccountId,
-    ) -> Result<MigrationPlan, crate::wallet::error::WalletError> {
+    ) -> Result<MigrationPlan, LightClientError> {
         let params = MigrationParams::provisional(self.chain_type());
         Ok(plan_migration(
             &self.migration_note_values(account)?,
-            self.splits_confirm_post_activation(),
+            self.splits_confirm_post_activation()?,
             &params,
         ))
     }
@@ -2212,7 +2214,7 @@ impl crate::wallet::LightWallet {
     /// Whether a transaction built now confirms at or after NU6.3
     /// activation. Note-splitting fees depend on it (the Orchard bundle's
     /// cross-address rules change the action count).
-    pub(crate) fn splits_confirm_post_activation(&self) -> bool {
+    pub(crate) fn splits_confirm_post_activation(&self) -> Result<bool, LightClientError> {
         match (
             self.sync_state.last_known_chain_height(),
             pepper_sync::wallet::PoolActivation::of(
@@ -2220,8 +2222,9 @@ impl crate::wallet::LightWallet {
                 zcash_protocol::ShieldedPool::Ironwood,
             ),
         ) {
-            (Some(chain_height), Some(activation)) => chain_height + 1 >= activation.height(),
-            _ => false,
+            (None, Some(_)) => Err(LightClientError::WalletError(WalletError::NoSyncData)),
+            (Some(chain_height), Some(activation)) => Ok(chain_height + 1 >= activation.height()),
+            _ => Ok(false),
         }
     }
 
@@ -3173,7 +3176,7 @@ mod tests {
         let params = MigrationParams::provisional(wallet.chain_type());
         let expected = crate::wallet::migration::plan_migration(
             &[600_000_000, 600_000_000],
-            wallet.splits_confirm_post_activation(),
+            wallet.splits_confirm_post_activation().unwrap(),
             &params,
         );
         assert!(

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -2178,14 +2178,14 @@ impl LightClient {
                 )
             };
             if let Some(txid) = failed {
-                return Err(MigrationError::MigrationTransactionFailed(txid).into());
+                return Err(MigrationError::TransactionFailed(txid).into());
             }
             if all_confirmed {
                 return Ok(());
             }
             tokio::time::sleep(CONFIRMATION_POLL_INTERVAL).await;
         }
-        Err(MigrationError::MigrationConfirmationTimeout.into())
+        Err(MigrationError::ConfirmationTimeout.into())
     }
 }
 

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -738,9 +738,7 @@ impl LightClient {
                     // The round's outputs enter planning once the anchor
                     // reaches their confirmation heights; replanning earlier
                     // would read a note set with the round half-applied.
-                    let (_, anchor_height) = wallet
-                        .get_migration_heights()?
-                        .ok_or(WalletError::NoSyncData)?;
+                    let (_, anchor_height) = wallet.get_migration_heights()?;
                     let unanchored = pending_txids.iter().any(|txid| {
                         wallet
                             .transaction_confirmed_height(txid)
@@ -970,14 +968,6 @@ impl LightClient {
         self.broadcast_due_parts_selected(client, None).await
     }
 
-    /// The due-part broadcast loop, optionally narrowed to a single part so
-    /// catch-up can sequence sends with spacing.
-    ///
-    /// Proving is parallelised across all due parts via
-    /// [`tokio::task::spawn_blocking`]: wallet reads happen under the write
-    /// lock (Phase A), all Halo2/Groth16 work runs concurrently on the
-    /// blocking thread pool without holding the lock (Phase B), and wallet
-    /// writes + submission happen sequentially under the lock again (Phase C).
     /// The due-part broadcast loop, optionally narrowed to a single part so
     /// catch-up can sequence sends with spacing.
     ///
@@ -2188,14 +2178,14 @@ impl LightClient {
                 )
             };
             if let Some(txid) = failed {
-                return Err(MigrationError::SplitTransactionFailed(txid).into());
+                return Err(MigrationError::MigrationTransactionFailed(txid).into());
             }
             if all_confirmed {
                 return Ok(());
             }
             tokio::time::sleep(CONFIRMATION_POLL_INTERVAL).await;
         }
-        Err(MigrationError::SplitConfirmationTimeout.into())
+        Err(MigrationError::MigrationConfirmationTimeout.into())
     }
 }
 

--- a/zingolib/src/wallet/balance.rs
+++ b/zingolib/src/wallet/balance.rs
@@ -584,8 +584,11 @@ impl LightWallet {
         account_id: zip32::AccountId,
         include_potentially_spent_notes: bool,
     ) -> Result<Zatoshis, BalanceError> {
-        // Zero while ironwood notes carry no positions, which is right
-        // because those notes are not witnessable.
+        // An ironwood note carries no position until a scan locates its
+        // block in the commitment tree; the wallet records its own outputs
+        // (migration parts included) at broadcast, before any scan. A
+        // positionless note is not witnessable, so counting it as
+        // unspendable here is right.
         let ironwood_balance = match self
             .spendable_balance::<IronwoodNote>(account_id, include_potentially_spent_notes)
         {

--- a/zingolib/src/wallet/migration/parts.rs
+++ b/zingolib/src/wallet/migration/parts.rs
@@ -985,9 +985,7 @@ impl crate::wallet::LightWallet {
             ));
         }
 
-        let (_, anchor_height) = self
-            .get_migration_heights()?
-            .ok_or(WalletError::NoSyncData)?;
+        let (_, anchor_height) = self.get_migration_heights()?;
         let mut ready: Vec<(u64, BoundNote)> = Vec::new();
         for note in self
             .spendable_notes::<pepper_sync::wallet::OrchardNote>(

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -494,9 +494,7 @@ impl crate::wallet::LightWallet {
     ) -> Result<Vec<u64>, crate::wallet::error::WalletError> {
         use pepper_sync::wallet::{NoteInterface as _, OutputInterface as _};
 
-        let (_, anchor_height) = self
-            .get_migration_heights()?
-            .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
+        let (_, anchor_height) = self.get_migration_heights()?;
         Ok(self
             .spendable_notes::<pepper_sync::wallet::OrchardNote>(
                 anchor_height,
@@ -546,9 +544,7 @@ impl crate::wallet::LightWallet {
     ) -> Result<bool, crate::wallet::error::WalletError> {
         use pepper_sync::wallet::{KeyIdInterface as _, NoteInterface as _, OutputInterface as _};
 
-        let (_, anchor_height) = self
-            .get_migration_heights()?
-            .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
+        let (_, anchor_height) = self.get_migration_heights()?;
         // A failed transaction carries no confirmed height
         Ok(self
             .wallet_transactions
@@ -617,20 +613,27 @@ impl crate::wallet::LightWallet {
         )
     }
 
+    /// The target and anchor heights every migration site plans and builds
+    /// against. A thin wrapper over `get_target_and_anchor_heights` that pins
+    /// the wallet's own `min_confirmations` and turns the no-sync-data case
+    /// into the typed [`WalletError::NoSyncData`], so no caller re-derives
+    /// either.
+    ///
+    /// [`WalletError::NoSyncData`]: crate::wallet::error::WalletError::NoSyncData
     pub(crate) fn get_migration_heights(
         &self,
     ) -> Result<
-        Option<(
+        (
             zcash_protocol::consensus::BlockHeight,
             zcash_protocol::consensus::BlockHeight,
-        )>,
+        ),
         crate::wallet::error::WalletError,
     > {
         use zcash_client_backend::data_api::WalletRead as _;
-        Ok(self
-            .get_target_and_anchor_heights(self.wallet_settings.min_confirmations)
+        self.get_target_and_anchor_heights(self.wallet_settings.min_confirmations)
             .expect("infallible")
-            .map(|(target, anchor)| (target.into(), anchor)))
+            .map(|(target, anchor)| (target.into(), anchor))
+            .ok_or(crate::wallet::error::WalletError::NoSyncData)
     }
 
     #[allow(clippy::result_large_err)]
@@ -646,9 +649,7 @@ impl crate::wallet::LightWallet {
 
         use crate::wallet::error::WalletError;
 
-        let (target_height, anchor_height) = self
-            .get_migration_heights()?
-            .ok_or(WalletError::NoSyncData)?;
+        let (target_height, anchor_height) = self.get_migration_heights()?;
 
         // Pick one spendable V2 note per planned input value (distinct notes
         // for repeated values), copying out what the builder needs so the

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -895,6 +895,36 @@ mod tests {
         assert!(params().sweep_min >= MARGINAL_FEE);
     }
 
+    /// The wrapper's typed contract: `get_migration_heights` turns the
+    /// absent-sync case into [`crate::wallet::error::WalletError::NoSyncData`]
+    /// itself, so every migration site inherits the typed refusal from one
+    /// place. A freshly constructed wallet has never synced, which is
+    /// exactly the case the wrapper must type.
+    #[test]
+    fn migration_heights_on_an_unsynced_wallet_are_typed_no_sync_data() {
+        use zingo_common_components::protocol::ActivationHeights;
+
+        use crate::config::WalletConfig;
+        use crate::testutils::default_test_wallet_settings;
+        use crate::wallet::error::WalletError;
+
+        let wallet = crate::wallet::LightWallet::new(
+            ChainType::Regtest(ActivationHeights::default()),
+            WalletConfig::MnemonicPhrase {
+                mnemonic_phrase: zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED.to_string(),
+                no_of_accounts: 1.try_into().expect("hard-coded non-zero"),
+                birthday: 1,
+                wallet_settings: default_test_wallet_settings(),
+            },
+        )
+        .expect("a fresh mnemonic wallet constructs");
+
+        assert!(matches!(
+            wallet.get_migration_heights(),
+            Err(WalletError::NoSyncData)
+        ));
+    }
+
     /// The action-count rule the fee model rests on: an Orchard bundle from
     /// NU6.3 disables cross-address transfers, so a spend and an output no
     /// longer share an action. The crates own that rule and the split fee


### PR DESCRIPTION
Your review of #2428 left thirteen threads unresolved when the PR merged. This PR is the collected answer. It changes the code where a comment still described it, and it accounts for every other thread below, so each can be resolved from here.

## Changed in this PR

**`get_migration_heights` returns the heights directly** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3537628868)). Agreed, and done. The helper wrapped an infallible call yet returned `Result<Option<_>>`, and all five callers unwrapped the `None` case with the same `ok_or(WalletError::NoSyncData)`. The function now returns the heights directly and maps the `None` case to `NoSyncData` itself, which deleted the identical `ok_or` at all five call sites. The wrapper survives for one reason, which its doc now states: it pins the wallet's own `min_confirmations` and types the no-sync-data case once.

**The confirmation-wait errors drop their `Split` names** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3550815924)). Agreed. The function is generic over migration transactions, yet its errors said "split". This PR renames the two shared variants to `MigrationTransactionFailed` and `MigrationConfirmationTimeout`; `SplitDidNotConverge` keeps its name, being genuinely split-only. The rename is breaking on the public `MigrationError` enum.

**The duplicated comment is gone** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3550543915)). The doc on `broadcast_due_parts_selected` carried its two paragraphs twice, verbatim. Fixed.

**The ironwood balance comment now answers your question** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3529898930)). You asked why compact block scanning would fail to find positions for ironwood. It does not fail: scanning finds ironwood positions, and pepper-sync carries ironwood located trees and a nullifier-to-position map. A note lacks a position only until a scan locates its block in the commitment tree, and the wallet records its own outputs at broadcast, before any scan, so those notes hold no position and cannot be witnessed. The comment in `shielded_spendable_balance` now states this reason instead of asserting the conclusion.

## Resolved by work that landed since the review

**The `COIN` constant** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3535820553)). Agreed: in this codebase "coin" names a transparent output, and the constant collided with that sense. The local constant is gone. `params.rs` now imports `zcash_protocol::value::COIN`, so the workspace defines no such name of its own.

**The `dust_floor` field** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3535837660)). The field is renamed, though not to `denom_floor`. Your name has the virtue of saying what the field does: it floors the denomination ladder. We chose `max_residual_value` instead, because ZIP 318 names the quantity `MAX_RESIDUAL_VALUE` and the reference crate exports it under that name; a field that mirrors the specification reads without translation.

**An error when sync data is missing** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3535920358)). Done as you suggested. `WalletError::NoSyncData` now exists, and every planning and broadcast path returns it when `last_known_chain_height` is `None`. This PR folds the same mapping into `get_migration_heights`, so the migration height reads are typed as well.

**Visibility of `migration_note_values`** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3535972815)). The function is `pub(crate)` now.

**Visibility of `build_note_split_transaction`** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3535976179)). The function is `pub(crate)` now.

**Protection before NU6.3 activation** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3550585693)). Later work added the protection you asked about. The start path refuses with `IronwoodEraTooYoung` until the first window boundary after NU6.3 activation, and the scheduler floors every anchor at activation, so a pre-activation release fails once with a typed error instead of striking the build error repeatedly.

**Checkpoint count versus bucket modulus** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3550606149)). The code landed where your third comment arrived. Raising the checkpoint retention would have guaranteed every boundary a witness, but, as you said, it would store extra data forever for the sake of a single migration. Instead, `refresh_part_witnesses` caches each part's witness while its boundary checkpoint is still retained, and a part whose boundary is pruned takes the `MissedBoundary` skip and is re-assigned.

## Kept as it is

**The `SyncDomain` re-export** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3535531922)). Removing the re-export would give `SyncDomain` a single canonical path and spare the reader one indirection. We kept it nonetheless: `wallet/traits.rs` and `sync/spend.rs` both import `crate::SyncDomain` through it, and because it is `pub(crate)` it adds nothing to the crate's public surface.

## Tracked onward

**The dust-floor economics** ([thread](https://github.com/zingolabs/zingolib/pull/2428#discussion_r3537094086)). Later work resolved most of this in your direction. The floor is no longer local policy: it is ZIP 318's `MAX_RESIDUAL_VALUE` (0.01 ZEC), imported from the reference crate. Notes at or below `sweep_min`, and any pool too small to fund the smallest denomination, now stay in the pre-Ironwood pool as residual — recorded in the plan and covered by the consent hash — rather than folding into fees. One fee-fold remains: when a pool funds at least one denomination, the sizing surplus below the smallest denomination becomes the final split transaction's fee. That surplus is bounded below 0.01 ZEC per migration, but your underlying point stands — the user should not pay value away silently — so #2573 tracks whether the surplus should become a residual V2 change note instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
