### PR TITLE
refactor: split the two senses of "batch" into load and decryption batch

### DIFF
--- a/pepper-sync/diagrams/process_scan_results.mmd
+++ b/pepper-sync/diagrams/process_scan_results.mmd
@@ -9,7 +9,7 @@ flowchart TD
   P6 --> P7["Check coins output ids vs outpoint map; if spent: mark coin and set surrounding narrow block range -> 'found note'"]
   P7 --> P8["Check notes derived nullifiers vs nullifier map; if spent: mark note and set surrounding shard range -> 'found note'"]
   P8 --> P9["Add wallet blocks; retain only: range bounds, blocks with relevant txs, and within max verification window of highest scanned block"]
-  P9 --> P10["Mark scan range containing this batch -> 'scanned'"]
+  P9 --> P10["Mark scan range containing this load -> 'scanned'"]
   P10 --> P11["Merge adjacent 'scanned' ranges"]
   P11 --> P12["Clean wallet data no longer relevant"]
   P12 --> END([End])

--- a/pepper-sync/diagrams/sync.mmd
+++ b/pepper-sync/diagrams/sync.mmd
@@ -3,16 +3,16 @@ flowchart LR
   %% SYNC
   START([Start sync]) --> INIT["Initialization"]
   INIT --> S0
-  S0{Batcher idle?}
+  S0{Loader idle?}
   S0 -- No --> S6
   S0 -- Yes --> S1{All ranges in wallet state are 'scanned'?}
   S1 -- Yes --> SHUTDOWN([Shutdown sync])
   S1 -- No --> S2["Pick highest-priority scan range"]
   S2 --> S3{Priority is 'historic'?}
-  S3 -- Yes --> S4["Split orchard shard range off lower end"] --> S5["Set range to 'scanning' and send to batcher"]
+  S3 -- Yes --> S4["Split orchard shard range off lower end"] --> S5["Set range to 'scanning' and send to loader"]
   S3 -- No --> S5
   S5 --> S6
-  S6["Batcher: stream compact blocks until fixed output threshold; store batch; when entire scan range batched, set batcher idle"]
+  S6["Loader: stream compact blocks until the output budget would be exceeded; store load; when entire scan range loaded, set loader idle"]
   subgraph WORKERS[Scan workers]
     direction LR
     W1["Scan Worker 1"]

--- a/pepper-sync/src/config.rs
+++ b/pepper-sync/src/config.rs
@@ -12,7 +12,7 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 // TODO: revisit after implementing nullifier refetching
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PerformanceLevel {
-    /// - number of outputs per batch is quartered
+    /// - output budget per scan load is quartered
     /// - nullifier map only contains chain tip
     Low,
     /// - nullifier map has a small maximum size
@@ -21,7 +21,7 @@ pub enum PerformanceLevel {
     /// - nullifier map has a large maximum size
     #[default]
     High,
-    /// - number of outputs per batch is quadrupled
+    /// - output budget per scan load is quadrupled
     /// - nullifier map has no maximum size
     ///
     /// WARNING: this may cause the wallet to become less responsive on slower systems and may use a lot of memory for

--- a/pepper-sync/src/keys.rs
+++ b/pepper-sync/src/keys.rs
@@ -172,7 +172,7 @@ pub(crate) struct ScanningKeys {
     pub(crate) sapling: HashMap<KeyId, ScanningKey<SaplingIvk, NullifierDerivingKey>>,
     pub(crate) orchard: HashMap<KeyId, ScanningKey<IncomingViewingKey, FullViewingKey>>,
     /// Ironwood scans with the same key material as Orchard, held separately
-    /// so the ironwood batch runner has its own key set.
+    /// so the ironwood decryption batch runner has its own key set.
     pub(crate) ironwood: HashMap<KeyId, ScanningKey<IncomingViewingKey, FullViewingKey>>,
 }
 

--- a/pepper-sync/src/lib.rs
+++ b/pepper-sync/src/lib.rs
@@ -9,7 +9,7 @@ Pepper-sync is a rust-based sync engine library for wallets operating on the zca
 - Spend-before-sync, combines the shard roots with high priority chain tip scanning to enable spending of notes as they are scanned.
 - Speed, trial decryption and tree building are computed in parallel and a multi-task architecture maximizes throughput for fetching and scanning.
 - Scan by shards, uses subtree metadata to create scan ranges that contain all note commitments to each shard to enable faster spending of decrypted outputs.
-- Fixed memory batching, each scan worker receives a batch with a fixed number of outputs for stable memory usage.
+- Fixed memory loading, each scan worker receives a load of whole blocks whose combined output count stays within a fixed budget for stable memory usage.
 - Pause/resume and stop, the sync engine can be paused to allow the wallet to perform time critical tasks that would require the acquisition of the wallet lock multiple times in quick succession. It can also be stopped before the wallet is fully synchronized.
 
 ## Terminology
@@ -33,11 +33,11 @@ Pepper-sync is a rust-based sync engine library for wallets operating on the zca
 8. Set the first 10 blocks after the highest previously scanned blocks to "verify" priority to check for re-org.
 
 ## Scanning
-1. If the "batcher" task is idle, set the highest priority scan range to "Scanning" priority and send it to the "batcher" task. If the scan priority is "Historic", first split an orchard shard range off the lower end. If the lowest unscanned range is of "ScannedWithoutMapping" priority, prioritize this range and set it to "RefetchingNullifiers" priority. If all scan ranges in the wallet's sync state are "scanned", shutdown the sync process.
-2. Batch the scan range:
-  2a. Stream compact blocks from server until a fixed threshold of outputs is reached. If the entire scan range is batched, the "batcher" task goes idle.
-  2b. Store the batch and wait until it is taken by an idle "scan worker" before returning to step 2a
-3. Scan each batch:
+1. If the "loader" task is idle, set the highest priority scan range to "Scanning" priority and send it to the "loader" task. If the scan priority is "Historic", first split an orchard shard range off the lower end. If the lowest unscanned range is of "ScannedWithoutMapping" priority, prioritize this range and set it to "RefetchingNullifiers" priority. If all scan ranges in the wallet's sync state are "scanned", shutdown the sync process.
+2. Load the scan range:
+  2a. Stream compact blocks from server, cutting a load at the last whole block that keeps the output budget unexceeded. If the entire scan range is loaded, the "loader" task goes idle.
+  2b. Store the load and wait until it is taken by an idle "scan worker" before returning to step 2a
+3. Scan each load:
   3a. Check block hash and height continuity
   3b. Collect all inputs in each compact block to populate the nullifier maps and outpoint maps for spend detection
   3c. Trial decrypt all notes in each compact block
@@ -56,7 +56,7 @@ Pepper-sync is a rust-based sync engine library for wallets operating on the zca
   4g. Check output id of all coins in wallet against the outpoint map. If a spend is found, update the coin's spend status and set the surrounding narrow range of blocks to "found note" priority
   4h. Check derived nullifiers of all notes in wallet against the nullifier map. If a spend is found, update the note's spend status and set the surrounding shard range of its corresponding shielded protocol to "found note" priority
   4i. Add wallet blocks to the wallet. Only retaining blocks at scan ranges bounds, blocks containing relevant transactions to the wallet or blocks within the max verification window of the highest scanned block in the wallet
-  4j. Set the scan range containing the batch of scanned blocks to "scanned" priority
+  4j. Set the scan range containing the load of scanned blocks to "scanned" priority
   4k. Merge all adjacent scanned ranges together
   4l. Clean wallet of data that is no longer relevant
 5. Scan mempool transactions.
@@ -72,14 +72,14 @@ After the sync process is initialized, it will be in a state of verification, on
 
 ### Performance Level
 - Low
--- Number of outputs per batch is quartered
+-- Output budget per scan load is quartered
 -- Nullifier map only contains chain tip
 - Medium
 -- Nullifier map only contains chain tip
 - High
 -- Nullifier map has a large maximum size
 - Maximum
--- Number of outputs per batch is quadrupled
+-- Output budget per scan load is quadrupled
 -- Nullifier map has no maximum size
 
 "#]

--- a/pepper-sync/src/scan.rs
+++ b/pepper-sync/src/scan.rs
@@ -125,7 +125,7 @@ pub(crate) async fn scan<P>(
     consensus_parameters: &P,
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
     scan_task: ScanTask,
-    max_batch_outputs: usize,
+    max_outputs: usize,
 ) -> Result<ScanResults, ScanError>
 where
     P: consensus::Parameters + Sync + Send + 'static,
@@ -195,7 +195,7 @@ where
             &consensus_parameters_clone,
             &ufvks_clone,
             initial_scan_data,
-            max_batch_outputs / 8,
+            max_outputs / 8,
         )
     })
     .await
@@ -239,17 +239,17 @@ where
                 witness::build_located_trees(
                     sapling_initial_position,
                     sapling_leaves_and_retentions,
-                    max_batch_outputs / 8,
+                    max_outputs / 8,
                 ),
                 witness::build_located_trees(
                     orchard_initial_position,
                     orchard_leaves_and_retentions,
-                    max_batch_outputs / 8,
+                    max_outputs / 8,
                 ),
                 witness::build_located_trees(
                     ironwood_initial_position,
                     ironwood_leaves_and_retentions,
-                    max_batch_outputs / 8,
+                    max_outputs / 8,
                 ),
             )
         })

--- a/pepper-sync/src/scan.rs
+++ b/pepper-sync/src/scan.rs
@@ -10,7 +10,10 @@ use tokio::sync::mpsc;
 use incrementalmerkletree::Position;
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::transaction::TxId;
-use zcash_protocol::consensus::{self, BlockHeight};
+use zcash_protocol::{
+    ShieldedPool,
+    consensus::{self, BlockHeight},
+};
 use zingo_netutils::lightwallet_protocol::{CompactBlock, CompactTx};
 use zip32::AccountId;
 
@@ -50,10 +53,20 @@ impl InitialScanData {
     {
         let (sapling_initial_tree_size, orchard_initial_tree_size, ironwood_initial_tree_size) =
             if let Some(prev) = &start_seam_block {
+                let prev_bounds = prev.tree_bounds();
+                let ironwood_initial_tree_size = if prev_bounds.ironwood_final_tree_size == 0 {
+                    first_block.chain_metadata.map_or(0, |chain_metadata| {
+                        chain_metadata.ironwood_commitment_tree_size.saturating_sub(
+                            block::shielded_output_count(first_block, ShieldedPool::Ironwood),
+                        )
+                    })
+                } else {
+                    prev_bounds.ironwood_final_tree_size
+                };
                 (
-                    prev.tree_bounds().sapling_final_tree_size,
-                    prev.tree_bounds().orchard_final_tree_size,
-                    prev.tree_bounds().ironwood_final_tree_size,
+                    prev_bounds.sapling_final_tree_size,
+                    prev_bounds.orchard_final_tree_size,
+                    ironwood_initial_tree_size,
                 )
             } else {
                 let tree_bounds = compact_blocks::calculate_block_tree_bounds(

--- a/pepper-sync/src/scan.rs
+++ b/pepper-sync/src/scan.rs
@@ -10,10 +10,7 @@ use tokio::sync::mpsc;
 use incrementalmerkletree::Position;
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::transaction::TxId;
-use zcash_protocol::{
-    ShieldedPool,
-    consensus::{self, BlockHeight},
-};
+use zcash_protocol::consensus::{self, BlockHeight};
 use zingo_netutils::lightwallet_protocol::{CompactBlock, CompactTx};
 use zip32::AccountId;
 
@@ -53,20 +50,10 @@ impl InitialScanData {
     {
         let (sapling_initial_tree_size, orchard_initial_tree_size, ironwood_initial_tree_size) =
             if let Some(prev) = &start_seam_block {
-                let prev_bounds = prev.tree_bounds();
-                let ironwood_initial_tree_size = if prev_bounds.ironwood_final_tree_size == 0 {
-                    first_block.chain_metadata.map_or(0, |chain_metadata| {
-                        chain_metadata.ironwood_commitment_tree_size.saturating_sub(
-                            block::shielded_output_count(first_block, ShieldedPool::Ironwood),
-                        )
-                    })
-                } else {
-                    prev_bounds.ironwood_final_tree_size
-                };
                 (
-                    prev_bounds.sapling_final_tree_size,
-                    prev_bounds.orchard_final_tree_size,
-                    ironwood_initial_tree_size,
+                    prev.tree_bounds().sapling_final_tree_size,
+                    prev.tree_bounds().orchard_final_tree_size,
+                    prev.tree_bounds().ironwood_final_tree_size,
                 )
             } else {
                 let tree_bounds = compact_blocks::calculate_block_tree_bounds(

--- a/pepper-sync/src/scan/compact_blocks.rs
+++ b/pepper-sync/src/scan/compact_blocks.rs
@@ -27,7 +27,7 @@ use crate::{
 
 use zcash_protocol::{PoolType, ShieldedPool};
 
-use self::runners::{BatchRunners, DecryptedOutput};
+use self::runners::{DecryptedOutput, DecryptionBatchRunners};
 
 use super::{DecryptedNoteData, InitialScanData, ScanData, collect_nullifiers};
 
@@ -38,7 +38,7 @@ pub(super) fn scan_compact_blocks<P>(
     consensus_parameters: &P,
     ufvks: &HashMap<AccountId, UnifiedFullViewingKey>,
     initial_scan_data: InitialScanData,
-    trial_decrypt_task_size: usize,
+    decryption_batch_size: usize,
 ) -> Result<ScanData, ScanError>
 where
     P: consensus::Parameters + Sync + Send + 'static,
@@ -54,7 +54,7 @@ where
         consensus_parameters,
         &scanning_keys,
         &compact_blocks,
-        trial_decrypt_task_size,
+        decryption_batch_size,
     )?;
 
     let mut wallet_blocks: BTreeMap<BlockHeight, WalletBlock> = BTreeMap::new();
@@ -222,12 +222,13 @@ fn trial_decrypt<P>(
     consensus_parameters: &P,
     scanning_keys: &ScanningKeys,
     compact_blocks: &[CompactBlock],
-    trial_decrypt_task_size: usize,
-) -> Result<BatchRunners<(), (), ()>, ScanError>
+    decryption_batch_size: usize,
+) -> Result<DecryptionBatchRunners<(), (), ()>, ScanError>
 where
     P: consensus::Parameters + Send + 'static,
 {
-    let mut runners = BatchRunners::<(), (), ()>::for_keys(trial_decrypt_task_size, scanning_keys);
+    let mut runners =
+        DecryptionBatchRunners::<(), (), ()>::for_keys(decryption_batch_size, scanning_keys);
     for block in compact_blocks {
         runners.add_block(consensus_parameters, block.clone())?;
     }
@@ -236,7 +237,7 @@ where
     Ok(runners)
 }
 
-/// Checks height and hash continuity of a batch of compact blocks.
+/// Checks height and hash continuity of a load of compact blocks.
 ///
 /// If available, also checks continuity with the blocks adjacent to the `compact_blocks` forming the start and end
 /// seams of the scan ranges.

--- a/pepper-sync/src/scan/compact_blocks/runners.rs
+++ b/pepper-sync/src/scan/compact_blocks/runners.rs
@@ -29,59 +29,67 @@ use crate::utils::get_compact_output_description;
 use crate::utils::transaction;
 use crate::wallet::OutputId;
 
-type TaggedSaplingBatch = Batch<
+type TaggedSaplingDecryptionBatch = DecryptionBatch<
     SaplingDomain,
     sapling_crypto::note_encryption::CompactOutputDescription,
     CompactDecryptor,
 >;
-type TaggedSaplingBatchRunner<Tasks> = BatchRunner<
+type TaggedSaplingDecryptionBatchRunner<Tasks> = DecryptionBatchRunner<
     SaplingDomain,
     sapling_crypto::note_encryption::CompactOutputDescription,
     CompactDecryptor,
     Tasks,
 >;
 
-type TaggedOrchardBatch =
-    Batch<OrchardDomain, orchard::note_encryption::CompactAction, CompactDecryptor>;
-type TaggedOrchardBatchRunner<Tasks> =
-    BatchRunner<OrchardDomain, orchard::note_encryption::CompactAction, CompactDecryptor, Tasks>;
+type TaggedOrchardDecryptionBatch =
+    DecryptionBatch<OrchardDomain, orchard::note_encryption::CompactAction, CompactDecryptor>;
+type TaggedOrchardDecryptionBatchRunner<Tasks> = DecryptionBatchRunner<
+    OrchardDomain,
+    orchard::note_encryption::CompactAction,
+    CompactDecryptor,
+    Tasks,
+>;
 
-type TaggedIronwoodBatch =
-    Batch<IronwoodDomain, orchard::note_encryption::CompactAction, CompactDecryptor>;
-type TaggedIronwoodBatchRunner<Tasks> =
-    BatchRunner<IronwoodDomain, orchard::note_encryption::CompactAction, CompactDecryptor, Tasks>;
+type TaggedIronwoodDecryptionBatch =
+    DecryptionBatch<IronwoodDomain, orchard::note_encryption::CompactAction, CompactDecryptor>;
+type TaggedIronwoodDecryptionBatchRunner<Tasks> = DecryptionBatchRunner<
+    IronwoodDomain,
+    orchard::note_encryption::CompactAction,
+    CompactDecryptor,
+    Tasks,
+>;
 
-pub(crate) trait SaplingTasks: Tasks<TaggedSaplingBatch> {}
-impl<T: Tasks<TaggedSaplingBatch>> SaplingTasks for T {}
+pub(crate) trait SaplingTasks: Tasks<TaggedSaplingDecryptionBatch> {}
+impl<T: Tasks<TaggedSaplingDecryptionBatch>> SaplingTasks for T {}
 
-pub(crate) trait OrchardTasks: Tasks<TaggedOrchardBatch> {}
-impl<T: Tasks<TaggedOrchardBatch>> OrchardTasks for T {}
+pub(crate) trait OrchardTasks: Tasks<TaggedOrchardDecryptionBatch> {}
+impl<T: Tasks<TaggedOrchardDecryptionBatch>> OrchardTasks for T {}
 
-pub(crate) trait IronwoodTasks: Tasks<TaggedIronwoodBatch> {}
-impl<T: Tasks<TaggedIronwoodBatch>> IronwoodTasks for T {}
+pub(crate) trait IronwoodTasks: Tasks<TaggedIronwoodDecryptionBatch> {}
+impl<T: Tasks<TaggedIronwoodDecryptionBatch>> IronwoodTasks for T {}
 
-pub(crate) struct BatchRunners<TS: SaplingTasks, TO: OrchardTasks, TI: IronwoodTasks> {
-    pub(crate) sapling: TaggedSaplingBatchRunner<TS>,
-    pub(crate) orchard: TaggedOrchardBatchRunner<TO>,
-    pub(crate) ironwood: TaggedIronwoodBatchRunner<TI>,
+pub(crate) struct DecryptionBatchRunners<TS: SaplingTasks, TO: OrchardTasks, TI: IronwoodTasks> {
+    pub(crate) sapling: TaggedSaplingDecryptionBatchRunner<TS>,
+    pub(crate) orchard: TaggedOrchardDecryptionBatchRunner<TO>,
+    pub(crate) ironwood: TaggedIronwoodDecryptionBatchRunner<TI>,
 }
 
-impl<TS, TO, TI> BatchRunners<TS, TO, TI>
+impl<TS, TO, TI> DecryptionBatchRunners<TS, TO, TI>
 where
     TS: SaplingTasks,
     TO: OrchardTasks,
     TI: IronwoodTasks,
 {
     pub(crate) fn for_keys(batch_size_threshold: usize, scanning_keys: &ScanningKeys) -> Self {
-        BatchRunners {
-            sapling: BatchRunner::new(
+        DecryptionBatchRunners {
+            sapling: DecryptionBatchRunner::new(
                 batch_size_threshold,
                 scanning_keys
                     .sapling
                     .iter()
                     .map(|(id, key)| (*id, key.prepare())),
             ),
-            orchard: BatchRunner::new(
+            orchard: DecryptionBatchRunner::new(
                 batch_size_threshold,
                 scanning_keys.orchard.iter().map(|(id, key)| {
                     (
@@ -90,7 +98,7 @@ where
                     )
                 }),
             ),
-            ironwood: BatchRunner::new(
+            ironwood: DecryptionBatchRunner::new(
                 batch_size_threshold,
                 scanning_keys.ironwood.iter().map(|(id, key)| {
                     (
@@ -281,9 +289,9 @@ impl<D: Domain, M> DynamicUsage for OutputReplier<D, M> {
 }
 
 /// The receiver for the result of batch scanning a specific transaction.
-struct BatchReceiver<D: Domain, M>(channel::Receiver<OutputItem<D, M>>);
+struct DecryptionBatchReceiver<D: Domain, M>(channel::Receiver<OutputItem<D, M>>);
 
-impl<D: Domain, M> DynamicUsage for BatchReceiver<D, M> {
+impl<D: Domain, M> DynamicUsage for DecryptionBatchReceiver<D, M> {
     fn dynamic_usage(&self) -> usize {
         // We count the memory usage of items in the channel on the receiver side.
         let num_items = self.0.len();
@@ -315,7 +323,7 @@ impl<D: Domain, M> DynamicUsage for BatchReceiver<D, M> {
 
 /// A tracker for the batch scanning tasks that are currently running.
 ///
-/// This enables a [`BatchRunner`] to be optionally configured to track heap memory usage.
+/// This enables a [`DecryptionBatchRunner`] to be optionally configured to track heap memory usage.
 pub(crate) trait Tasks<Item> {
     type Task: Task;
     fn new() -> Self;
@@ -342,7 +350,7 @@ impl<Item: Task> Tasks<Item> for () {
 }
 
 /// A batch of outputs to trial decrypt.
-pub(crate) struct Batch<D: BatchDomain, Output, Dec: Decryptor<D, Output>> {
+pub(crate) struct DecryptionBatch<D: BatchDomain, Output, Dec: Decryptor<D, Output>> {
     tags: Vec<KeyId>,
     ivks: Vec<D::IncomingViewingKey>,
     /// We currently store outputs and repliers as parallel vectors, because
@@ -356,7 +364,7 @@ pub(crate) struct Batch<D: BatchDomain, Output, Dec: Decryptor<D, Output>> {
     repliers: Vec<OutputReplier<D, Dec::Memo>>,
 }
 
-impl<D, Output, Dec> DynamicUsage for Batch<D, Output, Dec>
+impl<D, Output, Dec> DynamicUsage for DecryptionBatch<D, Output, Dec>
 where
     D: BatchDomain + DynamicUsage,
     D::IncomingViewingKey: DynamicUsage,
@@ -387,7 +395,7 @@ where
     }
 }
 
-impl<D, Output, Dec> Batch<D, Output, Dec>
+impl<D, Output, Dec> DecryptionBatch<D, Output, Dec>
 where
     D: BatchDomain,
     Dec: Decryptor<D, Output>,
@@ -409,7 +417,7 @@ where
     }
 }
 
-impl<D, Output, Dec> Task for Batch<D, Output, Dec>
+impl<D, Output, Dec> Task for DecryptionBatch<D, Output, Dec>
 where
     D: BatchDomain + Send + 'static,
     D::IncomingViewingKey: Send,
@@ -437,7 +445,7 @@ where
             decryption_results.into_iter().zip(repliers.into_iter())
         {
             // If `decryption_result` is `None` then we will just drop `replier`,
-            // indicating to the parent `BatchRunner` that this output was not for us.
+            // indicating to the parent `DecryptionBatchRunner` that this output was not for us.
             if let Some(value) = decryption_result {
                 let result = OutputIndex {
                     output_index: replier.output_index,
@@ -445,7 +453,7 @@ where
                 };
 
                 if replier.value.send(result).is_err() {
-                    tracing::debug!("BatchRunner was dropped before batch finished");
+                    tracing::debug!("DecryptionBatchRunner was dropped before batch finished");
                     break;
                 }
             }
@@ -453,7 +461,7 @@ where
     }
 }
 
-impl<D, Output, Dec> Batch<D, Output, Dec>
+impl<D, Output, Dec> DecryptionBatch<D, Output, Dec>
 where
     D: BatchDomain,
     Output: Clone,
@@ -500,28 +508,28 @@ impl DynamicUsage for ResultKey {
 }
 
 /// Logic to run batches of trial decryptions on the global threadpool.
-pub(crate) struct BatchRunner<D, Output, Dec, T>
+pub(crate) struct DecryptionBatchRunner<D, Output, Dec, T>
 where
     D: BatchDomain,
     Dec: Decryptor<D, Output>,
-    T: Tasks<Batch<D, Output, Dec>>,
+    T: Tasks<DecryptionBatch<D, Output, Dec>>,
 {
     batch_size_threshold: usize,
     // The batch currently being accumulated.
-    acc: Batch<D, Output, Dec>,
+    acc: DecryptionBatch<D, Output, Dec>,
     // The running batches.
     running_tasks: T,
     // Receivers for the results of the running batches.
-    pending_results: HashMap<ResultKey, BatchReceiver<D, Dec::Memo>>,
+    pending_results: HashMap<ResultKey, DecryptionBatchReceiver<D, Dec::Memo>>,
 }
 
-impl<D, Output, Dec, T> DynamicUsage for BatchRunner<D, Output, Dec, T>
+impl<D, Output, Dec, T> DynamicUsage for DecryptionBatchRunner<D, Output, Dec, T>
 where
     D: BatchDomain + DynamicUsage,
     D::IncomingViewingKey: DynamicUsage,
     Output: DynamicUsage,
     Dec: Decryptor<D, Output>,
-    T: Tasks<Batch<D, Output, Dec>> + DynamicUsage,
+    T: Tasks<DecryptionBatch<D, Output, Dec>> + DynamicUsage,
 {
     fn dynamic_usage(&self) -> usize {
         self.acc.dynamic_usage()
@@ -547,11 +555,11 @@ where
     }
 }
 
-impl<D, Output, Dec, T> BatchRunner<D, Output, Dec, T>
+impl<D, Output, Dec, T> DecryptionBatchRunner<D, Output, Dec, T>
 where
     D: BatchDomain,
     Dec: Decryptor<D, Output>,
-    T: Tasks<Batch<D, Output, Dec>>,
+    T: Tasks<DecryptionBatch<D, Output, Dec>>,
 {
     /// Constructs a new batch runner for the given incoming viewing keys.
     pub(crate) fn new(
@@ -561,14 +569,14 @@ where
         let (tags, ivks) = ivks.unzip();
         Self {
             batch_size_threshold,
-            acc: Batch::new(tags, ivks),
+            acc: DecryptionBatch::new(tags, ivks),
             running_tasks: T::new(),
             pending_results: HashMap::default(),
         }
     }
 }
 
-impl<D, Output, Dec, T> BatchRunner<D, Output, Dec, T>
+impl<D, Output, Dec, T> DecryptionBatchRunner<D, Output, Dec, T>
 where
     D: BatchDomain + Send + 'static,
     D::IncomingViewingKey: Clone + Send,
@@ -577,7 +585,7 @@ where
     D::Recipient: Send,
     Output: Clone + Send + 'static,
     Dec: Decryptor<D, Output>,
-    T: Tasks<Batch<D, Output, Dec>>,
+    T: Tasks<DecryptionBatch<D, Output, Dec>>,
 {
     /// Batches the given outputs for trial decryption.
     ///
@@ -598,7 +606,7 @@ where
         let (tx, rx) = channel::unbounded();
         self.acc.add_outputs(domain, outputs, tx);
         self.pending_results
-            .insert(ResultKey(block_tag, txid), BatchReceiver(rx));
+            .insert(ResultKey(block_tag, txid), DecryptionBatchReceiver(rx));
 
         if self.acc.outputs.len() >= self.batch_size_threshold {
             self.flush();
@@ -610,7 +618,7 @@ where
     /// Subsequent calls to `Self::add_outputs` will be accumulated into a new batch.
     pub(crate) fn flush(&mut self) {
         if !self.acc.is_empty() {
-            let mut batch = Batch::new(self.acc.tags.clone(), self.acc.ivks.clone());
+            let mut batch = DecryptionBatch::new(self.acc.tags.clone(), self.acc.ivks.clone());
             mem::swap(&mut batch, &mut self.acc);
             self.running_tasks.run_task(batch);
         }
@@ -630,7 +638,7 @@ where
             .remove(&ResultKey(block_tag, txid))
             // We won't have a pending result if the transaction didn't have outputs of
             // this runner's kind.
-            .map(|BatchReceiver(rx)| {
+            .map(|DecryptionBatchReceiver(rx)| {
                 // This iterator will end once the channel becomes empty and disconnected.
                 // We created one sender per output, and each sender is dropped after the
                 // batch it is in completes (and in the case of successful decryptions,

--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -37,7 +37,7 @@ use crate::{
 use super::{ScanResults, scan};
 
 const MAX_WORKER_POOLSIZE: usize = 2;
-const MAX_BATCH_NULLIFIERS: usize = 2usize.pow(14);
+const MAX_LOAD_NULLIFIERS: usize = 2usize.pow(14);
 
 use zingo_netutils::time::{SCANNER_SHUTDOWN_TIMEOUT, STREAM_MSG_TIMEOUT};
 
@@ -59,7 +59,7 @@ impl ScannerState {
 
 pub(crate) struct Scanner<P> {
     pub(crate) state: ScannerState,
-    batcher: Option<Batcher<P>>,
+    loader: Option<Loader<P>>,
     workers: Vec<ScanWorker<P>>,
     unique_id: usize,
     scan_results_sender: mpsc::UnboundedSender<(ScanRange, Result<ScanResults, ScanError>)>,
@@ -82,7 +82,7 @@ where
 
         Self {
             state: ScannerState::Verification,
-            batcher: None,
+            loader: None,
             workers,
             unique_id: 0,
             scan_results_sender,
@@ -93,48 +93,48 @@ where
     }
 
     pub(crate) fn launch(&mut self, performance_level: PerformanceLevel) {
-        let max_batch_outputs = match performance_level {
+        let max_outputs = match performance_level {
             PerformanceLevel::Low => 2usize.pow(11),
             PerformanceLevel::Medium => 2usize.pow(13),
             PerformanceLevel::High => 2usize.pow(13),
             PerformanceLevel::Maximum => 2usize.pow(15),
         };
 
-        self.spawn_batcher(max_batch_outputs);
-        self.spawn_workers(max_batch_outputs);
+        self.spawn_loader(max_outputs);
+        self.spawn_workers(max_outputs);
     }
 
     pub(crate) fn worker_poolsize(&self) -> usize {
         self.workers.len()
     }
 
-    /// Spawns the batcher.
+    /// Spawns the loader.
     ///
-    /// When the batcher is running it will wait for a scan task.
-    pub(crate) fn spawn_batcher(&mut self, max_batch_outputs: usize) {
-        tracing::debug!("Spawning batcher");
-        let mut batcher = Batcher::new(
+    /// When the loader is running it will wait for a scan task.
+    pub(crate) fn spawn_loader(&mut self, max_load_outputs: usize) {
+        tracing::debug!("Spawning loader");
+        let mut loader = Loader::new(
             self.consensus_parameters.clone(),
             self.fetch_request_sender.clone(),
         );
-        batcher.run(max_batch_outputs);
-        self.batcher = Some(batcher);
+        loader.run(max_load_outputs);
+        self.loader = Some(loader);
     }
 
-    fn check_batcher_error(&mut self) -> Result<(), ServerError> {
-        let batcher = self.batcher.take();
-        if let Some(mut batcher) = batcher {
-            batcher.check_error()?;
-            self.batcher = Some(batcher);
+    fn check_loader_error(&mut self) -> Result<(), ServerError> {
+        let loader = self.loader.take();
+        if let Some(mut loader) = loader {
+            loader.check_error()?;
+            self.loader = Some(loader);
         }
 
         Ok(())
     }
 
-    async fn shutdown_batcher(&mut self) -> Result<(), ServerError> {
-        let batcher = self.batcher.take();
-        if let Some(mut batcher) = batcher {
-            batcher.shutdown().await
+    async fn shutdown_loader(&mut self) -> Result<(), ServerError> {
+        let loader = self.loader.take();
+        if let Some(mut loader) = loader {
+            loader.shutdown().await
         } else {
             Ok(())
         }
@@ -143,7 +143,7 @@ where
     /// Spawns a worker.
     ///
     /// When the worker is running it will wait for a scan task.
-    pub(crate) fn spawn_worker(&mut self, max_batch_outputs: usize) {
+    pub(crate) fn spawn_worker(&mut self, max_outputs: usize) {
         tracing::debug!("Spawning worker {}", self.unique_id);
         let mut worker = ScanWorker::new(
             self.unique_id,
@@ -152,7 +152,7 @@ where
             self.fetch_request_sender.clone(),
             self.ufvks.clone(),
         );
-        worker.run(max_batch_outputs);
+        worker.run(max_outputs);
         self.workers.push(worker);
         self.unique_id += 1;
     }
@@ -160,9 +160,9 @@ where
     /// Spawns the initial pool of workers.
     ///
     /// Poolsize is set by [`self::MAX_WORKER_POOLSIZE`].
-    pub(crate) fn spawn_workers(&mut self, max_batch_outputs: usize) {
+    pub(crate) fn spawn_workers(&mut self, max_outputs: usize) {
         for _ in 0..MAX_WORKER_POOLSIZE {
-            self.spawn_worker(max_batch_outputs);
+            self.spawn_worker(max_outputs);
         }
     }
 
@@ -190,12 +190,12 @@ where
 
     /// Updates the scanner.
     ///
-    /// Creates a new scan task and sends to batcher if it's idle.
-    /// The batcher will stream compact blocks into the scan task, splitting the scan task when the maximum number of
-    /// outputs is reached. When a scan task is ready it is stored in the batcher ready to be taken by an idle scan
+    /// Creates a new scan task and sends to loader if it's idle.
+    /// The loader will stream compact blocks into the scan task, splitting the scan task when the maximum number of
+    /// outputs is reached. When a scan task is ready it is stored in the loader ready to be taken by an idle scan
     /// worker for scanning.
     /// When verification is still in progress, only scan tasks with `Verify` scan priority are created.
-    /// When all ranges are scanned, the batcher, idle workers and mempool are shutdown.
+    /// When all ranges are scanned, the loader, idle workers and mempool are shutdown.
     pub(crate) async fn update<W>(
         &mut self,
         wallet: &mut W,
@@ -205,14 +205,14 @@ where
     where
         W: SyncWallet + SyncBlocks + SyncNullifiers,
     {
-        self.check_batcher_error()?;
+        self.check_loader_error()?;
 
         match self.state {
             ScannerState::Verification => {
-                self.batcher
+                self.loader
                     .as_mut()
-                    .expect("batcher should be running")
-                    .update_batch_store();
+                    .expect("loader should be running")
+                    .update_load_store();
                 self.update_workers();
 
                 let sync_state = wallet.get_sync_state().map_err(SyncError::WalletError)?;
@@ -235,16 +235,16 @@ where
                 }
 
                 // scan ranges with `Verify` priority
-                self.update_batcher(wallet, nullifier_map_limit_exceeded)
+                self.update_loader(wallet, nullifier_map_limit_exceeded)
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Scan => {
-                self.batcher
+                self.loader
                     .as_mut()
-                    .expect("batcher should be running")
-                    .update_batch_store();
+                    .expect("loader should be running")
+                    .update_load_store();
                 self.update_workers();
-                self.update_batcher(wallet, nullifier_map_limit_exceeded)
+                self.update_loader(wallet, nullifier_map_limit_exceeded)
                     .map_err(SyncError::WalletError)?;
             }
             ScannerState::Shutdown => {
@@ -252,7 +252,7 @@ where
                 while let Some(worker) = self.idle_worker() {
                     self.shutdown_worker(worker.id).await;
                 }
-                self.shutdown_batcher().await?;
+                self.shutdown_loader().await?;
             }
         }
 
@@ -260,23 +260,20 @@ where
     }
 
     fn update_workers(&mut self) {
-        let batcher = self.batcher.as_ref().expect("batcher should be running");
-        if batcher.batch.is_some()
+        let loader = self.loader.as_ref().expect("loader should be running");
+        if loader.load.is_some()
             && let Some(worker) = self.idle_worker()
         {
-            let batch = batcher
-                .batch
+            let load = loader
+                .load
                 .clone()
-                .expect("batch should exist in this closure");
-            worker.add_scan_task(batch);
-            self.batcher
-                .as_mut()
-                .expect("batcher should be running")
-                .batch = None;
+                .expect("load should exist in this closure");
+            worker.add_scan_task(load);
+            self.loader.as_mut().expect("loader should be running").load = None;
         }
     }
 
-    fn update_batcher<W>(
+    fn update_loader<W>(
         &mut self,
         wallet: &mut W,
         nullifier_map_limit_exceeded: bool,
@@ -284,14 +281,14 @@ where
     where
         W: SyncWallet + SyncBlocks + SyncNullifiers,
     {
-        let batcher = self.batcher.as_ref().expect("batcher should be running");
-        if !batcher.is_batching() {
+        let loader = self.loader.as_ref().expect("loader should be running");
+        if !loader.is_loading() {
             if let Some(scan_task) = sync::state::create_scan_task(
                 &self.consensus_parameters,
                 wallet,
                 nullifier_map_limit_exceeded,
             )? {
-                batcher.add_scan_task(scan_task);
+                loader.add_scan_task(scan_task);
             } else if wallet.get_sync_state()?.scan_complete() {
                 self.state.shutdown();
             }
@@ -301,17 +298,17 @@ where
     }
 }
 
-struct Batcher<P> {
+struct Loader<P> {
     handle: Option<JoinHandle<Result<(), ServerError>>>,
-    is_batching: Arc<AtomicBool>,
-    batch: Option<ScanTask>,
+    is_loading: Arc<AtomicBool>,
+    load: Option<ScanTask>,
     consensus_parameters: P,
     scan_task_sender: Option<mpsc::Sender<ScanTask>>,
-    batch_receiver: Option<mpsc::Receiver<ScanTask>>,
+    load_receiver: Option<mpsc::Receiver<ScanTask>>,
     fetch_request_sender: mpsc::UnboundedSender<FetchRequest>,
 }
 
-impl<P> Batcher<P>
+impl<P> Loader<P>
 where
     P: consensus::Parameters + Sync + Send + 'static,
 {
@@ -321,24 +318,25 @@ where
     ) -> Self {
         Self {
             handle: None,
-            is_batching: Arc::new(AtomicBool::new(false)),
-            batch: None,
+            is_loading: Arc::new(AtomicBool::new(false)),
+            load: None,
             consensus_parameters,
             scan_task_sender: None,
-            batch_receiver: None,
+            load_receiver: None,
             fetch_request_sender,
         }
     }
 
-    /// Runs the batcher in a new tokio task.
+    /// Runs the loader in a new tokio task.
     ///
-    /// Waits for a scan task and then fetches compact blocks to form fixed output batches. The scan task is split if
-    /// needed and the compact blocks are added to each scan task and sent to the scan workers for scanning.
-    fn run(&mut self, max_batch_outputs: usize) {
+    /// Waits for a scan task and then fetches compact blocks to form loads within a fixed output budget. The scan
+    /// task is split if needed and the compact blocks are added to each scan task and sent to the scan workers for
+    /// scanning.
+    fn run(&mut self, max_load_outputs: usize) {
         let (scan_task_sender, mut scan_task_receiver) = mpsc::channel::<ScanTask>(1);
-        let (batch_sender, batch_receiver) = mpsc::channel::<ScanTask>(1);
+        let (load_sender, load_receiver) = mpsc::channel::<ScanTask>(1);
 
-        let is_batching = self.is_batching.clone();
+        let is_loading = self.is_loading.clone();
         let fetch_request_sender = self.fetch_request_sender.clone();
         let consensus_parameters = self.consensus_parameters.clone();
 
@@ -353,19 +351,19 @@ where
                     scan_task.scan_range.priority() == ScanPriority::ScannedWithoutMapping;
 
                 let mut retry_height = scan_task.scan_range.block_range().start;
-                let mut batch_sapling_output_count = 0;
-                let mut batch_orchard_output_count = 0;
-                let mut batch_ironwood_output_count = 0;
-                let mut batch_sapling_nullifier_count = 0;
-                let mut batch_orchard_nullifier_count = 0;
-                let mut batch_ironwood_nullifier_count = 0;
+                let mut load_sapling_output_count = 0;
+                let mut load_orchard_output_count = 0;
+                let mut load_ironwood_output_count = 0;
+                let mut load_sapling_nullifier_count = 0;
+                let mut load_orchard_nullifier_count = 0;
+                let mut load_ironwood_nullifier_count = 0;
                 let mut current_block_sapling_output_count = 0;
                 let mut current_block_orchard_output_count = 0;
                 let mut current_block_ironwood_output_count = 0;
                 let mut current_block_sapling_nullifier_count = 0;
                 let mut current_block_orchard_nullifier_count = 0;
                 let mut current_block_ironwood_nullifier_count = 0;
-                let mut first_batch = true;
+                let mut awaiting_first_block = true;
 
                 let mut block_stream = if fetch_nullifiers_only {
                     client::get_nullifier_range(
@@ -446,15 +444,15 @@ where
                         current_block_sapling_nullifier_count =
                             block::shielded_input_count(&compact_block, ShieldedPool::Sapling)
                                 as usize;
-                        batch_sapling_nullifier_count += current_block_sapling_nullifier_count;
+                        load_sapling_nullifier_count += current_block_sapling_nullifier_count;
                         current_block_orchard_nullifier_count =
                             block::shielded_input_count(&compact_block, ShieldedPool::Orchard)
                                 as usize;
-                        batch_orchard_nullifier_count += current_block_orchard_nullifier_count;
+                        load_orchard_nullifier_count += current_block_orchard_nullifier_count;
                         current_block_ironwood_nullifier_count =
                             block::shielded_input_count(&compact_block, ShieldedPool::Ironwood)
                                 as usize;
-                        batch_ironwood_nullifier_count += current_block_ironwood_nullifier_count;
+                        load_ironwood_nullifier_count += current_block_ironwood_nullifier_count;
                     } else {
                         if let Some(block) = previous_task_last_block.as_ref()
                             && scan_task.start_seam_block.is_none()
@@ -468,7 +466,7 @@ where
                         {
                             scan_task.end_seam_block = previous_task_first_block.clone();
                         }
-                        if first_batch {
+                        if awaiting_first_block {
                             previous_task_first_block = Some(
                                 WalletBlock::from_compact_block(
                                     &consensus_parameters,
@@ -477,7 +475,7 @@ where
                                 )
                                 .await?,
                             );
-                            first_batch = false;
+                            awaiting_first_block = false;
                         }
                         if block::get_compact_height(&compact_block)
                             == scan_task.scan_range.block_range().end - 1
@@ -495,29 +493,29 @@ where
                         current_block_sapling_output_count =
                             block::shielded_output_count(&compact_block, ShieldedPool::Sapling)
                                 as usize;
-                        batch_sapling_output_count += current_block_sapling_output_count;
+                        load_sapling_output_count += current_block_sapling_output_count;
                         current_block_orchard_output_count =
                             block::shielded_output_count(&compact_block, ShieldedPool::Orchard)
                                 as usize;
-                        batch_orchard_output_count += current_block_orchard_output_count;
+                        load_orchard_output_count += current_block_orchard_output_count;
                         current_block_ironwood_output_count =
                             block::shielded_output_count(&compact_block, ShieldedPool::Ironwood)
                                 as usize;
-                        batch_ironwood_output_count += current_block_ironwood_output_count;
+                        load_ironwood_output_count += current_block_ironwood_output_count;
                     }
 
-                    if (batch_sapling_output_count
-                        + batch_orchard_output_count
-                        + batch_ironwood_output_count
-                        > max_batch_outputs
-                        || batch_sapling_nullifier_count
-                            + batch_orchard_nullifier_count
-                            + batch_ironwood_nullifier_count
-                            > MAX_BATCH_NULLIFIERS)
+                    if (load_sapling_output_count
+                        + load_orchard_output_count
+                        + load_ironwood_output_count
+                        > max_load_outputs
+                        || load_sapling_nullifier_count
+                            + load_orchard_nullifier_count
+                            + load_ironwood_nullifier_count
+                            > MAX_LOAD_NULLIFIERS)
                         && scan_task.scan_range.block_range().start
                             != block::get_compact_height(&compact_block)
                     {
-                        let (full_batch, new_batch) = scan_task
+                        let (full_load, new_load) = scan_task
                             .clone()
                             .split(
                                 &consensus_parameters,
@@ -526,58 +524,58 @@ where
                             )
                             .await?;
 
-                        let _ignore_error = batch_sender.send(full_batch).await;
+                        let _ignore_error = load_sender.send(full_load).await;
 
-                        scan_task = new_batch;
-                        batch_sapling_output_count = current_block_sapling_output_count;
-                        batch_orchard_output_count = current_block_orchard_output_count;
-                        batch_ironwood_output_count = current_block_ironwood_output_count;
-                        batch_sapling_nullifier_count = current_block_sapling_nullifier_count;
-                        batch_orchard_nullifier_count = current_block_orchard_nullifier_count;
-                        batch_ironwood_nullifier_count = current_block_ironwood_nullifier_count;
+                        scan_task = new_load;
+                        load_sapling_output_count = current_block_sapling_output_count;
+                        load_orchard_output_count = current_block_orchard_output_count;
+                        load_ironwood_output_count = current_block_ironwood_output_count;
+                        load_sapling_nullifier_count = current_block_sapling_nullifier_count;
+                        load_orchard_nullifier_count = current_block_orchard_nullifier_count;
+                        load_ironwood_nullifier_count = current_block_ironwood_nullifier_count;
                     }
 
                     retry_height = block::get_compact_height(&compact_block) + 1;
                     scan_task.compact_blocks.push(compact_block);
                 }
 
-                let _ignore_error = batch_sender.send(scan_task).await;
+                let _ignore_error = load_sender.send(scan_task).await;
 
-                is_batching.store(false, atomic::Ordering::Release);
+                is_loading.store(false, atomic::Ordering::Release);
             }
 
-            is_batching.store(false, atomic::Ordering::Release);
+            is_loading.store(false, atomic::Ordering::Release);
 
             Ok(())
         });
 
         self.handle = Some(handle);
         self.scan_task_sender = Some(scan_task_sender);
-        self.batch_receiver = Some(batch_receiver);
+        self.load_receiver = Some(load_receiver);
     }
 
-    fn is_batching(&self) -> bool {
-        self.is_batching.load(atomic::Ordering::Acquire)
+    fn is_loading(&self) -> bool {
+        self.is_loading.load(atomic::Ordering::Acquire)
     }
 
     fn add_scan_task(&self, scan_task: ScanTask) {
-        tracing::trace!("Adding scan task to batcher:\n{:#?}", &scan_task);
+        tracing::trace!("Adding scan task to loader:\n{:#?}", &scan_task);
         self.scan_task_sender
             .clone()
-            .expect("batcher should be running")
+            .expect("loader should be running")
             .try_send(scan_task)
-            .expect("batcher should never be sent multiple tasks at one time");
-        self.is_batching.store(true, atomic::Ordering::Release);
+            .expect("loader should never be sent multiple tasks at one time");
+        self.is_loading.store(true, atomic::Ordering::Release);
     }
 
-    fn update_batch_store(&mut self) {
-        let batch_receiver = self
-            .batch_receiver
+    fn update_load_store(&mut self) {
+        let load_receiver = self
+            .load_receiver
             .as_mut()
-            .expect("batcher should be running");
-        if self.batch.is_none() && !batch_receiver.is_empty() {
-            self.batch = Some(
-                batch_receiver
+            .expect("loader should be running");
+        if self.load.is_none() && !load_receiver.is_empty() {
+            self.load = Some(
+                load_receiver
                     .try_recv()
                     .expect("channel should be non-empty!"),
             );
@@ -596,29 +594,29 @@ where
         Ok(())
     }
 
-    /// Shuts down batcher by dropping the sender to the batcher task and awaiting the handle.
+    /// Shuts down loader by dropping the sender to the loader task and awaiting the handle.
     ///
     /// This should always be called in the context of the scanner as it must be also be taken from the Scanner struct.
     async fn shutdown(&mut self) -> Result<(), ServerError> {
-        tracing::debug!("Shutting down batcher");
+        tracing::debug!("Shutting down loader");
         if let Some(sender) = self.scan_task_sender.take() {
             drop(sender);
         }
-        if let Some(receiver) = self.batch_receiver.take() {
+        if let Some(receiver) = self.load_receiver.take() {
             drop(receiver);
         }
 
         let mut handle = self
             .handle
             .take()
-            .expect("batcher should always have a handle to take!");
+            .expect("loader should always have a handle to take!");
 
         match tokio::time::timeout(SCANNER_SHUTDOWN_TIMEOUT, &mut handle).await {
             Ok(join_res) => join_res.expect("task panicked")?,
             Err(_) => {
                 handle.abort();
                 let _ = handle.await;
-                return Err(tonic::Status::deadline_exceeded("batcher shutdown timeout").into());
+                return Err(tonic::Status::deadline_exceeded("loader shutdown timeout").into());
             }
         }
 
@@ -663,7 +661,7 @@ where
     /// Runs the worker in a new tokio task.
     ///
     /// Waits for a scan task and then calls [`crate::scan::scan`] on the given range.
-    fn run(&mut self, max_batch_outputs: usize) {
+    fn run(&mut self, max_outputs: usize) {
         let (scan_task_sender, mut scan_task_receiver) = mpsc::channel::<ScanTask>(1);
 
         let is_scanning = self.is_scanning.clone();
@@ -680,7 +678,7 @@ where
                     &consensus_parameters,
                     &ufvks,
                     scan_task,
-                    max_batch_outputs,
+                    max_outputs,
                 )
                 .await;
                 let _ignore_error = scan_results_sender.send((scan_range, scan_results));

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1259,7 +1259,7 @@ where
             } = results;
 
             if scan_range.priority() == ScanPriority::ScannedWithoutMapping {
-                // add missing block bounds in the case that nullifier batch limit was reached and the fetch nullifier
+                // add missing block bounds in the case that the load's nullifier budget was reached and the fetch nullifier
                 // scan range was split.
                 let full_refetching_nullifiers_range = wallet
                     .get_sync_state()


### PR DESCRIPTION
Pepper-sync used one word for two different units. This change gives each its own name, stacked on #2599.

The batcher's unit is a maximal contiguous sequence of whole blocks whose combined output count stays within a budget — the block that would cross the line starts the next unit. It is now a **load**, built by the `Loader`, bounded by `max_load_outputs` and `MAX_LOAD_NULLIFIERS`. The trial-decryption unit is a flattened, transaction-aligned buffer of one pool's outputs, indifferent to block boundaries. It keeps **batch**, qualified at the types as `DecryptionBatch`, `DecryptionBatchRunner`, and friends, staying continuous with the upstream `zcash_note_encryption::batch` API it wraps; bare "batch" inside the runners module still reads unambiguously as the decryption sense, so module-local prose and locals keep it.

The worker-side budget takes the neutral name `max_outputs`, because `scan` derives both the decryption batch size and the located-tree build size from it; only the value handed to the runners is `decryption_batch_size`, retiring the inverted `trial_decrypt_task_size` name. The crate docs and mermaid diagrams follow the split, and the loading step's description now states the true cut rule — a load is cut at the last whole block that keeps the output budget unexceeded — replacing the previous "a fixed number of outputs" wording, which described the mechanism incorrectly.

The rename is behavior-preserving and entirely `pub(crate)`-internal: no public API surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)