### PR TITLE
feat: netutils funnels through zingolib; price fetch compiles only behind socks5-fetch

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,13 +7,15 @@ filter = 'package(libtonode-tests) | package(zingo-cli)'
 
 # store_all_checkpoints_in_verification_window builds its ~116-block
 # chain on the first run per machine (or under
-# ZINGO_REGENERATE_CHAIN_CACHE): 507s measured solo, which clears the
-# default 600s ceiling with no margin for container contention (this
-# file documents 5-7x stretch under load). Replay runs (~24s) fit the
-# normal budget untouched.
+# ZINGO_REGENERATE_CHAIN_CACHE): 507s measured solo on 2026-07-08, and
+# 1165s on a green CI shard on 2026-07-29, whose sibling run was killed
+# at the previous 1200s ceiling minutes later (runs 30419601214 and
+# 30420777014). The build's cost grows with the wallet stack, so the
+# ceiling carries ~50% headroom over the latest CI measurement. Replay
+# runs (~24s) fit the normal budget untouched.
 [[profile.default.overrides]]
 filter = 'test(store_all_checkpoints_in_verification_window)'
-slow-timeout = { period = "60s", terminate-after = 20, grace-period = "30s" }
+slow-timeout = { period = "60s", terminate-after = 30, grace-period = "30s" }
 
 # unavailable_boundary_tree_state_skips_without_sync mines and scans a
 # ~235-block leap past the first migration bucket boundary (test-injected
@@ -54,7 +56,7 @@ filter = 'package(libtonode-tests) | package(zingo-cli)'
 # Same first-run build allowance as the default profile (see above).
 [[profile.ci.overrides]]
 filter = 'test(store_all_checkpoints_in_verification_window)'
-slow-timeout = { period = "60s", terminate-after = 20, grace-period = "30s" }
+slow-timeout = { period = "60s", terminate-after = 30, grace-period = "30s" }
 
 # Same boundary-leap allowance as the default profile (see above).
 [[profile.ci.overrides]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,6 +4987,7 @@ dependencies = [
  "zingo-status",
  "zingo_common_components",
  "zingo_grpc_proxy",
+ "zingo_test_vectors",
  "zingolib",
  "zip32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,11 @@ pepper-sync = { path = "pepper-sync" } # NOTE: for development between releases
 zingo-memo = { path = "zingo-memo" }   # NOTE: for development between releases
 # zingo-memo = "0.1.1"
 zingo-net-diag = { path = "zingo-net-diag" }
-zingo-price = { path = "zingo-price" }
+# default-features = false: the fetch machinery (socks5-fetch) is opt-in;
+# zingolib re-enables it only under its `nym` feature (the mixnet-only
+# price rule). The crate's own default keeps the fetch for standalone
+# builds and tests.
+zingo-price = { path = "zingo-price", default-features = false }
 zingo-status = { path = "zingo-status" } # NOTE: for development between releases
 # zingo-status = "0.2.1"
 zingolib = { path = "zingolib" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -82,14 +82,15 @@ Reproduce the latest failing or incomplete nextest run:
 Run ignored tests explicitly:
   makers run-ignored
 
-Launch the wallet CLI (offline unless a Connectivity Consent stored by
-a previous run takes the session online; ADR 0025):
+Launch the wallet CLI with the mixnet transport compiled in, nym-proxy
+bundled beside the binary, and a proxy sidecar running for the session
+(logs to target/nym-proxy.log). The session is still offline unless a
+Connectivity Consent stored by a previous run takes it online
+(ADR 0025); other args are forwarded to zingo-cli:
   makers run-cli
 
-Also compile the mixnet transport in, bundle nym-proxy beside the
-binary, and launch a proxy sidecar for the session (logs to
-target/nym-proxy.log); other args are forwarded to zingo-cli:
-  makers run-cli --nym
+Opt out of the mixnet default — plain build, no sidecar:
+  makers run-cli --clearnet
 
 Install cargo-make if these commands are unavailable:
   cargo install cargo-make
@@ -408,7 +409,7 @@ args = [
 ]
 
 [tasks.run-cli]
-description = "Build and launch zingo-cli. The session starts offline and goes online only through a Connectivity Consent — one stored by a previous run, or an explicit consent act in the forwarded arguments (ADR 0025); launching never implies consent. Pass --nym to compile the mixnet transport in, bundle nym-proxy beside the binary, and launch the proxy alongside (logs to target/nym-proxy.log, stopped when the CLI exits); pass --release for release builds. Every other argument is forwarded to zingo-cli."
+description = "Build and launch zingo-cli with the mixnet transport compiled in, nym-proxy bundled beside the binary, and the proxy running alongside (logs to target/nym-proxy.log, stopped when the CLI exits). The session starts offline and goes online only through a Connectivity Consent — one stored by a previous run, or an explicit consent act in the forwarded arguments (ADR 0025); launching never implies consent. Pass --clearnet to opt out of the mixnet default (plain build, no sidecar); pass --release for release builds. Every other argument is forwarded to zingo-cli."
 command = "cargo"
 args = [
     "run",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -82,6 +82,15 @@ Reproduce the latest failing or incomplete nextest run:
 Run ignored tests explicitly:
   makers run-ignored
 
+Launch the wallet CLI (offline unless a Connectivity Consent stored by
+a previous run takes the session online; ADR 0025):
+  makers run-cli
+
+Also compile the mixnet transport in, bundle nym-proxy beside the
+binary, and launch a proxy sidecar for the session (logs to
+target/nym-proxy.log); other args are forwarded to zingo-cli:
+  makers run-cli --nym
+
 Install cargo-make if these commands are unavailable:
   cargo install cargo-make
 HELP
@@ -394,6 +403,20 @@ args = [
     "tools/workbench/Cargo.toml",
     "--bin",
     "bundle-nym-proxy",
+    "--",
+    "${@}",
+]
+
+[tasks.run-cli]
+description = "Build and launch zingo-cli. The session starts offline and goes online only through a Connectivity Consent — one stored by a previous run, or an explicit consent act in the forwarded arguments (ADR 0025); launching never implies consent. Pass --nym to compile the mixnet transport in, bundle nym-proxy beside the binary, and launch the proxy alongside (logs to target/nym-proxy.log, stopped when the CLI exits); pass --release for release builds. Every other argument is forwarded to zingo-cli."
+command = "cargo"
+args = [
+    "run",
+    "-q",
+    "--manifest-path",
+    "tools/workbench/Cargo.toml",
+    "--bin",
+    "run-cli",
     "--",
     "${@}",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -82,14 +82,15 @@ Reproduce the latest failing or incomplete nextest run:
 Run ignored tests explicitly:
   makers run-ignored
 
-Launch the wallet CLI with the mixnet transport compiled in, nym-proxy
-bundled beside the binary, and a proxy sidecar running for the session
-(logs to target/nym-proxy.log). The session is still offline unless a
+Launch the wallet CLI with the mixnet transport compiled in and
+nym-proxy bundled beside the binary. The CLI itself boots the proxy
+only at an Online session's start (Mixnet Mode forced on, ADR 0024);
+an offline session boots no proxy, and the session is offline unless a
 Connectivity Consent stored by a previous run takes it online
-(ADR 0025); other args are forwarded to zingo-cli:
+(ADR 0025). Other args are forwarded to zingo-cli:
   makers run-cli
 
-Opt out of the mixnet default — plain build, no sidecar:
+Opt out of the mixnet default — plain build, nothing bundled:
   makers run-cli --clearnet
 
 Install cargo-make if these commands are unavailable:
@@ -409,7 +410,7 @@ args = [
 ]
 
 [tasks.run-cli]
-description = "Build and launch zingo-cli with the mixnet transport compiled in, nym-proxy bundled beside the binary, and the proxy running alongside (logs to target/nym-proxy.log, stopped when the CLI exits). The session starts offline and goes online only through a Connectivity Consent — one stored by a previous run, or an explicit consent act in the forwarded arguments (ADR 0025); launching never implies consent. Pass --clearnet to opt out of the mixnet default (plain build, no sidecar); pass --release for release builds. Every other argument is forwarded to zingo-cli."
+description = "Build and launch zingo-cli with the mixnet transport compiled in and nym-proxy bundled beside the binary. The proxy is never launched here: the CLI spawns it only at an Online session's go-online moment (ADR 0024), and an offline session boots no proxy. The session starts offline and goes online only through a Connectivity Consent — one stored by a previous run, or an explicit consent act in the forwarded arguments (ADR 0025); launching never implies consent. Pass --clearnet to opt out of the mixnet default (plain build, nothing bundled); pass --release for release builds. Every other argument is forwarded to zingo-cli."
 command = "cargo"
 args = [
     "run",

--- a/tools/workbench/src/bin/run-cli.rs
+++ b/tools/workbench/src/bin/run-cli.rs
@@ -1,29 +1,29 @@
-//! Build and launch `zingo-cli`, by default with a `nym-proxy` sidecar.
+//! Build and launch `zingo-cli`, by default mixnet-capable.
 //!
 //! Usage: `run-cli [--clearnet] [--release] [<zingo-cli args...>]`. The
 //! `--clearnet` and `--release` flags are consumed wherever they appear
 //! (as is the retired `--nym`, a no-op now that it names the default);
 //! every other argument is forwarded to `zingo-cli` unchanged.
 //!
+//! The default run compiles the mixnet transport into the CLI and bundles
+//! the `nym-proxy` binary beside it, where the CLI's provisioning
+//! precedence resolves it. This tool never launches the proxy: the CLI
+//! owns that lifecycle, spawning the proxy at its go-online moment for an
+//! Online session (Mixnet Mode forced on, ADR 0024) and never for an
+//! offline one — an offline session boots no proxy at all (ADR 0025).
+//! `--clearnet` opts out of both the feature and the bundling: a plain
+//! build with no mixnet capability.
+//!
 //! The launched session decides its own connectivity: first boot is offline,
 //! and only a consent act — a stored standing Connectivity Consent from a
 //! previous run, or an explicit `--online`/`--server` passed through in the
 //! trailing arguments — takes it online (ADR 0025). Neither this tool nor a
-//! running proxy implies consent: the CLI launches offline beside a live
-//! sidecar exactly as it does without one.
-//!
-//! The default run compiles the mixnet transport into the CLI, bundles the
-//! `nym-proxy` binary beside it (so the CLI's proxy-path resolution finds it
-//! when Mixnet Mode is enabled), and launches one `nym-proxy` process
-//! alongside the CLI, logging to `target/nym-proxy.log`. The sidecar is
-//! killed when the CLI exits, so no orphan survives the session.
-//! `--clearnet` opts out of all three: a plain build with no bundled proxy
-//! and no sidecar.
+//! bundled proxy binary implies consent.
 
 #![forbid(unsafe_code)]
 
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio, exit};
+use std::path::Path;
+use std::process::{Command, exit};
 
 use workbench::repo_root;
 
@@ -42,8 +42,8 @@ fn main() {
     }
 }
 
-/// Build the CLI (and, unless `--clearnet` opts out, bundle and launch the
-/// proxy sidecar), run the CLI to completion, and return its exit code.
+/// Build the CLI (and, unless `--clearnet` opts out, bundle the proxy
+/// binary beside it), run the CLI to completion, and return its exit code.
 fn launch(args: &[String]) -> Result<i32, Vec<String>> {
     let clearnet = args.iter().any(|arg| arg == "--clearnet");
     let nym_flag = args.iter().any(|arg| arg == "--nym");
@@ -82,11 +82,9 @@ fn launch(args: &[String]) -> Result<i32, Vec<String>> {
         return Err(vec![format!("cargo build of zingo-cli failed ({status})")]);
     }
 
-    let mut sidecar = if nym {
-        Some(launch_proxy_sidecar(&root, release)?)
-    } else {
-        None
-    };
+    if nym {
+        bundle_proxy(&root, release)?;
+    }
 
     let cli = root
         .join("target")
@@ -97,19 +95,14 @@ fn launch(args: &[String]) -> Result<i32, Vec<String>> {
         .status()
         .map_err(|e| vec![format!("failed to launch {}: {e}", cli.display())]);
 
-    if let Some(proxy) = sidecar.as_mut() {
-        proxy.kill().ok();
-        proxy.wait().ok();
-        eprintln!("{PROG}: nym-proxy sidecar stopped with the session");
-    }
-
     Ok(cli_status?.code().unwrap_or(1))
 }
 
 /// Bundle `nym-proxy` beside the wallet binaries via the sibling
-/// `bundle-nym-proxy` tool, then spawn it with both output streams appended
-/// to `target/nym-proxy.log`, returning the child for session-bound teardown.
-fn launch_proxy_sidecar(root: &Path, release: bool) -> Result<Child, Vec<String>> {
+/// `bundle-nym-proxy` tool, so the CLI's provisioning precedence finds it.
+/// The CLI decides whether the proxy ever runs: it spawns it only at an
+/// Online session's go-online moment, never for an offline session.
+fn bundle_proxy(root: &Path, release: bool) -> Result<(), Vec<String>> {
     let mut bundle = Command::new("cargo");
     bundle.current_dir(root).args([
         "run",
@@ -132,32 +125,12 @@ fn launch_proxy_sidecar(root: &Path, release: bool) -> Result<Child, Vec<String>
             bundled.status
         )]);
     }
-    let proxy_path = PathBuf::from(
-        String::from_utf8(bundled.stdout)
-            .map_err(|e| vec![format!("bundle-nym-proxy output not utf-8: {e}")])?
-            .trim(),
-    );
-
-    let log_path = root.join("target").join("nym-proxy.log");
-    let log = std::fs::File::create(&log_path)
-        .map_err(|e| vec![format!("cannot create {}: {e}", log_path.display())])?;
-    let log_for_stderr = log
-        .try_clone()
-        .map_err(|e| vec![format!("cannot clone log handle: {e}")])?;
-    // Detach stdin: the sidecar would otherwise share the raw-mode tty with
-    // zingo-cli's readline and steal keystrokes byte by byte.
-    let child = Command::new(&proxy_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(log))
-        .stderr(Stdio::from(log_for_stderr))
-        .spawn()
-        .map_err(|e| vec![format!("failed to launch {}: {e}", proxy_path.display())])?;
+    let proxy_path = String::from_utf8(bundled.stdout)
+        .map_err(|e| vec![format!("bundle-nym-proxy output not utf-8: {e}")])?;
     eprintln!(
-        "{PROG}: nym-proxy sidecar launched (pid {}); its SOCKS5_ADDR line will \
-         appear in {}. The session it runs beside still starts offline unless a \
-         stored Connectivity Consent takes it online.",
-        child.id(),
-        log_path.display()
+        "{PROG}: nym-proxy bundled at {}; the CLI spawns it only for an Online \
+         session (offline sessions boot no proxy)",
+        proxy_path.trim()
     );
-    Ok(child)
+    Ok(())
 }

--- a/tools/workbench/src/bin/run-cli.rs
+++ b/tools/workbench/src/bin/run-cli.rs
@@ -144,7 +144,10 @@ fn launch_proxy_sidecar(root: &Path, release: bool) -> Result<Child, Vec<String>
     let log_for_stderr = log
         .try_clone()
         .map_err(|e| vec![format!("cannot clone log handle: {e}")])?;
+    // Detach stdin: the sidecar would otherwise share the raw-mode tty with
+    // zingo-cli's readline and steal keystrokes byte by byte.
     let child = Command::new(&proxy_path)
+        .stdin(Stdio::null())
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_for_stderr))
         .spawn()

--- a/tools/workbench/src/bin/run-cli.rs
+++ b/tools/workbench/src/bin/run-cli.rs
@@ -1,8 +1,9 @@
-//! Build and launch `zingo-cli`, optionally with a `nym-proxy` sidecar.
+//! Build and launch `zingo-cli`, by default with a `nym-proxy` sidecar.
 //!
-//! Usage: `run-cli [--nym] [--release] [<zingo-cli args...>]`. The `--nym`
-//! and `--release` flags are consumed wherever they appear; every other
-//! argument is forwarded to `zingo-cli` unchanged.
+//! Usage: `run-cli [--clearnet] [--release] [<zingo-cli args...>]`. The
+//! `--clearnet` and `--release` flags are consumed wherever they appear
+//! (as is the retired `--nym`, a no-op now that it names the default);
+//! every other argument is forwarded to `zingo-cli` unchanged.
 //!
 //! The launched session decides its own connectivity: first boot is offline,
 //! and only a consent act — a stored standing Connectivity Consent from a
@@ -11,16 +12,18 @@
 //! running proxy implies consent: the CLI launches offline beside a live
 //! sidecar exactly as it does without one.
 //!
-//! `--nym` compiles the mixnet transport into the CLI, bundles the
+//! The default run compiles the mixnet transport into the CLI, bundles the
 //! `nym-proxy` binary beside it (so the CLI's proxy-path resolution finds it
 //! when Mixnet Mode is enabled), and launches one `nym-proxy` process
 //! alongside the CLI, logging to `target/nym-proxy.log`. The sidecar is
 //! killed when the CLI exits, so no orphan survives the session.
+//! `--clearnet` opts out of all three: a plain build with no bundled proxy
+//! and no sidecar.
 
 #![forbid(unsafe_code)]
 
 use std::path::{Path, PathBuf};
-use std::process::{exit, Child, Command, Stdio};
+use std::process::{Child, Command, Stdio, exit};
 
 use workbench::repo_root;
 
@@ -39,14 +42,26 @@ fn main() {
     }
 }
 
-/// Build the CLI (and, under `--nym`, bundle and launch the proxy sidecar),
-/// run the CLI to completion, and return its exit code.
+/// Build the CLI (and, unless `--clearnet` opts out, bundle and launch the
+/// proxy sidecar), run the CLI to completion, and return its exit code.
 fn launch(args: &[String]) -> Result<i32, Vec<String>> {
-    let nym = args.iter().any(|arg| arg == "--nym");
+    let clearnet = args.iter().any(|arg| arg == "--clearnet");
+    let nym_flag = args.iter().any(|arg| arg == "--nym");
+    if clearnet && nym_flag {
+        return Err(vec![
+            "--clearnet and --nym contradict each other; pass --clearnet for a \
+         plain build, or nothing for the mixnet default"
+                .to_string(),
+        ]);
+    }
+    if nym_flag {
+        eprintln!("{PROG}: note: --nym is now the default and the flag is ignored");
+    }
+    let nym = !clearnet;
     let release = args.iter().any(|arg| arg == "--release");
     let cli_args: Vec<&String> = args
         .iter()
-        .filter(|arg| *arg != "--nym" && *arg != "--release")
+        .filter(|arg| *arg != "--nym" && *arg != "--release" && *arg != "--clearnet")
         .collect();
 
     let root = repo_root()?;

--- a/tools/workbench/src/bin/run-cli.rs
+++ b/tools/workbench/src/bin/run-cli.rs
@@ -1,0 +1,145 @@
+//! Build and launch `zingo-cli`, optionally with a `nym-proxy` sidecar.
+//!
+//! Usage: `run-cli [--nym] [--release] [<zingo-cli args...>]`. The `--nym`
+//! and `--release` flags are consumed wherever they appear; every other
+//! argument is forwarded to `zingo-cli` unchanged.
+//!
+//! The launched session decides its own connectivity: first boot is offline,
+//! and only a consent act — a stored standing Connectivity Consent from a
+//! previous run, or an explicit `--online`/`--server` passed through in the
+//! trailing arguments — takes it online (ADR 0025). Neither this tool nor a
+//! running proxy implies consent: the CLI launches offline beside a live
+//! sidecar exactly as it does without one.
+//!
+//! `--nym` compiles the mixnet transport into the CLI, bundles the
+//! `nym-proxy` binary beside it (so the CLI's proxy-path resolution finds it
+//! when Mixnet Mode is enabled), and launches one `nym-proxy` process
+//! alongside the CLI, logging to `target/nym-proxy.log`. The sidecar is
+//! killed when the CLI exits, so no orphan survives the session.
+
+#![forbid(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::{exit, Child, Command, Stdio};
+
+use workbench::repo_root;
+
+const PROG: &str = "run-cli";
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match launch(&args) {
+        Ok(code) => exit(code),
+        Err(lines) => {
+            for line in lines {
+                eprintln!("{PROG}: {line}");
+            }
+            exit(1);
+        }
+    }
+}
+
+/// Build the CLI (and, under `--nym`, bundle and launch the proxy sidecar),
+/// run the CLI to completion, and return its exit code.
+fn launch(args: &[String]) -> Result<i32, Vec<String>> {
+    let nym = args.iter().any(|arg| arg == "--nym");
+    let release = args.iter().any(|arg| arg == "--release");
+    let cli_args: Vec<&String> = args
+        .iter()
+        .filter(|arg| *arg != "--nym" && *arg != "--release")
+        .collect();
+
+    let root = repo_root()?;
+    let profile = if release { "release" } else { "debug" };
+
+    let mut build = Command::new("cargo");
+    build.current_dir(&root).args(["build", "-p", "zingo-cli"]);
+    if release {
+        build.arg("--release");
+    }
+    if nym {
+        build.args(["--features", "nym"]);
+    }
+    let status = build
+        .status()
+        .map_err(|e| vec![format!("failed to run cargo build: {e}")])?;
+    if !status.success() {
+        return Err(vec![format!("cargo build of zingo-cli failed ({status})")]);
+    }
+
+    let mut sidecar = if nym {
+        Some(launch_proxy_sidecar(&root, release)?)
+    } else {
+        None
+    };
+
+    let cli = root
+        .join("target")
+        .join(profile)
+        .join(format!("zingo-cli{}", std::env::consts::EXE_SUFFIX));
+    let cli_status = Command::new(&cli)
+        .args(&cli_args)
+        .status()
+        .map_err(|e| vec![format!("failed to launch {}: {e}", cli.display())]);
+
+    if let Some(proxy) = sidecar.as_mut() {
+        proxy.kill().ok();
+        proxy.wait().ok();
+        eprintln!("{PROG}: nym-proxy sidecar stopped with the session");
+    }
+
+    Ok(cli_status?.code().unwrap_or(1))
+}
+
+/// Bundle `nym-proxy` beside the wallet binaries via the sibling
+/// `bundle-nym-proxy` tool, then spawn it with both output streams appended
+/// to `target/nym-proxy.log`, returning the child for session-bound teardown.
+fn launch_proxy_sidecar(root: &Path, release: bool) -> Result<Child, Vec<String>> {
+    let mut bundle = Command::new("cargo");
+    bundle.current_dir(root).args([
+        "run",
+        "-q",
+        "--manifest-path",
+        "tools/workbench/Cargo.toml",
+        "--bin",
+        "bundle-nym-proxy",
+        "--",
+    ]);
+    if release {
+        bundle.arg("--release");
+    }
+    let bundled = bundle
+        .output()
+        .map_err(|e| vec![format!("failed to run bundle-nym-proxy: {e}")])?;
+    if !bundled.status.success() {
+        return Err(vec![format!(
+            "bundle-nym-proxy failed ({})",
+            bundled.status
+        )]);
+    }
+    let proxy_path = PathBuf::from(
+        String::from_utf8(bundled.stdout)
+            .map_err(|e| vec![format!("bundle-nym-proxy output not utf-8: {e}")])?
+            .trim(),
+    );
+
+    let log_path = root.join("target").join("nym-proxy.log");
+    let log = std::fs::File::create(&log_path)
+        .map_err(|e| vec![format!("cannot create {}: {e}", log_path.display())])?;
+    let log_for_stderr = log
+        .try_clone()
+        .map_err(|e| vec![format!("cannot clone log handle: {e}")])?;
+    let child = Command::new(&proxy_path)
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_for_stderr))
+        .spawn()
+        .map_err(|e| vec![format!("failed to launch {}: {e}", proxy_path.display())])?;
+    eprintln!(
+        "{PROG}: nym-proxy sidecar launched (pid {}); its SOCKS5_ADDR line will \
+         appear in {}. The session it runs beside still starts offline unless a \
+         stored Connectivity Consent takes it online.",
+        child.id(),
+        log_path.display()
+    );
+    Ok(child)
+}

--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -45,6 +45,10 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# The offline-contract tests build Indexerless clients from synthetic
+# wallets, so every command's offline behavior is pinned without a network.
+zingolib = { workspace = true, features = ["testutils"] }
+zingo_test_vectors = { workspace = true }
 # The heartbeat and log-file tests read their temporal parameters from
 # `time::test`.
 zingo-netutils = { workspace = true, features = ["testutils"] }

--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -15,7 +15,10 @@ nym-diary = ["zingolib/nym-diary"]
 [dependencies]
 pepper-sync = { workspace = true }
 zingo_common_components = { workspace = true }
-zingo-netutils = { workspace = true }
+# No direct zingo-netutils dependency: this consumer funnels through
+# zingolib's re-exports (`zingolib::netutils`, ADR 0024 decision 7). The
+# dev-dependency below reaches netutils' test scaffolding directly, which
+# ships nothing and creates no duplicate copy.
 zingolib = { workspace = true }
 
 zcash_address = { workspace = true }

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -40,7 +40,7 @@ use zingolib::wallet::migration::{self, MigrationPhase};
 
 pub static RT: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
 
-use zingo_netutils::time::TRANSMIT_HEARTBEAT_INTERVAL;
+use zingolib::netutils::time::TRANSMIT_HEARTBEAT_INTERVAL;
 
 /// Awaits `operation`, emitting a heartbeat every
 /// [`TRANSMIT_HEARTBEAT_INTERVAL`]: the latest line from `latest` (the
@@ -826,7 +826,7 @@ fn parse_nym_args(args: &[&str]) -> Result<NymSubCommand, NymCommandError> {
 }
 
 #[cfg(feature = "nym")]
-use zingo_netutils::time::PROBE_LEG_TIMEOUT;
+use zingolib::netutils::time::PROBE_LEG_TIMEOUT;
 
 /// Render one paired probe: the two legs side by side, so a mixnet-specific
 /// failure (clearnet ok, mixnet failed) reads at a glance. Pure, pinned by

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -665,6 +665,10 @@ impl Command for CurrentPriceCommand {
         indoc! {r"
             Fetch the current ZEC price over the Nym mixnet. USD only.
 
+            The fetch races all three price sources (gemini, kraken,
+            coingecko) through the tunnel and reports the first answer,
+            naming the winning source and the round-trip time.
+
             Price travels only over the mixnet (ADR 0011): the fetch runs while
             Mixnet Mode is ready and refuses in every other state, including
             switched off — the clearnet consent covers sends, never price,
@@ -685,8 +689,11 @@ impl Command for CurrentPriceCommand {
         Ok(RT.block_on(async move {
             match lightclient.update_current_price().await {
                 Ok(fetch) => format!(
-                    "current price: {} (fetched over the mixnet via {})",
-                    fetch.usd, fetch.via_socks5
+                    "current price: {} USD (source: {}, rtt: {} ms, fetched over the mixnet via {})",
+                    fetch.usd,
+                    fetch.source.name(),
+                    fetch.round_trip.as_millis(),
+                    fetch.via_socks5
                 ),
                 Err(e) => format!("error: {e}"),
             }
@@ -1635,12 +1642,15 @@ impl Command for QuickSendCommand {
                 "quicksend",
                 move || progress.latest(),
                 |line| eprintln!("{line}"),
-                lightclient.quick_send(request, zip32::AccountId::ZERO, true),
+                lightclient.quick_send_reported(request, zip32::AccountId::ZERO, true),
             )
             .await
             {
-                Ok(txids) => {
-                    object! { "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>() }
+                Ok(reports) => {
+                    object! {
+                        "txids" => reports.iter().map(|report| report.txid.to_string()).collect::<Vec<_>>(),
+                        "transmissions" => reports.iter().map(render_transmit_report).collect::<Vec<_>>(),
+                    }
                 }
                 Err(e) => {
                     object! { "error" => e.to_string() }
@@ -1648,6 +1658,31 @@ impl Command for QuickSendCommand {
             }
             .pretty(2)
         }))
+    }
+}
+
+/// One transmitted transaction's attestation as JSON: the route it
+/// traveled, the endpoint that accepted it, and the round-trip time.
+fn render_transmit_report(report: &zingolib::lightclient::send::TransmitReport) -> json::JsonValue {
+    use zingolib::lightclient::send::TransmitRoute;
+    let rtt_ms = u64::try_from(report.round_trip.as_millis()).unwrap_or(u64::MAX);
+    match &report.route {
+        TransmitRoute::Clearnet { indexer } => object! {
+            "txid" => report.txid.to_string(),
+            "over_mixnet" => false,
+            "indexer" => indexer.clone(),
+            "rtt_ms" => rtt_ms,
+        },
+        TransmitRoute::Mixnet {
+            witness,
+            via_socks5,
+        } => object! {
+            "txid" => report.txid.to_string(),
+            "over_mixnet" => true,
+            "witness" => witness.clone(),
+            "via_socks5" => via_socks5.clone(),
+            "rtt_ms" => rtt_ms,
+        },
     }
 }
 
@@ -3780,6 +3815,527 @@ mod nym_command_parsing {
                     "the disclaimer must name {phrase:?} in mode {mode:?}: {out}"
                 );
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod offline_contract {
+    //! The Offline-mode contract at the command surface (issue #2286,
+    //! ADR 0006, ADR 0025). Every client here is genuinely Indexerless —
+    //! built by [`LightClient::new_for_test`] from a synthetic wallet, with
+    //! no server configured and no network object constructed — so these
+    //! tests run with zero traffic and prove two halves of one contract:
+    //!
+    //! - every wallet-local command completes offline, meaning connectivity
+    //!   is never the obstacle (a domain failure such as "nothing to
+    //!   shield" is legitimate; the Offline refusal is not); and
+    //! - every connectivity-requiring command refuses offline with the one
+    //!   typed refusal, [`zingolib::lightclient::error::LightClientError::Offline`],
+    //!   rendered through the command's own error channel — never a hang, a
+    //!   panic, or a silent clearnet fallback.
+    //!
+    //! The `change_server` pin lives at the REPL dispatch, not here: see
+    //! `offline_mode_refusal` and its tests in `crate::tests`.
+    //!
+    //! Deliberately untested, with the reasoning on record: `drain now`,
+    //! `split now`, and `migration catchup` refuse at the transmit stage,
+    //! whose pre-flight `transmit` and `quicksend` pin below (each extra
+    //! case would buy another proving run, not another guarantee); `nym on`
+    //! and `nym probe` currently carry NO offline gate (they would emit
+    //! traffic from an Offline session — a known gap tracked for the ADR
+    //! 0024 session driver), and the REPL-owned `servers` command likewise
+    //! probes the network unguarded.
+
+    use zingolib::lightclient::LightClient;
+    use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+    use super::{CommandError, RT, get_commands};
+
+    /// The Display of `LightClientError::Offline`: the single refusal every
+    /// connectivity-requiring command must surface, and the string no
+    /// offline-capable command may ever emit.
+    const OFFLINE_REFUSAL: &str =
+        "Offline: no indexer configured. Call set_indexer_uri() to connect.";
+
+    /// An Indexerless client over an empty synthetic wallet.
+    fn offline_client() -> LightClient {
+        RT.block_on(LightClient::new_for_test(
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED).build(),
+        ))
+    }
+
+    /// An Indexerless client whose wallet holds a spendable orchard note
+    /// and a transparent coin, so proposing, planning, and shielding have
+    /// material to work with.
+    fn funded_offline_client() -> LightClient {
+        RT.block_on(LightClient::new_for_test(
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+                .orchard_note(100_000_000)
+                .transparent_coin(50_000_000)
+                .build(),
+        ))
+    }
+
+    fn exec(
+        client: &mut LightClient,
+        command: &str,
+        args: &[&str],
+    ) -> Result<String, CommandError> {
+        get_commands()
+            .get(command)
+            .unwrap_or_else(|| panic!("command `{command}` is registered"))
+            .exec(args, client)
+    }
+
+    /// Asserts `command` succeeds offline and returns its output.
+    fn assert_works_offline(client: &mut LightClient, command: &str, args: &[&str]) -> String {
+        let output = exec(client, command, args)
+            .unwrap_or_else(|error| panic!("`{command}` must work offline: {error}"));
+        assert!(
+            !output.contains(OFFLINE_REFUSAL),
+            "`{command}` must not surface the Offline refusal: {output}"
+        );
+        output
+    }
+
+    /// Asserts connectivity is never `command`'s obstacle: it may succeed
+    /// or fail on domain grounds, but must not surface the Offline refusal.
+    fn assert_unblocked_offline(client: &mut LightClient, command: &str, args: &[&str]) -> String {
+        let rendered = match exec(client, command, args) {
+            Ok(output) => output,
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            !rendered.contains(OFFLINE_REFUSAL),
+            "`{command}` must not be blocked by Offline mode: {rendered}"
+        );
+        rendered
+    }
+
+    /// Asserts `command` refuses offline through its `Err` channel with the
+    /// typed Offline refusal.
+    fn assert_refuses_offline_via_err(client: &mut LightClient, command: &str, args: &[&str]) {
+        let error = exec(client, command, args).expect_err(command);
+        assert!(
+            error.to_string().contains(OFFLINE_REFUSAL),
+            "`{command}` must refuse with the typed Offline error: {error}"
+        );
+    }
+
+    /// Asserts `command` refuses offline through its rendered `error` field
+    /// (the send family reports failure inside its JSON success string).
+    fn assert_refuses_offline_in_output(client: &mut LightClient, command: &str, args: &[&str]) {
+        let output = exec(client, command, args)
+            .unwrap_or_else(|error| panic!("`{command}` renders refusals into output: {error}"));
+        assert!(
+            output.contains(OFFLINE_REFUSAL),
+            "`{command}` must report the typed Offline refusal: {output}"
+        );
+    }
+
+    /// A fresh unified address from the wallet itself, so send-family tests
+    /// stay on the wallet's own chain.
+    fn own_unified_address(client: &mut LightClient) -> String {
+        let output = assert_works_offline(client, "new_address", &["o"]);
+        let parsed = json::parse(&output).expect("new_address returns JSON");
+        parsed["encoded_address"]
+            .as_str()
+            .expect("encoded_address is a string")
+            .to_string()
+    }
+
+    mod works_offline {
+        //! The offline-capable surface: every command here must complete
+        //! against an Indexerless client.
+
+        use super::*;
+
+        #[test]
+        fn version() {
+            let output = assert_works_offline(&mut offline_client(), "version", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn help() {
+            let output = assert_works_offline(&mut offline_client(), "help", &[]);
+            assert!(output.contains("Wallet commands"), "{output}");
+        }
+
+        #[test]
+        fn parse_address_of_the_wallets_own() {
+            let mut client = offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "parse_address", &[&address]);
+            assert!(output.contains("success"), "{output}");
+        }
+
+        #[test]
+        fn parse_viewkey_of_the_exported_ufvk() {
+            let mut client = offline_client();
+            let exported = assert_works_offline(&mut client, "export_ufvk", &[]);
+            let ufvk = json::parse(&exported).expect("export_ufvk returns JSON")["ufvk"]
+                .as_str()
+                .expect("ufvk is a string")
+                .to_string();
+            let output = assert_works_offline(&mut client, "parse_viewkey", &[&ufvk]);
+            assert!(output.contains("success"), "{output}");
+        }
+
+        #[test]
+        fn addresses() {
+            let output = assert_works_offline(&mut offline_client(), "addresses", &[]);
+            json::parse(&output).expect("addresses returns JSON");
+        }
+
+        #[test]
+        fn t_addresses() {
+            let output = assert_works_offline(&mut offline_client(), "t_addresses", &[]);
+            json::parse(&output).expect("t_addresses returns JSON");
+        }
+
+        #[test]
+        fn new_address() {
+            let output = assert_works_offline(&mut offline_client(), "new_address", &["oz"]);
+            assert!(output.contains("encoded_address"), "{output}");
+        }
+
+        /// Funded, because the address-gap rule (a new transparent address
+        /// only after the latest one received funds) is a domain rule that
+        /// applies offline exactly as it does online.
+        #[test]
+        fn new_taddress() {
+            let output = assert_works_offline(&mut funded_offline_client(), "new_taddress", &[]);
+            assert!(output.contains("encoded_address"), "{output}");
+        }
+
+        #[test]
+        fn balance() {
+            let output = assert_works_offline(&mut funded_offline_client(), "balance", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn spendable_balance() {
+            let output =
+                assert_works_offline(&mut funded_offline_client(), "spendable_balance", &[]);
+            assert!(output.contains("spendable_balance"), "{output}");
+        }
+
+        #[test]
+        fn max_send_value() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "max_send_value", &[&address]);
+            assert!(output.contains("max_send_value"), "{output}");
+        }
+
+        #[test]
+        fn birthday() {
+            let output = assert_works_offline(&mut offline_client(), "birthday", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn height_reports_the_wallets_own_view() {
+            let output = assert_works_offline(&mut offline_client(), "height", &[]);
+            assert!(output.contains("20"), "the synthetic tip is 20: {output}");
+        }
+
+        #[test]
+        fn notes() {
+            assert_works_offline(&mut funded_offline_client(), "notes", &[]);
+        }
+
+        #[test]
+        fn coins() {
+            assert_works_offline(&mut funded_offline_client(), "coins", &[]);
+        }
+
+        #[test]
+        fn transactions() {
+            assert_works_offline(&mut offline_client(), "transactions", &[]);
+        }
+
+        #[test]
+        fn value_transfers() {
+            assert_works_offline(&mut offline_client(), "value_transfers", &[]);
+        }
+
+        #[test]
+        fn messages() {
+            assert_works_offline(&mut offline_client(), "messages", &[]);
+        }
+
+        #[test]
+        fn sends_to_address() {
+            assert_works_offline(&mut offline_client(), "sends_to_address", &[]);
+        }
+
+        #[test]
+        fn value_to_address() {
+            assert_works_offline(&mut offline_client(), "value_to_address", &[]);
+        }
+
+        #[test]
+        fn memobytes_to_address() {
+            assert_works_offline(&mut offline_client(), "memobytes_to_address", &[]);
+        }
+
+        #[test]
+        fn wallet_kind() {
+            let output = assert_works_offline(&mut offline_client(), "wallet_kind", &[]);
+            assert!(output.contains("mnemonic"), "{output}");
+        }
+
+        #[test]
+        fn settings() {
+            assert_unblocked_offline(&mut offline_client(), "settings", &[]);
+        }
+
+        #[test]
+        fn recovery_info() {
+            let output = assert_works_offline(&mut offline_client(), "recovery_info", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn export_ufvk() {
+            let output = assert_works_offline(&mut offline_client(), "export_ufvk", &[]);
+            assert!(output.contains("ufvk"), "{output}");
+        }
+
+        #[test]
+        fn check_address_recognizes_the_wallets_own() {
+            let mut client = offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "check_address", &[&address]);
+            assert!(output.contains("is_wallet_address"), "{output}");
+        }
+
+        #[test]
+        fn clear() {
+            let output = assert_works_offline(&mut offline_client(), "clear", &[]);
+            assert!(output.contains("success"), "{output}");
+        }
+
+        /// `sync status` reads wallet state only; on a synthetic wallet it
+        /// reports a wallet-shape error (no wallet blocks are fabricated),
+        /// which is a domain outcome — connectivity is never the obstacle.
+        #[test]
+        fn sync_status() {
+            assert_unblocked_offline(&mut offline_client(), "sync", &["status"]);
+        }
+
+        #[test]
+        fn sync_poll() {
+            let output = assert_works_offline(&mut offline_client(), "sync", &["poll"]);
+            assert_eq!(output, "Sync task has not been launched.");
+        }
+
+        #[test]
+        fn quit() {
+            let output = assert_works_offline(&mut offline_client(), "quit", &[]);
+            assert!(output.contains("quit successfully"), "{output}");
+        }
+
+        /// Proposing is an Indexerless capability (ADR 0006): `send` shows
+        /// the fee offline, for a later `calculate`/`transmit`.
+        #[test]
+        fn send_proposes_offline() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "send", &[&address, "50000"]);
+            assert!(output.contains("fee"), "{output}");
+        }
+
+        #[test]
+        fn send_all_proposes_offline() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "send_all", &[&address]);
+            assert!(output.contains("fee"), "{output}");
+        }
+
+        #[test]
+        fn shield_proposes_offline() {
+            let output = assert_works_offline(&mut funded_offline_client(), "shield", &[]);
+            assert!(output.contains("fee"), "{output}");
+        }
+
+        /// Offline signing (ADR 0006): `calculate` signs the stored
+        /// proposal with no Indexer, leaving Calculated transactions for a
+        /// connected `transmit`.
+        #[test]
+        fn calculate_signs_offline() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            assert_works_offline(&mut client, "send", &[&address, "50000"]);
+            let output = assert_works_offline(&mut client, "calculate", &[]);
+            assert!(output.contains("txids"), "{output}");
+        }
+
+        #[test]
+        fn drain_plan() {
+            let output = assert_works_offline(&mut funded_offline_client(), "drain", &["plan"]);
+            assert!(output.contains("transactions"), "{output}");
+        }
+
+        #[test]
+        fn split_plan() {
+            let output = assert_works_offline(&mut funded_offline_client(), "split", &["plan"]);
+            assert!(output.contains("split_rounds"), "{output}");
+        }
+
+        #[test]
+        fn migration_plan() {
+            let output = assert_works_offline(&mut funded_offline_client(), "migration", &["plan"]);
+            assert!(output.contains("plan_hash"), "{output}");
+        }
+
+        #[test]
+        fn migration_status() {
+            let output =
+                assert_works_offline(&mut funded_offline_client(), "migration", &["status"]);
+            assert!(output.contains("phase"), "{output}");
+        }
+
+        #[test]
+        fn migration_windows() {
+            assert_unblocked_offline(&mut funded_offline_client(), "migration", &["windows"]);
+        }
+
+        /// `nym status` reads the wallet's mode: an offline session never
+        /// bootstraps the mixnet, so a fresh client reports unattached.
+        #[cfg(feature = "nym")]
+        #[test]
+        fn nym_status_reports_unattached() {
+            let output = assert_works_offline(&mut offline_client(), "nym", &["status"]);
+            assert!(output.contains("unattached"), "{output}");
+        }
+
+        #[test]
+        fn remove_transaction_fails_on_the_txid_never_on_connectivity() {
+            let unknown_txid = "ab".repeat(32);
+            assert_unblocked_offline(
+                &mut offline_client(),
+                "remove_transaction",
+                &[&unknown_txid],
+            );
+        }
+
+        #[test]
+        fn delete_fails_on_the_file_never_on_connectivity() {
+            assert_unblocked_offline(&mut offline_client(), "delete", &[]);
+        }
+    }
+
+    mod refuses_offline {
+        //! The connectivity-requiring surface: every command here must
+        //! refuse offline with the typed Offline error, through its own
+        //! error channel.
+
+        use super::*;
+
+        #[test]
+        fn sync_run() {
+            assert_refuses_offline_via_err(&mut offline_client(), "sync", &["run"]);
+        }
+
+        #[test]
+        fn rescan() {
+            assert_refuses_offline_via_err(&mut offline_client(), "rescan", &[]);
+        }
+
+        /// `info` renders the typed failure at its presentation boundary:
+        /// the output IS the refusal, byte for byte.
+        #[test]
+        fn info() {
+            let output = exec(&mut offline_client(), "info", &[]).expect("info renders errors");
+            assert_eq!(output, OFFLINE_REFUSAL);
+        }
+
+        /// `confirm` pre-flights the Indexer before touching the stored
+        /// proposal, so the refusal needs no proposal and costs no proving.
+        #[test]
+        fn confirm() {
+            assert_refuses_offline_in_output(&mut offline_client(), "confirm", &[]);
+        }
+
+        /// `transmit` pre-flights the Indexer before resolving txids, so
+        /// even an unknown txid refuses on connectivity first.
+        #[test]
+        fn transmit() {
+            let txid = "ab".repeat(32);
+            assert_refuses_offline_in_output(&mut offline_client(), "transmit", &[&txid]);
+        }
+
+        /// `quicksend` proposes and signs offline (both Indexerless
+        /// capabilities), then refuses at the transmit stage: the wallet
+        /// does the work it can and leaks nothing.
+        #[test]
+        fn quicksend() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            assert_refuses_offline_in_output(&mut client, "quicksend", &[&address, "50000"]);
+        }
+
+        /// `quickshield` mirrors `quicksend`: the shield proposal and its
+        /// signing succeed offline, and the transmit stage refuses.
+        #[test]
+        fn quickshield() {
+            assert_refuses_offline_in_output(&mut funded_offline_client(), "quickshield", &[]);
+        }
+
+        /// `migrate` syncs before building anything, so the refusal
+        /// arrives from the sync pre-flight with no proving spent.
+        #[test]
+        fn migrate() {
+            assert_refuses_offline_via_err(&mut funded_offline_client(), "migrate", &[]);
+        }
+
+        #[test]
+        fn migration_continue() {
+            assert_refuses_offline_via_err(
+                &mut funded_offline_client(),
+                "migration",
+                &["continue"],
+            );
+        }
+
+        #[test]
+        fn migration_execute() {
+            assert_refuses_offline_via_err(&mut funded_offline_client(), "migration", &["execute"]);
+        }
+
+        #[test]
+        fn migration_auto() {
+            assert_refuses_offline_via_err(&mut funded_offline_client(), "migration", &["auto"]);
+        }
+
+        /// `current_price` is mixnet-only (ADR 0011): an offline session
+        /// never bootstraps the mixnet, so the fetch refuses from the
+        /// unattached mode — a typed refusal, zero traffic.
+        #[cfg(feature = "nym")]
+        #[test]
+        fn current_price_refuses_from_the_unattached_mixnet() {
+            let output = exec(&mut offline_client(), "current_price", &[])
+                .expect("current_price renders refusals");
+            assert!(
+                output.contains("error: the Nym mixnet is not enabled"),
+                "{output}"
+            );
+        }
+
+        /// Without the nym feature there is no price fetch at all: the
+        /// command says so instead of touching the network.
+        #[cfg(not(feature = "nym"))]
+        #[test]
+        fn current_price_has_no_fetch_to_offer() {
+            let output = exec(&mut offline_client(), "current_price", &[])
+                .expect("current_price explains the absent fetch");
+            assert!(output.contains("no price fetch"), "{output}");
         }
     }
 }

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -29,10 +29,10 @@ use log::{error, info};
 use log::{debug, warn};
 
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
-use zingo_netutils::Indexer as _;
 use zingolib::config::{ChainType, ClientConfig, DEFAULT_WALLET_NAME, WalletConfig};
 use zingolib::data::PollReport;
 use zingolib::lightclient::{DEFAULT_REQUEST_TIMEOUT, LightClient};
+use zingolib::netutils::Indexer as _;
 use zingolib::wallet::WalletSettings;
 
 use crate::commands::{RT, ShortCircuitedCommand};
@@ -770,7 +770,7 @@ fn build_zingo_config(filled_template: &ConfigTemplate) -> std::io::Result<Clien
         let chain_height = match filled_template.server.clone() {
             Some(server) => RT
                 .block_on(async move {
-                    zingo_netutils::GrpcIndexer::new(server)
+                    zingolib::netutils::GrpcIndexer::new(server)
                         .await
                         .map_err(|e| format!("{e:?}"))?
                         .get_latest_block(DEFAULT_REQUEST_TIMEOUT)

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -425,14 +425,8 @@ pub(crate) fn command_loop(
                 }
             };
             // The Offline-mode pin: this session never configures an Indexer.
-            if communication_mode == CommunicationMode::Offline && cmd == "change_server" {
-                resp_transmitter
-                    .send(
-                        "Error: this session is in Offline mode; no Indexer may be configured. \
-                         Restart without --offline to change servers."
-                            .to_string(),
-                    )
-                    .unwrap();
+            if let Some(refusal) = offline_mode_refusal(communication_mode, &cmd) {
+                resp_transmitter.send(refusal).unwrap();
                 continue;
             }
             let args: Vec<_> = args.iter().map(std::convert::AsRef::as_ref).collect();
@@ -501,6 +495,19 @@ enum CommunicationMode {
     /// The session never configures an Indexer: the client remains
     /// Indexerless, and only that state's capability set is available.
     Offline,
+}
+
+/// The Offline-mode pin at the REPL dispatch (issue #2286): an Offline
+/// session never configures an Indexer, so `change_server` is refused
+/// before it reaches command execution. Returns the refusal to send in
+/// place of executing `cmd`, or `None` when the command may proceed.
+/// Pure, so the pin is testable without a REPL thread.
+fn offline_mode_refusal(communication_mode: CommunicationMode, cmd: &str) -> Option<String> {
+    (communication_mode == CommunicationMode::Offline && cmd == "change_server").then(|| {
+        "Error: this session is in Offline mode; no Indexer may be configured. \
+         Restart without --offline to change servers."
+            .to_string()
+    })
 }
 
 /// One session's connectivity verdict (ADR 0025): how the launch acts and

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -305,17 +305,17 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
     let send_command =
         |cmd: String, args: Vec<String>| -> String { send_request(Request::Command(cmd, args)) };
 
-    let mut chain_name = String::new();
+    // The prompt's chain label comes from local config, not the server. An
+    // `info` round trip here blocked the first prompt behind the cold mixnet
+    // tunnel (up to MIXNET_ROUND_TRIP_BOUND), and an offline session got a
+    // refusal instead of a name, leaving the prompt's parens empty.
+    let chain_name = match cli_config.chaintype {
+        ChainType::Mainnet => "main",
+        ChainType::Testnet => "test",
+        ChainType::Regtest(_) => "regtest",
+    };
 
     loop {
-        if chain_name.is_empty() {
-            let info = send_command("info".to_string(), vec![]);
-            chain_name = json::parse(&info)
-                .map(|mut json_info| json_info.remove("chain_name"))
-                .ok()
-                .and_then(|name| name.as_str().map(ToString::to_string))
-                .unwrap_or_default();
-        }
         // Read the height first
         let height = json::parse(&send_command(
             "height".to_string(),

--- a/zingo-cli/src/main.rs
+++ b/zingo-cli/src/main.rs
@@ -82,7 +82,7 @@ fn handle_error(e: std::io::Error) {
 }
 
 pub fn main() {
-    zingo_netutils::ensure_default_crypto_provider();
+    zingolib::netutils::ensure_default_crypto_provider();
     let matches = parse_args_or_exit_for_help();
     init_tracing(&matches);
     if let Err(e) = zingo_cli::run_cli(matches) {

--- a/zingo-cli/src/server_select.rs
+++ b/zingo-cli/src/server_select.rs
@@ -1,15 +1,15 @@
 //! Dynamic server selection via `get_info()` against a curated list of indexers.
 //!
 //! When no `--server` is specified, we call `get_info()` on each URI in
-//! `zingo_netutils::indexers::MOST_UP_INDEXER_URIS` (the census) concurrently,
+//! `zingolib::netutils::indexers::MOST_UP_INDEXER_URIS` (the census) concurrently,
 //! measure response time, and return the responsive servers sorted
 //! from fastest to slowest.
 
 use std::time::{Duration, Instant};
 
 use crate::commands::RT;
-use zingo_netutils::indexers::MOST_UP_INDEXER_URIS;
-use zingo_netutils::{GrpcIndexer, Indexer as _};
+use zingolib::netutils::indexers::MOST_UP_INDEXER_URIS;
+use zingolib::netutils::{GrpcIndexer, Indexer as _};
 
 /// A server that responded successfully to `get_info()`, with its measured latency.
 #[derive(Debug)]
@@ -23,7 +23,7 @@ pub(crate) struct RankedServer {
 ///
 /// Uses a per-server timeout so one slow server doesn't block the rest.
 pub(crate) fn select_servers() -> Vec<RankedServer> {
-    use zingo_netutils::time::SERVER_RANKING_TIMEOUT;
+    use zingolib::netutils::time::SERVER_RANKING_TIMEOUT;
 
     let uris: Vec<http::Uri> = MOST_UP_INDEXER_URIS
         .iter()

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -893,3 +893,37 @@ mod config_template {
         }
     }
 }
+
+mod offline_mode_pin {
+    //! The REPL-dispatch half of the Offline-mode contract (issue #2286):
+    //! `change_server` is refused before command execution, since an
+    //! Offline session may never configure an Indexer. The command-surface
+    //! half lives in `commands::offline_contract`.
+
+    use crate::{CommunicationMode, offline_mode_refusal};
+
+    #[test]
+    fn offline_mode_refuses_change_server_before_dispatch() {
+        let refusal = offline_mode_refusal(CommunicationMode::Offline, "change_server")
+            .expect("an Offline session must refuse change_server");
+        assert_eq!(
+            refusal,
+            "Error: this session is in Offline mode; no Indexer may be configured. \
+             Restart without --offline to change servers."
+        );
+    }
+
+    #[test]
+    fn online_mode_and_other_commands_pass_the_pin() {
+        assert_eq!(
+            offline_mode_refusal(CommunicationMode::Online, "change_server"),
+            None,
+            "an Online session may change servers"
+        );
+        assert_eq!(
+            offline_mode_refusal(CommunicationMode::Offline, "balance"),
+            None,
+            "the pin refuses exactly one command, never the local surface"
+        );
+    }
+}

--- a/zingo-price/Cargo.toml
+++ b/zingo-price/Cargo.toml
@@ -8,6 +8,26 @@ repository = "https://github.com/zingolabs/zingolib"
 homepage = "https://github.com/zingolabs/zingolib"
 license = "MIT"
 
+[features]
+# The fetch machinery: reqwest + TLS + the net-diag classification. On by
+# default so the standalone crate builds and tests its whole surface;
+# zingolib depends on this crate with default features off and re-enables
+# the fetch only under its `nym` feature, per the mixnet-only price rule
+# (ADR 0011, amendment 2026-07-28) — a wallet build without the mixnet
+# compiles no fetch, and no fetch dependencies either. Without this
+# feature the crate is the storage-only price data model.
+default = ["socks5-fetch"]
+socks5-fetch = [
+    "dep:reqwest",
+    "dep:rustls",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:rust_decimal",
+    "dep:thiserror",
+    "dep:zingo-net-diag",
+    "dep:futures",
+]
+
 [dependencies]
 zcash_encoding = { workspace = true }
 
@@ -17,19 +37,19 @@ byteorder = { workspace = true }
 # rustls CryptoProvider; the fetch path installs aws-lc-rs (first-install-wins)
 # before requesting. The `socks` feature backs the optional Nym mixnet route;
 # the fetch defaults to clearnet.
-reqwest = { workspace = true, default-features = false, features = [
+reqwest = { workspace = true, optional = true, default-features = false, features = [
     "cookies",
     "rustls-tls-webpki-roots-no-provider",
     "json",
     "socks",
 ] }
-rust_decimal = { workspace = true }
-rustls = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
-zingo-net-diag.workspace = true
-futures.workspace = true
+rust_decimal = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+zingo-net-diag = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util"] }

--- a/zingo-price/src/lib.rs
+++ b/zingo-price/src/lib.rs
@@ -6,21 +6,32 @@
 //! wants to hide the client IP from the price source passes a local SOCKS5
 //! proxy address (the Nym mixnet transport, ADR 0011) and the request is
 //! routed through it instead.
+//!
+//! The whole fetch surface — and every dependency it needs — sits behind
+//! the `socks5-fetch` feature (on by default for this crate alone).
+//! Without it the crate is the storage-only data model: [`Price`] and
+//! [`PriceList`] with their wallet-file serialization. This is the
+//! dependency half of the mixnet-only price rule (ADR 0011, amendment
+//! 2026-07-28): a wallet build without the mixnet compiles no fetch.
 
+#[cfg(feature = "socks5-fetch")]
+use std::time::Duration;
 use std::{
     collections::HashSet,
     io::{Read, Write},
-    time::Duration,
 };
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
+#[cfg(feature = "socks5-fetch")]
 use serde::Deserialize;
 use zcash_encoding::{Optional, Vector};
+#[cfg(feature = "socks5-fetch")]
 use zingo_net_diag::{NetOpFailure, NetOpStage, chain_texts};
 
 /// Errors with price requests and parsing.
 // TODO: remove unused when historical data is implemented
+#[cfg(feature = "socks5-fetch")]
 #[derive(Debug, thiserror::Error)]
 pub enum PriceError {
     /// The HTTP request failed. The typed [`NetOpFailure`] names the stage
@@ -70,6 +81,7 @@ pub enum PriceError {
     UnexpectedShape(&'static str),
 }
 
+#[cfg(feature = "socks5-fetch")]
 #[derive(Debug, Deserialize)]
 struct CurrentPriceResponse {
     price: String,
@@ -158,6 +170,7 @@ impl PriceList {
     /// transport); `None` fetches over clearnet. The caller decides which
     /// route to use. The fetched price is recorded on `self` as
     /// [`Self::current_price`].
+    #[cfg(feature = "socks5-fetch")]
     pub async fn update_current_price(
         &mut self,
         socks5_proxy: Option<&str>,
@@ -245,6 +258,7 @@ impl PriceList {
 /// kept). Required because reqwest is built with `rustls-tls-no-provider`.
 /// Mirrors `zingo_netutils::ensure_default_crypto_provider`, which cannot be
 /// used here: zingo-netutils sits above this crate in the dependency graph.
+#[cfg(feature = "socks5-fetch")]
 fn ensure_default_crypto_provider() {
     if rustls::crypto::CryptoProvider::get_default().is_none() {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
@@ -254,13 +268,16 @@ fn ensure_default_crypto_provider() {
 /// How many trades the fetch requests from the price source. Eleven, so the
 /// median of the sorted list is a robust current price. [`GEMINI_ZECUSD_URL`]
 /// embeds this value; a test pins the two together.
+#[cfg(feature = "socks5-fetch")]
 const TRADES_REQUESTED: usize = 11;
 
 /// The median position in the sorted trades list.
+#[cfg(feature = "socks5-fetch")]
 const MEDIAN_INDEX: usize = TRADES_REQUESTED / 2;
 
 /// The public price source: Gemini's recent-trades endpoint for the ZEC/USD
 /// pair, requesting [`TRADES_REQUESTED`] trades.
+#[cfg(feature = "socks5-fetch")]
 const GEMINI_ZECUSD_URL: &str = "https://api.gemini.com/v1/trades/zecusd?limit_trades=11";
 
 /// The client-side bound on the whole request. Twenty seconds keeps the
@@ -268,9 +285,11 @@ const GEMINI_ZECUSD_URL: &str = "https://api.gemini.com/v1/trades/zecusd?limit_t
 /// ends (and releases whatever holds it) before or shortly after the UI
 /// gives up. A hang through a half-dead tunnel becomes a typed
 /// [`NetOpStage::TimedOut`] failure instead of an unbounded wait.
+#[cfg(feature = "socks5-fetch")]
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// The client-side bound on establishing the connection alone.
+#[cfg(feature = "socks5-fetch")]
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Fetch the current price of ZEC in USD from the public price source,
@@ -283,6 +302,7 @@ pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// side effects, so a caller can run it without holding any wallet lock and
 /// store the result under a briefly-held lock afterwards (the net-diag
 /// polling-blackout remedy).
+#[cfg(feature = "socks5-fetch")]
 pub async fn fetch_current_price(socks5_proxy: Option<&str>) -> Result<Price, PriceError> {
     fetch_current_price_from(PriceSource::Gemini, socks5_proxy).await
 }
@@ -291,6 +311,7 @@ pub async fn fetch_current_price(socks5_proxy: Option<&str>) -> Result<Price, Pr
 /// through a local SOCKS5 proxy (`socks5h://`, so hostname resolution
 /// happens at the proxy). The same lock-free contract as
 /// [`fetch_current_price`] applies.
+#[cfg(feature = "socks5-fetch")]
 pub async fn fetch_current_price_from(
     source: PriceSource,
     socks5_proxy: Option<&str>,
@@ -307,6 +328,7 @@ pub async fn fetch_current_price_from(
 
 /// The winning answer of the three-source race: the price and the source
 /// that answered first.
+#[cfg(feature = "socks5-fetch")]
 #[derive(Debug, Clone, Copy)]
 pub struct RacedPrice {
     /// The first price to arrive.
@@ -318,6 +340,7 @@ pub struct RacedPrice {
 /// Every source in the race failed. Each failure keeps its source's name
 /// beside the typed error, and the rendered report carries every cause
 /// chain, so a total outage is diagnosable per operator.
+#[cfg(feature = "socks5-fetch")]
 #[derive(Debug, thiserror::Error)]
 #[error("every price source failed. {}", self.report())]
 pub struct PriceRaceFailure {
@@ -325,6 +348,7 @@ pub struct PriceRaceFailure {
     pub failures: Vec<(PriceSource, PriceError)>,
 }
 
+#[cfg(feature = "socks5-fetch")]
 impl PriceRaceFailure {
     /// One line per source: its name, its error, and the full cause chain.
     pub fn report(&self) -> String {
@@ -349,6 +373,7 @@ impl PriceRaceFailure {
 /// losing fetches are cancelled. When every source fails, the error names
 /// each source's typed failure. Bounded by [`REQUEST_TIMEOUT`] per leg, so
 /// the whole race settles within the single-fetch bound.
+#[cfg(feature = "socks5-fetch")]
 pub async fn race_current_price(
     socks5_proxy: Option<&str>,
 ) -> Result<RacedPrice, PriceRaceFailure> {
@@ -367,6 +392,7 @@ pub async fn race_current_price(
 
 /// The race mechanism, URL-injectable for tests. First `Ok` wins and
 /// aborts the rest; all-fail collects every typed failure.
+#[cfg(feature = "socks5-fetch")]
 async fn race_sources(
     socks5_proxy: Option<&str>,
     entries: [(PriceSource, String); 3],
@@ -405,15 +431,18 @@ async fn race_sources(
 
 /// Kraken's public recent-trades endpoint for the ZEC/USD pair, requesting
 /// [`TRADES_REQUESTED`] trades so the Gemini median contract transfers.
+#[cfg(feature = "socks5-fetch")]
 const KRAKEN_ZECUSD_URL: &str = "https://api.kraken.com/0/public/Trades?pair=ZECUSD&count=11";
 
 /// CoinGecko's simple-price endpoint for ZEC in USD. An aggregator spot
 /// value with its update time; there are no trades to take a median of.
+#[cfg(feature = "socks5-fetch")]
 const COINGECKO_ZECUSD_URL: &str = "https://api.coingecko.com/api/v3/simple/price?ids=zcash&vs_currencies=usd&include_last_updated_at=true";
 
 /// The public price sources, each an independent operator and failure
 /// domain. Rotation order is the declaration order, wrapping; the caller
 /// owning rotation policy decides when to advance.
+#[cfg(feature = "socks5-fetch")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PriceSource {
     /// Gemini's recent-trades endpoint, median of eleven trades.
@@ -424,6 +453,7 @@ pub enum PriceSource {
     CoinGecko,
 }
 
+#[cfg(feature = "socks5-fetch")]
 impl PriceSource {
     /// The next source in rotation order, wrapping at the end.
     pub fn next(self) -> PriceSource {
@@ -463,6 +493,7 @@ impl PriceSource {
 
 /// The median of a sorted trades list, guarded so a structurally short
 /// response is a typed refusal, never an index panic.
+#[cfg(feature = "socks5-fetch")]
 fn median_price(mut trades: Vec<Price>) -> Result<Price, PriceError> {
     trades.sort_by(|a, b| {
         a.price_usd
@@ -476,6 +507,7 @@ fn median_price(mut trades: Vec<Price>) -> Result<Price, PriceError> {
         .ok_or(PriceError::InsufficientTrades { received })
 }
 
+#[cfg(feature = "socks5-fetch")]
 fn parse_gemini_trades(body: &str) -> Result<Price, PriceError> {
     let responses: Vec<CurrentPriceResponse> = serde_json::from_str(body)?;
     let trades = responses
@@ -494,6 +526,7 @@ fn parse_gemini_trades(body: &str) -> Result<Price, PriceError> {
     median_price(trades)
 }
 
+#[cfg(feature = "socks5-fetch")]
 fn parse_kraken_trades(body: &str) -> Result<Price, PriceError> {
     let envelope: serde_json::Value = serde_json::from_str(body)?;
     if let Some(reported) = envelope["error"].as_array()
@@ -540,17 +573,20 @@ fn parse_kraken_trades(body: &str) -> Result<Price, PriceError> {
     median_price(trades)
 }
 
+#[cfg(feature = "socks5-fetch")]
 #[derive(Debug, Deserialize)]
 struct CoinGeckoZecQuote {
     usd: f32,
     last_updated_at: u32,
 }
 
+#[cfg(feature = "socks5-fetch")]
 #[derive(Debug, Deserialize)]
 struct CoinGeckoSimplePrice {
     zcash: CoinGeckoZecQuote,
 }
 
+#[cfg(feature = "socks5-fetch")]
 fn parse_coingecko_simple(body: &str) -> Result<Price, PriceError> {
     let quote: CoinGeckoSimplePrice = serde_json::from_str(body)?;
     if !quote.zcash.usd.is_finite() {
@@ -566,6 +602,7 @@ fn parse_coingecko_simple(body: &str) -> Result<Price, PriceError> {
 /// extracted into a plain struct so the classification table is a pure
 /// function testable with fabricated inputs (a `reqwest::Error` cannot be
 /// constructed by hand).
+#[cfg(feature = "socks5-fetch")]
 #[derive(Clone, Copy, Debug, Default)]
 struct RequestSignals {
     is_timeout: bool,
@@ -574,6 +611,7 @@ struct RequestSignals {
     is_decode_or_body: bool,
 }
 
+#[cfg(feature = "socks5-fetch")]
 impl RequestSignals {
     fn of(error: &reqwest::Error) -> Self {
         RequestSignals {
@@ -595,6 +633,7 @@ impl RequestSignals {
 /// handshake and is `TunnelTransport`. Chain-text inspection here is
 /// classification input as the design's table specifies, not a decision on
 /// the rendered stability contract.
+#[cfg(feature = "socks5-fetch")]
 fn classify_stage(
     signals: RequestSignals,
     chain: &[String],
@@ -640,6 +679,7 @@ fn classify_stage(
 /// local stages, the price URL otherwise), cause chain captured layer by
 /// layer. The `reqwest::Error` itself travels beside it, untouched, in
 /// [`PriceError::RequestFailed`].
+#[cfg(feature = "socks5-fetch")]
 fn classify_request(
     error: &reqwest::Error,
     socks5_proxy: Option<&str>,
@@ -666,7 +706,7 @@ fn classify_request(
 ///
 /// Production callers go through [`fetch_current_price`]; tests point `url`
 /// at a local server and shrink the bounds.
-#[cfg(test)]
+#[cfg(all(test, feature = "socks5-fetch"))]
 async fn get_current_price(
     socks5_proxy: Option<&str>,
     url: &str,
@@ -687,6 +727,7 @@ async fn get_current_price(
 /// the source's parser. Transport failures classify through the net-diag
 /// table; a body that arrives but does not parse is the parser's typed
 /// refusal.
+#[cfg(feature = "socks5-fetch")]
 async fn get_source_price(
     source: PriceSource,
     socks5_proxy: Option<&str>,
@@ -718,7 +759,7 @@ async fn get_source_price(
     source.parse(&body)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "socks5-fetch"))]
 mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [features]
 default = []
-nym = ["zingo-netutils/socks5-transmit"]
+nym = ["zingo-netutils/socks5-transmit", "zingo-price/socks5-fetch"]
 # Let the wallet open the on-disk indexer diary (indexer-history.tsv beside
 # the wallet). Off by default; even when compiled, recording is a per-session
 # runtime opt-in, the outcome column is a sanitized category token, and the

--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod connectivity;
 pub mod data;
 pub mod lightclient;
+pub mod netutils;
 pub mod utils;
 pub mod wallet;
 

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -99,17 +99,25 @@ impl WalletMeta {
     }
 }
 
-/// A successfully fetched ZEC price, attested with the route it traveled.
+/// A successfully fetched ZEC price, attested with the route it traveled,
+/// the source that answered, and the time the answer took.
 ///
-/// The attestation is the mixnet tunnel's local SOCKS5 endpoint the fetch
-/// went through. It rides the success value — not a log — so every consumer
-/// of [`LightClient::update_current_price`] holds per-fetch
-/// evidence that this fetch ran over the mixnet (ADR 0011).
+/// The route attestation is the mixnet tunnel's local SOCKS5 endpoint the
+/// fetch went through. It rides the success value — not a log — so every
+/// consumer of [`LightClient::update_current_price`] holds per-fetch
+/// evidence that this fetch ran over the mixnet (ADR 0011). The source and
+/// round trip ride beside it: the fetch races all three price sources and
+/// reports the one whose answer arrived first.
 #[cfg(feature = "nym")]
 #[derive(Clone, Debug, PartialEq)]
 pub struct MixnetPriceFetch {
     /// The current ZEC price in USD.
     pub usd: f32,
+    /// The price source whose answer won the three-source race.
+    pub source: zingo_price::PriceSource,
+    /// Wall-clock time from dispatching the race to the winning answer,
+    /// tunnel traversal included.
+    pub round_trip: std::time::Duration,
     /// The local SOCKS5 endpoint of the mixnet tunnel this fetch traveled
     /// through.
     pub via_socks5: String,
@@ -635,7 +643,11 @@ impl LightClient {
     /// availability argument earns it a clearnet tier. A build without the
     /// `nym` feature has no price fetch at all.
     ///
-    /// The returned fetch carries the tunnel endpoint it traveled through, so
+    /// The fetch races all three price sources (Gemini, Kraken, CoinGecko)
+    /// through the tunnel and takes the first answer; only when every
+    /// source fails does it report an error, naming each source's typed
+    /// failure. The returned fetch carries the tunnel endpoint it traveled
+    /// through, the winning source, and the race's round-trip time, so
     /// every consumer holds per-fetch evidence of the route rather than
     /// trusting the method name alone.
     #[cfg(feature = "nym")]
@@ -651,13 +663,19 @@ impl LightClient {
         // polling-blackout remedy), so a hung tunnel can no longer freeze
         // every wallet-state observer. The route was resolved above and
         // could die mid-fetch; the fetch itself then reports that as a
-        // typed transport failure rather than anything falling back.
-        let price = zingo_price::fetch_current_price(Some(&socks5_addr))
+        // typed transport failure rather than anything falling back. All
+        // three sources race through the tunnel; the first answer wins and
+        // the losing legs are cancelled (zingo-mobile parity).
+        let dispatched = std::time::Instant::now();
+        let raced = zingo_price::race_current_price(Some(&socks5_addr))
             .await
             .map_err(crate::wallet::error::PriceError::from)?;
-        self.wallet().write().await.record_price_update(price);
+        let round_trip = dispatched.elapsed();
+        self.wallet().write().await.record_price_update(raced.price);
         Ok(MixnetPriceFetch {
-            usd: price.price_usd,
+            usd: raced.price.price_usd,
+            source: raced.source,
+            round_trip,
             via_socks5: socks5_addr,
         })
     }

--- a/zingolib/src/lightclient/error.rs
+++ b/zingolib/src/lightclient/error.rs
@@ -7,10 +7,10 @@ use zcash_protocol::TxId;
 use pepper_sync::error::{SyncError, SyncModeError};
 use zingo_netutils::GetClientError;
 
+#[cfg(feature = "nym")]
+use crate::wallet::error::PriceError;
 use crate::wallet::{
-    error::{
-        CalculateTransactionError, PriceError, ProposeSendError, ProposeShieldError, WalletError,
-    },
+    error::{CalculateTransactionError, ProposeSendError, ProposeShieldError, WalletError},
     output::OutputRef,
 };
 
@@ -49,7 +49,9 @@ pub enum LightClientError {
     /// No indexer configured. Call set_indexer_uri() to connect before calling network operations.
     #[error("Offline: no indexer configured. Call set_indexer_uri() to connect.")]
     Offline,
-    /// Price fetch error.
+    /// Price fetch error. Exists only in nym builds: the mixnet-only price
+    /// rule leaves other builds with no fetch to fail.
+    #[cfg(feature = "nym")]
     #[error("Price fetch error. {0}")]
     PriceError(#[from] PriceError),
     /// The mixnet-routed price fetch was requested while Mixnet Mode is toggled

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -55,6 +55,42 @@ use crate::lightclient::{DEFAULT_REQUEST_TIMEOUT, LightClient};
 use crate::wallet::error::WalletError;
 use crate::wallet::output::OutputRef;
 
+/// Attestation of one transmitted transaction: the route the bytes
+/// traveled, the endpoint that accepted them, and the transmission's
+/// round-trip time. It rides the success value — not a log — the same
+/// doctrine as [`crate::lightclient::MixnetPriceFetch`] (ADR 0011), so
+/// every consumer of a send holds per-transaction evidence of the route.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransmitReport {
+    /// The transmitted transaction.
+    pub txid: TxId,
+    /// The route the transaction traveled and the endpoint that accepted
+    /// it.
+    pub route: TransmitRoute,
+    /// Wall-clock time from dispatching the transmission to its delivery
+    /// confirmation, retries and fan-out escalation included.
+    pub round_trip: std::time::Duration,
+}
+
+/// The route one transmitted transaction traveled (ADR 0011).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransmitRoute {
+    /// Clearnet submission through the session's configured sync indexer.
+    Clearnet {
+        /// The sync indexer's host.
+        indexer: String,
+    },
+    /// Mixnet fan-out over the Broadcast Witnesses (ADR 0022), reached
+    /// through the local SOCKS5 tunnel endpoint.
+    Mixnet {
+        /// The host of the Broadcast Witness whose delivery confirmation
+        /// won the fan-out.
+        witness: String,
+        /// The local SOCKS5 endpoint of the mixnet tunnel.
+        via_socks5: String,
+    },
+}
+
 /// ZIP 203: `nExpiryHeight` values at or above this threshold are
 /// interpreted as a block time rather than a block height, so a
 /// transaction's expiry height must stay strictly below it.
@@ -199,7 +235,7 @@ async fn transmit_one_transaction(
     txid: &TxId,
     progress: &TransmitProgressHandle,
     history: &IndexerHistoryHandle,
-) -> Result<String, String> {
+) -> Result<(String, TransmitRoute), String> {
     match socks5_proxy {
         None => {
             let host = indexer
@@ -221,21 +257,28 @@ async fn transmit_one_transaction(
             .await
             .map_err(|TransmitFailed(status)| status.to_string());
             record_send_attempt(history, &host, AttemptRoute::Clearnet, started, &outcome);
-            outcome
+            outcome.map(|server_txid| (server_txid, TransmitRoute::Clearnet { indexer: host }))
         }
         #[cfg(feature = "nym")]
-        Some(socks5_addr) => {
-            mixnet_fanout_transmit(
-                socks5_addr,
-                indexer.uri(),
-                tx_bytes,
-                height,
-                txid,
-                progress,
-                history,
+        Some(socks5_addr) => mixnet_fanout_transmit(
+            socks5_addr,
+            indexer.uri(),
+            tx_bytes,
+            height,
+            txid,
+            progress,
+            history,
+        )
+        .await
+        .map(|(server_txid, witness)| {
+            (
+                server_txid,
+                TransmitRoute::Mixnet {
+                    witness,
+                    via_socks5: socks5_addr.to_string(),
+                },
             )
-            .await
-        }
+        }),
         #[cfg(not(feature = "nym"))]
         Some(_) => Err("a mixnet route requires the nym feature".to_string()),
     }
@@ -260,7 +303,7 @@ async fn mixnet_fanout_transmit(
     txid: &TxId,
     progress: &TransmitProgressHandle,
     history: &IndexerHistoryHandle,
-) -> Result<String, String> {
+) -> Result<(String, String), String> {
     use crate::nym::broadcast::{MAX_BROADCAST_WITNESSES, fanout_broadcast};
     use crate::nym::broadcast_indexers::eligible_witnesses;
 
@@ -293,7 +336,7 @@ async fn mixnet_fanout_transmit(
             .map_err(|TransmitFailed(error)| crate::nym::socks5_transmit_failure(&error, &host));
             let rendered = outcome.clone().map_err(|failure| failure.to_string());
             record_send_attempt(history, &host, AttemptRoute::Mixnet, started, &rendered);
-            outcome
+            outcome.map(|server_txid| (server_txid, host))
         }
     };
 
@@ -323,7 +366,7 @@ async fn mock_fanout_transmit(
     txid: &TxId,
     progress: &TransmitProgressHandle,
     history: &IndexerHistoryHandle,
-) -> Result<String, String> {
+) -> Result<(String, String), String> {
     use crate::nym::broadcast::{MAX_BROADCAST_WITNESSES, fanout_broadcast};
     use crate::nym::broadcast_indexers::eligible_witnesses;
 
@@ -348,7 +391,7 @@ async fn mock_fanout_transmit(
             .await
             .map_err(|TransmitFailed(status)| status.to_string());
             record_send_attempt(history, &host, AttemptRoute::Mixnet, started, &outcome);
-            outcome
+            outcome.map(|server_txid| (server_txid, host))
         }
     };
 
@@ -368,7 +411,7 @@ impl LightClient {
         &mut self,
         proposal: Proposal<zip317::FeeRule, OutputRef>,
         sending_account: zip32::AccountId,
-    ) -> Result<NonEmpty<TxId>, LightClientError> {
+    ) -> Result<NonEmpty<TransmitReport>, LightClientError> {
         self.require_indexer()?;
         let mut wallet = self.wallet().write().await;
         let highest_refund_address_index = wallet.highest_refund_address_index();
@@ -417,7 +460,7 @@ impl LightClient {
         &mut self,
         proposal: Proposal<zip317::FeeRule, Infallible>,
         shielding_account: zip32::AccountId,
-    ) -> Result<NonEmpty<TxId>, LightClientError> {
+    ) -> Result<NonEmpty<TransmitReport>, LightClientError> {
         let calculated_txids = self
             .wallet()
             .write()
@@ -443,7 +486,7 @@ impl LightClient {
         self.require_indexer()?;
         let opt_proposal = self.wallet().write().await.take_proposal();
         if let Some(proposal) = opt_proposal {
-            let txids = match proposal {
+            let reports = match proposal {
                 ZingoProposal::Send {
                     proposal,
                     sending_account,
@@ -456,7 +499,7 @@ impl LightClient {
 
             self.release_proposal_pause(resume_sync);
 
-            txids
+            reports.map(|reports| reports.map(|report| report.txid))
         } else {
             Err(SendError::NoStoredProposal.into())
         }
@@ -543,7 +586,9 @@ impl LightClient {
         &mut self,
         calculated_txids: NonEmpty<TxId>,
     ) -> Result<NonEmpty<TxId>, LightClientError> {
-        self.transmit_transactions(calculated_txids).await
+        self.transmit_transactions(calculated_txids)
+            .await
+            .map(|reports| reports.map(|report| report.txid))
     }
 
     /// Proposes and transmits transactions from a transaction request skipping proposal confirmation.
@@ -558,6 +603,20 @@ impl LightClient {
         account_id: zip32::AccountId,
         resume_sync: bool,
     ) -> Result<NonEmpty<TxId>, LightClientError> {
+        self.quick_send_reported(request, account_id, resume_sync)
+            .await
+            .map(|reports| reports.map(|report| report.txid))
+    }
+
+    /// [`Self::quick_send`] with the transmission attested: each
+    /// transaction's [`TransmitReport`] carries the route it traveled, the
+    /// endpoint that accepted it, and the transmission's round-trip time.
+    pub async fn quick_send_reported(
+        &mut self,
+        request: TransactionRequest,
+        account_id: zip32::AccountId,
+        resume_sync: bool,
+    ) -> Result<NonEmpty<TransmitReport>, LightClientError> {
         // Proposing is an Indexerless capability; only the calculate/transmit
         // stage below demands a connection.
         let guard = self.pause_sync_scoped().ok();
@@ -567,7 +626,7 @@ impl LightClient {
             .await
             .create_send_proposal(request, account_id)
             .map_err(SendError::ProposeSendError);
-        let txids = match proposal_result {
+        let reports = match proposal_result {
             Ok(proposal) => self.send(proposal, account_id).await,
             Err(e) => Err(e.into()),
         };
@@ -577,7 +636,7 @@ impl LightClient {
             guard.disarm();
         }
 
-        txids
+        reports
     }
 
     /// Shields all transparent funds skipping proposal confirmation. The
@@ -599,7 +658,9 @@ impl LightClient {
             .create_shield_proposal(account_id)
             .map_err(SendError::ProposeShieldError)?;
 
-        self.shield(proposal, account_id).await
+        self.shield(proposal, account_id)
+            .await
+            .map(|reports| reports.map(|report| report.txid))
     }
 
     /// Tranmits calculated transactions stored in the wallet matching txids of `calculated_txids` in the given order.
@@ -607,7 +668,7 @@ impl LightClient {
     pub(crate) async fn transmit_transactions(
         &mut self,
         calculated_txids: NonEmpty<TxId>,
-    ) -> Result<NonEmpty<TxId>, LightClientError> {
+    ) -> Result<NonEmpty<TransmitReport>, LightClientError> {
         let indexer = self.require_indexer()?.clone();
 
         // Resolve the Mixnet Mode route once for the whole send (ADR 0011).
@@ -639,6 +700,7 @@ impl LightClient {
         let _progress_scope = TransmitProgressScope(progress.clone());
         let history = self.indexer_history.clone();
         let total = calculated_txids.len();
+        let mut reports: Vec<TransmitReport> = Vec::with_capacity(total);
 
         let mut wallet = self.wallet().write().await;
         for (index, txid) in calculated_txids.iter().enumerate() {
@@ -676,6 +738,7 @@ impl LightClient {
             // once in `transmit::resilient_transmit`; the clearnet path runs it
             // directly and the mixnet path runs it per fan-out arm. Wallet-state
             // effects stay here, around the pure transmission.
+            let dispatched = std::time::Instant::now();
             #[cfg(all(feature = "nym", any(test, feature = "testutils")))]
             let transmit_outcome = if mock_arms {
                 mock_fanout_transmit(
@@ -687,6 +750,15 @@ impl LightClient {
                     &history,
                 )
                 .await
+                .map(|(server_txid, witness)| {
+                    (
+                        server_txid,
+                        TransmitRoute::Mixnet {
+                            witness,
+                            via_socks5: socks5_proxy.clone().unwrap_or_default(),
+                        },
+                    )
+                })
             } else {
                 transmit_one_transaction(
                     socks5_proxy.as_deref(),
@@ -710,8 +782,8 @@ impl LightClient {
                 &history,
             )
             .await;
-            let txid_from_server = match transmit_outcome {
-                Ok(server_txid) => server_txid,
+            let (txid_from_server, route) = match transmit_outcome {
+                Ok(server_txid_and_route) => server_txid_and_route,
                 Err(message) => {
                     pepper_sync::set_transactions_failed(
                         &mut wallet.wallet_transactions,
@@ -752,9 +824,15 @@ impl LightClient {
             // and the two are mutually exclusive in practice.
             self.immediate_migration_progress.set_sent(index as u32 + 1);
             self.split_progress.set_sent(index as u32 + 1);
+
+            reports.push(TransmitReport {
+                txid: *txid,
+                route,
+                round_trip: dispatched.elapsed(),
+            });
         }
 
-        Ok(calculated_txids)
+        Ok(NonEmpty::from_vec(reports).expect("one report per calculated transaction"))
     }
 }
 

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -72,6 +72,32 @@ pub struct TransmitReport {
     pub round_trip: std::time::Duration,
 }
 
+/// Resolves whether a transmission runs over the mixnet tunnel (`Some`
+/// SOCKS5 address) or clearnet through the configured sync indexer
+/// (`None`), from the session's connectivity and its Mixnet Mode route.
+///
+/// An Indexerless session transmits only over a ready mixnet (ruling
+/// 2026-07-29): the Broadcast Witness fan-out needs no sync indexer, so
+/// the ADR 0022 exclusion holds vacuously. A mixnet-less offline session
+/// keeps the typed [`LightClientError::Offline`] refusal — an unattached
+/// mixnet carries no online intent — while attached-but-not-ready states
+/// (bootstrapping, died) surface their own typed error, so the caller
+/// learns to wait or repair rather than to connect an indexer.
+#[cfg(feature = "nym")]
+fn resolve_transmit_route(
+    has_indexer: bool,
+    route: Result<crate::nym::MixnetRoute, crate::nym::MixnetNotReady>,
+) -> Result<Option<String>, LightClientError> {
+    use crate::nym::{MixnetNotReady, MixnetRoute};
+    match (has_indexer, route) {
+        (_, Ok(MixnetRoute::Mixnet(socks5_addr))) => Ok(Some(socks5_addr)),
+        (true, Ok(MixnetRoute::Clearnet)) => Ok(None),
+        (false, Ok(MixnetRoute::Clearnet)) => Err(LightClientError::Offline),
+        (false, Err(MixnetNotReady::Unattached)) => Err(LightClientError::Offline),
+        (_, Err(e)) => Err(LightClientError::MixnetNotReady(e)),
+    }
+}
+
 /// The route one transmitted transaction traveled (ADR 0011).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TransmitRoute {
@@ -229,7 +255,7 @@ impl TransmitTarget for SocksTarget {
 /// failure message.
 async fn transmit_one_transaction(
     socks5_proxy: Option<&str>,
-    indexer: &zingo_netutils::GrpcIndexer,
+    indexer: Option<&zingo_netutils::GrpcIndexer>,
     tx_bytes: &[u8],
     height: u64,
     txid: &TxId,
@@ -238,6 +264,11 @@ async fn transmit_one_transaction(
 ) -> Result<(String, TransmitRoute), String> {
     match socks5_proxy {
         None => {
+            // The route resolver refuses an Indexerless clearnet route
+            // before any transaction is built, so this arm always holds one.
+            let Some(indexer) = indexer else {
+                return Err("clearnet transmission requires a configured indexer".to_string());
+            };
             let host = indexer
                 .uri()
                 .host()
@@ -262,7 +293,7 @@ async fn transmit_one_transaction(
         #[cfg(feature = "nym")]
         Some(socks5_addr) => mixnet_fanout_transmit(
             socks5_addr,
-            indexer.uri(),
+            indexer.map(|indexer| indexer.uri()),
             tx_bytes,
             height,
             txid,
@@ -297,7 +328,7 @@ async fn transmit_one_transaction(
 #[cfg(feature = "nym")]
 async fn mixnet_fanout_transmit(
     socks5_addr: &str,
-    sync_indexer: &http::Uri,
+    sync_indexer: Option<&http::Uri>,
     tx_bytes: &[u8],
     height: u64,
     txid: &TxId,
@@ -370,7 +401,7 @@ async fn mock_fanout_transmit(
     use crate::nym::broadcast::{MAX_BROADCAST_WITNESSES, fanout_broadcast};
     use crate::nym::broadcast_indexers::eligible_witnesses;
 
-    let witnesses = eligible_witnesses(indexer.uri()).map_err(|e| e.to_string())?;
+    let witnesses = eligible_witnesses(Some(indexer.uri())).map_err(|e| e.to_string())?;
     let run_arm = |witness: http::Uri| {
         let target = ClearnetTarget(indexer.clone());
         let tx_bytes = tx_bytes.to_vec();
@@ -412,8 +443,19 @@ impl LightClient {
         proposal: Proposal<zip317::FeeRule, OutputRef>,
         sending_account: zip32::AccountId,
     ) -> Result<NonEmpty<TransmitReport>, LightClientError> {
-        self.require_indexer()?;
+        self.preflight_transmit()?;
+        let indexerless = self.indexer.is_none();
         let mut wallet = self.wallet().write().await;
+        // An Indexerless calculation cannot trust the wallet's stale chain
+        // view for an ordinary tip-plus-delta expiry, so it takes the
+        // epoch-limit retarget the offline-signing flow uses (issue #2455).
+        let proposal = if indexerless {
+            let chain_type = wallet.chain_type();
+            retarget_for_offline_signing(&proposal, &chain_type)
+                .map_err(SendError::RetargetError)?
+        } else {
+            proposal
+        };
         let highest_refund_address_index = wallet.highest_refund_address_index();
         let calculated_txids = wallet
             .calculate_transactions(proposal, sending_account)
@@ -577,6 +619,23 @@ impl LightClient {
         result.map_err(LightClientError::from)
     }
 
+    /// Pre-flights the transmission route without transmitting, so a route
+    /// that would refuse is caught before any transaction is built and no
+    /// freshly Calculated transaction is stranded. The same resolution
+    /// [`Self::transmit_transactions`] performs for real: clearnet demands
+    /// the configured indexer, and an Indexerless session passes only with
+    /// a ready mixnet (ruling 2026-07-29).
+    fn preflight_transmit(&self) -> Result<(), LightClientError> {
+        #[cfg(feature = "nym")]
+        {
+            resolve_transmit_route(self.indexer.is_some(), self.mixnet_route()).map(|_| ())
+        }
+        #[cfg(not(feature = "nym"))]
+        {
+            self.require_indexer().map(|_| ())
+        }
+    }
+
     /// Transmits previously calculated transactions to the Indexer, in the
     /// given order, the transmission half of the offline-signing flow.
     /// Requires an Indexer. An Indexerless attempt fails with
@@ -669,20 +728,23 @@ impl LightClient {
         &mut self,
         calculated_txids: NonEmpty<TxId>,
     ) -> Result<NonEmpty<TransmitReport>, LightClientError> {
-        let indexer = self.require_indexer()?.clone();
+        let indexer = self.indexer.clone();
 
         // Resolve the Mixnet Mode route once for the whole send (ADR 0011).
         // `Clearnet` submits through the configured indexer; `Mixnet(addr)`
-        // routes the fan-out through the SOCKS5 proxy; `Bootstrapping` fails
-        // closed here, before any submission, rather than leaking to clearnet.
-        // Without the `nym` feature there is no mixnet, so the route is clearnet.
+        // routes the fan-out through the SOCKS5 proxy — with or without a
+        // sync indexer (ruling 2026-07-29); `Bootstrapping` fails closed
+        // here, before any submission, rather than leaking to clearnet.
+        // Without the `nym` feature there is no mixnet, so the route is
+        // clearnet and demands the indexer.
         #[cfg(feature = "nym")]
-        let socks5_proxy: Option<String> = match self.mixnet_route()? {
-            crate::nym::MixnetRoute::Clearnet => None,
-            crate::nym::MixnetRoute::Mixnet(socks5_addr) => Some(socks5_addr),
-        };
+        let socks5_proxy: Option<String> =
+            resolve_transmit_route(indexer.is_some(), self.mixnet_route())?;
         #[cfg(not(feature = "nym"))]
         let socks5_proxy: Option<String> = None;
+        if socks5_proxy.is_none() && indexer.is_none() {
+            return Err(LightClientError::Offline);
+        }
 
         // A test-attached slot pairs its Ready route with arms that submit
         // over the mock indexer's channel; a live Ready session keeps the
@@ -742,7 +804,9 @@ impl LightClient {
             #[cfg(all(feature = "nym", any(test, feature = "testutils")))]
             let transmit_outcome = if mock_arms {
                 mock_fanout_transmit(
-                    &indexer,
+                    indexer
+                        .as_ref()
+                        .expect("the test-attached slot always carries a mock indexer"),
                     &transaction_bytes,
                     height.into(),
                     txid,
@@ -762,7 +826,7 @@ impl LightClient {
             } else {
                 transmit_one_transaction(
                     socks5_proxy.as_deref(),
-                    &indexer,
+                    indexer.as_ref(),
                     &transaction_bytes,
                     height.into(),
                     txid,
@@ -774,7 +838,7 @@ impl LightClient {
             #[cfg(not(all(feature = "nym", any(test, feature = "testutils"))))]
             let transmit_outcome = transmit_one_transaction(
                 socks5_proxy.as_deref(),
-                &indexer,
+                indexer.as_ref(),
                 &transaction_bytes,
                 height.into(),
                 txid,

--- a/zingolib/src/netutils.rs
+++ b/zingolib/src/netutils.rs
@@ -1,0 +1,26 @@
+//! The consumer funnel over `zingo-netutils` (ADR 0024, decision 7).
+//!
+//! Consumers declare exactly one wallet dependency — zingolib, pinned by
+//! git rev — and reach every netutils item they legitimately need through
+//! these re-exports instead of holding a second direct dependency. One
+//! dependent means one feature configuration and one compiled copy, which
+//! is the fix for zingo-mobile's capability-less duplicate netutils copy
+//! (issue #2566).
+//!
+//! The funnel's root is zingolib itself — the shallow option of issue
+//! #2578's deferred choice. The deeper alternative (pepper-sync as the
+//! sole direct dependent, re-exporting netutils verbatim) was declined at
+//! implementation time: it would graft the transmit surface onto the sync
+//! engine's public API for no consumer-visible gain, since out-of-repo
+//! consumers see only zingolib either way.
+//!
+//! The set is curated, not the whole crate: what consumers legitimately
+//! need is the indexer client and its trait, the process-level crypto
+//! provider hook, the curated indexer lists, and the temporal calibration.
+//! Widening the set is a deliberate API decision, not a convenience.
+#![forbid(unsafe_code)]
+
+pub use zingo_netutils::{GrpcIndexer, Indexer, ensure_default_crypto_provider};
+
+pub use zingo_netutils::indexers;
+pub use zingo_netutils::time;

--- a/zingolib/src/nym/broadcast.rs
+++ b/zingolib/src/nym/broadcast.rs
@@ -106,16 +106,16 @@ impl<E: std::fmt::Display + std::fmt::Debug> std::error::Error for FanoutError<E
 /// `report` receives a succinct progress line whenever the race's shape
 /// changes (a launch or an arm failure), rendering the planner's own
 /// [`RaceProgress`] snapshot for display.
-pub(crate) async fn fanout_broadcast<A, F, E, R, P>(
+pub(crate) async fn fanout_broadcast<A, F, E, R, P, T>(
     indexers: &[Uri],
     rng: &mut R,
     cap: usize,
     run_arm: A,
     report: P,
-) -> Result<String, FanoutError<E>>
+) -> Result<T, FanoutError<E>>
 where
     A: Fn(Uri) -> F,
-    F: Future<Output = Result<String, E>>,
+    F: Future<Output = Result<T, E>>,
     E: std::fmt::Display,
     R: Rng + ?Sized,
     P: Fn(String),

--- a/zingolib/src/nym/broadcast_indexers.rs
+++ b/zingolib/src/nym/broadcast_indexers.rs
@@ -113,8 +113,17 @@ pub(crate) struct NoEligibleWitnesses {
 /// Refuses with [`NoEligibleWitnesses`] if the exclusion empties the pool,
 /// so a misconfigured list fails closed instead of silently broadcasting to
 /// the sync indexer.
-pub(crate) fn eligible_witnesses(sync_indexer: &Uri) -> Result<Vec<Uri>, NoEligibleWitnesses> {
-    eligible_from(broadcast_indexers(), sync_indexer)
+///
+/// An Indexerless session passes `None`: it has no accumulating sync
+/// operator to exclude, so the ADR 0022 invariant holds vacuously over the
+/// full pool (ruling 2026-07-29).
+pub(crate) fn eligible_witnesses(
+    sync_indexer: Option<&Uri>,
+) -> Result<Vec<Uri>, NoEligibleWitnesses> {
+    match sync_indexer {
+        Some(sync_indexer) => eligible_from(broadcast_indexers(), sync_indexer),
+        None => Ok(broadcast_indexers()),
+    }
 }
 
 /// Pure core of [`eligible_witnesses`], over an arbitrary pool for
@@ -241,7 +250,7 @@ mod tests {
         // ever weakens to exact-URI matching: the accumulating party is the
         // operator (ADR 0022).
         let sync: Uri = "https://eu.zec.rocks:443".parse().unwrap();
-        let pool = eligible_witnesses(&sync).expect("ten operators remain");
+        let pool = eligible_witnesses(Some(&sync)).expect("ten operators remain");
         assert_eq!(pool.len(), BROADCAST_INDEXERS.len() - 1);
         assert!(
             pool.iter()
@@ -253,7 +262,13 @@ mod tests {
     #[test]
     fn a_sync_indexer_outside_the_pool_excludes_nothing() {
         let sync: Uri = "https://my.private.indexer.example:443".parse().unwrap();
-        let pool = eligible_witnesses(&sync).expect("nothing to exclude");
+        let pool = eligible_witnesses(Some(&sync)).expect("nothing to exclude");
+        assert_eq!(pool.len(), BROADCAST_INDEXERS.len());
+    }
+
+    #[test]
+    fn an_indexerless_session_draws_from_the_full_pool() {
+        let pool = eligible_witnesses(None).expect("nothing to exclude");
         assert_eq!(pool.len(), BROADCAST_INDEXERS.len());
     }
 

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -141,7 +141,10 @@ pub enum WalletError {
     WalletAlreadyCreated,
 }
 
-/// Price error
+/// Price error. Exists only in nym builds: the mixnet-only price rule
+/// (ADR 0011, amendment 2026-07-28) leaves other builds with no fetch and
+/// therefore no fetch failures.
+#[cfg(feature = "nym")]
 #[derive(Debug, thiserror::Error)]
 pub enum PriceError {
     /// Price error

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -150,6 +150,10 @@ pub enum PriceError {
     /// Price error
     #[error("price error. {0}")]
     PriceError(#[from] zingo_price::PriceError),
+    /// Every source in the three-source race failed; the report names each
+    /// source's typed failure with its cause chain.
+    #[error("price race failed. {0}")]
+    RaceFailed(#[from] zingo_price::PriceRaceFailure),
     /// Price list not initialised
     #[error("price list not initialised. please wait for sync to obtain time of wallet birthday")]
     NotInitialised,

--- a/zingolib_testutils/Cargo.toml
+++ b/zingolib_testutils/Cargo.toml
@@ -28,3 +28,11 @@ http.workspace = true
 zip32.workspace = true
 tokio = { workspace = true, features = ["net", "time", "rt", "io-util", "sync", "macros"] }
 zingo-netutils.workspace = true
+
+[features]
+# Regtest scenario clients transmit over clearnet as recorded consent: the
+# five-state wallet refuses an unconsented send (MixnetNotReady, ADR 0011),
+# so nym-feature consumers (zingo-mobile's integration harness) enable this
+# to have the scenarios record the deliberate switch-off before their
+# funding sends.
+nym = ["zingolib/nym"]

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -1007,6 +1007,20 @@ pub async fn custom_clients_default() -> (MeteredNet, ClientBuilder) {
     (local_net, client_builder)
 }
 
+/// Records the deliberate clearnet consent a regtest scenario client needs
+/// before it may transmit. The five-state wallet refuses an unconsented
+/// send — a never-enabled client is Unattached, and absence is never
+/// consent (ADR 0011) — so a nym-feature build of these scenarios lands
+/// each sending client in SwitchedOff first, exactly as a `--no-mixnet`
+/// session would. Without the feature the wallet has no mixnet surface and
+/// nothing needs recording.
+#[cfg(feature = "nym")]
+async fn consent_to_clearnet(client: &mut zingolib::lightclient::LightClient) {
+    client.disable_mixnet().await;
+}
+#[cfg(not(feature = "nym"))]
+async fn consent_to_clearnet(_client: &mut zingolib::lightclient::LightClient) {}
+
 /// TODO: Add Doc Comment Here!
 pub async fn unfunded_mobileclient() -> LocalNet<DefaultValidator, DefaultIndexer> {
     launch_test::<DefaultValidator, DefaultIndexer>(
@@ -1040,6 +1054,7 @@ pub async fn funded_orchard_mobileclient(value: u64) -> LocalNet<DefaultValidato
         wallet_activation_heights(&local_net.validator().get_activation_heights().await),
     );
     let mut faucet = client_builder.build_faucet(true).await;
+    consent_to_clearnet(&mut faucet).await;
     let recipient = client_builder
         .build_client(
             WalletConfig::MnemonicPhrase {
@@ -1088,6 +1103,8 @@ pub async fn funded_orchard_with_3_txs_mobileclient(
             true,
         )
         .await;
+    consent_to_clearnet(&mut faucet).await;
+    consent_to_clearnet(&mut recipient).await;
     // Fund the faucet with spendable Orchard coinbase (see
     // funded_orchard_mobileclient / faucet()).
     normalize_shielded_faucet_balance(&local_net, PoolType::ORCHARD, &mut faucet).await;
@@ -1154,6 +1171,7 @@ pub async fn funded_transparent_mobileclient(
             true,
         )
         .await;
+    consent_to_clearnet(&mut faucet).await;
     // Fund the faucet with spendable Orchard coinbase (see
     // funded_orchard_mobileclient / faucet()).
     normalize_shielded_faucet_balance(&local_net, PoolType::ORCHARD, &mut faucet).await;


### PR DESCRIPTION
Sixth arc of the ADR 0024 convergence, stacked on #2584. Completes the two remaining phase-1 items of #2578.

**The netutils funnel (decision 7).** Consumers declare exactly one wallet dependency — zingolib, pinned by git rev — and reach every netutils item they legitimately need through the new `zingolib::netutils` module: the indexer client and trait, the crypto-provider hook, the curated indexer lists, and the temporal calibration. One dependent means one feature configuration and one compiled copy, which is the fix for zingo-mobile's capability-less duplicate netutils copy (#2566). This resolves #2578's deliberately deferred depth choice in favor of the shallow root: zingolib keeps its direct dependency, because the deeper alternative (pepper-sync as sole dependent, re-exporting verbatim) would graft the transmit surface onto the sync engine's public API for no consumer-visible gain — out-of-repo consumers see only zingolib either way. zingo-cli is the in-repo proof: its direct zingo-netutils dependency is dropped and every use site goes through the re-exports (the dev-dependency on test scaffolding remains; it ships nothing and duplicates nothing).

**The price dependency trim.** The mixnet-only price rule already removed the fetch API from default builds; this completes its dependency half. zingo-price gains a `socks5-fetch` feature gating the entire fetch surface and the reqwest/rustls/serde/serde_json/rust_decimal/thiserror/zingo-net-diag/futures dependencies behind it; without it the crate is the storage-only data model. The feature is on by default for the standalone crate (its own tests keep covering the fetch), the workspace dependency turns default features off, and zingolib re-enables the fetch only under `nym`. A default zingolib build now carries no reqwest anywhere in its dependency tree, verified with `cargo tree`. The wallet- and client-level `PriceError` wrappers follow the same gate.

Verified: clippy and check warning-free on default, `nym,nym-diary`, and trimmed zingo-price configurations; zingolib 414/414 (nym) and 336/336 (default); zingo-cli 120/120 and 112/112; zingo-price 14/14 standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)