### PR TITLE
implement wallet truncation before rescan

### DIFF
--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1588,6 +1588,17 @@ where
         panic!("{target_pool:?} reported a tree size on a chain that never activates it");
     };
     let rescan_from = activation.max_with(birthday);
+    let rescan_targets = wallet
+        .get_wallet_transactions()
+        .map_err(SyncError::WalletError)?
+        .values()
+        .filter(|&transaction| transaction.status().is_confirmed_after_or_at(&rescan_from))
+        .map(|transaction| ScanTarget {
+            block_height: transaction.status().get_height(),
+            txid: transaction.txid(),
+            narrow_scan_area: true,
+        })
+        .collect::<Vec<_>>();
 
     truncate_stores(wallet, rescan_from - 1, false)?;
 
@@ -1637,6 +1648,7 @@ where
         .get_sync_state_mut()
         .map_err(SyncError::WalletError)?;
     state::reopen_scan_ranges_from(sync_state, rescan_from);
+    add_scan_targets(sync_state, &rescan_targets);
     wallet.set_save_flag().map_err(SyncError::WalletError)?;
 
     Ok(SyncError::PoolHistoryReopened(

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool, AtomicU8, AtomicU32};
 use std::time::{Duration, SystemTime};
 
+use shardtree::ShardTree;
 use tokio::sync::{RwLock, mpsc};
 
 use incrementalmerkletree::{Marking, Retention};
@@ -1547,7 +1548,7 @@ where
                 "{pool:?} history recorded a commitment tree of {calculated_size} where the chain \
                  reports {block_metadata_size}."
             );
-            return Err(reopen_pool_history(
+            return Err(truncate_to_pool_activation_height(
                 consensus_parameters,
                 fetch_request_sender.clone(),
                 wallet,
@@ -1561,62 +1562,76 @@ where
     Ok(())
 }
 
-/// Reopens one pool's history for scanning, after its recorded commitment
-/// tree could not account for the chain's.
+/// Truncates the wallet back to the `target_pool` activation height.
 ///
-/// Only that pool is disturbed. Its tree is replaced by the state the chain
-/// itself dictates, and every scanned range above that point is reopened, so
-/// the next session rebuilds the pool's history from evidence rather than
-/// from the record that was found wanting. The other pools keep their trees
-/// and are rescanned harmlessly alongside it, since re-inserting note
-/// commitments the tree already holds merges rather than conflicts.
+/// Wallet blocks, transactions, nullifiers and outpoints are all cleared at or above the target pool's activation
+/// height.
 ///
-/// The rescan begins at the later of the pool's activation and the wallet's
-/// birthday, both derived rather than assumed, so the work is bounded by the
-/// pool's own existence on this chain and by the wallet's own lifetime. At
-/// the birthday the pool's tree is whatever the chain says, fetched as a
-/// frontier; at an activation above the birthday it is empty.
-///
-/// Returns the error that ends the session. The wallet is saved first, so
-/// the reopening survives even if the caller never syncs again.
-async fn reopen_pool_history<W>(
+/// The target pool and any pool that came in a later network upgrade have their shard trees cleared. Any earlier
+/// pool's will truncate back to the earliest checkpoint above the target pool's acitvation height. This means that
+/// some shard tree data above the target pool's activation height may be retained in the wallet. However, in the
+/// case of an older version of the sync engine scanning blocks from a new incompatible pool epoch, all shard tree data
+/// for earlier pool's will be correct. Re-insertion of this shard tree data on rescan will not cause any issues.
+async fn truncate_to_pool_activation_height<W>(
     consensus_parameters: &impl consensus::Parameters,
     fetch_request_sender: mpsc::UnboundedSender<FetchRequest>,
     wallet: &mut W,
-    pool: ShieldedPool,
+    target_pool: ShieldedPool,
 ) -> Result<SyncError<W::Error>, SyncError<W::Error>>
 where
-    W: SyncWallet + SyncShardTrees,
+    W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints + SyncShardTrees,
 {
     let birthday = wallet.get_birthday().map_err(SyncError::WalletError)?;
-    let Some(activation) = PoolActivation::of(consensus_parameters, pool) else {
+    let Some(activation) = PoolActivation::of(consensus_parameters, target_pool) else {
         // A pool the chain never activates cannot have been served, so it
         // cannot be the one that disagreed.
-        panic!("{pool:?} reported a tree size on a chain that never activates it");
+        panic!("{target_pool:?} reported a tree size on a chain that never activates it");
     };
     let rescan_from = activation.max_with(birthday);
 
-    wallet.clear_pool_shard_tree(pool)?;
+    truncate_stores(wallet, rescan_from - 1, false)?;
+
     let frontiers = client::get_frontiers(fetch_request_sender, birthday).await?;
-    let shard_trees = wallet
-        .get_shard_trees_mut()
-        .map_err(SyncError::WalletError)?;
     let retention = Retention::Checkpoint {
         id: birthday,
         marking: Marking::None,
     };
-    match pool {
-        ShieldedPool::Sapling => shard_trees
-            .sapling
-            .insert_frontier(frontiers.final_sapling_tree().clone(), retention),
-        ShieldedPool::Orchard => shard_trees
-            .orchard
-            .insert_frontier(frontiers.final_orchard_tree().clone(), retention),
-        ShieldedPool::Ironwood => shard_trees
-            .ironwood
-            .insert_frontier(frontiers.final_ironwood_tree().clone(), retention),
+    let shard_trees = wallet
+        .get_shard_trees_mut()
+        .map_err(SyncError::WalletError)?;
+    for pool in [
+        ShieldedPool::Sapling,
+        ShieldedPool::Orchard,
+        ShieldedPool::Ironwood,
+    ] {
+        if target_pool >= pool {
+            shard_trees.clear_pool(pool);
+            match pool {
+                ShieldedPool::Sapling => shard_trees
+                    .sapling
+                    .insert_frontier(frontiers.final_sapling_tree().clone(), retention),
+                ShieldedPool::Orchard => shard_trees
+                    .orchard
+                    .insert_frontier(frontiers.final_orchard_tree().clone(), retention),
+                ShieldedPool::Ironwood => shard_trees
+                    .ironwood
+                    .insert_frontier(frontiers.final_ironwood_tree().clone(), retention),
+            }
+            .expect("infallible");
+        } else {
+            match pool {
+                ShieldedPool::Sapling => {
+                    truncate_tree_to_next_checkpoint(rescan_from - 1, &mut shard_trees.sapling)?;
+                }
+                ShieldedPool::Orchard => {
+                    truncate_tree_to_next_checkpoint(rescan_from - 1, &mut shard_trees.orchard)?;
+                }
+                ShieldedPool::Ironwood => {
+                    truncate_tree_to_next_checkpoint(rescan_from - 1, &mut shard_trees.ironwood)?;
+                }
+            }
+        }
     }
-    .expect("infallible");
 
     let sync_state = wallet
         .get_sync_state_mut()
@@ -1626,8 +1641,42 @@ where
 
     Ok(SyncError::PoolHistoryReopened(
         rescan_from,
-        PoolType::Shielded(pool),
+        PoolType::Shielded(target_pool),
     ))
+}
+
+/// Truncate the shard tree to the lowest checkpoint equal to or above the `target_height`.
+///
+/// If all checkpoints are below target height, do not truncate. Shard tree data at the target height is
+/// never removed, only data above the target height.
+fn truncate_tree_to_next_checkpoint<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
+    target_height: BlockHeight,
+    tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
+) -> Result<(), shardtree::error::ShardTreeError<S::Error>>
+where
+    S: ShardStore<CheckpointId = BlockHeight>,
+    S::H: incrementalmerkletree::Hashable + Clone + PartialEq,
+    S::CheckpointId: Clone + std::fmt::Debug + Ord,
+{
+    let mut truncation_height = None;
+    tree.store()
+        .for_each_checkpoint((MAX_REORG_ALLOWANCE + 1) as usize, |height, _| {
+            if truncation_height.is_some() {
+                return Ok(());
+            }
+
+            if *height >= target_height {
+                truncation_height = Some(*height);
+            }
+
+            Ok(())
+        })
+        .expect("infallible");
+    if let Some(h) = truncation_height {
+        tree.truncate_to_checkpoint(&h)?;
+    }
+
+    Ok(())
 }
 
 /// Processes mempool transaction.
@@ -1726,11 +1775,11 @@ where
     match truncate::plan_truncation(wallet_state, truncate_height) {
         truncate::TruncationPlan::NoOp => Ok(()),
         truncate::TruncationPlan::ClearAll => {
-            truncate_stores(wallet, consensus::H0)?;
+            truncate_stores(wallet, consensus::H0, true)?;
             wallet.clear_shard_trees()
         }
         truncate::TruncationPlan::Truncate { height } => {
-            truncate_stores(wallet, height)?;
+            truncate_stores(wallet, height, true)?;
             match wallet.truncate_shard_trees(height) {
                 Ok(()) => Ok(()),
                 Err(SyncError::TruncationError(height, pooltype)) => {
@@ -1746,9 +1795,13 @@ where
 
 /// Removes wallet blocks, transactions, nullifiers and outpoints above the
 /// given `truncate_height`.
+///
+/// If `set_truncated_transactions_failed` is set, transactions will not be removed from the wallet but their status
+/// will be updated to `Failed`.
 fn truncate_stores<W>(
     wallet: &mut W,
     truncate_height: BlockHeight,
+    set_truncated_transactions_failed: bool,
 ) -> Result<(), SyncError<W::Error>>
 where
     W: SyncWallet + SyncBlocks + SyncTransactions + SyncNullifiers + SyncOutPoints,
@@ -1757,7 +1810,7 @@ where
         .truncate_wallet_blocks(truncate_height)
         .map_err(SyncError::WalletError)?;
     wallet
-        .truncate_wallet_transactions(truncate_height)
+        .truncate_wallet_transactions(truncate_height, set_truncated_transactions_failed)
         .map_err(SyncError::WalletError)?;
     wallet
         .truncate_nullifiers(truncate_height)

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -1,12 +1,14 @@
 //! Entrypoint for sync engine
 
 use std::collections::{BTreeMap, HashMap};
+use std::convert::Infallible;
 use std::ops::Range;
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool, AtomicU8, AtomicU32};
 use std::time::{Duration, SystemTime};
 
 use shardtree::ShardTree;
+use shardtree::store::memory::MemoryShardStore;
 use tokio::sync::{RwLock, mpsc};
 
 use incrementalmerkletree::{Marking, Retention};
@@ -32,6 +34,7 @@ use crate::keys::transparent::TransparentAddressId;
 use crate::scan::ScanResults;
 use crate::scan::task::{Scanner, ScannerState};
 use crate::scan::transactions::scan_transaction;
+use crate::shardtree_ext::{RollbackOutcome, ShardTreeExt};
 use crate::sync::state::truncate_scan_ranges;
 use crate::wallet::traits::{
     SyncBlocks, SyncNullifiers, SyncOutPoints, SyncShardTrees, SyncTransactions, SyncWallet,
@@ -1661,14 +1664,12 @@ where
 ///
 /// If all checkpoints are below target height, do not truncate. Shard tree data at the target height is
 /// never removed, only data above the target height.
-fn truncate_tree_to_next_checkpoint<S, const DEPTH: u8, const SHARD_HEIGHT: u8>(
+fn truncate_tree_to_next_checkpoint<H, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     target_height: BlockHeight,
-    tree: &mut ShardTree<S, DEPTH, SHARD_HEIGHT>,
-) -> Result<(), shardtree::error::ShardTreeError<S::Error>>
+    tree: &mut ShardTree<MemoryShardStore<H, BlockHeight>, DEPTH, SHARD_HEIGHT>,
+) -> Result<(), shardtree::error::ShardTreeError<Infallible>>
 where
-    S: ShardStore<CheckpointId = BlockHeight>,
-    S::H: incrementalmerkletree::Hashable + Clone + PartialEq,
-    S::CheckpointId: Clone + std::fmt::Debug + Ord,
+    H: incrementalmerkletree::Hashable + Clone + PartialEq,
 {
     let mut truncation_height = None;
     tree.store()
@@ -1685,7 +1686,10 @@ where
         })
         .expect("infallible");
     if let Some(h) = truncation_height {
-        tree.truncate_to_checkpoint(&h)?;
+        match tree.rollback_to_checkpoint(h)? {
+            RollbackOutcome::RolledBack => (),
+            RollbackOutcome::NoSuchCheckpoint => panic!("checkpoint must exist in this scope"),
+        }
     }
 
     Ok(())

--- a/pepper-sync/src/wallet.rs
+++ b/pepper-sync/src/wallet.rs
@@ -39,7 +39,8 @@ use crate::{
     error::{ServerError, SyncModeError},
     keys::{self, KeyId, transparent::TransparentAddressId},
     scan::compact_blocks::calculate_block_tree_bounds,
-    sync::{ScanPriority, ScanRange},
+    shardtree_ext::{CheckpointAppendOutcome, ShardTreeExt as _},
+    sync::{MAX_REORG_ALLOWANCE, ScanPriority, ScanRange},
     utils::{
         get_compact_block_hash, get_compact_block_height, get_compact_block_prev_hash,
         get_compact_tx_txid,
@@ -1796,9 +1797,24 @@ impl ShardTrees {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            sapling: traits::empty_shard_tree(),
-            orchard: traits::empty_shard_tree(),
-            ironwood: traits::empty_shard_tree(),
+            sapling: empty_shard_tree(),
+            orchard: empty_shard_tree(),
+            ironwood: empty_shard_tree(),
+        }
+    }
+
+    /// Replaces one pool's shard tree with an empty tree, leaving the other
+    /// pools alone.
+    ///
+    /// The empty tree is that pool's correct state at its own activation, so
+    /// this is the rollback a pool needs when its recorded history cannot be
+    /// trusted and no checkpoint survives to roll back to.
+    pub(crate) fn clear_pool(&mut self, pool: ShieldedPool) {
+        tracing::info!("Clearing {pool:?} shard tree.");
+        match pool {
+            ShieldedPool::Sapling => self.sapling = empty_shard_tree(),
+            ShieldedPool::Orchard => self.orchard = empty_shard_tree(),
+            ShieldedPool::Ironwood => self.ironwood = empty_shard_tree(),
         }
     }
 }
@@ -1807,6 +1823,25 @@ impl Default for ShardTrees {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// An empty shard tree with the crate's standard checkpoint retention and
+/// the zero-height checkpoint that every fresh tree must carry.
+pub(crate) fn empty_shard_tree<H, const DEPTH: u8, const SHARD_HEIGHT: u8>()
+-> ShardTree<MemoryShardStore<H, BlockHeight>, DEPTH, SHARD_HEIGHT>
+where
+    H: incrementalmerkletree::Hashable + Clone + PartialEq,
+{
+    let mut tree = ShardTree::new(MemoryShardStore::empty(), MAX_REORG_ALLOWANCE as usize);
+
+    // `NotAboveNewest` is impossible on an empty checkpoint store.
+    assert_eq!(
+        tree.append_checkpoint(BlockHeight::from_u32(0))
+            .expect("should never fail"),
+        CheckpointAppendOutcome::Appended
+    );
+
+    tree
 }
 
 use shardtree::store::ShardStore;

--- a/pepper-sync/src/wallet/traits.rs
+++ b/pepper-sync/src/wallet/traits.rs
@@ -18,12 +18,13 @@ use zip32::AccountId;
 
 use crate::error::{ServerError, SyncError};
 use crate::keys::transparent::TransparentAddressId;
-use crate::shardtree_ext::{CheckpointAppendOutcome, RollbackOutcome, ShardTreeExt};
+use crate::reset_spends;
+use crate::shardtree_ext::{RollbackOutcome, ShardTreeExt};
 use crate::sync::truncate::{PoolTruncation, plan_pool_truncation, tree_facts};
 use crate::sync::{MAX_REORG_ALLOWANCE, ScanRange};
 use crate::wallet::{
     Ironwood, NullifierMap, Orchard, OutputId, Sapling, ShardTrees, SyncState, WalletBlock,
-    WalletTransaction,
+    WalletTransaction, empty_shard_tree,
 };
 use crate::witness::LocatedTreeData;
 use crate::{SyncDomain, client, sync::set_transactions_failed_unchecked};
@@ -152,6 +153,7 @@ pub trait SyncTransactions: SyncWallet {
     fn truncate_wallet_transactions(
         &mut self,
         truncate_height: BlockHeight,
+        set_truncated_transactions_failed: bool,
     ) -> Result<(), Self::Error> {
         let invalid_txids: Vec<TxId> = self
             .get_wallet_transactions()?
@@ -160,7 +162,13 @@ pub trait SyncTransactions: SyncWallet {
             .map(|tx| tx.transaction().txid())
             .collect();
 
-        set_transactions_failed_unchecked(self.get_wallet_transactions_mut()?, invalid_txids);
+        if set_truncated_transactions_failed {
+            set_transactions_failed_unchecked(self.get_wallet_transactions_mut()?, invalid_txids);
+        } else {
+            let wallet_transactions = self.get_wallet_transactions_mut()?;
+            wallet_transactions.retain(|txid, _| !invalid_txids.contains(txid));
+            reset_spends(wallet_transactions, invalid_txids);
+        }
 
         Ok(())
     }
@@ -359,24 +367,6 @@ pub trait SyncShardTrees: SyncWallet {
         Ok(())
     }
 
-    /// Replaces one pool's shard tree with an empty tree, leaving the other
-    /// pools alone.
-    ///
-    /// The empty tree is that pool's correct state at its own activation, so
-    /// this is the rollback a pool needs when its recorded history cannot be
-    /// trusted and no checkpoint survives to roll back to.
-    fn clear_pool_shard_tree(&mut self, pool: ShieldedPool) -> Result<(), SyncError<Self::Error>> {
-        let shard_trees = self.get_shard_trees_mut().map_err(SyncError::WalletError)?;
-        tracing::info!("Clearing {pool:?} shard tree.");
-        match pool {
-            ShieldedPool::Sapling => shard_trees.sapling = empty_shard_tree(),
-            ShieldedPool::Orchard => shard_trees.orchard = empty_shard_tree(),
-            ShieldedPool::Ironwood => shard_trees.ironwood = empty_shard_tree(),
-        }
-
-        Ok(())
-    }
-
     /// Removes all shard tree data above the given `truncate_height`:
     /// each tree rolls back to its checkpoint at that height, stays
     /// untouched because it records nothing above it, or, holding state
@@ -400,25 +390,6 @@ pub trait SyncShardTrees: SyncWallet {
 
         Ok(())
     }
-}
-
-/// An empty shard tree with the crate's standard checkpoint retention and
-/// the zero-height checkpoint that every fresh tree must carry.
-pub(crate) fn empty_shard_tree<H, const DEPTH: u8, const SHARD_HEIGHT: u8>()
--> ShardTree<MemoryShardStore<H, BlockHeight>, DEPTH, SHARD_HEIGHT>
-where
-    H: Hashable + Clone + PartialEq,
-{
-    let mut tree = ShardTree::new(MemoryShardStore::empty(), MAX_REORG_ALLOWANCE as usize);
-
-    // `NotAboveNewest` is impossible on an empty checkpoint store.
-    assert_eq!(
-        tree.append_checkpoint(BlockHeight::from_u32(0))
-            .expect("should never fail"),
-        CheckpointAppendOutcome::Appended
-    );
-
-    tree
 }
 
 /// Truncates one pool's shard tree: reads the tree's facts, decides its


### PR DESCRIPTION
implement wallet data truncation to avoid issues with corrupted data such as wallet blocks with incorrect tree bounds leading to recurring rescan triggers in the cases where the rescan is non-linear.

#2603 implements a soft rescan where most data is kept in the wallet and overwritten by the rescanned ranges. this would be safe in the case that rescan was linear as tree bounds would be updated in order. However, there is an edge case where non-linear sync uses the wallet block with incorrect ironwood tree bounds as the seam block during rescan which would result in a repeated IncoorectTreeSize error leading to further rescans.

It is much safer for the sync state to be as accurate as possible, meaning when ranges are not scanned, the wallet does not hold data for those regions. Therefore, this PR proposes a truncation to the target pool (in this case ironwood) activation height, allowing the rescan to restore the discarded wallet data along with the missed ironwood data.

The only wallet data that cannot be fully truncated is the shard tree. However, this is not an issue as all shard tree data above the ironwood activation height is correct and re-inserting does not cause issues. There is also no risk of re-org complications as we truncate the other trees back to the lowest checkpoint equal to or above the ironwood activation height.

