### PR TITLE
fix: split note detection

### DIFF
--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -3784,6 +3784,7 @@ mod tests {
     /// Planning under a sync stalled below the recorded tip: the spend
     /// horizon withholds every note and the planners error instead of
     /// returning an empty plan.
+    #[cfg(test)]
     mod stalled_sync_planning {
         use pepper_sync::sync::{ScanPriority, ScanRange};
         use pepper_sync::wallet::SyncState;

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -3812,6 +3812,8 @@ mod tests {
         #[test]
         fn migration_planner_errors_when_the_horizon_withholds_every_note() {
             let mut wallet = SyntheticWalletBuilder::new(SEED)
+                // The builder confirms this note in block 2, its first
+                // synthetic note slot, deep below the stall gap.
                 .orchard_note(1_234_567_890)
                 .tip(360)
                 .build();
@@ -3828,6 +3830,8 @@ mod tests {
         #[test]
         fn immediate_planner_errors_when_the_horizon_withholds_every_note() {
             let mut wallet = SyntheticWalletBuilder::new(SEED)
+                // The builder confirms this note in block 2, its first
+                // synthetic note slot, deep below the stall gap.
                 .orchard_note(1_234_567_890)
                 .tip(360)
                 .build();

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -3781,6 +3781,78 @@ mod tests {
         }
     }
 
+    /// Planning under a sync stalled below the recorded tip: the spend
+    /// horizon withholds every note and the planners error instead of
+    /// returning an empty plan.
+    mod stalled_sync_planning {
+        use pepper_sync::sync::{ScanPriority, ScanRange};
+        use pepper_sync::wallet::SyncState;
+        use zcash_protocol::consensus::BlockHeight;
+
+        use super::*;
+        use crate::wallet::error::WalletError;
+
+        const SEED: &str = zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
+
+        /// Headers reach 600, scanning stopped at the old tip 360.
+        fn stall_past_scanned_tip(wallet: &mut LightWallet) {
+            wallet.sync_state = SyncState::new_for_test(vec![
+                ScanRange::from_parts(
+                    BlockHeight::from_u32(1)..BlockHeight::from_u32(361),
+                    ScanPriority::Scanned,
+                ),
+                ScanRange::from_parts(
+                    BlockHeight::from_u32(361)..BlockHeight::from_u32(601),
+                    ScanPriority::Historic,
+                ),
+            ]);
+        }
+
+        #[test]
+        fn migration_planner_errors_when_the_horizon_withholds_every_note() {
+            let mut wallet = SyntheticWalletBuilder::new(SEED)
+                .orchard_note(1_234_567_890)
+                .tip(360)
+                .build();
+            stall_past_scanned_tip(&mut wallet);
+
+            let planned = wallet.plan_ironwood_migration_now(AccountId::ZERO);
+            assert!(
+                matches!(planned, Err(WalletError::SyncIncomplete)),
+                "a stalled sync must not read as an empty wallet, got {planned:?}"
+            );
+        }
+
+        /// The immediate (drain) planner shares the error.
+        #[test]
+        fn immediate_planner_errors_when_the_horizon_withholds_every_note() {
+            let mut wallet = SyntheticWalletBuilder::new(SEED)
+                .orchard_note(1_234_567_890)
+                .tip(360)
+                .build();
+            stall_past_scanned_tip(&mut wallet);
+
+            let planned = wallet.plan_immediate_migration(AccountId::ZERO);
+            assert!(
+                matches!(planned, Err(WalletError::SyncIncomplete)),
+                "a stalled sync must not read as an empty wallet, got {planned:?}"
+            );
+        }
+
+        /// A wallet with no V2 notes plans an empty migration under the same
+        /// stalled ranges, without error.
+        #[test]
+        fn empty_wallet_still_plans_empty_under_a_stalled_sync() {
+            let mut wallet = SyntheticWalletBuilder::new(SEED).tip(360).build();
+            stall_past_scanned_tip(&mut wallet);
+
+            let plan = wallet
+                .plan_ironwood_migration_now(AccountId::ZERO)
+                .expect("an empty note set is not a sync failure");
+            assert!(plan.is_split() && plan.parts.is_empty());
+        }
+    }
+
     mod continue_note_splitting {
         use std::num::NonZeroU32;
 

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -55,6 +55,12 @@ pub enum WalletError {
     /// No sync data. Wallet has never been synced with the block chain.
     #[error("No sync data. Wallet has never been synced with the block chain.")]
     NoSyncData,
+    /// The wallet holds notes whose spend status sync has not yet confirmed.
+    #[error(
+        "Sync incomplete: the wallet's notes await spend-status confirmation. \
+         Complete sync and retry."
+    )]
+    SyncIncomplete,
     /// Maximum number of accounts already in use.
     #[error("Maximum number of accounts already in use.")]
     AccountCreationFailed,

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -487,6 +487,11 @@ fn split_into(
 impl crate::wallet::LightWallet {
     /// The values (zatoshis) of the account's spendable pre-Ironwood (V2)
     /// Orchard notes, the input to [`plan_migration`].
+    ///
+    /// Errors with [`WalletError::SyncIncomplete`] when the spend horizon
+    /// withholds every V2 note the anchor would otherwise offer.
+    ///
+    /// [`WalletError::SyncIncomplete`]: crate::wallet::error::WalletError::SyncIncomplete
     #[allow(clippy::result_large_err)]
     pub(crate) fn migration_note_values(
         &self,
@@ -497,17 +502,27 @@ impl crate::wallet::LightWallet {
         let (_, anchor_height) = self
             .get_migration_heights()?
             .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
-        Ok(self
-            .spendable_notes::<pepper_sync::wallet::OrchardNote>(
-                anchor_height,
-                &[],
-                account,
-                false,
-            )?
-            .into_iter()
-            .filter(|note| note.note().version() == orchard::note::NoteVersion::V2)
-            .map(|note| note.value())
-            .collect())
+        let anchored_v2_values = |include_potentially_spent: bool| {
+            Ok::<_, crate::wallet::error::WalletError>(
+                self.spendable_notes::<pepper_sync::wallet::OrchardNote>(
+                    anchor_height,
+                    &[],
+                    account,
+                    include_potentially_spent,
+                )?
+                .into_iter()
+                .filter(|note| note.note().version() == orchard::note::NoteVersion::V2)
+                .map(|note| note.value())
+                .collect::<Vec<u64>>(),
+            )
+        };
+        let confirmed_unspent = anchored_v2_values(false)?;
+        // The queries differ only in the spend-horizon filter, so empty
+        // first with non-empty second means sync stalled below the tip.
+        if confirmed_unspent.is_empty() && !anchored_v2_values(true)?.is_empty() {
+            return Err(crate::wallet::error::WalletError::SyncIncomplete);
+        }
+        Ok(confirmed_unspent)
     }
 
     /// The values of the account's live pre-Ironwood (V2) Orchard notes:

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -497,32 +497,68 @@ impl crate::wallet::LightWallet {
         &self,
         account: zip32::AccountId,
     ) -> Result<Vec<u64>, crate::wallet::error::WalletError> {
-        use pepper_sync::wallet::{NoteInterface as _, OutputInterface as _};
-
         let (_, anchor_height) = self
             .get_migration_heights()?
             .ok_or(crate::wallet::error::WalletError::NoSyncData)?;
-        let anchored_v2_values = |include_potentially_spent: bool| {
-            Ok::<_, crate::wallet::error::WalletError>(
-                self.spendable_notes::<pepper_sync::wallet::OrchardNote>(
-                    anchor_height,
-                    &[],
-                    account,
-                    include_potentially_spent,
-                )?
-                .into_iter()
-                .filter(|note| note.note().version() == orchard::note::NoteVersion::V2)
-                .map(|note| note.value())
-                .collect::<Vec<u64>>(),
-            )
-        };
-        let confirmed_unspent = anchored_v2_values(false)?;
-        // The queries differ only in the spend-horizon filter, so empty
-        // first with non-empty second means sync stalled below the tip.
-        if confirmed_unspent.is_empty() && !anchored_v2_values(true)?.is_empty() {
+        let known_unspent = self.anchored_v2_known_unspent(account, anchor_height)?;
+        let not_known_spent = self.anchored_v2_not_known_spent(account, anchor_height)?;
+        // The two sets differ only in the spend-confirmation filter, so
+        // an empty first with a non-empty second means spend detection
+        // is incomplete below the recorded tip for every note.
+        if known_unspent.is_empty() && !not_known_spent.is_empty() {
             return Err(crate::wallet::error::WalletError::SyncIncomplete);
         }
-        Ok(confirmed_unspent)
+        Ok(known_unspent)
+    }
+
+    /// The values of the account's anchored V2 notes that sync has proven
+    /// unspent: every block in each note's possible spend window is scanned
+    /// and no spend appeared. Only this set is safe to plan spends from.
+    #[allow(clippy::result_large_err)]
+    fn anchored_v2_known_unspent(
+        &self,
+        account: zip32::AccountId,
+        anchor_height: zcash_protocol::consensus::BlockHeight,
+    ) -> Result<Vec<u64>, crate::wallet::error::WalletError> {
+        self.anchored_v2_values(account, anchor_height, false)
+    }
+
+    /// The values of the account's anchored V2 notes with no recorded
+    /// spending transaction: the known-unspent set plus the notes whose
+    /// spend status sync cannot yet vouch for. A superset of
+    /// [`Self::anchored_v2_known_unspent`]; the difference is exactly the
+    /// notes awaiting spend detection.
+    #[allow(clippy::result_large_err)]
+    fn anchored_v2_not_known_spent(
+        &self,
+        account: zip32::AccountId,
+        anchor_height: zcash_protocol::consensus::BlockHeight,
+    ) -> Result<Vec<u64>, crate::wallet::error::WalletError> {
+        self.anchored_v2_values(account, anchor_height, true)
+    }
+
+    /// The shared query behind the named pair above; callers reach it
+    /// through them so the spend-certainty mode always has a name.
+    #[allow(clippy::result_large_err)]
+    fn anchored_v2_values(
+        &self,
+        account: zip32::AccountId,
+        anchor_height: zcash_protocol::consensus::BlockHeight,
+        include_potentially_spent: bool,
+    ) -> Result<Vec<u64>, crate::wallet::error::WalletError> {
+        use pepper_sync::wallet::{NoteInterface as _, OutputInterface as _};
+
+        Ok(self
+            .spendable_notes::<pepper_sync::wallet::OrchardNote>(
+                anchor_height,
+                &[],
+                account,
+                include_potentially_spent,
+            )?
+            .into_iter()
+            .filter(|note| note.note().version() == orchard::note::NoteVersion::V2)
+            .map(|note| note.value())
+            .collect())
     }
 
     /// The values of the account's live pre-Ironwood (V2) Orchard notes:

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -217,6 +217,14 @@ impl LightWallet {
     /// Useful for determining which height all the nullifiers have been mapped from for guaranteeing if a note is
     /// unspent.
     ///
+    /// The horizon *withholds* a note when the note's confirmation height lies below it. A spending
+    /// transaction can be mined only at or above the block that mined the note, so a note at or
+    /// above the horizon has had its entire spend window scanned, and the absence of a discovered
+    /// spend proves the note unspent. For a note below the horizon, the unscanned gap may conceal
+    /// a spend, so the strict form of [`Self::spendable_notes`] omits the note rather than vouch
+    /// for it. Withholding asserts nothing about the note; it records only that the wallet does
+    /// not yet know.
+    ///
     /// `all_spends_known` may be set if all the spend locations are already known before scanning starts. For example,
     /// the location of all transparent spends are known due to the pre-scan gRPC calls. In this case, the height returned
     /// is the lowest height where there are no higher scan ranges with `FoundNote` or higher scan priority.

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -23,7 +23,10 @@ use crate::{
     config::ChainType,
     data::proposal::{ProportionalFeeProposal, ZingoProposal},
 };
-use pepper_sync::{keys::transparent::TransparentScope, sync::ScanPriority};
+use pepper_sync::{
+    keys::transparent::TransparentScope,
+    sync::{ScanPriority, ScanRange},
+};
 
 impl LightWallet {
     /// Creates a proposal from a transaction request.
@@ -218,25 +221,20 @@ impl LightWallet {
     /// the location of all transparent spends are known due to the pre-scan gRPC calls. In this case, the height returned
     /// is the lowest height where there are no higher scan ranges with `FoundNote` or higher scan priority.
     pub(crate) fn spend_horizon(&self, all_spends_known: bool) -> Option<BlockHeight> {
-        self.sync_state
-            .scan_ranges()
-            .iter()
-            .rev()
-            .find(|scan_range| {
-                if all_spends_known {
-                    scan_range.priority() >= ScanPriority::FoundNote
-                        || scan_range.priority() == ScanPriority::Scanning
-                } else {
-                    !scan_range.priority().is_scanned()
-                }
-            })
-            .map(|scan_range| scan_range.block_range().end)
-            .or_else(|| {
-                self.sync_state
-                    .scan_ranges()
-                    .first()
-                    .map(|range| range.block_range().start)
-            })
+        let mut scan_ranges_top_to_bottom = self.sync_state.scan_ranges().iter().rev();
+        let awaits_spend_detection = |scan_range: &&ScanRange| {
+            if all_spends_known {
+                scan_range.priority() >= ScanPriority::FoundNote
+                    || scan_range.priority() == ScanPriority::Scanning
+            } else {
+                !scan_range.priority().is_scanned()
+            }
+        };
+        let highest_range_awaiting_detection =
+            scan_ranges_top_to_bottom.find(awaits_spend_detection);
+        highest_range_awaiting_detection
+            .map(|awaiting_range| awaiting_range.block_range().end)
+            .or_else(|| self.sync_state.wallet_birthday())
     }
 
     /// Returns `true` if all nullifiers above `note_height` have been checked for this note's spend status.

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -207,8 +207,8 @@ impl LightWallet {
         MemoBytes::from(Memo::Arbitrary(Box::new(uas_bytes)))
     }
 
-    /// Returns the block height at which all blocks equal to and above this height are scanned (scan ranges set to
-    /// `Scanned`, `ScannedWithoutMapping` or `RefetchingNullifiers` priority).
+    /// Returns the block height at which all blocks equal to and above this height are scanned (scan ranges whose
+    /// priority satisfies [`ScanPriority::is_scanned`]).
     /// Returns `None` if `self.scan_ranges` is empty.
     ///
     /// Useful for determining which height all the nullifiers have been mapped from for guaranteeing if a note is
@@ -218,8 +218,7 @@ impl LightWallet {
     /// the location of all transparent spends are known due to the pre-scan gRPC calls. In this case, the height returned
     /// is the lowest height where there are no higher scan ranges with `FoundNote` or higher scan priority.
     pub(crate) fn spend_horizon(&self, all_spends_known: bool) -> Option<BlockHeight> {
-        if let Some(scan_range) = self
-            .sync_state
+        self.sync_state
             .scan_ranges()
             .iter()
             .rev()
@@ -228,19 +227,16 @@ impl LightWallet {
                     scan_range.priority() >= ScanPriority::FoundNote
                         || scan_range.priority() == ScanPriority::Scanning
                 } else {
-                    scan_range.priority() != ScanPriority::Scanned
-                        && scan_range.priority() != ScanPriority::ScannedWithoutMapping
-                        && scan_range.priority() != ScanPriority::RefetchingNullifiers
+                    !scan_range.priority().is_scanned()
                 }
             })
-        {
-            Some(scan_range.block_range().end)
-        } else {
-            self.sync_state
-                .scan_ranges()
-                .first()
-                .map(|range| range.block_range().start)
-        }
+            .map(|scan_range| scan_range.block_range().end)
+            .or_else(|| {
+                self.sync_state
+                    .scan_ranges()
+                    .first()
+                    .map(|range| range.block_range().start)
+            })
     }
 
     /// Returns `true` if all nullifiers above `note_height` have been checked for this note's spend status.


### PR DESCRIPTION
Fixes an issue where an unresponsive server would make zingolib present an inconsistent view of notes when doing a send-all migration.