### PR TITLE
refactor(perspective): drop the unreachable memo guards in messages_containing

### DIFF
--- a/zingo-perspective/src/ext.rs
+++ b/zingo-perspective/src/ext.rs
@@ -320,26 +320,19 @@ impl LightWalletPerspectiveExt for LightWallet {
         // Filter out VTs where all memos are empty.
         value_transfers.retain(|vt| vt.memos.iter().any(|memo| !memo.is_empty()));
 
-        match filter {
-            Some(s) => {
-                value_transfers.retain(|vt| {
-                    if vt.memos.is_empty() {
-                        return false;
-                    }
-
-                    if vt.recipient_address == Some(s.to_string()) {
-                        true
-                    } else {
-                        for memo in &vt.memos {
-                            if memo.contains(s) {
-                                return true;
-                            }
+        if let Some(s) = filter {
+            value_transfers.retain(|vt| {
+                if vt.recipient_address == Some(s.to_string()) {
+                    true
+                } else {
+                    for memo in &vt.memos {
+                        if memo.contains(s) {
+                            return true;
                         }
-                        false
                     }
-                });
-            }
-            None => value_transfers.retain(|vt| !vt.memos.is_empty()),
+                    false
+                }
+            });
         }
 
         Ok(value_transfers)


### PR DESCRIPTION
The cleanup slice anticipated in the review of #2611: it deletes the two unreachable memo guards in `messages_containing`, carried over verbatim by the extraction.

The method's first `retain` already drops every value transfer whose memos are all empty, so the `None` arm's second `retain` on non-empty memos and the `Some` arm's early return on an empty memo list could never fire. The extraction kept them deliberately, so the golden fixtures could prove the move byte-identical before any cleanup touched the logic. With those goldens standing, this change deletes both guards; the emptied `None` arm turns the `match` into an `if let`.

Verification: `cargo fmt` and `cargo clippy -p zingo-perspective --all-targets --all-features` are clean, and `cargo nextest run -p zingo-perspective --all-features` passes 11/11 — including the golden harness, which pins this method's JSON and Display output bit-for-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
