### PR TITLE
feat(netutils)!: GrpcIndexer chooses its transport at construction

### DIFF
--- a/zingo-netutils/CHANGELOG.md
+++ b/zingo-netutils/CHANGELOG.md
@@ -9,9 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GrpcIndexer::new_via_socks5` (behind `socks5-transmit`): constructs the
+  indexer over a channel dialed through the local SOCKS5 proxy — the mixnet
+  tunnel — so every `Indexer`/`TransparentIndexer` RPC on that instance
+  travels the mixnet. Keeps the 5.0.1 promise that nym-enabled clients
+  "will also be held by `GrpcIndexer`", with the transport chosen at
+  construction instead of per call.
+
 ### Changed
 
+- `GrpcIndexer`'s private channel field renamed `clear_net_client` →
+  `client`: construction now decides the transport, so the field may hold
+  a tunnel-dialed channel.
+
 ### Removed
+
+- `GrpcIndexer::get_clear_net_client`: it had no callers, and its name
+  promises a clearnet channel the type no longer guarantees.
 
 ### Deprecated
 

--- a/zingo-netutils/CHANGELOG.md
+++ b/zingo-netutils/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GrpcIndexer`'s private channel field renamed `clear_net_client` →
   `client`: construction now decides the transport, so the field may hold
   a tunnel-dialed channel.
+- **Breaking:** the wholesale `pub use lightwallet_protocol` re-export is
+  replaced by a curated facade module of the same path, carrying the
+  protocol's message types and the generated server trait pair (for mock
+  indexers) but not the generated client stub. Consumers hold a
+  `GrpcIndexer` and speak through the `Indexer` trait; existing message-type
+  import paths are unchanged.
 
 ### Removed
 

--- a/zingo-netutils/src/globally_public.rs
+++ b/zingo-netutils/src/globally_public.rs
@@ -96,11 +96,7 @@ impl TransparentIndexer for GrpcIndexer {
     ) -> Result<tonic::Streaming<RawTransaction>, tonic::Status> {
         let mut request = Request::new(filter);
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_taddress_txids(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_taddress_txids(request).await?.into_inner())
     }
 
     async fn get_taddress_transactions(
@@ -111,7 +107,7 @@ impl TransparentIndexer for GrpcIndexer {
         let mut request = Request::new(filter);
         request.set_timeout(timeout);
         Ok(self
-            .clear_net_client
+            .client
             .get_taddress_transactions(request)
             .await?
             .into_inner())
@@ -125,7 +121,7 @@ impl TransparentIndexer for GrpcIndexer {
         let mut request = Request::new(addresses);
         request.set_timeout(timeout);
         Ok(self
-            .clear_net_client
+            .client
             .get_taddress_balance(request)
             .await?
             .into_inner())
@@ -137,7 +133,7 @@ impl TransparentIndexer for GrpcIndexer {
     ) -> Result<Balance, tonic::Status> {
         let stream = tokio_stream::iter(addresses);
         Ok(self
-            .clear_net_client
+            .client
             .get_taddress_balance_stream(stream)
             .await?
             .into_inner())
@@ -150,11 +146,7 @@ impl TransparentIndexer for GrpcIndexer {
     ) -> Result<GetAddressUtxosReplyList, tonic::Status> {
         let mut request = Request::new(arg);
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_address_utxos(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_address_utxos(request).await?.into_inner())
     }
 
     async fn get_address_utxos_stream(
@@ -165,7 +157,7 @@ impl TransparentIndexer for GrpcIndexer {
         let mut request = Request::new(arg);
         request.set_timeout(timeout);
         Ok(self
-            .clear_net_client
+            .client
             .get_address_utxos_stream(request)
             .await?
             .into_inner())

--- a/zingo-netutils/src/globally_public.rs
+++ b/zingo-netutils/src/globally_public.rs
@@ -8,7 +8,7 @@
 
 use std::{future::Future, time::Duration};
 
-use lightwallet_protocol::{
+use ::lightwallet_protocol::{
     Address, AddressList, Balance, GetAddressUtxosArg, GetAddressUtxosReply,
     GetAddressUtxosReplyList, RawTransaction, TransparentAddressBlockFilter,
 };

--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -108,6 +108,27 @@ fn client_tls_config() -> ClientTlsConfig {
     ClientTlsConfig::new().with_webpki_roots()
 }
 
+pub(crate) fn channel_endpoint(
+    uri: &http::Uri,
+    tls: Option<ClientTlsConfig>,
+) -> Result<Endpoint, tonic::transport::Error> {
+    let endpoint = Endpoint::from_shared(uri.to_string())?.tcp_nodelay(true);
+    match tls {
+        Some(config) => endpoint.tls_config(config),
+        None => Ok(endpoint),
+    }
+}
+
+fn clearnet_endpoint(uri: &http::Uri) -> Result<Endpoint, GetClientError> {
+    let scheme = uri.scheme_str().ok_or(GetClientError::InvalidScheme)?;
+    if scheme != "http" && scheme != "https" {
+        return Err(GetClientError::InvalidScheme);
+    }
+    uri.authority().ok_or(GetClientError::InvalidAuthority)?;
+    let tls = (scheme == "https").then(client_tls_config);
+    Ok(channel_endpoint(uri, tls)?)
+}
+
 /// Trait for communicating with a Zcash chain indexer.
 ///
 /// Implementors provide access to a server speaking the lightwallet gRPC protocol.
@@ -271,80 +292,51 @@ pub trait Indexer {
 }
 
 /// gRPC-backed [`Indexer`] that connects to a Zcash chain indexer (server).
+/// The channel's transport is fixed at construction: [`Self::new`] and
+/// [`Self::new_lazy`] dial clearnet, while `new_via_socks5` dials through
+/// the local mixnet tunnel, so every RPC the indexer performs travels the
+/// transport its constructor chose.
 #[derive(Debug, Clone)]
 pub struct GrpcIndexer {
     uri: http::Uri,
-    clear_net_client: CompactTxStreamerClient<Channel>,
+    client: CompactTxStreamerClient<Channel>,
 }
 
 impl GrpcIndexer {
     pub async fn new(uri: http::Uri) -> Result<Self, GetClientError> {
-        let scheme = uri
-            .scheme_str()
-            .ok_or(GetClientError::InvalidScheme)?
-            .to_string();
-        if scheme != "http" && scheme != "https" {
-            return Err(GetClientError::InvalidScheme);
-        }
-        let _authority = uri
-            .authority()
-            .ok_or(GetClientError::InvalidAuthority)?
-            .clone();
+        let channel = clearnet_endpoint(&uri)?.connect().await?;
+        let client = CompactTxStreamerClient::new(channel);
 
-        let endpoint = Endpoint::from_shared(uri.to_string())?.tcp_nodelay(true);
-        let endpoint = if scheme == "https" {
-            endpoint.tls_config(client_tls_config())?
-        } else {
-            endpoint
-        };
-        let channel = endpoint.connect().await?;
-        let clear_net_client = CompactTxStreamerClient::new(channel);
+        Ok(Self { uri, client })
+    }
 
-        Ok(Self {
-            uri,
-            clear_net_client,
-        })
+    /// As [`Self::new`], but the channel dials through the local SOCKS5
+    /// proxy at `socks5_addr` — the mixnet tunnel — so every RPC this
+    /// indexer performs travels over the mixnet. https-only, like the
+    /// transmit path; `timeout` bounds tunnel and TLS establishment.
+    #[cfg(feature = "socks5-transmit")]
+    pub async fn new_via_socks5(
+        uri: http::Uri,
+        socks5_addr: &str,
+        timeout: Duration,
+    ) -> Result<Self, Socks5TransmitError> {
+        let client = socks5_transmit::connect_via_socks5(socks5_addr, &uri, timeout).await?;
+        Ok(Self { uri, client })
     }
 
     /// As [`Self::new`], but the underlying channel connects on first use
     /// instead of eagerly. Useful when the indexer may not be reachable at
     /// construction time, including offline tests that never issue an RPC.
     pub fn new_lazy(uri: http::Uri) -> Result<Self, GetClientError> {
-        let scheme = uri
-            .scheme_str()
-            .ok_or(GetClientError::InvalidScheme)?
-            .to_string();
-        if scheme != "http" && scheme != "https" {
-            return Err(GetClientError::InvalidScheme);
-        }
-        let _authority = uri
-            .authority()
-            .ok_or(GetClientError::InvalidAuthority)?
-            .clone();
+        let channel = clearnet_endpoint(&uri)?.connect_lazy();
+        let client = CompactTxStreamerClient::new(channel);
 
-        let endpoint = Endpoint::from_shared(uri.to_string())?.tcp_nodelay(true);
-        let endpoint = if scheme == "https" {
-            endpoint.tls_config(client_tls_config())?
-        } else {
-            endpoint
-        };
-        let channel = endpoint.connect_lazy();
-        let clear_net_client = CompactTxStreamerClient::new(channel);
-
-        Ok(Self {
-            uri,
-            clear_net_client,
-        })
+        Ok(Self { uri, client })
     }
 
     /// Returns URI the gRPC client(s) are connected to.
     pub fn uri(&self) -> &http::Uri {
         &self.uri
-    }
-
-    /// Returns the "surface net" gRPC client where the IP address is not obfuscated.
-    pub async fn get_clear_net_client(&self) -> CompactTxStreamerClient<Channel> {
-        self.clear_net_client.clone()
     }
 }
 
@@ -435,21 +427,13 @@ impl Indexer for GrpcIndexer {
     async fn get_lightd_info(&mut self, timeout: Duration) -> Result<LightdInfo, tonic::Status> {
         let mut request = Request::new(Empty {});
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_lightd_info(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_lightd_info(request).await?.into_inner())
     }
 
     async fn get_latest_block(&mut self, timeout: Duration) -> Result<BlockId, tonic::Status> {
         let mut request = Request::new(ChainSpec {});
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_latest_block(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_latest_block(request).await?.into_inner())
     }
 
     async fn send_transaction(
@@ -459,11 +443,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<String, tonic::Status> {
         let mut request = Request::new(tx);
         request.set_timeout(timeout);
-        let sendresponse = self
-            .clear_net_client
-            .send_transaction(request)
-            .await?
-            .into_inner();
+        let sendresponse = self.client.send_transaction(request).await?.into_inner();
         // The clearnet path keeps its historical error text: the bare server
         // message, without the code prefix `SendRejection` renders.
         parse_send_response(sendresponse.error_code, sendresponse.error_message)
@@ -477,11 +457,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<TreeState, tonic::Status> {
         let mut request = Request::new(block_id);
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_tree_state(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_tree_state(request).await?.into_inner())
     }
 
     async fn get_block(
@@ -491,7 +467,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<CompactBlock, tonic::Status> {
         let mut request = Request::new(block_id);
         request.set_timeout(timeout);
-        Ok(self.clear_net_client.get_block(request).await?.into_inner())
+        Ok(self.client.get_block(request).await?.into_inner())
     }
 
     #[allow(deprecated)]
@@ -503,7 +479,7 @@ impl Indexer for GrpcIndexer {
         let mut request = Request::new(block_id);
         request.set_timeout(timeout);
         Ok(self
-            .clear_net_client
+            .client
             .get_block_nullifiers(request)
             .await?
             .into_inner())
@@ -516,11 +492,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<tonic::Streaming<CompactBlock>, tonic::Status> {
         let mut request = Request::new(range);
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_block_range(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_block_range(request).await?.into_inner())
     }
 
     #[allow(deprecated)]
@@ -532,7 +504,7 @@ impl Indexer for GrpcIndexer {
         let mut request = Request::new(range);
         request.set_timeout(timeout);
         Ok(self
-            .clear_net_client
+            .client
             .get_block_range_nullifiers(request)
             .await?
             .into_inner())
@@ -545,11 +517,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<RawTransaction, tonic::Status> {
         let mut request = Request::new(filter);
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_transaction(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_transaction(request).await?.into_inner())
     }
 
     async fn get_mempool_tx(
@@ -559,11 +527,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<tonic::Streaming<CompactTx>, tonic::Status> {
         let mut request = Request::new(request);
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_mempool_tx(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_mempool_tx(request).await?.into_inner())
     }
 
     async fn get_mempool_stream(
@@ -572,11 +536,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<tonic::Streaming<RawTransaction>, tonic::Status> {
         let mut request = Request::new(Empty {});
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_mempool_stream(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_mempool_stream(request).await?.into_inner())
     }
 
     async fn get_latest_tree_state(
@@ -586,7 +546,7 @@ impl Indexer for GrpcIndexer {
         let mut request = Request::new(Empty {});
         request.set_timeout(timeout);
         Ok(self
-            .clear_net_client
+            .client
             .get_latest_tree_state(request)
             .await?
             .into_inner())
@@ -599,11 +559,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<tonic::Streaming<SubtreeRoot>, tonic::Status> {
         let mut request = Request::new(arg);
         request.set_timeout(timeout);
-        Ok(self
-            .clear_net_client
-            .get_subtree_roots(request)
-            .await?
-            .into_inner())
+        Ok(self.client.get_subtree_roots(request).await?.into_inner())
     }
 
     #[cfg(feature = "ping-very-insecure")]
@@ -614,7 +570,7 @@ impl Indexer for GrpcIndexer {
     ) -> Result<PingResponse, tonic::Status> {
         let mut request = Request::new(duration);
         request.set_timeout(timeout);
-        Ok(self.clear_net_client.ping(request).await?.into_inner())
+        Ok(self.client.ping(request).await?.into_inner())
     }
 }
 
@@ -934,15 +890,10 @@ mod tests {
         let base = format!("https://127.0.0.1:{}", addr.port());
         let uri = base.parse::<http::Uri>().expect("bad base uri");
 
-        let endpoint = tonic::transport::Endpoint::from_shared(uri.to_string())
-            .expect("endpoint")
-            .tcp_nodelay(true);
+        let endpoint =
+            channel_endpoint(&uri, Some(client_tls_config())).expect("tls endpoint builds");
 
-        let connect_res = endpoint
-            .tls_config(client_tls_config())
-            .expect("tls_config failed")
-            .connect()
-            .await;
+        let connect_res = endpoint.connect().await;
 
         // A gRPC (HTTP/2) client must not succeed against an HTTP/1.1-only TLS server.
         assert!(

--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -11,8 +11,11 @@
 //!
 //! All proto types come from
 //! [`lightwallet-protocol`](https://crates.io/crates/lightwallet-protocol)
-//! and are re-exported via `pub use lightwallet_protocol` so consumers do
-//! not need an additional dependency.
+//! and the message types are re-exported through the curated
+//! [`lightwallet_protocol`] facade module so consumers do not need an
+//! additional dependency. The generated client stub is deliberately not
+//! re-exported: consumers hold a [`GrpcIndexer`] and speak through the
+//! [`Indexer`] trait, so the transport stays chosen at construction.
 //!
 //! # Feature gates
 //!
@@ -30,14 +33,14 @@ use std::time::Duration;
 use tonic::Request;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
-use lightwallet_protocol::{
+use ::lightwallet_protocol::{
     BlockId, BlockRange, ChainSpec, CompactBlock, CompactTx, CompactTxStreamerClient, Empty,
     GetMempoolTxRequest, GetSubtreeRootsArg, LightdInfo, RawTransaction, SubtreeRoot, TreeState,
     TxFilter,
 };
 
 #[cfg(feature = "ping-very-insecure")]
-use lightwallet_protocol::{Duration as ProtoDuration, PingResponse};
+use ::lightwallet_protocol::{Duration as ProtoDuration, PingResponse};
 
 pub mod crypto;
 pub mod error;
@@ -62,8 +65,24 @@ pub const NYM_STATUS_LINE_PREFIX: &str = "NYM_STATUS=";
 // the values owned by tests (`time::test`). See the module's registry.
 pub mod time;
 pub use error::*;
-pub use lightwallet_protocol;
 pub use tonic::{Status, Streaming};
+
+/// The lightwallet gRPC protocol's message types, re-exported so consumers
+/// need no direct `lightwallet-protocol` dependency. Curated, not the whole
+/// crate: the generated client stub stays out, because consumers hold a
+/// [`GrpcIndexer`] whose transport is chosen at construction and speak
+/// through the [`Indexer`] trait. The generated server trait pair stays in
+/// for mock indexers that implement the service.
+pub mod lightwallet_protocol {
+    pub use ::lightwallet_protocol::{
+        Address, AddressList, Balance, BlockId, BlockRange, ChainMetadata, ChainSpec, CompactBlock,
+        CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend, CompactTx, CompactTxIn,
+        CompactTxStreamer, CompactTxStreamerServer, Duration, Empty, GetAddressUtxosArg,
+        GetAddressUtxosReply, GetAddressUtxosReplyList, GetMempoolTxRequest, GetSubtreeRootsArg,
+        LightdInfo, PingResponse, RawTransaction, SendResponse, SubtreeRoot,
+        TransparentAddressBlockFilter, TreeState, TxFilter, TxOut,
+    };
+}
 
 #[cfg(feature = "globally-public-transparent")]
 mod globally_public;

--- a/zingo-netutils/src/socks5_transmit.rs
+++ b/zingo-netutils/src/socks5_transmit.rs
@@ -26,7 +26,7 @@ use std::time::{Duration, Instant};
 use http::Uri;
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpStream;
-use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tonic::transport::{Channel, ClientTlsConfig};
 
 use crate::SendRejection;
 use crate::crypto::ensure_default_crypto_provider;
@@ -318,7 +318,7 @@ pub async fn get_lightd_info_via_socks5(
 /// into an opaque "transport error", so the connector deposits the typed
 /// failure in a slot this function reads back in preference to tonic's
 /// rendering.
-async fn connect_via_socks5(
+pub(crate) async fn connect_via_socks5(
     socks5_addr: &str,
     indexer: &Uri,
     timeout: Duration,
@@ -346,31 +346,25 @@ async fn connect_via_socks5(
     let destination = format!("{host}:{port}");
     let socks5_addr = socks5_addr.to_string();
 
-    let endpoint = Endpoint::from_shared(indexer.to_string())
-        .map_err(|e| Socks5TransmitError::TunnelTransport {
-            destination: destination.clone(),
-            detail: error_chain(&e),
-            source: Some(e),
-        })?
-        .tcp_nodelay(true)
-        // `connect_timeout` bounds the channel establishment — critically
-        // the TLS handshake tonic runs on top of the SOCKS5 tunnel, which
-        // the connector's own per-phase timeouts do not cover. Without this
-        // a witness that completes the tunnel but stalls the handshake
-        // (observed: a lightwalletd on a non-standard port the mixnet exit
-        // mishandles) hangs for minutes instead of failing over. The RPC
-        // itself is deliberately NOT bounded here: tonic's channel timeout
-        // would surface as an opaque status racing the callers' own typed
-        // bound, so each via_socks5 operation wraps its RPC in
-        // `tokio::time::timeout` and classifies the elapse as
-        // [`Socks5TransmitError::TimedOut`] (issue #2564).
-        .connect_timeout(timeout)
-        .tls_config(ClientTlsConfig::new().with_webpki_roots())
-        .map_err(|e| Socks5TransmitError::TunnelTransport {
-            destination: destination.clone(),
-            detail: error_chain(&e),
-            source: Some(e),
-        })?;
+    let endpoint =
+        crate::channel_endpoint(indexer, Some(ClientTlsConfig::new().with_webpki_roots()))
+            .map_err(|e| Socks5TransmitError::TunnelTransport {
+                destination: destination.clone(),
+                detail: error_chain(&e),
+                source: Some(e),
+            })?
+            // `connect_timeout` bounds the channel establishment — critically
+            // the TLS handshake tonic runs on top of the SOCKS5 tunnel, which
+            // the connector's own per-phase timeouts do not cover. Without this
+            // a witness that completes the tunnel but stalls the handshake
+            // (observed: a lightwalletd on a non-standard port the mixnet exit
+            // mishandles) hangs for minutes instead of failing over. The RPC
+            // itself is deliberately NOT bounded here: tonic's channel timeout
+            // would surface as an opaque status racing the callers' own typed
+            // bound, so each via_socks5 operation wraps its RPC in
+            // `tokio::time::timeout` and classifies the elapse as
+            // [`Socks5TransmitError::TimedOut`] (issue #2564).
+            .connect_timeout(timeout);
 
     let phase_error: Arc<Mutex<Option<Socks5TransmitError>>> = Arc::default();
     let connector_phase = phase_error.clone();

--- a/zingo-netutils/src/socks5_transmit.rs
+++ b/zingo-netutils/src/socks5_transmit.rs
@@ -30,7 +30,9 @@ use tonic::transport::{Channel, ClientTlsConfig};
 
 use crate::SendRejection;
 use crate::crypto::ensure_default_crypto_provider;
-use lightwallet_protocol::{CompactTxStreamerClient, Empty, LightdInfo, RawTransaction, TxFilter};
+use ::lightwallet_protocol::{
+    CompactTxStreamerClient, Empty, LightdInfo, RawTransaction, TxFilter,
+};
 
 /// Why a SOCKS5-tunneled operation did not complete, typed by the connection
 /// phase that failed and carrying that phase's complete underlying data

--- a/zingolib/CONTEXT.md
+++ b/zingolib/CONTEXT.md
@@ -112,7 +112,9 @@
 
 **LightClient** — The user-facing entry point. Owns the connection to the Indexer, manages the sync lifecycle, and exposes operations such as send, shield, rescan, and balance.
 
-**Indexer** — Any gRPC server that serves compact blocks and transaction data to the LightClient. Abstracted behind `zingo_netutils::GrpcIndexer`. The implementation this repo targets is **zainod** (Rust, part of the zaino project); public-server deployments such as `zec.rocks:443` speak the same lightwallet gRPC protocol. This repo's test suites run zainod exclusively (the Core stack — see the test-infrastructure glossary).
+**Indexer** — Any gRPC server that serves compact blocks and transaction data to the LightClient. Abstracted behind `zingo_netutils::GrpcIndexer`. The implementation this repo targets is **zainod** (Rust, part of the zaino project); public-server deployments such as `zec.rocks:443` speak the same Lightwallet Protocol. This repo's test suites run zainod exclusively (the Core stack — see the test-infrastructure glossary).
+
+**Lightwallet Protocol** — The one gRPC protocol every Indexer speaks (the wire service named `CompactTxStreamer`, lightwalletd's lineage): compact scan data, chain view, transaction fetch, and Transmission all travel it. The protocol is single; the distinctions above it — Sync Indexer, Broadcast Indexer — are roles assigned by wallet policy, never dialects of the wire. Wallet-side code speaks it through an Indexer abstraction whose transport, clearnet or the mixnet tunnel, is chosen when the connection is constructed. *Avoid*: CompactTxStreamer as a domain term (it names the wire service only); lightwalletd protocol (names the legacy implementation, not the protocol).
 
 **ClientConfig** — Construction-time configuration for `LightClient`: indexer URI (optional), chain type, and wallet directory.
 


### PR DESCRIPTION
Three commits, all in zingo-netutils except one glossary entry.

**`GrpcIndexer` chooses its transport at construction** (408efaac7). New constructor `new_via_socks5(uri, socks5_addr, timeout)`, behind `socks5-transmit`, builds the channel through the existing SOCKS5 dial (`connect_via_socks5`, opened to `pub(crate)`): https-only, webpki TLS over the tunnel, phase-typed `Socks5TransmitError`. Every `Indexer` and `TransparentIndexer` RPC on such an instance travels the mixnet; there is no per-method routing flag. The private field is renamed `clear_net_client` → `client` to match, and `get_clear_net_client` is deleted — it had no callers in this workspace, zingo-mobile, or zingo-pc. The endpoint scaffolding that `new`, `new_lazy`, and the SOCKS5 dial each rebuilt collapses into shared `channel_endpoint` / `clearnet_endpoint` helpers (scheme and authority validation included); the SOCKS5 path keeps its `connect_timeout` and its deliberate no-RPC-bound policy.

**The protocol re-export is curated** (4cedf4e43). The wholesale `pub use lightwallet_protocol` is replaced by a facade module at the same path carrying the message types plus the generated server trait pair (`CompactTxStreamer` / `CompactTxStreamerServer`, which mock indexers implement) — but not the generated client stub, so consumers cannot construct a transport outside the constructors above. Every existing consumer import path is unchanged.

**Glossary** (c1490aa38). `zingolib/CONTEXT.md` gains a **Lightwallet Protocol** entry — the one protocol every Indexer speaks, with Sync Indexer and Broadcast Indexer as policy roles above it — and the Indexer entry now uses the term.

**Verification.** Standalone netutils workspace: rustfmt; `clippy -D warnings` on the default, `socks5-transmit`, and `globally-public-transparent,ping-very-insecure` configurations; 32/32 tests. Main workspace: `cargo check` clean for pepper-sync, zingolib (`nym` and `nym,testutils`), and the libtonode-tests test targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
