### PR TITLE
feat: add the curated pepper-sync consumer funnel (zingolib::sync)

### DIFF
--- a/zingolib/src/lib.rs
+++ b/zingolib/src/lib.rs
@@ -10,6 +10,7 @@ pub mod connectivity;
 pub mod data;
 pub mod lightclient;
 pub mod netutils;
+pub mod sync;
 pub mod utils;
 pub mod wallet;
 

--- a/zingolib/src/sync.rs
+++ b/zingolib/src/sync.rs
@@ -1,0 +1,28 @@
+//! The consumer funnel over `pepper-sync` (ADR 0024, decision 7).
+//!
+//! Consumers declare exactly one wallet dependency and reach every
+//! pepper-sync item they legitimately need through these re-exports
+//! instead of holding a second direct pin — the same doctrine as
+//! [`crate::netutils`], applied to the sync engine. The 2026-08-03 seed
+//! audit found the gap this module closes: every governed consumer
+//! imported pepper-sync directly, and two of the items below are the
+//! declared types of this crate's own API —
+//! [`crate::lightclient::LightClient::sync_mode`] returns [`SyncMode`],
+//! and the lightclient error type wraps [`SyncModeError`] — so a
+//! consumer without them cannot name a funneled method's return type or
+//! destructure a funneled error.
+//!
+//! The set is curated, not the whole crate: the sync-mode vocabulary and
+//! its error, the key-id trait consumers use to read scopes, the
+//! transparent key module, the per-pool note types the summaries expose,
+//! the free `sync_status` reader, and the confirmation-status vocabulary
+//! every summary carries. Widening the set is a deliberate API decision,
+//! not a convenience.
+#![forbid(unsafe_code)]
+
+pub use pepper_sync::error::SyncModeError;
+pub use pepper_sync::keys::transparent;
+pub use pepper_sync::sync_status;
+pub use pepper_sync::wallet::{IronwoodNote, KeyIdInterface, OrchardNote, SaplingNote, SyncMode};
+
+pub use zingo_status::confirmation_status::ConfirmationStatus;


### PR DESCRIPTION
The 2026-08-03 audit of the zingo-perspective seed (PR #2611) found that ADR 0024 rule 7's one-dependency promise fails in practice: every governed consumer imports pepper-sync directly for `SyncMode`, `SyncModeError`, `KeyIdInterface`, `keys::transparent`, the per-pool note types, and `sync_status` — and two of those are the declared types of zingolib's own funneled API (`LightClient::sync_mode` returns `SyncMode`; the lightclient error wraps `SyncModeError`), so a consumer holding only the funnel cannot name a funneled method's return type or destructure a funneled error.

This closes the gap the way `netutils.rs` closed it for the transmit stack: a curated, deliberately small re-export set at `zingolib::sync`, plus the confirmation-status vocabulary every summary (and the funnel's own `ValueTransfer.status`) carries. Widening the set remains a deliberate API decision, not a convenience.

Verified: `cargo check --workspace --all-targets`, workspace fmt, and a warning-free `cargo doc` (which pins the intra-doc links to the funneled APIs).

Follow-ups once this lands: one `pub use` line in the zingo-perspective spine passes the set through, after which zingo-cli can drop its `pepper-sync` and `zingo-status` pins and the zingo-mobile repoint unblocks (the mobile-funnel-tenant lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Ruling (2026-08-03):** when the zingo-perspective spine is authored, it takes `ConfirmationStatus` from the perspective crate's own `zingo-status` dependency — perspective's `ValueTransfer.status` exposes the type, so perspective owes the name. The `zingolib::sync` re-export here stands on zingolib's own coherence (`TransactionSummary.status` exposes it) and is unchanged by the ruling.
