### PR TITLE
Price travels only over the mixnet: one entry, typed refusals (ADR 0024 phase 1)

### DIFF
--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -663,12 +663,13 @@ struct CurrentPriceCommand {}
 impl Command for CurrentPriceCommand {
     fn help(&self) -> &'static str {
         indoc! {r"
-            Fetch the current ZEC price. USD only.
+            Fetch the current ZEC price over the Nym mixnet. USD only.
 
-            Fetches over clearnet, which discloses the client IP and wallet-alive
-            timing to the price source. A `nym`-feature build can instead route
-            the fetch over the Nym mixnet (see the `nym` command) via the
-            library's opt-in `update_current_price_over_mixnet`.
+            Price travels only over the mixnet (ADR 0011): the fetch runs while
+            Mixnet Mode is ready and refuses in every other state, including
+            switched off — the clearnet consent covers sends, never price,
+            because the price source is a third party outside the Zcash
+            ecosystem. A build without the `nym` feature has no price fetch.
 
             Usage:
             current_price
@@ -679,13 +680,26 @@ impl Command for CurrentPriceCommand {
         "Updates and returns current price of ZEC."
     }
 
+    #[cfg(feature = "nym")]
     fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
         Ok(RT.block_on(async move {
             match lightclient.update_current_price().await {
-                Ok(price) => format!("current price: {price}"),
+                Ok(fetch) => format!(
+                    "current price: {} (fetched over the mixnet via {})",
+                    fetch.usd, fetch.via_socks5
+                ),
                 Err(e) => format!("error: {e}"),
             }
         }))
+    }
+
+    #[cfg(not(feature = "nym"))]
+    fn exec(&self, _args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
+        Ok(
+            "This build has no price fetch: price travels only over the Nym mixnet (ADR 0011). \
+             Rebuild zingo-cli with `--features nym`."
+                .to_string(),
+        )
     }
 }
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -103,7 +103,7 @@ impl WalletMeta {
 ///
 /// The attestation is the mixnet tunnel's local SOCKS5 endpoint the fetch
 /// went through. It rides the success value — not a log — so every consumer
-/// of [`LightClient::update_current_price_over_mixnet`] holds per-fetch
+/// of [`LightClient::update_current_price`] holds per-fetch
 /// evidence that this fetch ran over the mixnet (ADR 0011).
 #[cfg(feature = "nym")]
 #[derive(Clone, Debug, PartialEq)]
@@ -608,41 +608,24 @@ impl LightClient {
         self.wallet().read().await.do_total_value_to_address().await
     }
 
-    /// Update and return the current ZEC price in USD over clearnet.
-    ///
-    /// This is the default price-fetch route and works in every build,
-    /// including those without the `nym` feature. It contacts a third-party
-    /// price API directly, so it discloses the client IP and wallet-alive
-    /// timing to that party; a caller that wants to hide those routes the
-    /// fetch over the Nym mixnet with `update_current_price_over_mixnet`
-    /// (a `nym`-feature method, ADR 0011).
-    ///
-    /// The fetch runs before any wallet lock is taken, and the lock is then
-    /// re-acquired briefly to record the update (the net-diag
-    /// polling-blackout remedy: an observer polling wallet state never
-    /// queues behind a network wait).
-    pub async fn update_current_price(&self) -> Result<f32, LightClientError> {
-        let price = zingo_price::fetch_current_price(None)
-            .await
-            .map_err(crate::wallet::error::PriceError::from)?;
-        self.wallet().write().await.record_price_update(price);
-        Ok(price.price_usd)
-    }
-
     /// Update and return the current ZEC price in USD over the Nym mixnet,
-    /// hiding the client IP from the price source (ADR 0011). Opt-in: the fetch
-    /// is routed through the mixnet when Mixnet Mode is ready, and fails closed
-    /// (never falling back to clearnet) while the mixnet is unattached, while
-    /// the mode bootstraps, after the proxy dies, or while it is switched off.
-    /// For the clearnet default, use [`Self::update_current_price`].
+    /// hiding the client IP from the price source. The price fetch travels
+    /// ONLY over the mixnet (ADR 0011, amendment 2026-07-28, reinstating the
+    /// 2026-07-23 rule): the fetch routes through the mixnet when Mixnet Mode
+    /// is ready and fails closed in every other state — a typed
+    /// [`MixnetNotReady`](crate::nym::MixnetNotReady) refusal while
+    /// unattached, bootstrapping, or died, and
+    /// [`LightClientError::PriceFetchRequiresMixnet`] while switched off,
+    /// because the switched-off consent covers Transmission and never price:
+    /// the price API is a third party outside the Zcash ecosystem, and no
+    /// availability argument earns it a clearnet tier. A build without the
+    /// `nym` feature has no price fetch at all.
     ///
     /// The returned fetch carries the tunnel endpoint it traveled through, so
     /// every consumer holds per-fetch evidence of the route rather than
     /// trusting the method name alone.
     #[cfg(feature = "nym")]
-    pub async fn update_current_price_over_mixnet(
-        &self,
-    ) -> Result<MixnetPriceFetch, LightClientError> {
+    pub async fn update_current_price(&self) -> Result<MixnetPriceFetch, LightClientError> {
         let socks5_addr = match self.mixnet_route()? {
             crate::nym::MixnetRoute::Mixnet(socks5_addr) => socks5_addr,
             crate::nym::MixnetRoute::Clearnet => {
@@ -1050,7 +1033,7 @@ mod tests {
             let client = LightClient::new_for_test(wallet()).await;
 
             let error = client
-                .update_current_price_over_mixnet()
+                .update_current_price()
                 .await
                 .expect_err("no transport was ever enabled, so the mixnet fetch must refuse");
             assert!(
@@ -1072,7 +1055,7 @@ mod tests {
             client.disable_mixnet().await;
 
             let error = client
-                .update_current_price_over_mixnet()
+                .update_current_price()
                 .await
                 .expect_err("switched off consents to clearnet, not to a mixnet fetch");
             assert!(
@@ -1106,7 +1089,7 @@ mod tests {
         /// failure from a TLS or HTTP failure by fields instead of parsing
         /// prose. The same value converts into
         /// [`LightClientError::PriceError`] by `From`, which is the exact
-        /// wiring `LightClient::update_current_price_over_mixnet`'s `?`
+        /// wiring `LightClient::update_current_price`'s `?`
         /// uses.
         #[tokio::test]
         #[allow(deprecated)] // the lock-holding path is the unit under test

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -416,6 +416,7 @@ impl LightWallet {
     /// [`zingo_price::fetch_current_price`] (no lock held) and then record
     /// the result under a briefly-held lock, as
     /// `LightClient::update_current_price` does.
+    #[cfg(feature = "nym")]
     #[deprecated(note = "holds the wallet lock across the network wait; \
                 fetch with zingo_price::fetch_current_price and record with \
                 record_price_update instead")]
@@ -436,7 +437,10 @@ impl LightWallet {
     /// Records a price fetched *outside* the wallet lock (the net-diag
     /// polling-blackout remedy: the caller fetches with no lock held, then
     /// re-acquires briefly and stores the result here). The price lands in
-    /// the price list, so it serializes with the wallet.
+    /// the price list, so it serializes with the wallet. Price fetching
+    /// exists only in `nym` builds (ADR 0011, amendment 2026-07-28), so the
+    /// recorder is gated with its only caller.
+    #[cfg(feature = "nym")]
     pub(crate) fn record_price_update(&mut self, price: zingo_price::Price) {
         self.price_list.record_current_price(price);
         self.save_required = true;

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -21,7 +21,11 @@ use zingo_price::PriceList;
 
 use crate::config::{ChainType, WalletConfig};
 use crate::data::proposal::ZingoProposal;
-use error::{KeyError, PriceError, WalletError};
+use error::{KeyError, WalletError};
+// The only price-consulting method left here is the nym-gated, deprecated
+// `update_current_price`; without the feature the import would be unused.
+#[cfg(feature = "nym")]
+use error::PriceError;
 use keys::unified::{UnifiedAddressId, UnifiedKeyStore};
 
 pub mod error;


### PR DESCRIPTION
Stacks on #2580 (which stacks on #2579); third arc of ADR 0024 phase 1 (#2578).

`101b0825f` reinstates the 2026-07-23 mixnet-only price rule per ADR 0011's 2026-07-28 amendment, superseding the clearnet default #2548 restored. The convergence audit supplied the motivation: with routing left to the callers, zingo-cli's help advertised the mixnet method while calling the clearnet one, and zingo-mobile fetched clearnet while its disclaimer claimed mixnet coverage — a per-caller choice every caller fumbled identically.

The two price entries fuse into one nym-gated `update_current_price` that routes by Mixnet Mode: `ready` fetches over the mixnet and returns the `MixnetPriceFetch` route evidence; `switched_off` refuses with `PriceFetchRequiresMixnet`, because the clearnet consent covers Transmission and never price (the price source is a third party outside the Zcash ecosystem, with no availability argument); `unattached`, `bootstrapping`, and `died` refuse typed via the route resolver. A default build has no price-fetch API; the deprecated lock-holding wallet fetch and the price recorder gate with their only callers.

zingo-cli's `current_price` now tells the truth in all three respects: the help names the rule, the nym build renders the price with the tunnel endpoint it traveled, and the default build states plainly that it has no price fetch.

Verified: both feature configurations compile warning-free, clippy clean, and the 5-test `price_fetch_contract` suite passes — the pre-existing typed-refusal pins (unattached, switched-off, dead proxy, black-holed proxy) now exercise the unified entry directly.

Remaining hygiene tracked on #2578: zingo-price still compiles its network dependencies in default builds; trimming them behind a `socks5-fetch` feature completes the amendment's dependency-graph claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)