### PR TITLE
refactor: unify per-pool compact counting behind a pure contract

### DIFF
--- a/libtonode-tests/Cargo.toml
+++ b/libtonode-tests/Cargo.toml
@@ -35,7 +35,7 @@ http = { workspace = true }
 incrementalmerkletree.workspace = true
 itertools = { workspace = true }
 json = { workspace = true }
-pepper-sync = { workspace = true }
+pepper-sync = { workspace = true, features = ["test-features"] }
 shardtree.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -2,11 +2,13 @@ use std::{num::NonZeroU32, time::Duration};
 
 use incrementalmerkletree::Position;
 use pepper_sync::sync::ScanPriority;
+use pepper_sync::test_support::block;
 use pepper_sync::wallet::ShardTrees;
 use shardtree::store::ShardStore;
 use zcash_local_net::validator::Validator;
+use zcash_protocol::PoolType;
+use zcash_protocol::ShieldedPool::{Ironwood, Orchard, Sapling};
 use zcash_protocol::consensus::BlockHeight;
-use zcash_protocol::{PoolType, ShieldedPool};
 use zingo_netutils::lightwallet_protocol::{BlockId, BlockRange, GetSubtreeRootsArg};
 use zingo_netutils::{GrpcIndexer, Indexer};
 use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
@@ -738,18 +740,9 @@ async fn served_outputs_match_chain_metadata_deltas() {
             )
         });
 
-        let sapling_served = u64::from(pepper_sync::test_support::block::shielded_output_count(
-            &block,
-            ShieldedPool::Sapling,
-        ));
-        let orchard_served = u64::from(pepper_sync::test_support::block::shielded_output_count(
-            &block,
-            ShieldedPool::Orchard,
-        ));
-        let ironwood_served = u64::from(pepper_sync::test_support::block::shielded_output_count(
-            &block,
-            ShieldedPool::Ironwood,
-        ));
+        let sapling_served = u64::from(block::shielded_output_count(&block, Sapling));
+        let orchard_served = u64::from(block::shielded_output_count(&block, Orchard));
+        let ironwood_served = u64::from(block::shielded_output_count(&block, Ironwood));
 
         if metadata.ironwood_commitment_tree_size > 0 {
             first_nonzero_ironwood_metadata.get_or_insert(block.height);

--- a/libtonode-tests/tests/sync.rs
+++ b/libtonode-tests/tests/sync.rs
@@ -5,8 +5,8 @@ use pepper_sync::sync::ScanPriority;
 use pepper_sync::wallet::ShardTrees;
 use shardtree::store::ShardStore;
 use zcash_local_net::validator::Validator;
-use zcash_protocol::PoolType;
 use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::{PoolType, ShieldedPool};
 use zingo_netutils::lightwallet_protocol::{BlockId, BlockRange, GetSubtreeRootsArg};
 use zingo_netutils::{GrpcIndexer, Indexer};
 use zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED;
@@ -738,13 +738,18 @@ async fn served_outputs_match_chain_metadata_deltas() {
             )
         });
 
-        let sapling_served: u64 = block.vtx.iter().map(|tx| tx.outputs.len() as u64).sum();
-        let orchard_served: u64 = block.vtx.iter().map(|tx| tx.actions.len() as u64).sum();
-        let ironwood_served: u64 = block
-            .vtx
-            .iter()
-            .map(|tx| tx.ironwood_actions.len() as u64)
-            .sum();
+        let sapling_served = u64::from(pepper_sync::test_support::block::shielded_output_count(
+            &block,
+            ShieldedPool::Sapling,
+        ));
+        let orchard_served = u64::from(pepper_sync::test_support::block::shielded_output_count(
+            &block,
+            ShieldedPool::Orchard,
+        ));
+        let ironwood_served = u64::from(pepper_sync::test_support::block::shielded_output_count(
+            &block,
+            ShieldedPool::Ironwood,
+        ));
 
         if metadata.ironwood_commitment_tree_size > 0 {
             first_nonzero_ironwood_metadata.get_or_insert(block.height);

--- a/pepper-sync/src/lib.rs
+++ b/pepper-sync/src/lib.rs
@@ -122,6 +122,45 @@ pub use sync::set_transactions_failed;
 pub use sync::sync;
 pub use sync::sync_status;
 
+#[cfg(any(test, feature = "test-features"))]
+pub mod test_support {
+    //! Test-only access to the per-pool counting contract, for test crates
+    //! auditing served blocks against the same arithmetic the scanner uses.
+
+    /// Per-transaction counts.
+    pub mod transaction {
+        use zcash_protocol::ShieldedPool;
+        use zingo_netutils::lightwallet_protocol::CompactTx;
+
+        /// Counts the outputs `compact_tx` appends to `pool`'s note commitment tree.
+        pub fn shielded_output_count(compact_tx: &CompactTx, pool: ShieldedPool) -> u32 {
+            crate::utils::transaction::shielded_output_count(compact_tx, pool)
+        }
+
+        /// Counts the shielded inputs `compact_tx` spends from `pool`.
+        pub fn shielded_input_count(compact_tx: &CompactTx, pool: ShieldedPool) -> u32 {
+            crate::utils::transaction::shielded_input_count(compact_tx, pool)
+        }
+    }
+
+    /// Per-block counts: compositions of the [`transaction`] operations of
+    /// the same name over `vtx`.
+    pub mod block {
+        use zcash_protocol::ShieldedPool;
+        use zingo_netutils::lightwallet_protocol::CompactBlock;
+
+        /// Counts the outputs `compact_block` appends to `pool`'s note commitment tree.
+        pub fn shielded_output_count(compact_block: &CompactBlock, pool: ShieldedPool) -> u32 {
+            crate::utils::block::shielded_output_count(compact_block, pool)
+        }
+
+        /// Counts the shielded inputs `compact_block` spends from `pool`.
+        pub fn shielded_input_count(compact_block: &CompactBlock, pool: ShieldedPool) -> u32 {
+            crate::utils::block::shielded_input_count(compact_block, pool)
+        }
+    }
+}
+
 #[cfg(test)]
 mod mocks;
 

--- a/pepper-sync/src/scan.rs
+++ b/pepper-sync/src/scan.rs
@@ -18,7 +18,7 @@ use crate::{
     client::FetchRequest,
     error::{ScanError, ServerError},
     sync::ScanPriority,
-    utils::{get_compact_block_height, get_compact_tx_txid},
+    utils::{block, transaction},
     wallet::{NullifierMap, OutputId, ScanTarget, WalletBlock, WalletTransaction},
     witness::{self, LocatedTreeData, WitnessData},
 };
@@ -159,7 +159,7 @@ where
             for transaction in &block.vtx {
                 collect_nullifiers(
                     &mut nullifiers,
-                    get_compact_block_height(block),
+                    block::get_compact_height(block),
                     transaction,
                 )?;
             }
@@ -284,7 +284,7 @@ fn collect_nullifiers(
                 nullifier,
                 ScanTarget {
                     block_height,
-                    txid: get_compact_tx_txid(transaction),
+                    txid: transaction::get_compact_txid(transaction),
                     narrow_scan_area: false,
                 },
             );
@@ -308,7 +308,7 @@ fn collect_nullifiers(
                 nullifier,
                 ScanTarget {
                     block_height,
-                    txid: get_compact_tx_txid(transaction),
+                    txid: transaction::get_compact_txid(transaction),
                     narrow_scan_area: false,
                 },
             );
@@ -332,7 +332,7 @@ fn collect_nullifiers(
                 nullifier,
                 ScanTarget {
                     block_height,
-                    txid: get_compact_tx_txid(transaction),
+                    txid: transaction::get_compact_txid(transaction),
                     narrow_scan_area: false,
                 },
             );

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -20,10 +20,7 @@ use crate::{
     client::{self, FetchRequest},
     error::{ContinuityError, ScanError, ServerError},
     keys::{KeyId, ScanningKeyOps, ScanningKeys},
-    utils::{
-        get_compact_action, get_compact_block_hash, get_compact_block_height,
-        get_compact_block_prev_hash, get_compact_output_description, get_compact_tx_txid,
-    },
+    utils::{block, get_compact_action, get_compact_output_description, transaction},
     wallet::{NullifierMap, OutputId, ScanTarget, TreeBounds, WalletBlock},
     witness::WitnessData,
 };
@@ -80,21 +77,21 @@ where
         orchard_initial_tree_size = orchard_final_tree_size;
         ironwood_initial_tree_size = ironwood_final_tree_size;
 
-        let block_height = get_compact_block_height(block);
+        let block_height = block::get_compact_height(block);
 
         for transaction in &block.vtx {
             // collect trial decryption results by transaction
             let incoming_sapling_outputs = runners.sapling.collect_results(
-                get_compact_block_hash(block),
-                get_compact_tx_txid(transaction),
+                block::get_compact_hash(block),
+                transaction::get_compact_txid(transaction),
             );
             let incoming_orchard_outputs = runners.orchard.collect_results(
-                get_compact_block_hash(block),
-                get_compact_tx_txid(transaction),
+                block::get_compact_hash(block),
+                transaction::get_compact_txid(transaction),
             );
             let incoming_ironwood_outputs = runners.ironwood.collect_results(
-                get_compact_block_hash(block),
-                get_compact_tx_txid(transaction),
+                block::get_compact_hash(block),
+                transaction::get_compact_txid(transaction),
             );
 
             // gather the txids of all transactions relevant to the wallet
@@ -124,7 +121,7 @@ where
 
             collect_nullifiers(
                 &mut nullifiers,
-                get_compact_block_height(block),
+                block::get_compact_height(block),
                 transaction,
             )?;
 
@@ -166,12 +163,12 @@ where
                 &mut decrypted_note_data.ironwood_nullifiers_and_positions,
             );
 
-            sapling_final_tree_size += u32::try_from(transaction.outputs.len())
-                .expect("should not be more than 2^32 outputs in a transaction");
-            orchard_final_tree_size += u32::try_from(transaction.actions.len())
-                .expect("should not be more than 2^32 outputs in a transaction");
-            ironwood_final_tree_size += u32::try_from(transaction.ironwood_actions.len())
-                .expect("should not be more than 2^32 outputs in a transaction");
+            sapling_final_tree_size +=
+                transaction::shielded_output_count(transaction, ShieldedPool::Sapling);
+            orchard_final_tree_size +=
+                transaction::shielded_output_count(transaction, ShieldedPool::Orchard);
+            ironwood_final_tree_size +=
+                transaction::shielded_output_count(transaction, ShieldedPool::Ironwood);
         }
 
         set_checkpoint_retentions(
@@ -188,11 +185,15 @@ where
         );
 
         let wallet_block = WalletBlock {
-            block_height: get_compact_block_height(block),
-            block_hash: get_compact_block_hash(block),
-            prev_hash: get_compact_block_prev_hash(block),
+            block_height: block::get_compact_height(block),
+            block_hash: block::get_compact_hash(block),
+            prev_hash: block::get_compact_prev_hash(block),
             time: block.time,
-            txids: block.vtx.iter().map(get_compact_tx_txid).collect(),
+            txids: block
+                .vtx
+                .iter()
+                .map(transaction::get_compact_txid)
+                .collect(),
             tree_bounds: TreeBounds {
                 sapling_initial_tree_size,
                 sapling_final_tree_size,
@@ -254,26 +255,26 @@ fn check_continuity(
 
     for block in compact_blocks {
         if let Some(prev_height) = prev_height
-            && get_compact_block_height(block) != prev_height + 1
+            && block::get_compact_height(block) != prev_height + 1
         {
             return Err(ContinuityError::HeightDiscontinuity {
-                height: get_compact_block_height(block),
+                height: block::get_compact_height(block),
                 previous_block_height: prev_height,
             });
         }
 
         if let Some(prev_hash) = prev_hash
-            && get_compact_block_prev_hash(block) != prev_hash
+            && block::get_compact_prev_hash(block) != prev_hash
         {
             return Err(ContinuityError::HashDiscontinuity {
-                height: get_compact_block_height(block),
-                prev_hash: get_compact_block_prev_hash(block),
+                height: block::get_compact_height(block),
+                prev_hash: block::get_compact_prev_hash(block),
                 previous_block_hash: prev_hash,
             });
         }
 
-        prev_height = Some(get_compact_block_height(block));
-        prev_hash = Some(get_compact_block_hash(block));
+        prev_height = Some(block::get_compact_height(block));
+        prev_hash = Some(block::get_compact_hash(block));
     }
 
     if let Some(end_seam_block) = end_seam_block {
@@ -475,11 +476,11 @@ pub(crate) async fn calculate_block_tree_bounds(
                 .activation_height(consensus::NetworkUpgrade::Sapling)
                 .expect("should have some sapling activation height");
 
-            match get_compact_block_height(compact_block).cmp(&sapling_activation_height) {
+            match block::get_compact_height(compact_block).cmp(&sapling_activation_height) {
                 cmp::Ordering::Greater => {
                     let frontiers = client::get_frontiers(
                         fetch_request_sender.clone(),
-                        get_compact_block_height(compact_block),
+                        block::get_compact_height(compact_block),
                     )
                     .await?;
                     (
@@ -505,27 +506,9 @@ pub(crate) async fn calculate_block_tree_bounds(
             }
         };
 
-    let sapling_output_count: u32 = compact_block
-        .vtx
-        .iter()
-        .map(|tx| tx.outputs.len())
-        .sum::<usize>()
-        .try_into()
-        .expect("Sapling output count cannot exceed a u32");
-    let orchard_output_count: u32 = compact_block
-        .vtx
-        .iter()
-        .map(|tx| tx.actions.len())
-        .sum::<usize>()
-        .try_into()
-        .expect("Sapling output count cannot exceed a u32");
-    let ironwood_output_count: u32 = compact_block
-        .vtx
-        .iter()
-        .map(|tx| tx.ironwood_actions.len())
-        .sum::<usize>()
-        .try_into()
-        .expect("Ironwood output count cannot exceed a u32");
+    let sapling_output_count = block::shielded_output_count(compact_block, ShieldedPool::Sapling);
+    let orchard_output_count = block::shielded_output_count(compact_block, ShieldedPool::Orchard);
+    let ironwood_output_count = block::shielded_output_count(compact_block, ShieldedPool::Ironwood);
 
     Ok(TreeBounds {
         sapling_initial_tree_size: sapling_final_tree_size.saturating_sub(sapling_output_count),

--- a/pepper-sync/src/scan/compact_blocks/runners.rs
+++ b/pepper-sync/src/scan/compact_blocks/runners.rs
@@ -23,11 +23,10 @@ use crate::error::EncodingInvalid;
 use crate::keys::KeyId;
 use crate::keys::ScanningKeyOps;
 use crate::keys::ScanningKeys;
+use crate::utils::block;
 use crate::utils::get_compact_action;
-use crate::utils::get_compact_block_hash;
-use crate::utils::get_compact_block_height;
 use crate::utils::get_compact_output_description;
-use crate::utils::get_compact_tx_txid;
+use crate::utils::transaction;
 use crate::wallet::OutputId;
 
 type TaggedSaplingBatch = Batch<
@@ -118,12 +117,12 @@ where
     where
         P: consensus::Parameters + Send + 'static,
     {
-        let block_hash = get_compact_block_hash(&block);
-        let block_height = get_compact_block_height(&block);
+        let block_hash = block::get_compact_hash(&block);
+        let block_height = block::get_compact_height(&block);
         let zip212_enforcement = zip212_enforcement(params, block_height);
 
         for tx in block.vtx {
-            let txid = get_compact_tx_txid(&tx);
+            let txid = transaction::get_compact_txid(&tx);
 
             self.sapling.add_outputs(
                 block_hash,

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -16,6 +16,7 @@ use tokio::{
 
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::transaction::TxId;
+use zcash_protocol::ShieldedPool;
 use zcash_protocol::consensus::{self, BlockHeight};
 use zingo_netutils::lightwallet_protocol::CompactBlock;
 use zip32::AccountId;
@@ -25,8 +26,8 @@ use crate::{
     config::PerformanceLevel,
     error::{ScanError, ServerError, SyncError},
     keys::transparent::TransparentAddressId,
-    scan::get_compact_block_height,
     sync::{self, ScanPriority, ScanRange},
+    utils::block,
     wallet::{
         ScanTarget, WalletBlock,
         traits::{SyncBlocks, SyncNullifiers, SyncWallet},
@@ -442,20 +443,17 @@ where
                     };
 
                     if fetch_nullifiers_only {
-                        current_block_sapling_nullifier_count = compact_block
-                            .vtx
-                            .iter()
-                            .fold(0, |acc, transaction| acc + transaction.spends.len());
+                        current_block_sapling_nullifier_count =
+                            block::shielded_input_count(&compact_block, ShieldedPool::Sapling)
+                                as usize;
                         batch_sapling_nullifier_count += current_block_sapling_nullifier_count;
-                        current_block_orchard_nullifier_count = compact_block
-                            .vtx
-                            .iter()
-                            .fold(0, |acc, transaction| acc + transaction.actions.len());
+                        current_block_orchard_nullifier_count =
+                            block::shielded_input_count(&compact_block, ShieldedPool::Orchard)
+                                as usize;
                         batch_orchard_nullifier_count += current_block_orchard_nullifier_count;
                         current_block_ironwood_nullifier_count =
-                            compact_block.vtx.iter().fold(0, |acc, transaction| {
-                                acc + transaction.ironwood_actions.len()
-                            });
+                            block::shielded_input_count(&compact_block, ShieldedPool::Ironwood)
+                                as usize;
                         batch_ironwood_nullifier_count += current_block_ironwood_nullifier_count;
                     } else {
                         if let Some(block) = previous_task_last_block.as_ref()
@@ -481,7 +479,7 @@ where
                             );
                             first_batch = false;
                         }
-                        if get_compact_block_height(&compact_block)
+                        if block::get_compact_height(&compact_block)
                             == scan_task.scan_range.block_range().end - 1
                         {
                             previous_task_last_block = Some(
@@ -494,20 +492,17 @@ where
                             );
                         }
 
-                        current_block_sapling_output_count = compact_block
-                            .vtx
-                            .iter()
-                            .fold(0, |acc, transaction| acc + transaction.outputs.len());
+                        current_block_sapling_output_count =
+                            block::shielded_output_count(&compact_block, ShieldedPool::Sapling)
+                                as usize;
                         batch_sapling_output_count += current_block_sapling_output_count;
-                        current_block_orchard_output_count = compact_block
-                            .vtx
-                            .iter()
-                            .fold(0, |acc, transaction| acc + transaction.actions.len());
+                        current_block_orchard_output_count =
+                            block::shielded_output_count(&compact_block, ShieldedPool::Orchard)
+                                as usize;
                         batch_orchard_output_count += current_block_orchard_output_count;
                         current_block_ironwood_output_count =
-                            compact_block.vtx.iter().fold(0, |acc, transaction| {
-                                acc + transaction.ironwood_actions.len()
-                            });
+                            block::shielded_output_count(&compact_block, ShieldedPool::Ironwood)
+                                as usize;
                         batch_ironwood_output_count += current_block_ironwood_output_count;
                     }
 
@@ -520,14 +515,14 @@ where
                             + batch_ironwood_nullifier_count
                             > MAX_BATCH_NULLIFIERS)
                         && scan_task.scan_range.block_range().start
-                            != get_compact_block_height(&compact_block)
+                            != block::get_compact_height(&compact_block)
                     {
                         let (full_batch, new_batch) = scan_task
                             .clone()
                             .split(
                                 &consensus_parameters,
                                 fetch_request_sender.clone(),
-                                get_compact_block_height(&compact_block),
+                                block::get_compact_height(&compact_block),
                             )
                             .await?;
 
@@ -542,7 +537,7 @@ where
                         batch_ironwood_nullifier_count = current_block_ironwood_nullifier_count;
                     }
 
-                    retry_height = get_compact_block_height(&compact_block) + 1;
+                    retry_height = block::get_compact_height(&compact_block) + 1;
                     scan_task.compact_blocks.push(compact_block);
                 }
 
@@ -785,7 +780,7 @@ impl ScanTask {
         let mut lower_compact_blocks = self.compact_blocks;
         let upper_compact_blocks = if let Some(index) = lower_compact_blocks
             .iter()
-            .position(|block| get_compact_block_height(block) == block_height)
+            .position(|block| block::get_compact_height(block) == block_height)
         {
             lower_compact_blocks.split_off(index)
         } else {

--- a/pepper-sync/src/utils.rs
+++ b/pepper-sync/src/utils.rs
@@ -1,69 +1,12 @@
 use orchard::note_encryption::CompactAction;
 use sapling_crypto::{note::ExtractedNoteCommitment, note_encryption::CompactOutputDescription};
 use zcash_note_encryption::EphemeralKeyBytes;
-use zcash_primitives::block::{BlockHash, BlockHeader};
-use zcash_protocol::{TxId, consensus::BlockHeight};
-use zingo_netutils::lightwallet_protocol::{
-    CompactBlock, CompactOrchardAction, CompactSaplingOutput, CompactTx,
-};
+use zingo_netutils::lightwallet_protocol::{CompactOrchardAction, CompactSaplingOutput};
 
 use crate::error::CompactFormatError;
 
-/// Returns the [`BlockHash`] for this block.
-///
-/// # Panics
-///
-/// This function will panic if `compact_block.header` is not set and
-/// `compact_block.hash` is not exactly 32 bytes.
-pub(crate) fn get_compact_block_hash(compact_block: &CompactBlock) -> BlockHash {
-    if let Some(header) = get_compact_block_header(compact_block) {
-        header.hash()
-    } else {
-        BlockHash::from_slice(&compact_block.hash)
-    }
-}
-
-/// Returns the [`BlockHash`] for this block's parent.
-///
-/// # Panics
-///
-/// This function will panic if `compact_block.header` is not set and
-/// `compact_block.hash` is not exactly 32 bytes.
-pub(crate) fn get_compact_block_prev_hash(compact_block: &CompactBlock) -> BlockHash {
-    if let Some(header) = get_compact_block_header(compact_block) {
-        header.prev_block
-    } else {
-        BlockHash::from_slice(&compact_block.prev_hash)
-    }
-}
-
-/// Returns the [`BlockHeight`] value for this block
-///
-/// # Panics
-///
-/// This function will panic if `compact_block.height` is not representable within a
-/// `u32`.
-pub(crate) fn get_compact_block_height(compact_block: &CompactBlock) -> BlockHeight {
-    compact_block.height.try_into().unwrap()
-}
-
-/// Returns the [`BlockHeader`] for this block if present.
-///
-/// A convenience method that parses `compact_block.height` if present.
-pub(crate) fn get_compact_block_header(compact_block: &CompactBlock) -> Option<BlockHeader> {
-    if compact_block.header.is_empty() {
-        None
-    } else {
-        BlockHeader::read(&compact_block.header[..]).ok()
-    }
-}
-
-/// Returns the transaction Id
-pub(crate) fn get_compact_tx_txid(compact_tx: &CompactTx) -> TxId {
-    let mut txid_bytes = [0u8; 32];
-    txid_bytes.copy_from_slice(&compact_tx.txid);
-    TxId::from_bytes(txid_bytes)
-}
+pub(crate) mod block;
+pub(crate) mod transaction;
 
 pub(crate) fn get_compact_output_description(
     compact_sapling_output: &CompactSaplingOutput,

--- a/pepper-sync/src/utils/block.rs
+++ b/pepper-sync/src/utils/block.rs
@@ -39,7 +39,10 @@ pub(crate) fn get_compact_prev_hash(compact_block: &CompactBlock) -> BlockHash {
 /// This function will panic if `compact_block.height` is not representable within a
 /// `u32`.
 pub(crate) fn get_compact_height(compact_block: &CompactBlock) -> BlockHeight {
-    compact_block.height.try_into().unwrap()
+    compact_block.height.try_into().expect(
+        "no valid chain height exceeds u32::MAX, so this u64 wire value came from a \
+         malicious or broken indexer; sync dies loudly rather than trust it",
+    )
 }
 
 /// Returns the [`BlockHeader`] for this block if present.

--- a/pepper-sync/src/utils/block.rs
+++ b/pepper-sync/src/utils/block.rs
@@ -1,0 +1,103 @@
+use zcash_primitives::block::{BlockHash, BlockHeader};
+use zcash_protocol::{ShieldedPool, consensus::BlockHeight};
+use zingo_netutils::lightwallet_protocol::CompactBlock;
+
+use super::transaction;
+
+/// Returns the [`BlockHash`] for this block.
+///
+/// # Panics
+///
+/// This function will panic if `compact_block.header` is not set and
+/// `compact_block.hash` is not exactly 32 bytes.
+pub(crate) fn get_compact_hash(compact_block: &CompactBlock) -> BlockHash {
+    if let Some(header) = get_compact_header(compact_block) {
+        header.hash()
+    } else {
+        BlockHash::from_slice(&compact_block.hash)
+    }
+}
+
+/// Returns the [`BlockHash`] for this block's parent.
+///
+/// # Panics
+///
+/// This function will panic if `compact_block.header` is not set and
+/// `compact_block.hash` is not exactly 32 bytes.
+pub(crate) fn get_compact_prev_hash(compact_block: &CompactBlock) -> BlockHash {
+    if let Some(header) = get_compact_header(compact_block) {
+        header.prev_block
+    } else {
+        BlockHash::from_slice(&compact_block.prev_hash)
+    }
+}
+
+/// Returns the [`BlockHeight`] value for this block
+///
+/// # Panics
+///
+/// This function will panic if `compact_block.height` is not representable within a
+/// `u32`.
+pub(crate) fn get_compact_height(compact_block: &CompactBlock) -> BlockHeight {
+    compact_block.height.try_into().unwrap()
+}
+
+/// Returns the [`BlockHeader`] for this block if present.
+///
+/// A convenience method that parses `compact_block.height` if present.
+pub(crate) fn get_compact_header(compact_block: &CompactBlock) -> Option<BlockHeader> {
+    if compact_block.header.is_empty() {
+        None
+    } else {
+        BlockHeader::read(&compact_block.header[..]).ok()
+    }
+}
+
+pub(crate) fn shielded_output_count(compact_block: &CompactBlock, pool: ShieldedPool) -> u32 {
+    compact_block
+        .vtx
+        .iter()
+        .map(|compact_tx| u64::from(transaction::shielded_output_count(compact_tx, pool)))
+        .sum::<u64>()
+        .try_into()
+        .expect("note commitment tree sizes are u32; a block cannot carry more outputs")
+}
+
+pub(crate) fn shielded_input_count(compact_block: &CompactBlock, pool: ShieldedPool) -> u32 {
+    compact_block
+        .vtx
+        .iter()
+        .map(|compact_tx| u64::from(transaction::shielded_input_count(compact_tx, pool)))
+        .sum::<u64>()
+        .try_into()
+        .expect("note commitment tree sizes are u32; a block cannot carry more inputs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::transaction::{ALL_POOLS, compact_tx};
+
+    #[test]
+    fn counts_sum_across_transactions() {
+        let block = CompactBlock {
+            vtx: vec![compact_tx(1, 2, 3, 4), compact_tx(5, 6, 7, 8)],
+            ..Default::default()
+        };
+        assert_eq!(shielded_output_count(&block, ShieldedPool::Sapling), 8);
+        assert_eq!(shielded_output_count(&block, ShieldedPool::Orchard), 10);
+        assert_eq!(shielded_output_count(&block, ShieldedPool::Ironwood), 12);
+        assert_eq!(shielded_input_count(&block, ShieldedPool::Sapling), 6);
+        assert_eq!(shielded_input_count(&block, ShieldedPool::Orchard), 10);
+        assert_eq!(shielded_input_count(&block, ShieldedPool::Ironwood), 12);
+    }
+
+    #[test]
+    fn empty_block_counts_zero_for_every_pool() {
+        let block = CompactBlock::default();
+        for pool in ALL_POOLS {
+            assert_eq!(shielded_output_count(&block, pool), 0);
+            assert_eq!(shielded_input_count(&block, pool), 0);
+        }
+    }
+}

--- a/pepper-sync/src/utils/transaction.rs
+++ b/pepper-sync/src/utils/transaction.rs
@@ -1,0 +1,103 @@
+use zcash_protocol::{ShieldedPool, TxId};
+use zingo_netutils::lightwallet_protocol::CompactTx;
+
+#[cfg(test)]
+use zingo_netutils::lightwallet_protocol::{
+    CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend,
+};
+
+/// Returns the transaction Id
+pub(crate) fn get_compact_txid(compact_tx: &CompactTx) -> TxId {
+    let mut txid_bytes = [0u8; 32];
+    txid_bytes.copy_from_slice(&compact_tx.txid);
+    TxId::from_bytes(txid_bytes)
+}
+
+pub(crate) fn shielded_output_count(compact_tx: &CompactTx, pool: ShieldedPool) -> u32 {
+    match pool {
+        ShieldedPool::Sapling => compact_tx.outputs.len(),
+        ShieldedPool::Orchard => compact_tx.actions.len(),
+        ShieldedPool::Ironwood => compact_tx.ironwood_actions.len(),
+    }
+    .try_into()
+    .expect("note commitment tree sizes are u32; a transaction cannot carry more outputs")
+}
+
+pub(crate) fn shielded_input_count(compact_tx: &CompactTx, pool: ShieldedPool) -> u32 {
+    match pool {
+        ShieldedPool::Sapling => compact_tx.spends.len(),
+        ShieldedPool::Orchard => compact_tx.actions.len(),
+        ShieldedPool::Ironwood => compact_tx.ironwood_actions.len(),
+    }
+    .try_into()
+    .expect("note commitment tree sizes are u32; a transaction cannot carry more inputs")
+}
+
+#[cfg(test)]
+pub(crate) const ALL_POOLS: [ShieldedPool; 3] = [
+    ShieldedPool::Sapling,
+    ShieldedPool::Orchard,
+    ShieldedPool::Ironwood,
+];
+
+#[cfg(test)]
+pub(crate) fn compact_tx(
+    spends: usize,
+    outputs: usize,
+    actions: usize,
+    ironwood_actions: usize,
+) -> CompactTx {
+    CompactTx {
+        index: 0,
+        txid: vec![0; 32],
+        fee: 0,
+        spends: vec![CompactSaplingSpend::default(); spends],
+        outputs: vec![CompactSaplingOutput::default(); outputs],
+        actions: vec![CompactOrchardAction::default(); actions],
+        ironwood_actions: vec![CompactOrchardAction::default(); ironwood_actions],
+        vin: vec![],
+        vout: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_count_reads_each_pools_own_field() {
+        let transaction = compact_tx(1, 2, 3, 4);
+        assert_eq!(
+            shielded_output_count(&transaction, ShieldedPool::Sapling),
+            2
+        );
+        assert_eq!(
+            shielded_output_count(&transaction, ShieldedPool::Orchard),
+            3
+        );
+        assert_eq!(
+            shielded_output_count(&transaction, ShieldedPool::Ironwood),
+            4
+        );
+    }
+
+    #[test]
+    fn input_count_reads_spends_for_sapling_and_actions_for_action_pools() {
+        let transaction = compact_tx(1, 2, 3, 4);
+        assert_eq!(shielded_input_count(&transaction, ShieldedPool::Sapling), 1);
+        assert_eq!(shielded_input_count(&transaction, ShieldedPool::Orchard), 3);
+        assert_eq!(
+            shielded_input_count(&transaction, ShieldedPool::Ironwood),
+            4
+        );
+    }
+
+    #[test]
+    fn empty_transaction_counts_zero_for_every_pool() {
+        let transaction = compact_tx(0, 0, 0, 0);
+        for pool in ALL_POOLS {
+            assert_eq!(shielded_output_count(&transaction, pool), 0);
+            assert_eq!(shielded_input_count(&transaction, pool), 0);
+        }
+    }
+}

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -41,10 +41,7 @@ use crate::{
     scan::compact_blocks::calculate_block_tree_bounds,
     shardtree_ext::ShardTreeExt,
     sync::{MAX_REORG_ALLOWANCE, ScanPriority, ScanRange},
-    utils::{
-        get_compact_block_hash, get_compact_block_height, get_compact_block_prev_hash,
-        get_compact_tx_txid,
-    },
+    utils::{block, transaction},
     witness,
 };
 
@@ -420,11 +417,15 @@ impl WalletBlock {
             calculate_block_tree_bounds(consensus_parameters, fetch_request_sender, block).await?;
 
         Ok(Self {
-            block_height: get_compact_block_height(block),
-            block_hash: get_compact_block_hash(block),
-            prev_hash: get_compact_block_prev_hash(block),
+            block_height: block::get_compact_height(block),
+            block_hash: block::get_compact_hash(block),
+            prev_hash: block::get_compact_prev_hash(block),
             time: block.time,
-            txids: block.vtx.iter().map(get_compact_tx_txid).collect(),
+            txids: block
+                .vtx
+                .iter()
+                .map(transaction::get_compact_txid)
+                .collect(),
             tree_bounds,
         })
     }


### PR DESCRIPTION
This change splits pepper-sync's `utils` into `block` and `transaction` modules, moving the noun out of the function names and into the module path. The `transaction` module gains `shielded_output_count` and `shielded_input_count`: pure, total functions from a compact transaction and a shielded pool to the count of elements the transaction carries for that pool. The `block` module holds the same-named operations as compositions over `vtx`, beside the renamed compact-block getters. `CompactTx` carries no transaction version, so a version-aware error arm is unrepresentable on the wire type and the functions are total; an empty ironwood list is the truthful count for any pre-v6 transaction.

The four inline counting sites in the scan loop, `calculate_block_tree_bounds`, and the batcher now share the contract, which retires a miscopied expect message on the orchard count. The counts are additionally exported behind the existing `test-features` gate as `pepper_sync::test_support`, mirroring the block and transaction split, so integration tests that audit served blocks (such as the sweep in #2598) can share the arithmetic the scanner uses. Unit tests pin the counts across every pool, both directions, and empty and multi-transaction shapes.

Note for reviewers: the `cargo-checkmate (doc)` job is red on dev itself at the merge base (a broken intra-doc link to `MixnetPriceFetch` from `zingolib/src/lightclient/send.rs`, gated items under non-nym features); this branch neither introduces nor fixes that failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)