### PR TITLE
docs: unlink TransmitReport's nym-gated price cross-reference

### DIFF
--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -58,8 +58,9 @@ use crate::wallet::output::OutputRef;
 /// Attestation of one transmitted transaction: the route the bytes
 /// traveled, the endpoint that accepted them, and the transmission's
 /// round-trip time. It rides the success value — not a log — the same
-/// doctrine as [`crate::lightclient::MixnetPriceFetch`] (ADR 0011), so
-/// every consumer of a send holds per-transaction evidence of the route.
+/// doctrine as the nym-gated `MixnetPriceFetch` price attestation
+/// (ADR 0011), so every consumer of a send holds per-transaction
+/// evidence of the route.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransmitReport {
     /// The transmitted transaction.


### PR DESCRIPTION
Dev's push CI has been red since the #2589 merge (run 30476124543): the Cargo Checkmate (doc) job exits 101 on an unresolved intra-doc link at `zingolib/src/lightclient/send.rs:61`.

The root cause is a feature-visibility mismatch #2589 created between two of its own changes. It gated the price-fetch machinery, including `MixnetPriceFetch`, behind the `nym` feature, and it introduced the ungated `TransmitReport`, whose doc-comment links to that struct. The checkmate doc gate documents the workspace at default features, where zingolib's `default = []` leaves the link without a target, and `-D warnings` promotes the broken intra-doc link to a hard error.

The fix names the doctrine in plain code font instead of linking it, so the sentence reads identically under every feature combination. No code changes.

Verified locally with `RUSTDOCFLAGS="-D warnings" cargo doc` over the whole workspace at default features. That run also documented zingo-cli, zingolib_testutils, and libtonode-tests cleanly — crates the failing CI run never reached because zingolib errored first.

For the record, the other red runs on dev are separate: the #2561 merge run failed on netutils doc-list clippy lints that #2579's content already fixed (green at 30469746801), and the nightly and coverage workflows fail on the android-build and coverage jobs, which predate #2589 and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
