### PR TITLE
refactor(cli)!: typed command table, single async seam, stdout carries only the result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -565,18 +565,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -787,7 +787,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -860,7 +860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1692,7 +1692,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1931,7 +1931,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2852,7 +2852,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3268,7 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3362,7 +3362,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4123,7 +4123,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/adr/0030-the-cli-crosses-sync-to-async-exactly-once.md
+++ b/docs/adr/0030-the-cli-crosses-sync-to-async-exactly-once.md
@@ -1,0 +1,72 @@
+---
+status: accepted
+date: 2026-08-05
+---
+
+# The CLI crosses sync to async exactly once, dispatching from a static command table
+
+`zingo-cli` accumulated some sixty-four `RT.block_on` call sites because every
+command privately chose where the sync world ended. Any call path that stacked
+two of them panicked with "Cannot start a runtime from within a runtime," and
+review 4852724030 of PR #2592 reached exactly that panic in testing: `network
+on`, already inside `block_on`, called the synchronous `select_servers()`
+wrapper. We decided that command bodies are ordinary `async` functions
+returning typed results, that the sync-to-async crossing happens at exactly
+one seam — `do_user_command` for the string frontends, plus the startup driver
+in `lib.rs` — and that a Clippy `disallowed-methods` rule bans `block_on`
+everywhere else in the crate, so the invariant is enforced rather than
+remembered.
+
+We further decided that the dispatch registry is a `static` slice of
+`CommandSpec` entries — name, help text, short help, a wallet-requirement
+marker, and an async function pointer — replacing the
+`HashMap<&'static str, Box<dyn Command>>` that was rebuilt on every dispatch.
+The map shape was zecwallet-light-cli lineage, not a decision: the commands
+are stateless fieldless structs, nothing outside the crate implements or
+consumes the `Command` trait, `help` had to re-impose an ordering by sorting
+because the map randomized it, and the `servers` command lived outside the
+registry entirely, patched into the help listing by hand. The table gives
+dispatch without allocation, `help` in declaration order, a registry home for
+`servers`, and a spec-resident command name from which usage hints and
+heartbeat labels derive instead of being re-typed at every site. The twin
+standalone/wallet maps and the single-implementor `ShortCircuitedCommand`
+trait dissolve into the marker field.
+
+We further decided that when one command body needs another's behavior, it
+calls that body directly as an async Rust function and never re-enters string
+dispatch, which exists only at the seam. The sole such edge is `quit`, which
+today reaches `save shutdown` through `do_user_command` — the crate's one
+path that stacks two `Command` executions. That path avoids the
+nested-runtime panic only by accident: the outer `exec` happens to hold no
+`block_on` of its own. Under the table, `quit`'s body awaits the save-shutdown
+function by name, so the compiler enforces the dependency and the hazard
+class cannot reappear there.
+
+A further grilling round refined the row type. A `CommandBody` enum —
+`Standalone(fn(&[&str]) -> Result<String, CommandError>)`,
+`Wallet(WalletRunFn)`, `Repl` — replaces the wallet-requirement marker field
+and the `Option` around the run pointer, so a command's capability and its
+body are one typed fact: a standalone body is synchronous and never receives
+the wallet, and the REPL-owned `servers` cannot claim a body, where the
+previous shape let the marker and the pointer contradict each other silently.
+The `wallet!` and `standalone!` table macros mint each command's name exactly
+once, via `stringify!`, from the body function's identifier, so the
+dispatched name and the body cannot diverge; `servers` carries the one
+literal name, having no body function to mint from.
+
+## Considered options
+
+A boxed-future `exec` method on the existing trait (K1) would have removed the
+crash class but kept the fifty unit structs and traded `RT.block_on` ceremony
+for `Box::pin` ceremony at every command. A nesting-detection helper around a
+sync `exec` (K2) would have detected the class at run time instead of
+eliminating it by construction. Both were rejected in favor of the table.
+
+## Consequences
+
+The twenty-five `Ok(RT.block_on(async move { … }))` scaffolds dissolve, and
+everything below the seam (server selection, the nym command body, the
+transmit heartbeat) becomes async-native and composable, which is what the
+`network on` consent flow of ADR 0026 needs. The failure contract for string
+frontends — what a failing command prints, and on which stream — is unblocked
+by this decision but is a separate ruling, recorded when ratified.

--- a/docs/adr/0031-cli-stdout-carries-only-the-result.md
+++ b/docs/adr/0031-cli-stdout-carries-only-the-result.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+date: 2026-08-05
+---
+
+# CLI stdout carries only the result; failures and narration travel on stderr, and a failed one-shot exits nonzero
+
+zingo-cli's string frontends printed everything to stdout — success JSON,
+`Error:` prose, in-band `{"error" => …}` objects at twenty-two construction
+sites, server-probing narration, and the quit/save trailer — and one-shot mode
+returned success unconditionally, so a failed send exited 0 and was
+indistinguishable from a successful one except by parsing prose. We decided
+that stdout carries exactly one thing: the command's result. Every failure
+travels as `Err(CommandError)` to the dispatch seam of ADR 0030, which renders
+`Error: {e}` once, to stderr; one-shot mode exits nonzero on failure (0 for
+success, 1 for any `CommandError`, finer codes deferred until a consumer
+demonstrates the need). All Narration — the Transmit Heartbeat, server
+probing, save and quit notices — goes to stderr, which carries no parse
+contract. The in-band error objects are deleted, their content moved into
+typed `CommandError` variants.
+
+## Considered options
+
+Blessing the status quo would have made the accidental shape the documented
+one and left the machine channel unparseable. A `{"ok"}/{"error"}` JSON
+envelope on stdout would have kept error data in the success channel by
+design and forced an unwrapping layer onto every consumer; it was rejected as
+re-blessing at the boundary exactly what the typed-error work removed inside.
+
+## Consequences
+
+This is a breaking change for any consumer that parses `{"error"}` from
+stdout or asserts exit code 0: the known audit surface is the
+cli-wallet-harness end-to-end work (PR #2453) and ad-hoc scripts. It ships
+with a CHANGELOG entry marked breaking. It also settles, by construction,
+that heartbeat and narration lines are presentation-only: nothing may parse
+stderr.

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Breaking.** A failing command now renders exactly once, as `Error: …` on
+  stderr, and one-shot mode exits nonzero. Both the message and the failure
+  itself previously went to stdout with an exit code of 0, so a failed send was
+  indistinguishable from a successful one except by parsing prose (ADR 0031).
+- **Breaking.** Stdout now carries exactly one thing, the command's result. The
+  in-band `{"error": …}` JSON objects that used to appear inside otherwise
+  successful output are gone, and their content travels as a typed command
+  error on stderr. A consumer that parses `{"error"}` out of stdout must read
+  stderr and the exit code instead (ADR 0031).
+- **Breaking.** An unknown command is now an error rather than a line of help
+  text on stdout, so a mistyped command fails loudly instead of appearing to
+  succeed (ADR 0031).
+- Progress narration moved from stdout to stderr: the transmit heartbeat, the
+  indexer probing notices, the save and sync launch notices, and the trailer
+  that `quit` prints while the wallet saves. Nothing may parse stderr
+  (ADR 0031).
+- Command dispatch now runs from a static command table of async command
+  bodies, and the crate crosses from sync to async at a single audited seam
+  that a Clippy `disallowed-methods` rule enforces. This is an internal change
+  that alters no command's output (ADR 0030).
 
 ### Removed
 

--- a/zingo-cli/clippy.toml
+++ b/zingo-cli/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    { path = "tokio::runtime::Runtime::block_on", reason = "ADR 0030: the CLI crosses sync to async only at audited seams (dispatch, the startup driver, server resolution); a new block_on needs an explicit allow and a seam justification" },
+    { path = "tokio::runtime::Handle::block_on", reason = "ADR 0030: same invariant as Runtime::block_on" },
+]

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1,22 +1,27 @@
 //! Command definitions and dispatch for zingo-cli.
 //!
-//! Each command implements the [`Command`] trait (or [`ShortCircuitedCommand`]
-//! for commands that run without a wallet). All commands are registered in
-//! [`get_commands`] and dispatched by [`do_user_command`].
+//! Every command is one row of [`COMMANDS`], the static spec table: its
+//! name, help texts, wallet requirement, and the async function that runs
+//! it. The sync world crosses into async exactly once, at
+//! [`do_user_command`] (ADR 0030), and a failure leaves a command only as
+//! a [`CommandError`], never as error prose in the result channel
+//! (ADR 0031).
 
 mod error;
+#[cfg(test)]
+mod tests;
 mod utils;
 
-use std::collections::HashMap;
 use std::convert::TryInto;
 use std::num::NonZeroU32;
+use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use indoc::indoc;
 use json::object;
 use pepper_sync::config::PerformanceLevel;
 use pepper_sync::keys::transparent;
-use std::sync::LazyLock;
 use tokio::runtime::Runtime;
 
 use zcash_address::unified::{Container, Encoding, Ufvk};
@@ -28,11 +33,11 @@ use zcash_protocol::value::Zatoshis;
 use pepper_sync::wallet::{IronwoodNote, KeyIdInterface, OrchardNote, SaplingNote, SyncMode};
 use zingo_common_components::protocol::ActivationHeights;
 use zingolib::data::{PollReport, proposal};
-use zingolib::lightclient::LightClient;
 use zingolib::lightclient::migrate::{
     ImmediateMigrationPhase, ImmediateMigrationStatus, PartSendResult, SplitOutcome, SplitPhase,
     SplitStatus, SplitStep,
 };
+use zingolib::lightclient::{LightClient, TransmitProgressHandle};
 use zingolib::utils::conversion::txid_from_hex_encoded_str;
 use zingolib::wallet::keys::WalletAddressRef;
 use zingolib::wallet::keys::unified::{ReceiverSelection, UnifiedKeyStore};
@@ -42,14 +47,6 @@ pub static RT: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new
 
 use zingolib::netutils::time::TRANSMIT_HEARTBEAT_INTERVAL;
 
-/// Awaits `operation`, emitting a heartbeat every
-/// [`TRANSMIT_HEARTBEAT_INTERVAL`]: the latest line from `latest` (the
-/// transmit-progress side channel `operation` narrates into) plus the elapsed
-/// seconds. `emit` is injected so tests capture the lines. Production prints
-/// them to STDERR, never stdout, because command results own stdout and a scripted
-/// `zingo-cli ... quicksend | jq` stays parseable however slow the send
-/// (PR #2470 review, M5). Grab the progress handle *before* building
-/// `operation`, which borrows the client mutably.
 async fn with_transmit_heartbeat<T>(
     label: &str,
     latest: impl Fn() -> Option<String>,
@@ -77,15 +74,40 @@ async fn with_transmit_heartbeat<T>(
     }
 }
 
-/// Typed failure of a CLI command. `do_user_command` remains the single
-/// site that renders these to prose for string frontends. Typed
-/// frontends consume them directly via `do_user_command_result`.
+/// Runs `operation` under the transmit heartbeat with the stderr sink: the
+/// one place a command names Narration's channel.
+async fn narrated<T>(
+    label: &str,
+    latest: impl Fn() -> Option<String>,
+    operation: impl Future<Output = T>,
+) -> T {
+    with_transmit_heartbeat(label, latest, |line| eprintln!("{line}"), operation).await
+}
+
+/// [`narrated`] over the transmit progress handle, for the send-family
+/// commands. Taking the handle by value lets a call site clone it from the
+/// client in argument position, before the operation's `&mut` borrow begins.
+async fn transmit_narrated<T>(
+    label: &str,
+    progress: TransmitProgressHandle,
+    operation: impl Future<Output = T>,
+) -> T {
+    narrated(label, move || progress.latest(), operation).await
+}
+
+/// Typed failure of a CLI command. The dispatch seam renders these to
+/// prose exactly once, on stderr, for string frontends (ADR 0031). Typed
+/// frontends consume them directly via [`do_user_command_result`].
 #[derive(Debug, thiserror::Error)]
 pub enum CommandError {
     #[error(transparent)]
     Migration(#[from] MigrationCommandError),
     #[error(transparent)]
     Nym(#[from] NymCommandError),
+    #[error("Unknown command : {0}. Type 'help' for a list of commands")]
+    UnknownCommand(String),
+    #[error("the `{0}` command runs only at the interactive prompt")]
+    ReplOnly(&'static str),
     /// Transitional quarantine for commands whose failure prose is not
     /// yet typed: the message is stored WITHOUT the "Error: " prefix
     /// (the renderer adds it). Every construction site is a candidate
@@ -94,310 +116,1047 @@ pub enum CommandError {
     NotYetTyped(String),
 }
 
-/// This command interface is used both by cli and also consumers.
-pub trait Command {
-    /// display command help (in cli)
-    fn help(&self) -> &'static str;
-
-    /// A one-line summary shown in the two-column command listing.
-    fn short_help(&self) -> &'static str;
-
-    /// in zingocli, the success string is printed to console
-    /// consumers occasionally make assumptions about this
-    /// e. expect it to be a json object
-    ///
-    /// Failure crosses the boundary structurally as a [`CommandError`].
-    /// [`do_user_command`] renders it to prose for string frontends.
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError>;
+/// A usage failure carrying the standard "Try 'help <command>'" pointer,
+/// with the command name drawn from the caller instead of re-typed prose.
+fn usage(command: &str, detail: impl std::fmt::Display) -> CommandError {
+    CommandError::NotYetTyped(format!(
+        "{detail}\nTry 'help {command}' for correct usage and examples."
+    ))
 }
 
-/// A command that can execute without an active [`LightClient`].
-///
-/// This is used for commands like `help` that must run before the wallet
-/// is loaded, for example when the user passes `help` as the COMMAND
-/// argument on the command line.
-pub trait ShortCircuitedCommand {
-    /// Execute the command without a [`LightClient`], returning the
-    /// output string that will be printed to the console.
-    fn exec_without_lc(args: Vec<String>) -> String;
+/// The future a wallet command's body returns: boxed so every row of the
+/// spec table shares one type, borrowing the arguments and the client.
+type CommandFuture<'a> = Pin<Box<dyn Future<Output = Result<String, CommandError>> + 'a>>;
+
+type WalletRunFn = for<'a> fn(&'a [&'a str], &'a mut LightClient) -> CommandFuture<'a>;
+
+/// What runs a command, and therefore what it may touch and where `help`
+/// lists it. A `Standalone` body never receives the wallet, so its
+/// wallet-freedom is enforced by construction; `Repl` marks a command the
+/// interactive REPL dispatches itself, holding state this seam does not.
+enum CommandBody {
+    /// Wallet-free and synchronous; listed under "Standalone commands".
+    Standalone(fn(&[&str]) -> Result<String, CommandError>),
+    /// Needs the loaded wallet; listed under "Wallet commands".
+    Wallet(WalletRunFn),
+    /// Owned by the interactive REPL; listed under "Standalone commands".
+    Repl,
 }
 
-struct GetVersionCommand {}
-impl Command for GetVersionCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the build's git describe --dirty.
-        "}
-    }
+/// One row of the command table: the single source of a command's name,
+/// help texts, and body. The name is minted once, by the `wallet!` and
+/// `standalone!` macros, from the body function's identifier.
+pub struct CommandSpec {
+    pub name: &'static str,
+    help: &'static str,
+    short_help: &'static str,
+    body: CommandBody,
+}
 
-    fn short_help(&self) -> &'static str {
-        "Get version of build code"
-    }
+macro_rules! wallet {
+    (
+        $body:ident,
+        short_help: $short_help:expr,
+        help: $help:expr,
+    ) => {
+        CommandSpec {
+            name: stringify!($body),
+            help: $help,
+            short_help: $short_help,
+            body: CommandBody::Wallet({
+                fn wrap<'a>(
+                    args: &'a [&'a str],
+                    lightclient: &'a mut LightClient,
+                ) -> CommandFuture<'a> {
+                    Box::pin($body(args, lightclient))
+                }
+                wrap
+            }),
+        }
+    };
+}
 
-    fn exec(&self, _args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(zingolib::git_description().to_string())
+macro_rules! standalone {
+    (
+        $body:ident,
+        short_help: $short_help:expr,
+        help: $help:expr,
+    ) => {
+        CommandSpec {
+            name: stringify!($body),
+            help: $help,
+            short_help: $short_help,
+            body: CommandBody::Standalone($body),
+        }
+    };
+}
+
+/// The help text of the named command, for bodies that echo their own
+/// usage. Empty for a name not in the table.
+fn help_for(name: &str) -> &'static str {
+    COMMANDS
+        .iter()
+        .find(|spec| spec.name == name)
+        .map(|spec| spec.help)
+        .unwrap_or_default()
+}
+
+async fn addresses(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(lightclient.unified_addresses_json().await.pretty(2))
+}
+
+async fn balance(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    match lightclient.account_balance(zip32::AccountId::ZERO).await {
+        Ok(bal) => Ok(bal.to_string()),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-struct ChangeServerCommand {}
-impl Command for ChangeServerCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Change the indexer server.\n",
-            "\n",
-            "Usage:\n",
-            "change_server <server_uri>\n",
-            "\n",
-            "Example:\n",
-            "change_server ",
-            crate::examples::server_uri!(),
-            "\n",
+async fn birthday(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(lightclient.birthday().to_string())
+}
+
+async fn calculate(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if !args.is_empty() {
+        return Err(usage("calculate", error::CommandError::InvalidArguments));
+    }
+    match lightclient.calculate_stored_proposal().await {
+        Ok(txids) => Ok(object! {
+            "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn change_server(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    async fn set(lightclient: &mut LightClient, uri: http::Uri) -> Result<String, CommandError> {
+        match lightclient.set_indexer_uri(uri).await {
+            Ok(()) => Ok("server set".to_string()),
+            Err(e) => Err(CommandError::NotYetTyped(format!(
+                "failed to set server: {e}"
+            ))),
+        }
+    }
+    match args.len() {
+        0 => set(lightclient, http::Uri::default()).await,
+        1 => match http::Uri::from_str(args[0]) {
+            Ok(uri) => set(lightclient, uri).await,
+            Err(_) => match args[0] {
+                "" => set(lightclient, http::Uri::default()).await,
+                _ => Err(CommandError::NotYetTyped("invalid server uri".to_string())),
+            },
+        },
+        _ => Err(CommandError::NotYetTyped(
+            help_for("change_server").to_string(),
+        )),
+    }
+}
+
+async fn check_address(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    if args.len() != 1 {
+        return Err(CommandError::NotYetTyped(
+            "no address specified. try 'help check_address' for correct usage and examples."
+                .to_string(),
+        ));
+    }
+    match lightclient
+        .wallet()
+        .read()
+        .await
+        .is_address_derived_by_keys(args[0])
+    {
+        Ok(address_ref) => Ok(address_ref
+            .map_or(
+                json::object! { "is_wallet_address" => "false".to_string() },
+                |address_ref| match address_ref {
+                    WalletAddressRef::Unified {
+                        account_id,
+                        address_index,
+                        has_orchard,
+                        has_sapling,
+                        has_transparent,
+                        encoded_address,
+                    } => json::object! {
+                        "is_wallet_address" => "true".to_string(),
+                        "address_type" => "unified".to_string(),
+                        "address_index" => address_index,
+                        "account_id" => u32::from(account_id),
+                        "has_orchard" => has_orchard,
+                        "has_sapling" => has_sapling,
+                        "has_transparent" => has_transparent,
+                        "encoded_address" => encoded_address,
+                    },
+                    WalletAddressRef::OrchardInternal {
+                        account_id,
+                        diversifier_index,
+                        encoded_address,
+                    } => json::object! {
+                        "is_wallet_address" => "true".to_string(),
+                        "address_type" => "orchard_internal".to_string(),
+                        "account_id" => u32::from(account_id),
+                        "diversifier_index" => u128::from(diversifier_index).to_string(),
+                        "encoded_address" => encoded_address,
+                    },
+                    WalletAddressRef::SaplingExternal {
+                        account_id,
+                        diversifier_index,
+                        encoded_address,
+                    } => json::object! {
+                        "is_wallet_address" => "true".to_string(),
+                        "address_type" => "sapling".to_string(),
+                        "account_id" => u32::from(account_id),
+                        "diversifier_index" => u128::from(diversifier_index).to_string(),
+                        "encoded_address" => encoded_address,
+                    },
+                    WalletAddressRef::Transparent {
+                        account_id,
+                        scope,
+                        address_index,
+                        encoded_address,
+                    } => json::object! {
+                        "is_wallet_address" => "true".to_string(),
+                        "address_type" => "transparent".to_string(),
+                        "account_id" => u32::from(account_id),
+                        "scope" => scope.to_string(),
+                        "address_index" => address_index.index(),
+                        "encoded_address" => encoded_address,
+                    },
+                },
+            )
+            .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn clear(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    lightclient.wallet().write().await.clear_all();
+    Ok(object! { "result" => "success" }.pretty(2))
+}
+
+async fn confirm(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if !args.is_empty() {
+        return Err(usage("confirm", error::CommandError::InvalidArguments));
+    }
+    match transmit_narrated(
+        "confirm",
+        lightclient.transmit_progress_handle(),
+        lightclient.send_stored_proposal(true),
+    )
+    .await
+    {
+        Ok(txids) => Ok(object! {
+            "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+#[cfg(feature = "nym")]
+async fn current_price(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    match lightclient.update_current_price().await {
+        Ok(fetch) => Ok(format!(
+            "current price: {} USD (source: {}, rtt: {} ms, fetched over the mixnet via {})",
+            fetch.usd,
+            fetch.source.name(),
+            fetch.round_trip.as_millis(),
+            fetch.via_socks5
+        )),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+#[cfg(not(feature = "nym"))]
+async fn current_price(
+    _args: &[&str],
+    _lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    Ok(
+        "This build has no price fetch: price travels only over the Nym mixnet (ADR 0011). \
+         Rebuild zingo-cli with `--features nym`."
+            .to_string(),
+    )
+}
+
+async fn delete(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    match lightclient.delete_wallet_file().await {
+        Ok(()) => Ok(object! {
+            "result" => "success",
+            "wallet_path" => lightclient.wallet_path().to_str().expect("should be valid UTF-8"),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn export_ufvk(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let ufvk: UnifiedFullViewingKey = match lightclient
+        .wallet()
+        .read()
+        .await
+        .unified_key_store
+        .get(&zip32::AccountId::ZERO)
+        .expect("account 0 must always exist")
+        .try_into()
+    {
+        Ok(ufvk) => ufvk,
+        Err(e) => return Err(CommandError::NotYetTyped(e.to_string())),
+    };
+    Ok(object! {
+        "ufvk" => ufvk.encode(&lightclient.chain_type()),
+        "birthday" => lightclient.birthday()
+    }
+    .pretty(2))
+}
+
+async fn height(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(object! {
+        "height" => json::JsonValue::from(
+            lightclient
+                .wallet()
+                .read()
+                .await
+                .sync_state
+                .last_known_chain_height()
+                .map_or(0, u32::from)
         )
     }
+    .pretty(2))
+}
 
-    fn short_help(&self) -> &'static str {
-        "Change indexer server"
+fn help(args: &[&str]) -> Result<String, CommandError> {
+    Ok(format_help(args))
+}
+
+async fn info(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    match lightclient.info().await {
+        Ok(info) => Ok(json::JsonValue::from(info).pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
+}
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            match args.len() {
-                0 => match lightclient.set_indexer_uri(http::Uri::default()).await {
-                    Ok(()) => "server set".to_string(),
-                    Err(e) => format!("failed to set server: {e}"),
-                },
-                1 => match http::Uri::from_str(args[0]) {
-                    Ok(uri) => match lightclient.set_indexer_uri(uri).await {
-                        Ok(()) => "server set".to_string(),
-                        Err(e) => format!("failed to set server: {e}"),
-                    },
-                    Err(_) => match args[0] {
-                        "" => match lightclient.set_indexer_uri(http::Uri::default()).await {
-                            Ok(()) => "server set".to_string(),
-                            Err(e) => format!("failed to set server: {e}"),
-                        },
-                        _ => "invalid server uri".to_string(),
-                    },
-                },
-                _ => self.help().to_string(),
+async fn max_send_value(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let (address, zennies_for_zingo) =
+        utils::parse_max_send_value_args(args).map_err(|e| usage("max_send_value", e))?;
+    match lightclient
+        .max_send_value(address, zennies_for_zingo, zip32::AccountId::ZERO)
+        .await
+    {
+        Ok(bal) => Ok(object! { "max_send_value" => bal.into_u64() }.pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn memobytes_to_address(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    if args.len() > 1 {
+        return Err(CommandError::NotYetTyped(format!(
+            "didn't understand arguments\n{}",
+            help_for("memobytes_to_address")
+        )));
+    }
+    match lightclient.do_total_memobytes_to_address().await {
+        Ok(total_memo_bytes) => Ok(json::JsonValue::from(total_memo_bytes).pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn messages(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if args.len() > 1 {
+        return Err(CommandError::NotYetTyped(
+            "invalid arguments\nTry 'help messages' for correct usage and examples".to_string(),
+        ));
+    }
+    match lightclient.messages_containing(args.first().copied()).await {
+        Ok(value_transfers) => Ok(json::JsonValue::from(value_transfers).pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn migrate(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(run_migrate(args, lightclient).await?)
+}
+
+async fn migration(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(run_migration(args, lightclient).await?)
+}
+
+async fn new_address(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if args.len() != 1 || (!args[0].contains('o') && !args[0].contains('z')) {
+        return Err(CommandError::NotYetTyped(format!(
+            "No address type specified\n{}",
+            help_for("new_address")
+        )));
+    }
+    let chain_type = lightclient.chain_type();
+    let mut wallet = lightclient.wallet().write().await;
+    let receivers = ReceiverSelection {
+        orchard: args[0].contains('o'),
+        sapling: args[0].contains('z'),
+    };
+    match wallet.generate_unified_address(receivers, zip32::AccountId::ZERO) {
+        Ok((id, unified_address)) => Ok(json::object! {
+            "account" => u32::from(zip32::AccountId::ZERO), // used concrete type instead of u32 to simplify upgrading CLI to multi-account
+            "address_index" => id.address_index,
+            "has_orchard" => unified_address.has_orchard(),
+            "has_sapling" => unified_address.has_sapling(),
+            "has_transparent" => unified_address.has_transparent(),
+            "encoded_address" => unified_address.encode(&chain_type),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn new_taddress(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let chain_type = lightclient.chain_type();
+    let mut wallet = lightclient.wallet().write().await;
+    match wallet.generate_transparent_address(zip32::AccountId::ZERO, true) {
+        Ok((id, transparent_address)) => Ok(json::object! {
+            "account" => u32::from(id.account_id()),
+            "address_index" => id.address_index().index(),
+            "scope" => id.scope().to_string(),
+            "encoded_address" => transparent::encode_address(&chain_type, transparent_address),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn new_taddress_allow_gap(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let chain_type = lightclient.chain_type();
+    let mut wallet = lightclient.wallet().write().await;
+    match wallet.generate_transparent_address(zip32::AccountId::ZERO, false) {
+        Ok((id, transparent_address)) => Ok(json::object! {
+            "account" => u32::from(id.account_id()),
+            "address_index" => id.address_index().index(),
+            "scope" => id.scope().to_string(),
+            "encoded_address" => transparent::encode_address(&chain_type, transparent_address),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn notes(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let all_notes = match args {
+        [] => false,
+        ["all"] => true,
+        [a] => {
+            return Err(CommandError::NotYetTyped(format!(
+                "Invalid argument \"{a}\". Specify 'all' to include spent notes"
+            )));
+        }
+        _ => {
+            return Err(CommandError::NotYetTyped(help_for("notes").to_string()));
+        }
+    };
+    let wallet = lightclient.wallet().read().await;
+    Ok(json::object! {
+        "ironwood_notes" => json::JsonValue::from(wallet.note_summaries::<IronwoodNote>(all_notes)),
+        "orchard_notes" => json::JsonValue::from(wallet.note_summaries::<OrchardNote>(all_notes)),
+        "sapling_notes" => json::JsonValue::from(wallet.note_summaries::<SaplingNote>(all_notes)),
+    }
+    .pretty(2))
+}
+
+async fn coins(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let all_coins = match args {
+        [] => false,
+        ["all"] => true,
+        [a] => {
+            return Err(CommandError::NotYetTyped(format!(
+                "Invalid argument \"{a}\". Specify 'all' to include spent coins"
+            )));
+        }
+        _ => {
+            return Err(CommandError::NotYetTyped(help_for("coins").to_string()));
+        }
+    };
+    Ok(json::object! {
+        "transparent_coins" => json::JsonValue::from(
+            lightclient.wallet().read().await.coin_summaries(all_coins)
+        ),
+    }
+    .pretty(2))
+}
+
+async fn quicksend(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let receivers = utils::parse_send_args(args).map_err(|e| usage("quicksend", e))?;
+    let request = zingolib::data::receivers::transaction_request_from_receivers(receivers)
+        .map_err(|e| usage("quicksend", e))?;
+    match transmit_narrated(
+        "quicksend",
+        lightclient.transmit_progress_handle(),
+        lightclient.quick_send_reported(request, zip32::AccountId::ZERO, true),
+    )
+    .await
+    {
+        Ok(reports) => Ok(object! {
+            "txids" => reports.iter().map(|report| report.txid.to_string()).collect::<Vec<_>>(),
+            "transmissions" => reports.iter().map(render_transmit_report).collect::<Vec<_>>(),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn quickshield(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if !args.is_empty() {
+        return Err(usage("shield", error::CommandError::InvalidArguments));
+    }
+    match transmit_narrated(
+        "quickshield",
+        lightclient.transmit_progress_handle(),
+        lightclient.quick_shield(zip32::AccountId::ZERO),
+    )
+    .await
+    {
+        Ok(txids) => Ok(object! {
+            "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+        }
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn quit(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    match lightclient.shutdown_save_task().await {
+        Ok(()) => eprintln!("Save task shutdown successfully."),
+        Err(e) => eprintln!("Error: save failed. {e}"),
+    }
+    Ok("Zingo CLI quit successfully.".to_string())
+}
+
+async fn recovery_info(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    match lightclient.wallet().read().await.recovery_info() {
+        Some(backup_info) => Ok(backup_info.to_string()),
+        None => Err(CommandError::NotYetTyped(
+            "no mnemonic found. wallet loaded from key.".to_string(),
+        )),
+    }
+}
+
+async fn remove_transaction(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    if args.len() != 1 {
+        return Err(CommandError::NotYetTyped(
+            "remove command expects 1 argument. Type \"help remove\" for usage.".to_string(),
+        ));
+    }
+    let txid =
+        txid_from_hex_encoded_str(args[0]).map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
+    match lightclient
+        .wallet()
+        .write()
+        .await
+        .remove_failed_transaction(txid)
+    {
+        Ok(()) => Ok("Successfully removed failed transaction.".to_string()),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn rescan(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if !args.is_empty() {
+        return Err(CommandError::NotYetTyped(
+            "rescan command expects no arguments. Type \"rescan help\" for usage.".to_string(),
+        ));
+    }
+    match lightclient.rescan().await {
+        Ok(()) => Ok("Launching rescan...".to_string()),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn save(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if args.len() != 1 {
+        return Err(CommandError::NotYetTyped(
+            "save command expects 1 argument. Type \"help save\" for usage.".to_string(),
+        ));
+    }
+    match args[0] {
+        "run" => {
+            lightclient.save_task().await;
+            Ok("Launching save task...".to_string())
+        }
+        "check" => match lightclient.check_save_error().await {
+            Ok(()) => Ok(String::new()),
+            Err(e) => Err(CommandError::NotYetTyped(format!(
+                "save failed. {e}\nRestarting save task..."
+            ))),
+        },
+        "shutdown" => match lightclient.shutdown_save_task().await {
+            Ok(()) => Ok("Save task shutdown successfully.".to_string()),
+            Err(e) => Err(CommandError::NotYetTyped(format!("save failed. {e}"))),
+        },
+        _ => Err(CommandError::NotYetTyped(
+            "invalid sub-command. Type \"help save\" for usage.".to_string(),
+        )),
+    }
+}
+
+async fn send(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let receivers = utils::parse_send_args(args).map_err(|e| usage("send", e))?;
+    let request = zingolib::data::receivers::transaction_request_from_receivers(receivers)
+        .map_err(|e| usage("send", e))?;
+    match lightclient
+        .propose_send(request, zip32::AccountId::ZERO)
+        .await
+    {
+        Ok(proposal) => match zingolib::data::proposal::total_fee(&proposal) {
+            Ok(fee) => Ok(object! { "fee" => fee.into_u64() }.pretty(2)),
+            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        },
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn send_all(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let (address, zennies_for_zingo, memo) =
+        utils::parse_send_all_args(args).map_err(|e| usage("sendall", e))?;
+    match lightclient
+        .propose_send_all(address, zennies_for_zingo, memo, zip32::AccountId::ZERO)
+        .await
+    {
+        Ok(proposal) => {
+            let amount = proposal::total_payment_amount(&proposal)
+                .map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
+            let fee = proposal::total_fee(&proposal)
+                .map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
+            Ok(object! {
+                "amount" => amount.into_u64(),
+                "fee" => fee.into_u64(),
             }
-        }))
+            .pretty(2))
+        }
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-struct BirthdayCommand {}
-impl Command for BirthdayCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the height the wallet was created at.
-
-            Usage:
-            birthday
-        "}
+async fn sends_to_address(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    if args.len() > 1 {
+        return Err(CommandError::NotYetTyped(format!(
+            "didn't understand arguments\n{}",
+            help_for("sends_to_address")
+        )));
     }
-
-    fn short_help(&self) -> &'static str {
-        "Returns block height wallet was created"
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(lightclient.birthday().to_string())
+    match lightclient.do_total_spends_to_address().await {
+        Ok(total_spends) => Ok(json::JsonValue::from(total_spends).pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-struct WalletKindCommand {}
-impl Command for WalletKindCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the loaded wallet's kind. For a UFVK, lists the supported pools.
-            Spend-capable wallets always spend from all three.
-            "}
+async fn settings(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let mut wallet = lightclient.wallet().write().await;
+
+    if args.is_empty() {
+        return Ok(format!(
+            r"
+performance: {}
+min confirmations: {}
+            ",
+            wallet.wallet_settings.sync_config.performance_level,
+            wallet.wallet_settings.min_confirmations,
+        ));
     }
 
-    fn short_help(&self) -> &'static str {
-        "Displays the kind of wallet currently loaded"
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            if lightclient.mnemonic_phrase().is_some() {
-                object! {"kind" => "Loaded from mnemonic (seed or phrase)",
-                        "transparent" => true,
-                        "sapling" => true,
-                        "orchard" => true,
+    let invalid_arguments = || {
+        CommandError::NotYetTyped(
+            "invalid arguments\nTry 'help settings' for correct usage and examples".to_string(),
+        )
+    };
+    match args[0] {
+        "performance" => {
+            wallet.wallet_settings.sync_config.performance_level =
+                match args.get(1).copied().ok_or_else(invalid_arguments)? {
+                    "low" => PerformanceLevel::Low,
+                    "medium" => PerformanceLevel::Medium,
+                    "high" => PerformanceLevel::High,
+                    "maximum" => PerformanceLevel::Maximum,
+                    _ => return Err(invalid_arguments()),
                 }
-                .pretty(4)
+        }
+        "min_confirmations" => {
+            let min_confirmations = args
+                .get(1)
+                .and_then(|value| value.parse::<u32>().ok())
+                .and_then(|m| NonZeroU32::try_from(m).ok())
+                .ok_or_else(invalid_arguments)?;
+            wallet.wallet_settings.min_confirmations = min_confirmations;
+        }
+        _ => return Err(invalid_arguments()),
+    }
+
+    wallet.mark_dirty();
+
+    Ok("Successfully updated settings.".to_string())
+}
+
+async fn shield(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if !args.is_empty() {
+        return Err(usage("shield", error::CommandError::InvalidArguments));
+    }
+    match lightclient.propose_shield(zip32::AccountId::ZERO).await {
+        Ok(proposal) => {
+            if proposal.steps().len() != 1 {
+                return Err(CommandError::NotYetTyped(
+                    "shielding transactions should not have multiple proposal steps".to_string(),
+                ));
+            }
+            let step = proposal.steps().first();
+            let Some(value_to_shield) = step
+                .balance()
+                .proposed_change()
+                .iter()
+                .try_fold(Zatoshis::ZERO, |acc, c| acc + c.value())
+            else {
+                return Err(CommandError::NotYetTyped(
+                    "shield amount outside valid range of zatoshis".to_string(),
+                ));
+            };
+            let fee = step.balance().fee_required();
+            Ok(object! {
+                "value_to_shield" => value_to_shield.into_u64(),
+                "fee" => fee.into_u64(),
+            }
+            .pretty(2))
+        }
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn spendable_balance(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let wallet = lightclient.wallet().read().await;
+    let spendable_balance = wallet
+        .shielded_spendable_balance(zip32::AccountId::ZERO, false)
+        .map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
+    Ok(object! {
+        "spendable_balance" => spendable_balance.into_u64(),
+    }
+    .pretty(2))
+}
+
+async fn sync(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    if args.len() != 1 {
+        return Err(CommandError::NotYetTyped(
+            "sync command expects 1 argument. Type \"help sync\" for usage.".to_string(),
+        ));
+    }
+
+    match args[0] {
+        "run" => {
+            if lightclient.sync_mode() == SyncMode::Paused {
+                lightclient.resume_sync().expect("sync should be paused");
+                Ok("Resuming sync task...".to_string())
             } else {
-                match lightclient
-                    .wallet()
-                    .read()
-                    .await
-                    .unified_key_store
-                    .get(&zip32::AccountId::ZERO)
-                    .expect("account 0 must always exist")
-                {
-                    UnifiedKeyStore::Spend(_) => object! {
-                        "kind" => "Loaded from unified spending key",
-                        "transparent" => true,
-                        "sapling" => true,
-                        "orchard" => true,
-                    }
-                    .pretty(4),
-                    UnifiedKeyStore::View(ufvk) => object! {
-                        "kind" => "Loaded from unified full viewing key",
-                        "transparent" => ufvk.transparent().is_some(),
-                        "sapling" => ufvk.sapling().is_some(),
-                        "orchard" => ufvk.orchard().is_some(),
-                    }
-                    .pretty(4),
-                    UnifiedKeyStore::Empty => object! {
-                        "kind" => "No keys found",
-                        "transparent" => false,
-                        "sapling" => false,
-                        "orchard" => false,
-                    }
-                    .pretty(4),
+                match lightclient.sync().await {
+                    Ok(()) => Ok("Launching sync task...".to_string()),
+                    Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
                 }
             }
-        }))
+        }
+        "pause" => match lightclient.pause_sync() {
+            Ok(()) => Ok("Pausing sync task...".to_string()),
+            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        },
+        "stop" => match lightclient.stop_sync() {
+            Ok(()) => Ok("Stopping sync task...".to_string()),
+            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        },
+        "status" => match pepper_sync::sync_status(&*lightclient.wallet().read().await).await {
+            Ok(status) => Ok(json::JsonValue::from(status).pretty(2)),
+            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        },
+        "poll" => match lightclient.poll_sync() {
+            PollReport::NoHandle => Ok("Sync task has not been launched.".to_string()),
+            PollReport::NotReady => Ok("Sync task is not complete.".to_string()),
+            PollReport::Ready(result) => match result {
+                Ok(sync_result) => Ok(sync_result.to_string()),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+            },
+        },
+        _ => Err(CommandError::NotYetTyped(
+            "invalid sub-command. Type \"help sync\" for usage.".to_string(),
+        )),
     }
 }
 
-struct ParseAddressCommand {}
-impl Command for ParseAddressCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Parse an address.\n",
-            "\n",
-            "Usage:\n",
-            "parse_address <address>\n",
-            "\n",
-            "Example\n",
-            "parse_address ",
-            crate::examples::transparent_address!(),
-            "\n",
-        )
-    }
+async fn t_addresses(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    Ok(lightclient.transparent_addresses_json().await.pretty(2))
+}
 
-    fn short_help(&self) -> &'static str {
-        "Parse an address"
+async fn transactions(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    if !args.is_empty() {
+        return Err(CommandError::NotYetTyped(
+            "invalid arguments\nTry 'help transactions' for correct usage and examples".to_string(),
+        ));
     }
+    match lightclient.transaction_summaries(false).await {
+        Ok(transactions) => Ok(transactions.to_string()),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
 
-    fn exec(&self, args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() > 1 || args.is_empty() {
-            return Ok(self.help().to_string());
-        }
-        fn make_decoded_chain_pair(
-            address: &str,
-        ) -> Option<(
-            zcash_client_backend::address::Address,
-            zingolib::config::ChainType,
-        )> {
-            [
-                zingolib::config::ChainType::Mainnet,
-                zingolib::config::ChainType::Testnet,
-                zingolib::config::ChainType::Regtest(ActivationHeights::default()),
-            ]
+async fn transmit(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let txids = if args.is_empty() {
+        // All Calculated transactions, ordered by target height and
+        // then txid for determinism.
+        let wallet = lightclient.wallet().read().await;
+        let mut calculated: Vec<_> = wallet
+            .wallet_transactions
             .iter()
-            .find_map(|chain| Address::decode(chain, address).zip(Some(*chain)))
+            .filter(|(_, transaction)| {
+                matches!(
+                    transaction.status(),
+                    zingo_status::confirmation_status::ConfirmationStatus::Calculated(_)
+                )
+            })
+            .map(|(txid, transaction)| (transaction.status().get_height(), *txid))
+            .collect();
+        calculated.sort_by_key(|&(height, txid)| (height, txid.as_ref().to_owned()));
+        calculated.into_iter().map(|(_, txid)| txid).collect()
+    } else {
+        args.iter()
+            .map(|arg| txid_from_hex_encoded_str(arg))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| usage("transmit", e))?
+    };
+
+    let Some(txids) = nonempty::NonEmpty::from_vec(txids) else {
+        return Err(CommandError::NotYetTyped(
+            "no calculated transactions to transmit".to_string(),
+        ));
+    };
+
+    match transmit_narrated(
+        "transmit",
+        lightclient.transmit_progress_handle(),
+        lightclient.transmit_calculated(txids),
+    )
+    .await
+    {
+        Ok(txids) => Ok(object! {
+            "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
         }
-        Ok(
-            if let Some((recipient_address, chain_name)) = make_decoded_chain_pair(args[0]) {
-                #[allow(unreachable_patterns)]
-                let chain_name_string = match chain_name {
-                    zingolib::config::ChainType::Mainnet => "main",
-                    zingolib::config::ChainType::Testnet => "test",
-                    zingolib::config::ChainType::Regtest(_) => "regtest",
-                    _ => unreachable!("Invalid chain type"),
-                };
-                match recipient_address {
-                    Address::Sapling(_) => object! {
+        .pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn value_to_address(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    if args.len() > 1 {
+        return Err(CommandError::NotYetTyped(format!(
+            "didn't understand arguments\n{}",
+            help_for("value_to_address")
+        )));
+    }
+    match lightclient.do_total_value_to_address().await {
+        Ok(total_values) => Ok(json::JsonValue::from(total_values).pretty(2)),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+async fn value_transfers(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    match lightclient.value_transfers(false).await {
+        Ok(value_transfers) => Ok(value_transfers.to_string()),
+        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+    }
+}
+
+fn version(_args: &[&str]) -> Result<String, CommandError> {
+    Ok(zingolib::git_description().to_string())
+}
+
+async fn wallet_kind(
+    _args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    if lightclient.mnemonic_phrase().is_some() {
+        return Ok(object! {"kind" => "Loaded from mnemonic (seed or phrase)",
+                "transparent" => true,
+                "sapling" => true,
+                "orchard" => true,
+        }
+        .pretty(4));
+    }
+    Ok(
+        match lightclient
+            .wallet()
+            .read()
+            .await
+            .unified_key_store
+            .get(&zip32::AccountId::ZERO)
+            .expect("account 0 must always exist")
+        {
+            UnifiedKeyStore::Spend(_) => object! {
+                "kind" => "Loaded from unified spending key",
+                "transparent" => true,
+                "sapling" => true,
+                "orchard" => true,
+            }
+            .pretty(4),
+            UnifiedKeyStore::View(ufvk) => object! {
+                "kind" => "Loaded from unified full viewing key",
+                "transparent" => ufvk.transparent().is_some(),
+                "sapling" => ufvk.sapling().is_some(),
+                "orchard" => ufvk.orchard().is_some(),
+            }
+            .pretty(4),
+            UnifiedKeyStore::Empty => object! {
+                "kind" => "No keys found",
+                "transparent" => false,
+                "sapling" => false,
+                "orchard" => false,
+            }
+            .pretty(4),
+        },
+    )
+}
+
+fn parse_address(args: &[&str]) -> Result<String, CommandError> {
+    if args.len() > 1 || args.is_empty() {
+        return Err(CommandError::NotYetTyped(
+            help_for("parse_address").to_string(),
+        ));
+    }
+    fn make_decoded_chain_pair(
+        address: &str,
+    ) -> Option<(
+        zcash_client_backend::address::Address,
+        zingolib::config::ChainType,
+    )> {
+        [
+            zingolib::config::ChainType::Mainnet,
+            zingolib::config::ChainType::Testnet,
+            zingolib::config::ChainType::Regtest(ActivationHeights::default()),
+        ]
+        .iter()
+        .find_map(|chain| Address::decode(chain, address).zip(Some(*chain)))
+    }
+    Ok(
+        if let Some((recipient_address, chain_name)) = make_decoded_chain_pair(args[0]) {
+            #[allow(unreachable_patterns)]
+            let chain_name_string = match chain_name {
+                zingolib::config::ChainType::Mainnet => "main",
+                zingolib::config::ChainType::Testnet => "test",
+                zingolib::config::ChainType::Regtest(_) => "regtest",
+                _ => unreachable!("Invalid chain type"),
+            };
+            match recipient_address {
+                Address::Sapling(_) => object! {
+                    "status" => "success",
+                    "chain_name" => chain_name_string,
+                    "address_kind" => "sapling",
+                }
+                .to_string(),
+                Address::Transparent(_) => object! {
+                    "status" => "success",
+                    "chain_name" => chain_name_string,
+                    "address_kind" => "transparent",
+                }
+                .to_string(),
+                Address::Tex(_) => object! {
+                    "status" => "success",
+                    "chain_name" => chain_name_string,
+                    "address_kind" => "tex",
+                }
+                .to_string(),
+                Address::Unified(ua) => {
+                    let mut receivers_available = vec![];
+                    if ua.sapling().is_some() {
+                        receivers_available.push("sapling");
+                    }
+                    if ua.transparent().is_some() {
+                        receivers_available.push("transparent");
+                    }
+                    if ua.orchard().is_some() {
+                        receivers_available.push("orchard");
+                        object! {
                         "status" => "success",
                         "chain_name" => chain_name_string,
-                        "address_kind" => "sapling",
+                        "address_kind" => "unified",
+                        "receivers_available" => receivers_available,
+                        "only_orchard_ua" => zcash_keys::address::UnifiedAddress::from_receivers(ua.orchard().copied(), None, None).expect("To construct UA").encode(&chain_name),
                     }
-                    .to_string(),
-                    Address::Transparent(_) => object! {
-                        "status" => "success",
-                        "chain_name" => chain_name_string,
-                        "address_kind" => "transparent",
-                    }
-                    .to_string(),
-                    Address::Tex(_) => object! {
-                        "status" => "success",
-                        "chain_name" => chain_name_string,
-                        "address_kind" => "tex",
-                    }
-                    .to_string(),
-                    Address::Unified(ua) => {
-                        let mut receivers_available = vec![];
-                        if ua.sapling().is_some() {
-                            receivers_available.push("sapling");
-                        }
-                        if ua.transparent().is_some() {
-                            receivers_available.push("transparent");
-                        }
-                        if ua.orchard().is_some() {
-                            receivers_available.push("orchard");
-                            object! {
+                    .to_string()
+                    } else {
+                        object! {
                             "status" => "success",
                             "chain_name" => chain_name_string,
                             "address_kind" => "unified",
                             "receivers_available" => receivers_available,
-                            "only_orchard_ua" => zcash_keys::address::UnifiedAddress::from_receivers(ua.orchard().copied(), None, None).expect("To construct UA").encode(&chain_name),
                         }
                         .to_string()
-                        } else {
-                            object! {
-                                "status" => "success",
-                                "chain_name" => chain_name_string,
-                                "address_kind" => "unified",
-                                "receivers_available" => receivers_available,
-                            }
-                            .to_string()
-                        }
                     }
                 }
-            } else {
-                object! {
-                    "status" => "Invalid address",
-                    "chain_name" => json::JsonValue::Null,
-                    "address_kind" => json::JsonValue::Null,
-                }
-                .to_string()
-            },
-        )
-    }
+            }
+        } else {
+            object! {
+                "status" => "Invalid address",
+                "chain_name" => json::JsonValue::Null,
+                "address_kind" => json::JsonValue::Null,
+            }
+            .to_string()
+        },
+    )
 }
 
-struct ParseViewKeyCommand {}
-impl Command for ParseViewKeyCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Parse a viewing key.\n",
-            "\n",
-            "Usage:\n",
-            "parse_viewkey <viewing_key>\n",
-            "\n",
-            "Example\n",
-            "parse_viewkey ",
-            crate::examples::unified_viewing_key!(),
-            "\n",
-        )
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Parse a view_key."
-    }
-
-    fn exec(&self, args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(match args.len() {
-            1 => json::stringify_pretty(
-                match Ufvk::decode(args[0]) {
-                    Ok((network, ufvk)) => {
-                        let mut pools_available = vec![];
-                        for fvk in ufvk.items_as_parsed() {
-                            match fvk {
+fn parse_viewkey(args: &[&str]) -> Result<String, CommandError> {
+    match args.len() {
+        1 => Ok(json::stringify_pretty(
+            match Ufvk::decode(args[0]) {
+                Ok((network, ufvk)) => {
+                    let mut pools_available = vec![];
+                    for fvk in ufvk.items_as_parsed() {
+                        match fvk {
                             zcash_address::unified::Fvk::Orchard(_) => {
                                 pools_available.push("orchard");
                             }
@@ -410,336 +1169,44 @@ impl Command for ParseViewKeyCommand {
                             zcash_address::unified::Fvk::Unknown { .. } => pools_available
                                 .push("Unknown future protocol. Perhaps you're using old software"),
                         }
-                        }
-                        object! {
-                            "status" => "success",
-                            "chain_name" => match network {
-                                NetworkType::Main => "main",
-                                NetworkType::Test => "test",
-                                NetworkType::Regtest => "regtest",
-                            },
-                            "address_kind" => "ufvk",
-                            "pools_available" => pools_available,
-                        }
                     }
-                    Err(_) => {
-                        object! {
-                            "status" => "Invalid viewkey",
-                            "chain_name" => json::JsonValue::Null,
-                            "address_kind" => json::JsonValue::Null
-                        }
+                    object! {
+                        "status" => "success",
+                        "chain_name" => match network {
+                            NetworkType::Main => "main",
+                            NetworkType::Test => "test",
+                            NetworkType::Regtest => "regtest",
+                        },
+                        "address_kind" => "ufvk",
+                        "pools_available" => pools_available,
                     }
-                },
-                4,
-            ),
-            _ => self.help().to_string(),
-        })
-    }
-}
-
-struct SyncCommand {}
-impl Command for SyncCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Sync the wallet to the chain tip.
-
-            `run` starts or resumes. `pause` halts scanning. `stop` shuts sync down
-            early. `status` reports progress. `poll` returns the result once complete,
-            and is not meant to be called by hand.
-
-            Usage:
-            sync run | pause | stop | status | poll
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Sync the wallet to the latest state of the blockchain."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() != 1 {
-            return Err(CommandError::NotYetTyped(
-                "sync command expects 1 argument. Type \"help sync\" for usage.".to_string(),
-            ));
-        }
-
-        match args[0] {
-            "run" => {
-                if lightclient.sync_mode() == SyncMode::Paused {
-                    lightclient.resume_sync().expect("sync should be paused");
-                    Ok("Resuming sync task...".to_string())
-                } else {
-                    RT.block_on(async move {
-                        match lightclient.sync().await {
-                            Ok(()) => Ok("Launching sync task...".to_string()),
-                            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-                        }
-                    })
                 }
-            }
-            "pause" => match lightclient.pause_sync() {
-                Ok(()) => Ok("Pausing sync task...".to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            },
-            "stop" => match lightclient.stop_sync() {
-                Ok(()) => Ok("Stopping sync task...".to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            },
-            "status" => RT.block_on(async move {
-                match pepper_sync::sync_status(&*lightclient.wallet().read().await).await {
-                    Ok(status) => Ok(json::JsonValue::from(status).pretty(2)),
-                    Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+                Err(_) => {
+                    object! {
+                        "status" => "Invalid viewkey",
+                        "chain_name" => json::JsonValue::Null,
+                        "address_kind" => json::JsonValue::Null
+                    }
                 }
-            }),
-            "poll" => match lightclient.poll_sync() {
-                PollReport::NoHandle => Ok("Sync task has not been launched.".to_string()),
-                PollReport::NotReady => Ok("Sync task is not complete.".to_string()),
-                PollReport::Ready(result) => match result {
-                    Ok(sync_result) => Ok(sync_result.to_string()),
-                    Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-                },
             },
-            _ => Err(CommandError::NotYetTyped(
-                "invalid sub-command. Type \"help sync\" for usage.".to_string(),
-            )),
-        }
+            4,
+        )),
+        _ => Err(CommandError::NotYetTyped(
+            help_for("parse_viewkey").to_string(),
+        )),
     }
 }
 
-struct RescanCommand {}
-impl Command for RescanCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Clear all chain-derived wallet data and sync again from the birthday.
-
-            Usage:
-            rescan
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Clear all chain-derived wallet data and sync again from the birthday."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if !args.is_empty() {
-            return Err(CommandError::NotYetTyped(
-                "rescan command expects no arguments. Type \"rescan help\" for usage.".to_string(),
-            ));
-        }
-
-        RT.block_on(async move {
-            match lightclient.rescan().await {
-                Ok(()) => Ok("Launching rescan...".to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
+async fn drain(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(run_drain(args, lightclient).await?)
 }
 
-struct ClearCommand {}
-impl Command for ClearCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Drop every note, coin and transaction, leaving the wallet to sync from scratch.
-
-            Usage:
-            clear
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Clear the wallet state, rolling back the wallet to an empty state."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            lightclient.wallet().write().await.clear_all();
-
-            let result = object! { "result" => "success" };
-            result.pretty(2)
-        }))
-    }
+async fn split(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(run_split(args, lightclient).await?)
 }
 
-/// Lists all available commands or shows detailed help for a specific command.
-pub struct HelpCommand {}
-impl Command for HelpCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            List every command, or show one command's help.
-
-            Usage:
-            help [command]
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Lists all available commands"
-    }
-
-    fn exec(&self, args: &[&str], _: &mut LightClient) -> Result<String, CommandError> {
-        Ok(format_help(args))
-    }
-}
-
-impl ShortCircuitedCommand for HelpCommand {
-    fn exec_without_lc(args: Vec<String>) -> String {
-        let refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        format_help(&refs)
-    }
-}
-
-fn format_help(args: &[&str]) -> String {
-    match args.len() {
-        0 => {
-            let mut lines = Vec::new();
-
-            lines.push("Standalone commands (no wallet required):".to_string());
-            let standalone = get_standalone_commands();
-            let mut standalone_lines: Vec<_> = standalone
-                .iter()
-                .map(|(cmd, obj)| format!("  {} - {}", cmd, obj.short_help()))
-                .collect();
-            // Also include `servers` which is handled by the REPL directly.
-            standalone_lines
-                .push("  servers - Show ranked indexer servers and response times".to_string());
-            standalone_lines.sort();
-            lines.extend(standalone_lines);
-
-            lines.push(String::new());
-            lines.push("Wallet commands:".to_string());
-            let wallet = get_wallet_commands();
-            let mut wallet_lines: Vec<_> = wallet
-                .iter()
-                .map(|(cmd, obj)| format!("  {} - {}", cmd, obj.short_help()))
-                .collect();
-            wallet_lines.sort();
-            lines.extend(wallet_lines);
-
-            lines.join("\n")
-        }
-        1 => {
-            if args[0] == "servers" {
-                return "Show ranked indexer servers and their get_info() response times.\nUsage: servers".to_string();
-            }
-            match get_commands().get(args[0]) {
-                Some(cmd) => cmd.help().to_string(),
-                None => format!("Command {} not found", args[0]),
-            }
-        }
-        _ => "Usage: help [command_name]".to_string(),
-    }
-}
-
-struct InfoCommand {}
-impl Command for InfoCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the connected indexer's info.
-
-            Usage:
-            info
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Get the indexer server's info"
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        // The presentation boundary: typed data becomes rendered JSON and
-        // typed failure becomes display text here, and nowhere earlier.
-        Ok(RT.block_on(async move {
-            match lightclient.info().await {
-                Ok(info) => json::JsonValue::from(info).pretty(2),
-                Err(e) => e.to_string(),
-            }
-        }))
-    }
-}
-
-struct CurrentPriceCommand {}
-impl Command for CurrentPriceCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Fetch the current ZEC price over the Nym mixnet. USD only.
-
-            The fetch races all three price sources (gemini, kraken,
-            coingecko) through the tunnel and reports the first answer,
-            naming the winning source and the round-trip time.
-
-            Price travels only over the mixnet (ADR 0011): the fetch runs while
-            Mixnet Mode is ready and refuses in every other state, including
-            switched off — the clearnet consent covers sends, never price,
-            because the price source is a third party outside the Zcash
-            ecosystem. A build without the `nym` feature has no price fetch.
-
-            Usage:
-            current_price
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Updates and returns current price of ZEC."
-    }
-
-    #[cfg(feature = "nym")]
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            match lightclient.update_current_price().await {
-                Ok(fetch) => format!(
-                    "current price: {} USD (source: {}, rtt: {} ms, fetched over the mixnet via {})",
-                    fetch.usd,
-                    fetch.source.name(),
-                    fetch.round_trip.as_millis(),
-                    fetch.via_socks5
-                ),
-                Err(e) => format!("error: {e}"),
-            }
-        }))
-    }
-
-    #[cfg(not(feature = "nym"))]
-    fn exec(&self, _args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(
-            "This build has no price fetch: price travels only over the Nym mixnet (ADR 0011). \
-             Rebuild zingo-cli with `--features nym`."
-                .to_string(),
-        )
-    }
-}
-
-struct NymCommand {}
-impl Command for NymCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Control the Nym mixnet transport for send and price-fetch.
-
-            With Mixnet Mode on, both route over the mixnet and fail closed while it
-            bootstraps, never falling back to clearnet. Turning it off is a deliberate
-            choice to transmit over clearnet.
-
-            `status` reports off, bootstrapping or ready. `on` starts the nym-proxy
-            child, taking the binary from the given path, else $ZINGO_NYM_PROXY, else
-            one bundled beside this binary, else PATH. `off` reverts to clearnet.
-            `probe` runs GetLightdInfo over both routes side by side to tell whether a
-            failure is mixnet-specific, and its clearnet leg uses your real IP.
-            `history` shows per-indexer attempts across sessions, and needs the
-            nym-diary feature plus --indexer-diary.
-
-            Usage:
-            nym status | on [binary_path] | off | probe [uri] | history
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Control the Nym mixnet transport (on/off/status/probe/history)."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(nym_command(args, lightclient)?)
-    }
+async fn nym(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(nym_command(args, lightclient).await?)
 }
 
 /// This consumer's platform hints for provisioning the `nym-proxy` binary:
@@ -1021,644 +1488,55 @@ fn render_status_with_disclaimer(
 
 /// The body of the `nym` command when the mixnet transport is compiled in.
 #[cfg(feature = "nym")]
-fn nym_command(args: &[&str], lightclient: &mut LightClient) -> Result<String, NymCommandError> {
-    let subcommand = parse_nym_args(args)?;
-    RT.block_on(async move {
-        match subcommand {
-            NymSubCommand::Status => Ok(render_status_with_disclaimer(
-                lightclient.mixnet_mode(),
-                lightclient.mixnet_socks5_addr().as_deref(),
-                lightclient.mixnet_bootstrap_detail().as_deref(),
-            )),
-            NymSubCommand::On { path } => {
-                let path = resolve_proxy_path(path.as_deref());
-                lightclient
-                    .enable_mixnet(std::path::Path::new(&path))
-                    .await
-                    .map_err(|source| NymCommandError::ProxyStart {
-                        path: path.clone(),
-                        source,
-                    })?;
-                Ok(format!(
-                    "Mixnet Mode enabling; the nym proxy at '{path}' is bootstrapping. \
-                     Run `nym status` to check readiness."
-                ))
-            }
-            NymSubCommand::Off => {
-                lightclient.disable_mixnet().await;
-                Ok("Mixnet Mode disabled; send and price-fetch will use clearnet.".to_string())
-            }
-            NymSubCommand::Probe { target } => {
-                let probes = lightclient
-                    .probe_broadcast_indexers(target, PROBE_LEG_TIMEOUT)
-                    .await;
-                Ok(probes
-                    .iter()
-                    .map(render_paired_probe)
-                    .collect::<Vec<_>>()
-                    .join("\n"))
-            }
-            NymSubCommand::History => Ok(nym_history_command(lightclient)),
+async fn nym_command(
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, NymCommandError> {
+    match parse_nym_args(args)? {
+        NymSubCommand::Status => Ok(render_status_with_disclaimer(
+            lightclient.mixnet_mode(),
+            lightclient.mixnet_socks5_addr().as_deref(),
+            lightclient.mixnet_bootstrap_detail().as_deref(),
+        )),
+        NymSubCommand::On { path } => {
+            let path = resolve_proxy_path(path.as_deref());
+            lightclient
+                .enable_mixnet(std::path::Path::new(&path))
+                .await
+                .map_err(|source| NymCommandError::ProxyStart {
+                    path: path.clone(),
+                    source,
+                })?;
+            Ok(format!(
+                "Mixnet Mode enabling; the nym proxy at '{path}' is bootstrapping. \
+                 Run `nym status` to check readiness."
+            ))
         }
-    })
+        NymSubCommand::Off => {
+            lightclient.disable_mixnet().await;
+            Ok("Mixnet Mode disabled; send and price-fetch will use clearnet.".to_string())
+        }
+        NymSubCommand::Probe { target } => {
+            let probes = lightclient
+                .probe_broadcast_indexers(target, PROBE_LEG_TIMEOUT)
+                .await;
+            Ok(probes
+                .iter()
+                .map(render_paired_probe)
+                .collect::<Vec<_>>()
+                .join("\n"))
+        }
+        NymSubCommand::History => Ok(nym_history_command(lightclient)),
+    }
 }
 
 /// The body of the `nym` command when the mixnet transport is not compiled in.
 #[cfg(not(feature = "nym"))]
-fn nym_command(_args: &[&str], _lightclient: &mut LightClient) -> Result<String, NymCommandError> {
+async fn nym_command(
+    _args: &[&str],
+    _lightclient: &mut LightClient,
+) -> Result<String, NymCommandError> {
     Err(NymCommandError::FeatureAbsent)
-}
-
-struct BalanceCommand {}
-impl Command for BalanceCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Return the wallet ZEC balance for each pool (account 0).
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Return the wallet ZEC balance for each pool (account 0)."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        RT.block_on(async move {
-            match lightclient.account_balance(zip32::AccountId::ZERO).await {
-                Ok(bal) => Ok(bal.to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct SpendableBalanceCommand {}
-impl Command for SpendableBalanceCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the wallet's spendable balance.
-
-            Usage:
-            spendable_balance
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Display the wallet's spendable balance."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        RT.block_on(async move {
-            let wallet = lightclient.wallet().read().await;
-            let spendable_balance =
-                match wallet.shielded_spendable_balance(zip32::AccountId::ZERO, false) {
-                    Ok(bal) => bal,
-                    Err(e) => return Err(CommandError::NotYetTyped(e.to_string())),
-                };
-            Ok(object! {
-                "spendable_balance" => spendable_balance.into_u64(),
-            }
-            .pretty(2))
-        })
-    }
-}
-
-struct MaxSendValueCommand {}
-impl Command for MaxSendValueCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r#"
-            Print the most the wallet can send to an address: shielded spendable
-            balance less the fee. Mid-sync this can trail the confirmed balance.
-            `zennies_for_zingo` also budgets 1_000_000 ZAT to the ZingoLabs developer
-            address.
-
-            Usage:
-            max_send_value <address>
-            max_send_value { "address": "<address>", "zennies_for_zingo": <true|false> }
-        "#}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Print the most the wallet can send to a given address."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        let (address, zennies_for_zingo) = match utils::parse_max_send_value_args(args) {
-            Ok(address_and_zennies) => address_and_zennies,
-            Err(e) => {
-                return Err(CommandError::NotYetTyped(format!(
-                    "{e}\nTry 'help max_send_value' for correct usage and examples."
-                )));
-            }
-        };
-        Ok(RT.block_on(async move {
-            match lightclient
-                .max_send_value(address, zennies_for_zingo, zip32::AccountId::ZERO)
-                .await
-            {
-                Ok(bal) => {
-                    object! {
-                        "max_send_value" => bal.into_u64(),
-                    }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct NewUnifiedAddressCommand {}
-impl Command for NewUnifiedAddressCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Create a new unified address, with an orchard receiver, a sapling one, or
-            both. No transparent receivers: use `new_taddress` for those.
-
-            Usage:
-            new_address o | z | oz
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Create a new unified address."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() != 1 {
-            return Ok(format!("No address type specified\n{}", self.help()));
-        }
-        if !args[0].contains('o') && !args[0].contains('z') {
-            return Ok(format!("No address type specified\n{}", self.help()));
-        }
-
-        Ok(RT.block_on(async move {
-            let chain_type = lightclient.chain_type();
-            let mut wallet = lightclient.wallet().write().await;
-            let receivers = ReceiverSelection {
-                orchard: args[0].contains('o'),
-                sapling: args[0].contains('z'),
-            };
-            match wallet.generate_unified_address(receivers, zip32::AccountId::ZERO) {
-                Ok((id, unified_address)) => {
-                    json::object! {
-                        "account" => u32::from(zip32::AccountId::ZERO), // used concrete type instead of u32 to simplify upgrading CLI to multi-account
-                        "address_index" => id.address_index,
-                        "has_orchard" => unified_address.has_orchard(),
-                        "has_sapling" => unified_address.has_sapling(),
-                        "has_transparent" => unified_address.has_transparent(),
-                        "encoded_address" => unified_address.encode(&chain_type),
-                    }
-                }
-                Err(e) => object! { "error" => e.to_string() },
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct NewTransparentAddressCommand {}
-impl Command for NewTransparentAddressCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Create a new transparent address.
-
-            Usage:
-            new_taddress
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Create a new transparent address."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            let chain_type = lightclient.chain_type();
-            let mut wallet = lightclient.wallet().write().await;
-            match wallet.generate_transparent_address(zip32::AccountId::ZERO, true) {
-                Ok((id, transparent_address)) => {
-                    json::object! {
-                        "account" => u32::from(id.account_id()),
-                        "address_index" => id.address_index().index(),
-                        "scope" => id.scope().to_string(),
-                        "encoded_address" => transparent::encode_address(&chain_type,  transparent_address),
-                    }
-                }
-                Err(e) => object! { "error" => e.to_string() },
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct NewTransparentAddressAllowGapCommand {}
-impl Command for NewTransparentAddressAllowGapCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r#"
-            Create a new transparent address even if the last one never received funds.
-
-            This bypasses the no-gap rule, which exists because recovery from seed may
-            not discover addresses beyond a gap. Funds sent to skipped addresses can go
-            missing after a restore unless you rescan or raise the gap limit, so you are
-            taking on tracking the unused ones yourself.
-
-            Usage:
-            new_taddress_allow_gap
-        "#}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Create a new transparent address (even if the last one did not receive any funds)."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            // Generate without enforcing the no-gap constraint
-            let chain_type= lightclient.chain_type();
-            let mut wallet = lightclient.wallet().write().await;
-
-            match wallet.generate_transparent_address(zip32::AccountId::ZERO, false) {
-                Ok((id, transparent_address)) => {
-                    json::object! {
-                        "account" => u32::from(id.account_id()),
-                        "address_index" => id.address_index().index(),
-                        "scope" => id.scope().to_string(),
-                        "encoded_address" => transparent::encode_address(&chain_type, transparent_address),
-                    }
-                }
-                Err(e) => object! { "error" => e.to_string() },
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct UnifiedAddressesCommand {}
-impl Command for UnifiedAddressesCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            List the wallet's unified addresses.
-
-            Usage:
-            addresses
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "List unified addresses in the wallet."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move { lightclient.unified_addresses_json().await.pretty(2) }))
-    }
-}
-
-struct TransparentAddressesCommand {}
-impl Command for TransparentAddressesCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            List the wallet's transparent addresses.
-
-            Usage:
-            t_addresses
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "List transparent addresses in the wallet."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move { lightclient.transparent_addresses_json().await.pretty(2) }))
-    }
-}
-
-struct CheckAddressCommand {}
-impl Command for CheckAddressCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Check whether an encoded address derives from the wallet's keys.
-
-            Usage:
-            check_address <encoded_address>
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Checks if the given encoded address is derived by the wallet's keys."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() != 1 {
-            return Ok(json::object! { "error" => "no address specified. try 'help check_address' for correct usage and examples."
-                .to_string() }.pretty(2))            ;
-        }
-        Ok(RT.block_on(async move {
-            match lightclient
-                .wallet()
-                .read()
-                .await
-                .is_address_derived_by_keys(args[0])
-            {
-                Ok(address_ref) => address_ref.map_or(
-                    json::object! { "is_wallet_address" => "false".to_string() },
-                    |address_ref| match address_ref {
-                        WalletAddressRef::Unified {
-                            account_id,
-                            address_index,
-                            has_orchard,
-                            has_sapling,
-                            has_transparent,
-                            encoded_address,
-                        } => json::object! {
-                            "is_wallet_address" => "true".to_string(),
-                            "address_type" => "unified".to_string(),
-                            "address_index" => address_index,
-                            "account_id" => u32::from(account_id),
-                            "has_orchard" => has_orchard,
-                            "has_sapling" => has_sapling,
-                            "has_transparent" => has_transparent,
-                            "encoded_address" => encoded_address,
-                        },
-                        WalletAddressRef::OrchardInternal {
-                            account_id,
-                            diversifier_index,
-                            encoded_address,
-                        } => json::object! {
-                            "is_wallet_address" => "true".to_string(),
-                            "address_type" => "orchard_internal".to_string(),
-                            "account_id" => u32::from(account_id),
-                            "diversifier_index" => u128::from(diversifier_index).to_string(),
-                            "encoded_address" => encoded_address,
-                        },
-                        WalletAddressRef::SaplingExternal {
-                            account_id,
-                            diversifier_index,
-                            encoded_address,
-                        } => json::object! {
-                            "is_wallet_address" => "true".to_string(),
-                            "address_type" => "sapling".to_string(),
-                            "account_id" => u32::from(account_id),
-                            "diversifier_index" => u128::from(diversifier_index).to_string(),
-                            "encoded_address" => encoded_address,
-                        },
-                        WalletAddressRef::Transparent {
-                            account_id,
-                            scope,
-                            address_index,
-                            encoded_address,
-                        } => json::object! {
-                            "is_wallet_address" => "true".to_string(),
-                            "address_type" => "transparent".to_string(),
-                            "account_id" => u32::from(account_id),
-                            "scope" => scope.to_string(),
-                            "address_index" => address_index.index(),
-                            "encoded_address" => encoded_address,
-                        },
-                    },
-                ),
-                Err(e) => json::object! { "error" => e.to_string() },
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct ExportUfvkCommand {}
-impl Command for ExportUfvkCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Export the wallet's unified full viewing key. To back up spend capability,
-            use `recovery_info` instead.
-
-            Usage:
-            export_ufvk
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Export unified full viewing key for the wallet."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            let ufvk: UnifiedFullViewingKey = match lightclient
-                .wallet()
-                .read()
-                .await
-                .unified_key_store
-                .get(&zip32::AccountId::ZERO)
-                .expect("account 0 must always exist")
-                .try_into()
-            {
-                Ok(ufvk) => ufvk,
-                Err(e) => return e.to_string(),
-            };
-            object! {
-                "ufvk" => ufvk.encode(&lightclient.chain_type()),
-                "birthday" => lightclient.birthday()
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct SendCommand {}
-impl Command for SendCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Propose a transfer of ZEC. Shows the fee, then 'confirm' broadcasts it.\n",
-            "\n",
-            "Usage:\n",
-            "    send <address> <zatoshis> \"<optional memo>\"\n",
-            "    send '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
-            "Example:\n",
-            "    send ",
-            crate::examples::sapling_address!(),
-            " ",
-            crate::examples::amount_zatoshis!(),
-            " \"",
-            crate::examples::memo!(),
-            "\"\n",
-            "    confirm\n",
-        )
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Propose a transfer of ZEC, for 'confirm' to broadcast."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        let receivers = match utils::parse_send_args(args) {
-            Ok(receivers) => receivers,
-            Err(e) => {
-                return Err(CommandError::NotYetTyped(format!(
-                    "{e}\nTry 'help send' for correct usage and examples."
-                )));
-            }
-        };
-        let request = match zingolib::data::receivers::transaction_request_from_receivers(receivers)
-        {
-            Ok(request) => request,
-            Err(e) => {
-                return Err(CommandError::NotYetTyped(format!(
-                    "{e}\nTry 'help send' for correct usage and examples."
-                )));
-            }
-        };
-        Ok(RT.block_on(async move {
-            match lightclient
-                .propose_send(request, zip32::AccountId::ZERO)
-                .await
-            {
-                Ok(proposal) => {
-                    let fee = match zingolib::data::proposal::total_fee(&proposal) {
-                        Ok(fee) => fee,
-                        Err(e) => return object! { "error" => e.to_string() }.pretty(2),
-                    };
-                    object! { "fee" => fee.into_u64() }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct SendAllCommand {}
-impl Command for SendAllCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Propose a transfer of every shielded ZEC to one address. Shows the fee,\n",
-            "then 'confirm' broadcasts it. `zennies_for_zingo` adds 1_000_000 ZAT to the\n",
-            "zingolabs developer address per transaction.\n",
-            "\n",
-            "Skips transparent funds: shield those first, see `help shield`.\n",
-            "\n",
-            "Usage:\n",
-            "    send_all <address> \"<optional memo>\"\n",
-            "    send_all '{ \"address\": \"<address>\", \"memo\": \"<optional memo>\", \"zennies_for_zingo\": <true|false> }'\n",
-            "Example:\n",
-            "    send_all ",
-            crate::examples::sapling_address!(),
-            " \"",
-            crate::examples::send_all_memo!(),
-            "\"\n",
-            "    confirm\n",
-        )
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Propose a transfer of all shielded ZEC to one address, for 'confirm' to broadcast."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        let (address, zennies_for_zingo, memo) = match utils::parse_send_all_args(args) {
-            Ok(parse_results) => parse_results,
-            Err(e) => {
-                return Err(CommandError::NotYetTyped(format!(
-                    "{e}\nTry 'help sendall' for correct usage and examples."
-                )));
-            }
-        };
-        Ok(RT.block_on(async move {
-            match lightclient
-                .propose_send_all(address, zennies_for_zingo, memo, zip32::AccountId::ZERO)
-                .await
-            {
-                Ok(proposal) => {
-                    let amount = match proposal::total_payment_amount(&proposal) {
-                        Ok(amount) => amount,
-                        Err(e) => return object! { "error" => e.to_string() }.pretty(2),
-                    };
-                    let fee = match proposal::total_fee(&proposal) {
-                        Ok(fee) => fee,
-                        Err(e) => return object! { "error" => e.to_string() }.pretty(2),
-                    };
-                    object! {
-                        "amount" => amount.into_u64(),
-                        "fee" => fee.into_u64(),
-                    }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct QuickSendCommand {}
-impl Command for QuickSendCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Send ZEC, fusing `send` and `confirm`. The fee comes out of your balance\n",
-            "and you never see it before the transaction goes out.\n",
-            "\n",
-            "Usage:\n",
-            "    quicksend <address> <zatoshis> \"<optional memo>\"\n",
-            "    quicksend '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
-            "Example:\n",
-            "    quicksend ",
-            crate::examples::sapling_address!(),
-            " ",
-            crate::examples::amount_zatoshis!(),
-            " \"",
-            crate::examples::memo!(),
-            "\"\n",
-        )
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Send ZEC, fusing `send` and `confirm`."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        let receivers = match utils::parse_send_args(args) {
-            Ok(receivers) => receivers,
-            Err(e) => {
-                return Err(CommandError::NotYetTyped(format!(
-                    "{e}\nTry 'help quicksend' for correct usage and examples."
-                )));
-            }
-        };
-        let request = match zingolib::data::receivers::transaction_request_from_receivers(receivers)
-        {
-            Ok(request) => request,
-            Err(e) => {
-                return Err(CommandError::NotYetTyped(format!(
-                    "{e}\nTry 'help quicksend' for correct usage and examples."
-                )));
-            }
-        };
-        Ok(RT.block_on(async move {
-            let progress = lightclient.transmit_progress_handle();
-            match with_transmit_heartbeat(
-                "quicksend",
-                move || progress.latest(),
-                |line| eprintln!("{line}"),
-                lightclient.quick_send_reported(request, zip32::AccountId::ZERO, true),
-            )
-            .await
-            {
-                Ok(reports) => {
-                    object! {
-                        "txids" => reports.iter().map(|report| report.txid.to_string()).collect::<Vec<_>>(),
-                        "transmissions" => reports.iter().map(render_transmit_report).collect::<Vec<_>>(),
-                    }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
 }
 
 /// One transmitted transaction's attestation as JSON: the route it
@@ -1683,851 +1561,6 @@ fn render_transmit_report(report: &zingolib::lightclient::send::TransmitReport) 
             "via_socks5" => via_socks5.clone(),
             "rtt_ms" => rtt_ms,
         },
-    }
-}
-
-struct ShieldCommand {}
-impl Command for ShieldCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Propose a shield of transparent funds into the ironwood pool. Shows the
-            fee, then 'confirm' broadcasts it.
-
-            Usage:
-                shield
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Propose a shield of transparent funds, for 'confirm' to broadcast."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if !args.is_empty() {
-            return Err(CommandError::NotYetTyped(format!(
-                "{}\nTry 'help shield' for correct usage and examples.",
-                error::CommandError::InvalidArguments
-            )));
-        }
-
-        Ok(RT.block_on(async move {
-            match lightclient.propose_shield(zip32::AccountId::ZERO).await {
-                Ok(proposal) => {
-                    if proposal.steps().len() != 1 {
-                        return object! { "error" => "shielding transactions should not have multiple proposal steps" }.pretty(2);
-                    }
-                    let step = proposal.steps().first();
-                    let Some(value_to_shield) = step
-                        .balance()
-                        .proposed_change()
-                        .iter()
-                        .try_fold(Zatoshis::ZERO, |acc, c| acc + c.value()) else {
-                            return object! { "error" => "shield amount outside valid range of zatoshis" }
-                                .pretty(2);
-                    };
-                    let fee = step.balance().fee_required();
-                    object! {
-                        "value_to_shield" => value_to_shield.into_u64(),
-                        "fee" => fee.into_u64(),
-                    }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct QuickShieldCommand {}
-impl Command for QuickShieldCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Shield transparent funds into the ironwood pool, fusing `shield` and
-            `confirm`. The fee comes out of your balance and you never see it before
-            the transaction goes out.
-
-            Usage:
-                quickshield
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Shield transparent funds, fusing `shield` and `confirm`."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if !args.is_empty() {
-            return Err(CommandError::NotYetTyped(format!(
-                "{}\nTry 'help shield' for correct usage and examples.",
-                error::CommandError::InvalidArguments
-            )));
-        }
-
-        Ok(RT.block_on(async move {
-            let progress = lightclient.transmit_progress_handle();
-            match with_transmit_heartbeat(
-                "quickshield",
-                move || progress.latest(),
-                |line| eprintln!("{line}"),
-                lightclient.quick_shield(zip32::AccountId::ZERO),
-            )
-            .await
-            {
-                Ok(txids) => {
-                    object! { "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>() }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct ConfirmCommand {}
-impl Command for ConfirmCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Build and transmit the latest proposal, then resume sync. Needs a proposal\n",
-            "from 'send', 'send_all' or 'shield' first.\n",
-            "\n",
-            "Usage:\n",
-            "    confirm\n",
-            "Example:\n",
-            "    send ",
-            crate::examples::sapling_address!(),
-            " ",
-            crate::examples::amount_zatoshis!(),
-            " \"",
-            crate::examples::memo!(),
-            "\"\n",
-            "    confirm\n",
-        )
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Build and transmit the latest proposal, then resume sync."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if !args.is_empty() {
-            return Err(CommandError::NotYetTyped(format!(
-                "{}\nTry 'help confirm' for correct usage and examples.",
-                error::CommandError::InvalidArguments
-            )));
-        }
-
-        Ok(RT.block_on(async move {
-            let progress = lightclient.transmit_progress_handle();
-            match with_transmit_heartbeat(
-                "confirm",
-                move || progress.latest(),
-                |line| eprintln!("{line}"),
-                lightclient.send_stored_proposal(true),
-            )
-            .await
-            {
-                Ok(txids) => {
-                    object! { "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>() }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct CalculateCommand {}
-impl Command for CalculateCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Sign the latest proposal without transmitting it, for offline signing. No\n",
-            "Indexer needed. The transactions are stored Calculated, for 'transmit' to send\n",
-            "later. Needs a proposal from 'send', 'send_all' or 'shield' first.\n",
-            "\n",
-            "In Offline mode the expiry is retargeted to the last height before the next\n",
-            "network upgrade, the longest life a pre-signed Zcash transaction can have.\n",
-            "Treat a Calculated transaction as live value in flight until it is transmitted,\n",
-            "expires, or another transaction spends its inputs.\n",
-            "\n",
-            "Usage:\n",
-            "    calculate\n",
-            "Example:\n",
-            "    send ",
-            crate::examples::sapling_address!(),
-            " ",
-            crate::examples::amount_zatoshis!(),
-            " \"",
-            crate::examples::memo!(),
-            "\"\n",
-            "    calculate\n",
-            "    transmit\n",
-        )
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Sign the latest proposal without transmitting it."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if !args.is_empty() {
-            return Err(CommandError::NotYetTyped(format!(
-                "{}\nTry 'help calculate' for correct usage and examples.",
-                error::CommandError::InvalidArguments
-            )));
-        }
-
-        Ok(RT.block_on(async move {
-            match lightclient.calculate_stored_proposal().await {
-                Ok(txids) => {
-                    object! {
-                        "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
-                    }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct TransmitCommand {}
-impl Command for TransmitCommand {
-    fn help(&self) -> &'static str {
-        concat!(
-            "Transmit calculated transactions to the Indexer. With no arguments, sends\n",
-            "every Calculated transaction in target-height order. Pass txids in the order\n",
-            "'calculate' printed them to fix the order yourself, which multi-step proposals\n",
-            "such as TEX sends require.\n",
-            "\n",
-            "Anything you leave untransmitted stays live value in flight until it expires or\n",
-            "its inputs are spent.\n",
-            "\n",
-            "Usage:\n",
-            "    transmit [txid ...]\n",
-            "Example:\n",
-            "    transmit\n",
-        )
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Transmit calculated transactions to the Indexer."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        RT.block_on(async move {
-            let txids = if args.is_empty() {
-                // All Calculated transactions, ordered by target height and
-                // then txid for determinism.
-                let wallet = lightclient.wallet().read().await;
-                let mut calculated: Vec<_> = wallet
-                    .wallet_transactions
-                    .iter()
-                    .filter(|(_, transaction)| {
-                        matches!(
-                            transaction.status(),
-                            zingo_status::confirmation_status::ConfirmationStatus::Calculated(_)
-                        )
-                    })
-                    .map(|(txid, transaction)| (transaction.status().get_height(), *txid))
-                    .collect();
-                calculated.sort_by_key(|&(height, txid)| (height, txid.as_ref().to_owned()));
-                calculated.into_iter().map(|(_, txid)| txid).collect()
-            } else {
-                match args
-                    .iter()
-                    .map(|arg| zingolib::utils::conversion::txid_from_hex_encoded_str(arg))
-                    .collect::<Result<Vec<_>, _>>()
-                {
-                    Ok(txids) => txids,
-                    Err(e) => {
-                        return Err(CommandError::NotYetTyped(format!(
-                            "{e}\nTry 'help transmit' for correct usage and examples."
-                        )));
-                    }
-                }
-            };
-
-            let Some(txids) = nonempty::NonEmpty::from_vec(txids) else {
-                return Ok(
-                    object! { "error" => "no calculated transactions to transmit" }.pretty(2),
-                );
-            };
-
-            let progress = lightclient.transmit_progress_handle();
-            Ok(match with_transmit_heartbeat(
-                "transmit",
-                move || progress.latest(),
-                |line| eprintln!("{line}"),
-                lightclient.transmit_calculated(txids),
-            )
-            .await
-            {
-                Ok(txids) => {
-                    object! { "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>() }
-                }
-                Err(e) => {
-                    object! { "error" => e.to_string() }
-                }
-            }
-            .pretty(2))
-        })
-    }
-}
-
-// TODO: add a decline command which deletes latest proposal?
-
-struct DeleteCommand {}
-impl Command for DeleteCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Delete the wallet file from disk.
-
-            Usage:
-            delete
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Delete wallet file from disk"
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            match lightclient.delete_wallet_file().await {
-                Ok(()) => {
-                    let r = object! { "result" => "success",
-                    "wallet_path" => lightclient.wallet_path().to_str().expect("should be valid UTF-8") };
-                    r.pretty(2)
-                }
-                Err(e) => {
-                    let r = object! {
-                        "result" => "error",
-                        "error" => e.to_string()
-                    };
-                    r.pretty(2)
-                }
-            }
-        }))
-    }
-}
-
-struct RecoveryInfoCommand {}
-impl Command for RecoveryInfoCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the wallet's seed phrase, birthday and account count.
-
-            The seed phrase recovers the whole wallet. Save it carefully, share it with
-            nobody.
-
-            Usage:
-            recovery_info
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Print the wallet's seed phrase, birthday and account count."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            match lightclient.wallet().read().await.recovery_info() {
-                Some(backup_info) => backup_info.to_string(),
-                None => "error: no mnemonic found. wallet loaded from key.".to_string(),
-            }
-        }))
-    }
-}
-
-struct ValueTransfersCommand {}
-impl Command for ValueTransfersCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            List the wallet's value transfers, each one a transaction's notes to a
-            single receiver.
-
-            Usage:
-            value_transfers
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "List all value transfers for this wallet."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        RT.block_on(async move {
-            match lightclient.value_transfers(false).await {
-                Ok(value_transfers) => Ok(value_transfers.to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct MessagesFilterCommand {}
-impl Command for MessagesFilterCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            List the wallet's memo-bearing value transfers. An address filters to that
-            correspondent, any other string filters to memos containing it, and no
-            argument shows every memo. Received messages are matched on the memo's
-            reply-to address.
-
-            Usage:
-            messages [address | string]
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "List memos for this wallet."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() > 1 {
-            return Err(CommandError::NotYetTyped(
-                "invalid arguments\nTry 'help messages' for correct usage and examples".to_string(),
-            ));
-        }
-
-        RT.block_on(async move {
-            match lightclient.messages_containing(args.first().copied()).await {
-                Ok(value_transfers) => Ok(json::JsonValue::from(value_transfers).pretty(2)),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct TransactionsCommand {}
-impl Command for TransactionsCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            List the wallet's transaction summaries by block height.
-
-            Usage:
-            transactions
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "List the wallet's transaction summaries by block height."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if !args.is_empty() {
-            return Err(CommandError::NotYetTyped(
-                "invalid arguments\nTry 'help transactions' for correct usage and examples"
-                    .to_string(),
-            ));
-        }
-        RT.block_on(async move {
-            match lightclient.transaction_summaries(false).await {
-                Ok(transactions) => Ok(transactions.to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct MemoBytesToAddressCommand {}
-impl Command for MemoBytesToAddressCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print total memo bytes sent, keyed by address.
-
-            Usage:
-            memobytes_to_address
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Show by address memo_bytes transfers for this seed."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() > 1 {
-            return Ok(format!("didn't understand arguments\n{}", self.help()));
-        }
-
-        RT.block_on(async move {
-            match lightclient.do_total_memobytes_to_address().await {
-                Ok(total_memo_bytes) => Ok(json::JsonValue::from(total_memo_bytes).pretty(2)),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct ValueToAddressCommand {}
-impl Command for ValueToAddressCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print total value sent, keyed by address.
-
-            Usage:
-            value_to_address
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Show by address value transfers for this seed."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() > 1 {
-            return Ok(format!("didn't understand arguments\n{}", self.help()));
-        }
-
-        RT.block_on(async move {
-            match lightclient.do_total_value_to_address().await {
-                Ok(total_values) => Ok(json::JsonValue::from(total_values).pretty(2)),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct SendsToAddressCommand {}
-impl Command for SendsToAddressCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the number of sends, keyed by address.
-
-            Usage:
-            sends_to_address
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Show by address number of sends for this seed."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() > 1 {
-            return Ok(format!("didn't understand arguments\n{}", self.help()));
-        }
-
-        RT.block_on(async move {
-            match lightclient.do_total_spends_to_address().await {
-                Ok(total_spends) => Ok(json::JsonValue::from(total_spends).pretty(2)),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct SettingsCommand {}
-impl Command for SettingsCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Show or set wallet settings. With no argument, prints them all. To set one,
-            name it and give a value.
-
-            performance        low | medium | high | maximum
-            min_confirmations  1 or greater
-
-            Usage:
-            settings
-            settings performance high
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Show or set wallet settings."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        RT.block_on(async move {
-            let mut wallet = lightclient.wallet().write().await;
-
-            if args.is_empty() {
-                return Ok(format!(
-                    r"
-performance: {}
-min confirmations: {}
-            ",
-                    wallet.wallet_settings.sync_config.performance_level,
-                    wallet.wallet_settings.min_confirmations,
-                ));
-            }
-
-            match args[0] {
-                "performance" => match args[1] {
-                    "low" => wallet.wallet_settings.sync_config.performance_level = PerformanceLevel::Low,
-                    "medium" => wallet.wallet_settings.sync_config.performance_level = PerformanceLevel::Medium,
-                    "high" => wallet.wallet_settings.sync_config.performance_level = PerformanceLevel::High,
-                    "maximum" => wallet.wallet_settings.sync_config.performance_level = PerformanceLevel::Maximum,
-                    _ => {
-                return Err(CommandError::NotYetTyped(
-                    "invalid arguments\nTry 'help settings' for correct usage and examples"
-                        .to_string(),
-                ));}
-                    },
-                "min_confirmations" => {
-                    let min_confirmations = match args[1].parse::<u32>() {
-                        Ok(m) => match NonZeroU32::try_from(m) {
-                            Ok(m) => m,
-                            Err(_) => {
-                                return Err(CommandError::NotYetTyped(
-                                    "invalid arguments\nTry 'help settings' for correct usage and examples"
-                                        .to_string(),
-                                ));
-                            }
-                        },
-                        Err(_) => {
-                            return Err(CommandError::NotYetTyped(
-                                "invalid arguments\nTry 'help settings' for correct usage and examples"
-                                    .to_string(),
-                            ));
-                        }
-                    };
-                    wallet.wallet_settings.min_confirmations = min_confirmations;
-                }
-                _ => {
-            return Err(CommandError::NotYetTyped(
-                "invalid arguments\nTry 'help settings' for correct usage and examples"
-                    .to_string(),
-            ));}
-            }
-
-            wallet.mark_dirty();
-
-            Ok("Successfully updated settings.".to_string())
-        })
-    }
-}
-
-struct HeightCommand {}
-impl Command for HeightCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Print the chain height as of the wallet's last request to the server.
-
-            Usage:
-            height
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Print the chain height as of the wallet's last request to the server."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(RT.block_on(async move {
-            object! { "height" => json::JsonValue::from(lightclient.wallet().read().await.sync_state.last_known_chain_height().map_or(0, u32::from))}.pretty(2)
-        }))
-    }
-}
-
-struct NotesCommand {}
-impl Command for NotesCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Show the wallet's notes (shielded outputs). `all` includes spent ones.
-
-            Usage:
-            notes [all]
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Show the wallet's notes (shielded outputs)."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        // Parse the args.
-        if args.len() > 1 {
-            return Ok(self.short_help().to_string());
-        }
-
-        // Make sure we can parse the amount
-        let all_notes = if args.len() == 1 {
-            match args[0] {
-                "all" => true,
-                a => {
-                    return Ok(format!(
-                        "Invalid argument \"{a}\". Specify 'all' to include spent notes"
-                    ));
-                }
-            }
-        } else {
-            false
-        };
-
-        Ok(RT.block_on(async move {
-            let wallet = lightclient.wallet().read().await;
-
-            json::object! {
-                "ironwood_notes" => json::JsonValue::from(wallet.note_summaries::<IronwoodNote>(all_notes)),
-                "orchard_notes" => json::JsonValue::from(wallet.note_summaries::<OrchardNote>(all_notes)),
-                "sapling_notes" => json::JsonValue::from(wallet.note_summaries::<SaplingNote>(all_notes)),
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct CoinsCommand {}
-impl Command for CoinsCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Show the wallet's coins (transparent outputs). `all` includes spent ones.
-
-            Usage:
-            coins [all]
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Show the wallet's coins (transparent outputs)."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        // Parse the args.
-        if args.len() > 1 {
-            return Ok(self.short_help().to_string());
-        }
-
-        // Make sure we can parse the amount
-        let all_coins = if args.len() == 1 {
-            match args[0] {
-                "all" => true,
-                a => {
-                    return Ok(format!(
-                        "Invalid argument \"{a}\". Specify 'all' to include spent coins"
-                    ));
-                }
-            }
-        } else {
-            false
-        };
-
-        Ok(RT.block_on(async move {
-            json::object! {
-                "transparent_coins" => json::JsonValue::from(lightclient.wallet().read().await.coin_summaries(all_coins)),
-            }
-            .pretty(2)
-        }))
-    }
-}
-
-struct RemoveTransactionCommand {}
-impl Command for RemoveTransactionCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Remove a failed transaction from the wallet. Manual on purpose, so a failed
-            send keeps its memos until you decide to drop them.
-
-            Usage:
-            remove_transaction <txid>
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Remove a failed transaction from the wallet."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() != 1 {
-            return Err(CommandError::NotYetTyped(
-                "remove command expects 1 argument. Type \"help remove\" for usage.".to_string(),
-            ));
-        }
-
-        let txid = match txid_from_hex_encoded_str(args[0]) {
-            Ok(txid) => txid,
-            Err(e) => return Err(CommandError::NotYetTyped(e.to_string())),
-        };
-
-        RT.block_on(async move {
-            match lightclient
-                .wallet()
-                .write()
-                .await
-                .remove_failed_transaction(txid)
-            {
-                Ok(()) => Ok("Successfully removed failed transaction.".to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-            }
-        })
-    }
-}
-
-struct SaveCommand {}
-impl Command for SaveCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Launch the task that persists the wallet as its state changes. Not meant to
-            be called by hand.
-
-            Usage:
-            save run | check | shutdown
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Launch the save task. Not meant to be called by hand."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        if args.len() != 1 {
-            return Err(CommandError::NotYetTyped(
-                "save command expects 1 argument. Type \"help save\" for usage.".to_string(),
-            ));
-        }
-
-        match args[0] {
-            "run" => {
-                RT.block_on(async move { lightclient.save_task().await });
-                Ok("Launching save task...".to_string())
-            }
-            "check" => match RT.block_on(async move { lightclient.check_save_error().await }) {
-                Ok(()) => Ok(String::new()),
-                Err(e) => Err(CommandError::NotYetTyped(format!(
-                    "save failed. {e}\nRestarting save task..."
-                ))),
-            },
-            "shutdown" => {
-                match RT.block_on(async move { lightclient.shutdown_save_task().await }) {
-                    Ok(()) => Ok("Save task shutdown successfully.".to_string()),
-                    Err(e) => Err(CommandError::NotYetTyped(format!("save failed. {e}"))),
-                }
-            }
-            _ => Err(CommandError::NotYetTyped(
-                "invalid sub-command. Type \"help save\" for usage.".to_string(),
-            )),
-        }
-    }
-}
-
-struct QuitCommand {}
-impl Command for QuitCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Quit the light client, saving state to disk.
-
-            Usage:
-            quit
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Quit the light client, saving state to disk."
-    }
-
-    fn exec(&self, _args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        let save_shutdown = do_user_command("save", &["shutdown"], lightclient);
-
-        Ok(format!("{save_shutdown}\nZingo CLI quit successfully."))
     }
 }
 
@@ -2682,22 +1715,21 @@ fn txids_json<T: ToString>(txids: &[T]) -> json::JsonValue {
         .into()
 }
 
-/// Runs the `migrate` command. Its errors cross `exec` as
-/// [`CommandError::Migration`] and render at `do_user_command`.
-fn run_migrate(
+/// Runs the `migrate` command. Its errors cross the dispatch seam as
+/// [`CommandError::Migration`].
+async fn run_migrate(
     args: &[&str],
     lightclient: &mut LightClient,
 ) -> Result<String, MigrationCommandError> {
     if !args.is_empty() {
         return Err(MigrationCommandError::UnexpectedArguments);
     }
-    let progress = lightclient.transmit_progress_handle();
-    let summary = RT.block_on(with_transmit_heartbeat(
+    let summary = transmit_narrated(
         "migrate",
-        move || progress.latest(),
-        |line| eprintln!("{line}"),
+        lightclient.transmit_progress_handle(),
         lightclient.migrate_to_ironwood(zip32::AccountId::ZERO),
-    ))?;
+    )
+    .await?;
     Ok(object! {
         "split_txids" => txids_json(&summary.split_txids),
         "part_txids" => txids_json(&summary.part_txids),
@@ -2707,13 +1739,15 @@ fn run_migrate(
 }
 
 /// Runs one `migration` sub-command.
-fn run_migration(
+async fn run_migration(
     args: &[&str],
     lightclient: &mut LightClient,
 ) -> Result<String, MigrationCommandError> {
     Ok(match parse_migration_args(args)? {
         MigrationSubCommand::Plan => {
-            let plan = RT.block_on(lightclient.plan_ironwood_migration(zip32::AccountId::ZERO))?;
+            let plan = lightclient
+                .plan_ironwood_migration(zip32::AccountId::ZERO)
+                .await?;
             object! {
                 "split_rounds" => plan.split_rounds.len(),
                 "split_transactions" => plan.split_rounds.iter().map(Vec::len).sum::<usize>(),
@@ -2728,24 +1762,25 @@ fn run_migration(
             plan_hash,
             per_bucket,
         } => {
-            let progress = lightclient.transmit_progress_handle();
-            RT.block_on(with_transmit_heartbeat(
+            transmit_narrated(
                 "migration start",
-                move || progress.latest(),
-                |line| eprintln!("{line}"),
+                lightclient.transmit_progress_handle(),
                 lightclient.start_ironwood_migration(
                     zip32::AccountId::ZERO,
                     migration::SigningStrategy::LazyAtBoundary,
                     plan_hash,
                     per_bucket,
                 ),
-            ))?;
+            )
+            .await?;
             "Migration started.".to_string()
         }
         MigrationSubCommand::Continue => {
-            RT.block_on(lightclient.sync_and_await())
+            lightclient
+                .sync_and_await()
+                .await
                 .map_err(MigrationCommandError::Sync)?;
-            match RT.block_on(lightclient.continue_note_splitting())? {
+            match lightclient.continue_note_splitting().await? {
                 SplitStep::RoundBroadcast { round, txids } => object! {
                     "round" => round,
                     "split_txids" => txids_json(&txids),
@@ -2766,19 +1801,21 @@ fn run_migration(
             }
         }
         MigrationSubCommand::Cadence { per_bucket } => {
-            RT.block_on(lightclient.reschedule_parts(per_bucket))?;
+            lightclient.reschedule_parts(per_bucket).await?;
             format!("Cadence set to {per_bucket} per window; the schedule was re-drawn.")
         }
         MigrationSubCommand::Execute { spacing } => {
-            RT.block_on(lightclient.sync_and_await())
+            lightclient
+                .sync_and_await()
+                .await
                 .map_err(MigrationCommandError::Sync)?;
             let progress = lightclient.batch_progress_handle();
-            let report = RT.block_on(with_transmit_heartbeat(
+            let report = narrated(
                 "migration execute",
                 move || progress.status().as_ref().map(batch_progress_line),
-                |line| eprintln!("{line}"),
                 lightclient.execute_due_parts(spacing),
-            ))?;
+            )
+            .await?;
             object! {
                 "outcomes" => report
                     .outcomes
@@ -2803,9 +1840,11 @@ fn run_migration(
             .pretty(2)
         }
         MigrationSubCommand::Auto => {
-            RT.block_on(lightclient.sync_and_await())
+            lightclient
+                .sync_and_await()
+                .await
                 .map_err(MigrationCommandError::Sync)?;
-            let txids = RT.block_on(lightclient.auto_broadcast_if_due())?;
+            let txids = lightclient.auto_broadcast_if_due().await?;
             if txids.is_empty() {
                 "No parts due yet.".to_string()
             } else {
@@ -2813,7 +1852,7 @@ fn run_migration(
             }
         }
         MigrationSubCommand::Status => {
-            let status = RT.block_on(lightclient.migration_status())?;
+            let status = lightclient.migration_status().await?;
             object! {
                 "orchard_confirmed_spendable" => status.orchard_confirmed_spendable,
                 "phase" => status.phase.as_ref().map(render_migration_phase),
@@ -2841,7 +1880,7 @@ fn run_migration(
             .pretty(2)
         }
         MigrationSubCommand::Windows => {
-            let timeline = RT.block_on(lightclient.window_timeline())?;
+            let timeline = lightclient.window_timeline().await?;
             match timeline {
                 None => "Wallet has no chain height yet; sync first.".to_string(),
                 Some(windows) => object! {
@@ -2863,7 +1902,7 @@ fn run_migration(
             }
         }
         MigrationSubCommand::Reconcile => {
-            let report = RT.block_on(lightclient.reconcile_migration())?;
+            let report = lightclient.reconcile_migration().await?;
             object! {
                 "assessments" => report
                     .assessments
@@ -2882,13 +1921,12 @@ fn run_migration(
             .pretty(2)
         }
         MigrationSubCommand::Catchup { spacing } => {
-            let progress = lightclient.transmit_progress_handle();
-            let txids = RT.block_on(with_transmit_heartbeat(
+            let txids = transmit_narrated(
                 "migration catchup",
-                move || progress.latest(),
-                |line| eprintln!("{line}"),
+                lightclient.transmit_progress_handle(),
                 lightclient.catch_up_migration(spacing),
-            ))?;
+            )
+            .await?;
             if txids.is_empty() {
                 "No overdue parts.".to_string()
             } else {
@@ -2896,7 +1934,7 @@ fn run_migration(
             }
         }
         MigrationSubCommand::Cancel => {
-            RT.block_on(lightclient.cancel_ironwood_migration())?;
+            lightclient.cancel_ironwood_migration().await?;
             "Migration canceled.".to_string()
         }
     })
@@ -2975,13 +2013,15 @@ fn split_progress_line(status: &SplitStatus) -> String {
 /// writes progress lines to stderr while it runs.
 ///
 /// Returns the summary as JSON.
-fn run_drain(
+async fn run_drain(
     args: &[&str],
     lightclient: &mut LightClient,
 ) -> Result<String, MigrationCommandError> {
     Ok(match parse_drain_args(args)? {
         DrainSubCommand::Plan => {
-            let plan = RT.block_on(lightclient.plan_immediate_migration(zip32::AccountId::ZERO))?;
+            let plan = lightclient
+                .plan_immediate_migration(zip32::AccountId::ZERO)
+                .await?;
             object! {
                 "transactions" => plan.transactions.len(),
                 "migrated" => plan.migrated,
@@ -2992,12 +2032,12 @@ fn run_drain(
         }
         DrainSubCommand::Now => {
             let progress = lightclient.immediate_migration_progress_handle();
-            let summary = RT.block_on(with_transmit_heartbeat(
+            let summary = narrated(
                 "drain",
                 move || progress.status().as_ref().map(drain_progress_line),
-                |line| eprintln!("{line}"),
                 lightclient.quick_immediate_migration(zip32::AccountId::ZERO, true),
-            ))?;
+            )
+            .await?;
             object! {
                 "txids" => txids_json(&summary.txids),
                 "migrated" => summary.migrated,
@@ -3014,13 +2054,13 @@ fn run_drain(
 /// `plan` previews the remaining rounds and sends nothing. `now` runs one
 /// round, writing progress lines to stderr while it runs. It returns the
 /// round's txids, or a message explaining why nothing was sent.
-fn run_split(
+async fn run_split(
     args: &[&str],
     lightclient: &mut LightClient,
 ) -> Result<String, MigrationCommandError> {
     Ok(match parse_split_args(args)? {
         SplitSubCommand::Plan => {
-            let plan = RT.block_on(lightclient.plan_note_split(zip32::AccountId::ZERO))?;
+            let plan = lightclient.plan_note_split(zip32::AccountId::ZERO).await?;
             object! {
                 "split_rounds" => plan.split_rounds.len(),
                 "split_transactions" => plan.split_rounds.iter().map(Vec::len).sum::<usize>(),
@@ -3032,12 +2072,13 @@ fn run_split(
         }
         SplitSubCommand::Now => {
             let progress = lightclient.split_progress_handle();
-            match RT.block_on(with_transmit_heartbeat(
+            match narrated(
                 "split",
                 move || progress.status().as_ref().map(split_progress_line),
-                |line| eprintln!("{line}"),
                 lightclient.quick_split(zip32::AccountId::ZERO, true),
-            ))? {
+            )
+            .await?
+            {
                 SplitOutcome::Round { txids } => {
                     object! { "split_txids" => txids_json(&txids) }.pretty(2)
                 }
@@ -3053,10 +2094,164 @@ fn run_split(
     })
 }
 
-struct DrainCommand {}
-impl Command for DrainCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
+/// Every command, in alphabetical order: the single source of the
+/// dispatchable names, help texts, and bodies (ADR 0030). `help` renders
+/// its listing straight from this table, so declaration order is display
+/// order.
+static COMMANDS: &[CommandSpec] = &[
+    wallet! {
+        addresses,
+        short_help: "List unified addresses in the wallet.",
+        help: indoc! {r"
+            List the wallet's unified addresses.
+
+            Usage:
+            addresses
+        "},
+    },
+    wallet! {
+        balance,
+        short_help: "Return the wallet ZEC balance for each pool (account 0).",
+        help: indoc! {r"
+            Return the wallet ZEC balance for each pool (account 0).
+        "},
+    },
+    wallet! {
+        birthday,
+        short_help: "Returns block height wallet was created",
+        help: indoc! {r"
+            Print the height the wallet was created at.
+
+            Usage:
+            birthday
+        "},
+    },
+    wallet! {
+        calculate,
+        short_help: "Sign the latest proposal without transmitting it.",
+        help: concat!(
+            "Sign the latest proposal without transmitting it, for offline signing. No\n",
+            "Indexer needed. The transactions are stored Calculated, for 'transmit' to send\n",
+            "later. Needs a proposal from 'send', 'send_all' or 'shield' first.\n",
+            "\n",
+            "In Offline mode the expiry is retargeted to the last height before the next\n",
+            "network upgrade, the longest life a pre-signed Zcash transaction can have.\n",
+            "Treat a Calculated transaction as live value in flight until it is transmitted,\n",
+            "expires, or another transaction spends its inputs.\n",
+            "\n",
+            "Usage:\n",
+            "    calculate\n",
+            "Example:\n",
+            "    send ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
+            "    calculate\n",
+            "    transmit\n",
+        ),
+    },
+    wallet! {
+        change_server,
+        short_help: "Change indexer server",
+        help: concat!(
+            "Change the indexer server.\n",
+            "\n",
+            "Usage:\n",
+            "change_server <server_uri>\n",
+            "\n",
+            "Example:\n",
+            "change_server ",
+            crate::examples::server_uri!(),
+            "\n",
+        ),
+    },
+    wallet! {
+        check_address,
+        short_help: "Checks if the given encoded address is derived by the wallet's keys.",
+        help: indoc! {r"
+            Check whether an encoded address derives from the wallet's keys.
+
+            Usage:
+            check_address <encoded_address>
+        "},
+    },
+    wallet! {
+        clear,
+        short_help: "Clear the wallet state, rolling back the wallet to an empty state.",
+        help: indoc! {r"
+            Drop every note, coin and transaction, leaving the wallet to sync from scratch.
+
+            Usage:
+            clear
+        "},
+    },
+    wallet! {
+        coins,
+        short_help: "Show the wallet's coins (transparent outputs).",
+        help: indoc! {r"
+            Show the wallet's coins (transparent outputs). `all` includes spent ones.
+
+            Usage:
+            coins [all]
+        "},
+    },
+    wallet! {
+        confirm,
+        short_help: "Build and transmit the latest proposal, then resume sync.",
+        help: concat!(
+            "Build and transmit the latest proposal, then resume sync. Needs a proposal\n",
+            "from 'send', 'send_all' or 'shield' first.\n",
+            "\n",
+            "Usage:\n",
+            "    confirm\n",
+            "Example:\n",
+            "    send ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
+            "    confirm\n",
+        ),
+    },
+    wallet! {
+        current_price,
+        short_help: "Updates and returns current price of ZEC.",
+        help: indoc! {r"
+            Fetch the current ZEC price over the Nym mixnet. USD only.
+
+            The fetch races all three price sources (gemini, kraken,
+            coingecko) through the tunnel and reports the first answer,
+            naming the winning source and the round-trip time.
+
+            Price travels only over the mixnet (ADR 0011): the fetch runs while
+            Mixnet Mode is ready and refuses in every other state, including
+            switched off — the clearnet consent covers sends, never price,
+            because the price source is a third party outside the Zcash
+            ecosystem. A build without the `nym` feature has no price fetch.
+
+            Usage:
+            current_price
+        "},
+    },
+    wallet! {
+        delete,
+        short_help: "Delete wallet file from disk",
+        help: indoc! {r"
+            Delete the wallet file from disk.
+
+            Usage:
+            delete
+        "},
+    },
+    wallet! {
+        drain,
+        short_help: "Send all Orchard funds into the Ironwood pool now (immediate ZIP 318 path).",
+        help: indoc! {r"
             Send every spendable Orchard note into the Ironwood pool now, ZIP 318's
             immediate path.
 
@@ -3073,55 +2268,90 @@ impl Command for DrainCommand {
 
             Usage:
             drain plan | now
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Send all Orchard funds into the Ironwood pool now (immediate ZIP 318 path)."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(run_drain(args, lightclient)?)
-    }
-}
-
-struct SplitCommand {}
-impl Command for SplitCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
-            Resize the wallet's Orchard notes into ZIP 318 part sizes, one round of
-            Orchard self-sends per call.
-
-            The rounds reveal no value and may run before NU6.3 activation. Each call
-            replans from the wallet's confirmed notes and persists no migration state.
-            Refused while a scheduled migration is active, since that flow does its own
-            splitting.
-
-            `plan` previews the remaining rounds, transactions, fees, resulting
-            denominations and residual dust. Nothing is signed or sent, and zero rounds
-            means every note is already part-ready.
-            `now` runs one round. Sync first, and again between rounds until each
-            round's self-sends confirm. It reports when a prior round is still
-            confirming and when splitting is done.
+        "},
+    },
+    wallet! {
+        export_ufvk,
+        short_help: "Export unified full viewing key for the wallet.",
+        help: indoc! {r"
+            Export the wallet's unified full viewing key. To back up spend capability,
+            use `recovery_info` instead.
 
             Usage:
-            split plan | now
-        "}
-    }
+            export_ufvk
+        "},
+    },
+    wallet! {
+        height,
+        short_help: "Print the chain height as of the wallet's last request to the server.",
+        help: indoc! {r"
+            Print the chain height as of the wallet's last request to the server.
 
-    fn short_help(&self) -> &'static str {
-        "Split Orchard notes into ZIP 318 part sizes, one round per call."
-    }
+            Usage:
+            height
+        "},
+    },
+    standalone! {
+        help,
+        short_help: "Lists all available commands",
+        help: indoc! {r"
+            List every command, or show one command's help.
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(run_split(args, lightclient)?)
-    }
-}
+            Usage:
+            help [command]
+        "},
+    },
+    wallet! {
+        info,
+        short_help: "Get the indexer server's info",
+        help: indoc! {r"
+            Print the connected indexer's info.
 
-struct MigrateCommand {}
-impl Command for MigrateCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
+            Usage:
+            info
+        "},
+    },
+    wallet! {
+        max_send_value,
+        short_help: "Print the most the wallet can send to a given address.",
+        help: indoc! {r#"
+            Print the most the wallet can send to an address: shielded spendable
+            balance less the fee. Mid-sync this can trail the confirmed balance.
+            `zennies_for_zingo` also budgets 1_000_000 ZAT to the ZingoLabs developer
+            address.
+
+            Usage:
+            max_send_value <address>
+            max_send_value { "address": "<address>", "zennies_for_zingo": <true|false> }
+        "#},
+    },
+    wallet! {
+        memobytes_to_address,
+        short_help: "Show by address memo_bytes transfers for this seed.",
+        help: indoc! {r"
+            Print total memo bytes sent, keyed by address.
+
+            Usage:
+            memobytes_to_address
+        "},
+    },
+    wallet! {
+        messages,
+        short_help: "List memos for this wallet.",
+        help: indoc! {r"
+            List the wallet's memo-bearing value transfers. An address filters to that
+            correspondent, any other string filters to memos containing it, and no
+            argument shows every memo. Received messages are matched on the memo's
+            reply-to address.
+
+            Usage:
+            messages [address | string]
+        "},
+    },
+    wallet! {
+        migrate,
+        short_help: "Migrate all Orchard funds to the Ironwood pool in one interactive run.",
+        help: indoc! {r"
             Migrate all Orchard funds to the Ironwood pool in one interactive run.
 
             Runs ZIP 318's two phases back to back: note-splitting rounds of Orchard
@@ -3135,22 +2365,12 @@ impl Command for MigrateCommand {
 
             Usage:
             migrate
-        "}
-    }
-
-    fn short_help(&self) -> &'static str {
-        "Migrate all Orchard funds to the Ironwood pool in one interactive run."
-    }
-
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(run_migrate(args, lightclient)?)
-    }
-}
-
-struct MigrationCommand {}
-impl Command for MigrationCommand {
-    fn help(&self) -> &'static str {
-        indoc! {r"
+        "},
+    },
+    wallet! {
+        migration,
+        short_help: "Drive the scheduled Orchard to Ironwood migration",
+        help: indoc! {r"
             Drive the scheduled Orchard to Ironwood migration (ZIP 318).
 
             `plan` computes the plan (rounds, parts, fees, residual dust) from the
@@ -3190,1152 +2410,458 @@ impl Command for MigrationCommand {
             migration execute [spacing_seconds]
             migration catchup [spacing_seconds]
             migration continue | auto | status | windows | reconcile | cancel
-        "}
-    }
+        "},
+    },
+    wallet! {
+        new_address,
+        short_help: "Create a new unified address.",
+        help: indoc! {r"
+            Create a new unified address, with an orchard receiver, a sapling one, or
+            both. No transparent receivers: use `new_taddress` for those.
 
-    fn short_help(&self) -> &'static str {
-        "Drive the scheduled Orchard to Ironwood migration"
-    }
+            Usage:
+            new_address o | z | oz
+        "},
+    },
+    wallet! {
+        new_taddress,
+        short_help: "Create a new transparent address.",
+        help: indoc! {r"
+            Create a new transparent address.
 
-    fn exec(&self, args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-        Ok(run_migration(args, lightclient)?)
-    }
-}
+            Usage:
+            new_taddress
+        "},
+    },
+    wallet! {
+        new_taddress_allow_gap,
+        short_help: "Create a new transparent address (even if the last one did not receive any funds).",
+        help: indoc! {r#"
+            Create a new transparent address even if the last one never received funds.
 
-/// Commands that do not require a wallet connection.
-pub fn get_standalone_commands() -> HashMap<&'static str, Box<dyn Command>> {
-    vec![
-        ("help", Box::new(HelpCommand {}) as Box<dyn Command>),
-        ("parse_address", Box::new(ParseAddressCommand {})),
-        ("parse_viewkey", Box::new(ParseViewKeyCommand {})),
-        ("version", Box::new(GetVersionCommand {})),
-    ]
-    .into_iter()
-    .collect()
-}
+            This bypasses the no-gap rule, which exists because recovery from seed may
+            not discover addresses beyond a gap. Funds sent to skipped addresses can go
+            missing after a restore unless you rescan or raise the gap limit, so you are
+            taking on tracking the unused ones yourself.
 
-/// Commands that require a wallet connection.
-pub fn get_wallet_commands() -> HashMap<&'static str, Box<dyn Command>> {
-    vec![
-        (
-            "addresses",
-            Box::new(UnifiedAddressesCommand {}) as Box<dyn Command>,
+            Usage:
+            new_taddress_allow_gap
+        "#},
+    },
+    wallet! {
+        notes,
+        short_help: "Show the wallet's notes (shielded outputs).",
+        help: indoc! {r"
+            Show the wallet's notes (shielded outputs). `all` includes spent ones.
+
+            Usage:
+            notes [all]
+        "},
+    },
+    wallet! {
+        nym,
+        short_help: "Control the Nym mixnet transport (on/off/status/probe/history).",
+        help: indoc! {r"
+            Control the Nym mixnet transport for send and price-fetch.
+
+            With Mixnet Mode on, both route over the mixnet and fail closed while it
+            bootstraps, never falling back to clearnet. Turning it off is a deliberate
+            choice to transmit over clearnet.
+
+            `status` reports off, bootstrapping or ready. `on` starts the nym-proxy
+            child, taking the binary from the given path, else $ZINGO_NYM_PROXY, else
+            one bundled beside this binary, else PATH. `off` reverts to clearnet.
+            `probe` runs GetLightdInfo over both routes side by side to tell whether a
+            failure is mixnet-specific, and its clearnet leg uses your real IP.
+            `history` shows per-indexer attempts across sessions, and needs the
+            nym-diary feature plus --indexer-diary.
+
+            Usage:
+            nym status | on [binary_path] | off | probe [uri] | history
+        "},
+    },
+    standalone! {
+        parse_address,
+        short_help: "Parse an address",
+        help: concat!(
+            "Parse an address.\n",
+            "\n",
+            "Usage:\n",
+            "parse_address <address>\n",
+            "\n",
+            "Example\n",
+            "parse_address ",
+            crate::examples::transparent_address!(),
+            "\n",
         ),
-        ("balance", Box::new(BalanceCommand {})),
-        ("birthday", Box::new(BirthdayCommand {})),
-        ("change_server", Box::new(ChangeServerCommand {})),
-        ("check_address", Box::new(CheckAddressCommand {})),
-        ("clear", Box::new(ClearCommand {})),
-        ("coins", Box::new(CoinsCommand {})),
-        ("calculate", Box::new(CalculateCommand {})),
-        ("confirm", Box::new(ConfirmCommand {})),
-        ("transmit", Box::new(TransmitCommand {})),
-        ("current_price", Box::new(CurrentPriceCommand {})),
-        ("delete", Box::new(DeleteCommand {})),
-        ("drain", Box::new(DrainCommand {})),
-        ("export_ufvk", Box::new(ExportUfvkCommand {})),
-        ("height", Box::new(HeightCommand {})),
-        ("info", Box::new(InfoCommand {})),
-        ("max_send_value", Box::new(MaxSendValueCommand {})),
-        (
-            "memobytes_to_address",
-            Box::new(MemoBytesToAddressCommand {}),
+    },
+    standalone! {
+        parse_viewkey,
+        short_help: "Parse a view_key.",
+        help: concat!(
+            "Parse a viewing key.\n",
+            "\n",
+            "Usage:\n",
+            "parse_viewkey <viewing_key>\n",
+            "\n",
+            "Example\n",
+            "parse_viewkey ",
+            crate::examples::unified_viewing_key!(),
+            "\n",
         ),
-        ("messages", Box::new(MessagesFilterCommand {})),
-        ("migrate", Box::new(MigrateCommand {})),
-        ("migration", Box::new(MigrationCommand {})),
-        ("new_address", Box::new(NewUnifiedAddressCommand {})),
-        ("new_taddress", Box::new(NewTransparentAddressCommand {})),
-        ("nym", Box::new(NymCommand {})),
-        (
-            "new_taddress_allow_gap",
-            Box::new(NewTransparentAddressAllowGapCommand {}),
+    },
+    wallet! {
+        quicksend,
+        short_help: "Send ZEC, fusing `send` and `confirm`.",
+        help: concat!(
+            "Send ZEC, fusing `send` and `confirm`. The fee comes out of your balance\n",
+            "and you never see it before the transaction goes out.\n",
+            "\n",
+            "Usage:\n",
+            "    quicksend <address> <zatoshis> \"<optional memo>\"\n",
+            "    quicksend '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
+            "Example:\n",
+            "    quicksend ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
         ),
-        ("notes", Box::new(NotesCommand {})),
-        ("quicksend", Box::new(QuickSendCommand {})),
-        ("quickshield", Box::new(QuickShieldCommand {})),
-        ("quit", Box::new(QuitCommand {})),
-        ("recovery_info", Box::new(RecoveryInfoCommand {})),
-        ("remove_transaction", Box::new(RemoveTransactionCommand {})),
-        ("rescan", Box::new(RescanCommand {})),
-        ("save", Box::new(SaveCommand {})),
-        ("send", Box::new(SendCommand {})),
-        ("send_all", Box::new(SendAllCommand {})),
-        ("sends_to_address", Box::new(SendsToAddressCommand {})),
-        ("settings", Box::new(SettingsCommand {})),
-        ("shield", Box::new(ShieldCommand {})),
-        ("spendable_balance", Box::new(SpendableBalanceCommand {})),
-        ("split", Box::new(SplitCommand {})),
-        ("sync", Box::new(SyncCommand {})),
-        ("t_addresses", Box::new(TransparentAddressesCommand {})),
-        ("transactions", Box::new(TransactionsCommand {})),
-        ("value_to_address", Box::new(ValueToAddressCommand {})),
-        ("value_transfers", Box::new(ValueTransfersCommand {})),
-        ("wallet_kind", Box::new(WalletKindCommand {})),
-    ]
-    .into_iter()
-    .collect()
+    },
+    wallet! {
+        quickshield,
+        short_help: "Shield transparent funds, fusing `shield` and `confirm`.",
+        help: indoc! {r"
+            Shield transparent funds into the ironwood pool, fusing `shield` and
+            `confirm`. The fee comes out of your balance and you never see it before
+            the transaction goes out.
+
+            Usage:
+                quickshield
+        "},
+    },
+    wallet! {
+        quit,
+        short_help: "Quit the light client, saving state to disk.",
+        help: indoc! {r"
+            Quit the light client, saving state to disk.
+
+            Usage:
+            quit
+        "},
+    },
+    wallet! {
+        recovery_info,
+        short_help: "Print the wallet's seed phrase, birthday and account count.",
+        help: indoc! {r"
+            Print the wallet's seed phrase, birthday and account count.
+
+            The seed phrase recovers the whole wallet. Save it carefully, share it with
+            nobody.
+
+            Usage:
+            recovery_info
+        "},
+    },
+    wallet! {
+        remove_transaction,
+        short_help: "Remove a failed transaction from the wallet.",
+        help: indoc! {r"
+            Remove a failed transaction from the wallet. Manual on purpose, so a failed
+            send keeps its memos until you decide to drop them.
+
+            Usage:
+            remove_transaction <txid>
+        "},
+    },
+    wallet! {
+        rescan,
+        short_help: "Clear all chain-derived wallet data and sync again from the birthday.",
+        help: indoc! {r"
+            Clear all chain-derived wallet data and sync again from the birthday.
+
+            Usage:
+            rescan
+        "},
+    },
+    wallet! {
+        save,
+        short_help: "Launch the save task. Not meant to be called by hand.",
+        help: indoc! {r"
+            Launch the task that persists the wallet as its state changes. Not meant to
+            be called by hand.
+
+            Usage:
+            save run | check | shutdown
+        "},
+    },
+    wallet! {
+        send,
+        short_help: "Propose a transfer of ZEC, for 'confirm' to broadcast.",
+        help: concat!(
+            "Propose a transfer of ZEC. Shows the fee, then 'confirm' broadcasts it.\n",
+            "\n",
+            "Usage:\n",
+            "    send <address> <zatoshis> \"<optional memo>\"\n",
+            "    send '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
+            "Example:\n",
+            "    send ",
+            crate::examples::sapling_address!(),
+            " ",
+            crate::examples::amount_zatoshis!(),
+            " \"",
+            crate::examples::memo!(),
+            "\"\n",
+            "    confirm\n",
+        ),
+    },
+    wallet! {
+        send_all,
+        short_help: "Propose a transfer of all shielded ZEC to one address, for 'confirm' to broadcast.",
+        help: concat!(
+            "Propose a transfer of every shielded ZEC to one address. Shows the fee,\n",
+            "then 'confirm' broadcasts it. `zennies_for_zingo` adds 1_000_000 ZAT to the\n",
+            "zingolabs developer address per transaction.\n",
+            "\n",
+            "Skips transparent funds: shield those first, see `help shield`.\n",
+            "\n",
+            "Usage:\n",
+            "    send_all <address> \"<optional memo>\"\n",
+            "    send_all '{ \"address\": \"<address>\", \"memo\": \"<optional memo>\", \"zennies_for_zingo\": <true|false> }'\n",
+            "Example:\n",
+            "    send_all ",
+            crate::examples::sapling_address!(),
+            " \"",
+            crate::examples::send_all_memo!(),
+            "\"\n",
+            "    confirm\n",
+        ),
+    },
+    wallet! {
+        sends_to_address,
+        short_help: "Show by address number of sends for this seed.",
+        help: indoc! {r"
+            Print the number of sends, keyed by address.
+
+            Usage:
+            sends_to_address
+        "},
+    },
+    CommandSpec {
+        name: "servers",
+        short_help: "Show ranked indexer servers and response times",
+        help: "Show ranked indexer servers and their get_info() response times.\nUsage: servers",
+        body: CommandBody::Repl,
+    },
+    wallet! {
+        settings,
+        short_help: "Show or set wallet settings.",
+        help: indoc! {r"
+            Show or set wallet settings. With no argument, prints them all. To set one,
+            name it and give a value.
+
+            performance        low | medium | high | maximum
+            min_confirmations  1 or greater
+
+            Usage:
+            settings
+            settings performance high
+        "},
+    },
+    wallet! {
+        shield,
+        short_help: "Propose a shield of transparent funds, for 'confirm' to broadcast.",
+        help: indoc! {r"
+            Propose a shield of transparent funds into the ironwood pool. Shows the
+            fee, then 'confirm' broadcasts it.
+
+            Usage:
+                shield
+        "},
+    },
+    wallet! {
+        spendable_balance,
+        short_help: "Display the wallet's spendable balance.",
+        help: indoc! {r"
+            Print the wallet's spendable balance.
+
+            Usage:
+            spendable_balance
+        "},
+    },
+    wallet! {
+        split,
+        short_help: "Split Orchard notes into ZIP 318 part sizes, one round per call.",
+        help: indoc! {r"
+            Resize the wallet's Orchard notes into ZIP 318 part sizes, one round of
+            Orchard self-sends per call.
+
+            The rounds reveal no value and may run before NU6.3 activation. Each call
+            replans from the wallet's confirmed notes and persists no migration state.
+            Refused while a scheduled migration is active, since that flow does its own
+            splitting.
+
+            `plan` previews the remaining rounds, transactions, fees, resulting
+            denominations and residual dust. Nothing is signed or sent, and zero rounds
+            means every note is already part-ready.
+            `now` runs one round. Sync first, and again between rounds until each
+            round's self-sends confirm. It reports when a prior round is still
+            confirming and when splitting is done.
+
+            Usage:
+            split plan | now
+        "},
+    },
+    wallet! {
+        sync,
+        short_help: "Sync the wallet to the latest state of the blockchain.",
+        help: indoc! {r"
+            Sync the wallet to the chain tip.
+
+            `run` starts or resumes. `pause` halts scanning. `stop` shuts sync down
+            early. `status` reports progress. `poll` returns the result once complete,
+            and is not meant to be called by hand.
+
+            Usage:
+            sync run | pause | stop | status | poll
+        "},
+    },
+    wallet! {
+        t_addresses,
+        short_help: "List transparent addresses in the wallet.",
+        help: indoc! {r"
+            List the wallet's transparent addresses.
+
+            Usage:
+            t_addresses
+        "},
+    },
+    wallet! {
+        transactions,
+        short_help: "List the wallet's transaction summaries by block height.",
+        help: indoc! {r"
+            List the wallet's transaction summaries by block height.
+
+            Usage:
+            transactions
+        "},
+    },
+    wallet! {
+        transmit,
+        short_help: "Transmit calculated transactions to the Indexer.",
+        help: concat!(
+            "Transmit calculated transactions to the Indexer. With no arguments, sends\n",
+            "every Calculated transaction in target-height order. Pass txids in the order\n",
+            "'calculate' printed them to fix the order yourself, which multi-step proposals\n",
+            "such as TEX sends require.\n",
+            "\n",
+            "Anything you leave untransmitted stays live value in flight until it expires or\n",
+            "its inputs are spent.\n",
+            "\n",
+            "Usage:\n",
+            "    transmit [txid ...]\n",
+            "Example:\n",
+            "    transmit\n",
+        ),
+    },
+    wallet! {
+        value_to_address,
+        short_help: "Show by address value transfers for this seed.",
+        help: indoc! {r"
+            Print total value sent, keyed by address.
+
+            Usage:
+            value_to_address
+        "},
+    },
+    wallet! {
+        value_transfers,
+        short_help: "List all value transfers for this wallet.",
+        help: indoc! {r"
+            List the wallet's value transfers, each one a transaction's notes to a
+            single receiver.
+
+            Usage:
+            value_transfers
+        "},
+    },
+    standalone! {
+        version,
+        short_help: "Get version of build code",
+        help: indoc! {r"
+            Print the build's git describe --dirty.
+        "},
+    },
+    wallet! {
+        wallet_kind,
+        short_help: "Displays the kind of wallet currently loaded",
+        help: indoc! {r"
+            Print the loaded wallet's kind. For a UFVK, lists the supported pools.
+            Spend-capable wallets always spend from all three.
+            "},
+    },
+];
+
+/// Renders the help listing (no arguments) or one command's help text,
+/// straight from [`COMMANDS`].
+pub fn format_help(args: &[&str]) -> String {
+    match args.len() {
+        0 => {
+            let mut lines = Vec::new();
+            lines.push("Standalone commands (no wallet required):".to_string());
+            lines.extend(
+                COMMANDS
+                    .iter()
+                    .filter(|spec| !matches!(spec.body, CommandBody::Wallet(_)))
+                    .map(|spec| format!("  {} - {}", spec.name, spec.short_help)),
+            );
+            lines.push(String::new());
+            lines.push("Wallet commands:".to_string());
+            lines.extend(
+                COMMANDS
+                    .iter()
+                    .filter(|spec| matches!(spec.body, CommandBody::Wallet(_)))
+                    .map(|spec| format!("  {} - {}", spec.name, spec.short_help)),
+            );
+            lines.join("\n")
+        }
+        1 => match COMMANDS.iter().find(|spec| spec.name == args[0]) {
+            Some(spec) => spec.help.to_string(),
+            None => format!("Command {} not found", args[0]),
+        },
+        _ => "Usage: help [command_name]".to_string(),
+    }
 }
 
-/// All commands (standalone + wallet). Used for dispatch and `help <command>`.
-pub fn get_commands() -> HashMap<&'static str, Box<dyn Command>> {
-    let mut all = get_standalone_commands();
-    all.extend(get_wallet_commands());
-    all
-}
-
-/// Dispatches a user command by name to the appropriate [`Command`] implementation,
-/// exposing the typed success/failure crossing.
-///
-/// An unknown command returns its "Unknown command" prose via `Ok`, mirroring
-/// the string entry point's historical behavior of not treating it as an error.
-pub fn do_user_command_result(
+/// Dispatches a user command by name through [`COMMANDS`], exposing the
+/// typed success/failure crossing. Unknown names and the REPL-owned
+/// `servers` command return typed errors (ADR 0031).
+pub async fn do_user_command_result(
     cmd: &str,
     args: &[&str],
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
-    match get_commands().get(cmd.to_ascii_lowercase().as_str()) {
-        Some(cmd) => cmd.exec(args, lightclient),
-        None => Ok(format!(
-            "Unknown command : {cmd}. Type 'help' for a list of commands"
-        )),
+    let lowered = cmd.to_ascii_lowercase();
+    match COMMANDS.iter().find(|spec| spec.name == lowered) {
+        Some(spec) => match spec.body {
+            CommandBody::Standalone(run) => run(args),
+            CommandBody::Wallet(run) => run(args, lightclient).await,
+            CommandBody::Repl => Err(CommandError::ReplOnly(spec.name)),
+        },
+        None => Err(CommandError::UnknownCommand(cmd.to_string())),
     }
 }
 
-/// Dispatches a user command by name to the appropriate [`Command`] implementation.
-///
-/// Returns the command's output string, or an "Unknown command" message
-/// if no command with the given name exists. This is the single site that
-/// renders [`CommandError`] to prose for string frontends.
-pub fn do_user_command(cmd: &str, args: &[&str], lightclient: &mut LightClient) -> String {
-    match do_user_command_result(cmd, args, lightclient) {
-        Ok(output) => output,
-        Err(e) => format!("Error: {e}"),
-    }
-}
-
-#[cfg(test)]
-mod transmit_heartbeat {
-    //! Paused-clock falsifiers for the transmit heartbeat's contract: silence
-    //! for fast transmissions, a narrated line on the ratified 20-40s cadence
-    //! for slow ones, always carrying the side channel's latest detail.
-
-    use std::sync::{Arc, Mutex};
-    use std::time::Duration;
-
-    use super::*;
-
-    /// HYPOTHESIS: a transmission finishing before the first tick emits
-    /// nothing, because the heartbeat must not add noise to a normal fast send.
-    #[tokio::test(start_paused = true)]
-    async fn a_fast_transmission_stays_silent() {
-        let lines: Arc<Mutex<Vec<String>>> = Arc::default();
-        let sink = lines.clone();
-        let out = with_transmit_heartbeat(
-            "confirm",
-            || Some("submitting".to_string()),
-            move |line| sink.lock().expect("line sink poisoned").push(line),
-            tokio::time::sleep(zingo_netutils::time::test::SIMULATED_TRANSMIT),
-        )
-        .await;
-        let () = out;
-        assert!(
-            lines.lock().expect("line sink poisoned").is_empty(),
-            "no heartbeat before the first interval"
-        );
-    }
-
-    /// HYPOTHESIS: a slow transmission is narrated on the interval cadence,
-    /// each line carrying the label, the side channel's latest detail, and
-    /// the elapsed seconds. Falsified if the wait stays silent or drops the
-    /// detail.
-    #[tokio::test(start_paused = true)]
-    async fn a_slow_transmission_heartbeats_the_latest_detail() {
-        let lines: Arc<Mutex<Vec<String>>> = Arc::default();
-        let sink = lines.clone();
-        with_transmit_heartbeat(
-            "confirm",
-            || Some("witness zec.rocks: submitting".to_string()),
-            move |line| sink.lock().expect("line sink poisoned").push(line),
-            tokio::time::sleep(Duration::from_secs(95)),
-        )
-        .await;
-        let lines = lines.lock().expect("line sink poisoned").clone();
-        assert_eq!(
-            lines,
-            vec![
-                "confirm: witness zec.rocks: submitting (30s elapsed)".to_string(),
-                "confirm: witness zec.rocks: submitting (60s elapsed)".to_string(),
-                "confirm: witness zec.rocks: submitting (90s elapsed)".to_string(),
-            ]
-        );
-    }
-
-    /// An empty side channel still heartbeats, falling back to a generic
-    /// line rather than skipping the tick.
-    #[tokio::test(start_paused = true)]
-    async fn an_empty_side_channel_still_heartbeats() {
-        let lines: Arc<Mutex<Vec<String>>> = Arc::default();
-        let sink = lines.clone();
-        with_transmit_heartbeat(
-            "transmit",
-            || None,
-            move |line| sink.lock().expect("line sink poisoned").push(line),
-            tokio::time::sleep(Duration::from_secs(35)),
-        )
-        .await;
-        assert_eq!(
-            lines.lock().expect("line sink poisoned").clone(),
-            vec!["transmit: transmitting (30s elapsed)".to_string()]
-        );
-    }
-}
-
-#[cfg(test)]
-mod migration_command_parsing {
-    //! Pins the pure argument parser and the byte-identity of the typed
-    //! errors' rendering with the in-band strings they replaced.
-
-    use super::*;
-
-    #[test]
-    fn start_parses_hash_and_per_bucket() {
-        let hash_hex = "11".repeat(32);
-        let parsed = parse_migration_args(&["start", &hash_hex, "--per-bucket", "3"])
-            .expect("well-formed arguments parse");
-        assert_eq!(
-            parsed,
-            MigrationSubCommand::Start {
-                plan_hash: [0x11; 32],
-                per_bucket: Some(3),
-            }
-        );
-    }
-
-    #[test]
-    fn malformed_plan_hash_is_typed() {
-        assert!(matches!(
-            parse_migration_args(&["start", "abc"]),
-            Err(MigrationCommandError::MalformedPlanHash)
-        ));
-    }
-
-    #[test]
-    fn continue_parses_bare() {
-        assert_eq!(
-            parse_migration_args(&["continue"]).expect("bare continue parses"),
-            MigrationSubCommand::Continue
-        );
-    }
-
-    #[test]
-    fn windows_parses_bare() {
-        assert_eq!(
-            parse_migration_args(&["windows"]).expect("bare windows parses"),
-            MigrationSubCommand::Windows
-        );
-    }
-
-    #[test]
-    fn cadence_requires_a_count() {
-        assert_eq!(
-            parse_migration_args(&["cadence", "4"]).expect("well-formed cadence parses"),
-            MigrationSubCommand::Cadence { per_bucket: 4 }
-        );
-        assert!(matches!(
-            parse_migration_args(&["cadence"]),
-            Err(MigrationCommandError::MalformedCadence)
-        ));
-    }
-
-    #[test]
-    fn execute_defaults_spacing_to_thirty_seconds() {
-        assert_eq!(
-            parse_migration_args(&["execute"]).expect("bare execute parses"),
-            MigrationSubCommand::Execute {
-                spacing: std::time::Duration::from_secs(30),
-            }
-        );
-        assert_eq!(
-            parse_migration_args(&["execute", "5"]).expect("spaced execute parses"),
-            MigrationSubCommand::Execute {
-                spacing: std::time::Duration::from_secs(5),
-            }
-        );
-    }
-
-    #[test]
-    fn catchup_defaults_spacing_to_thirty_seconds() {
-        assert_eq!(
-            parse_migration_args(&["catchup"]).expect("bare catchup parses"),
-            MigrationSubCommand::Catchup {
-                spacing: std::time::Duration::from_secs(30),
-            }
-        );
-    }
-
-    #[test]
-    fn errors_render_byte_identically_to_the_replaced_strings() {
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::MissingSubCommand),
-            "Error: migration command expects a sub-command. Type \"help migration\" for usage."
-        );
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::MalformedPerBucket),
-            "Error: --per-bucket expects a positive integer."
-        );
-    }
-}
-
-#[cfg(test)]
-mod drain_and_split_command_parsing {
-    //! Pins the pure argument parsers of the mobile-parity migration
-    //! commands: `drain` and `split` accept exactly `plan` or `now`.
-
-    use super::*;
-
-    #[test]
-    fn drain_accepts_exactly_plan_or_now() {
-        assert_eq!(
-            parse_drain_args(&["plan"]).expect("drain plan parses"),
-            DrainSubCommand::Plan
-        );
-        assert_eq!(
-            parse_drain_args(&["now"]).expect("drain now parses"),
-            DrainSubCommand::Now
-        );
-        for junk in [&[][..], &["bogus"][..], &["now", "extra"][..]] {
-            assert!(matches!(
-                parse_drain_args(junk),
-                Err(MigrationCommandError::DrainUsage)
-            ));
-        }
-    }
-
-    #[test]
-    fn split_accepts_exactly_plan_or_now() {
-        assert_eq!(
-            parse_split_args(&["plan"]).expect("split plan parses"),
-            SplitSubCommand::Plan
-        );
-        assert_eq!(
-            parse_split_args(&["now"]).expect("split now parses"),
-            SplitSubCommand::Now
-        );
-        for junk in [&[][..], &["bogus"][..], &["plan", "extra"][..]] {
-            assert!(matches!(
-                parse_split_args(junk),
-                Err(MigrationCommandError::SplitUsage)
-            ));
-        }
-    }
-
-    #[test]
-    fn usage_errors_render_with_help_pointers() {
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::DrainUsage),
-            "Error: drain expects a sub-command: plan | now. Type \"help drain\" for usage."
-        );
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::SplitUsage),
-            "Error: split expects a sub-command: plan | now. Type \"help split\" for usage."
-        );
-    }
-}
-
-#[cfg(test)]
-mod nym_command_parsing {
-    //! Pins the pure argument parser and the byte-identity of the typed
-    //! errors' rendering with the in-band strings they replaced.
-
-    use super::*;
-
-    #[cfg(feature = "nym")]
-    #[test]
-    fn bare_and_status_both_parse_to_status() {
-        assert_eq!(
-            parse_nym_args(&[]).expect("a bare nym parses"),
-            NymSubCommand::Status
-        );
-        assert_eq!(
-            parse_nym_args(&["status"]).expect("nym status parses"),
-            NymSubCommand::Status
-        );
-    }
-
-    #[cfg(feature = "nym")]
-    #[test]
-    fn on_captures_the_optional_path() {
-        assert_eq!(
-            parse_nym_args(&["on"]).expect("bare nym on parses"),
-            NymSubCommand::On { path: None }
-        );
-        assert_eq!(
-            parse_nym_args(&["on", "/opt/nym-proxy"]).expect("nym on with a path parses"),
-            NymSubCommand::On {
-                path: Some("/opt/nym-proxy".to_string()),
-            }
-        );
-    }
-
-    #[cfg(feature = "nym")]
-    #[test]
-    fn unknown_subcommand_renders_byte_identically_to_the_replaced_string() {
-        assert_eq!(
-            parse_nym_args(&["bogus"])
-                .expect_err("an unknown subcommand is typed")
-                .to_string(),
-            "unknown nym subcommand 'bogus'. Use: nym status | nym on [path] | nym off | \
-             nym probe [uri] | nym history"
-        );
-    }
-
-    #[cfg(feature = "nym")]
-    #[test]
-    fn probe_parses_its_optional_target_and_rejects_junk() {
-        assert_eq!(
-            parse_nym_args(&["probe"]).expect("bare probe parses"),
-            NymSubCommand::Probe { target: None }
-        );
-        assert_eq!(
-            parse_nym_args(&["probe", "https://zec.rocks:443"]).expect("probe with a uri parses"),
-            NymSubCommand::Probe {
-                target: Some("https://zec.rocks:443".parse().expect("static uri")),
-            }
-        );
-        assert!(matches!(
-            parse_nym_args(&["probe", "not a uri"]),
-            Err(NymCommandError::InvalidProbeTarget(_))
-        ));
-        assert!(
-            matches!(
-                parse_nym_args(&["probe", "http://zec.rocks:9067"]),
-                Err(NymCommandError::InvalidProbeTarget(_))
-            ),
-            "a plaintext http target is refused: mixnet transmission is https-only"
-        );
-        assert_eq!(
-            parse_nym_args(&["history"]).expect("history parses"),
-            NymSubCommand::History
-        );
-    }
-
-    /// HYPOTHESIS: the paired-probe rendering makes a mixnet-specific failure
-    /// legible at a glance: clearnet ok beside mixnet FAILED. Falsified if
-    /// either leg's outcome, timing, or the not-ready skip is dropped.
-    #[cfg(feature = "nym")]
-    #[test]
-    fn paired_probe_renders_both_legs_side_by_side() {
-        use zingo_net_diag::{NetOpFailure, NetOpStage};
-        use zingolib::nym::probe::{PairedProbe, ProbeLeg, ProbeSuccess};
-
-        let tip = ProbeSuccess {
-            chain: "main".to_string(),
-            height: 3_420_400,
-        };
-        let mixnet_specific = PairedProbe {
-            host: "carover0.xyz".to_string(),
-            clearnet: ProbeLeg {
-                outcome: Ok(tip.clone()),
-                millis: 210,
-            },
-            mixnet: Some(ProbeLeg {
-                outcome: Err(NetOpFailure {
-                    stage: NetOpStage::SocksHandshake,
-                    target: "carover0.xyz".to_string(),
-                    cause_chain: vec![
-                        "the mixnet exit could not reach carover0.xyz:9067 (timed out after 20.0s)"
-                            .to_string(),
-                    ],
-                }),
-                millis: 20_000,
-            }),
-        };
-        assert_eq!(
-            render_paired_probe(&mixnet_specific),
-            "carover0.xyz\n  clearnet: ok in 210ms: chain main, height 3420400\n  mixnet:   FAILED after 20000ms: failed at socks-handshake to carover0.xyz: the mixnet exit could not reach carover0.xyz:9067 (timed out after 20.0s)"
-        );
-
-        let proxy_not_ready = PairedProbe {
-            host: "zec.rocks".to_string(),
-            clearnet: ProbeLeg {
-                outcome: Ok(tip),
-                millis: 180,
-            },
-            mixnet: None,
-        };
-        assert_eq!(
-            render_paired_probe(&proxy_not_ready),
-            "zec.rocks\n  clearnet: ok in 180ms: chain main, height 3420400\n  mixnet:   skipped (mixnet proxy not ready)"
-        );
-    }
-
-    /// HYPOTHESIS: the history rendering aggregates per host and route with
-    /// the most recent outcome and its age. Falsified if counts mix routes
-    /// or the last outcome reflects file order rather than timestamps.
-    #[cfg(all(feature = "nym", feature = "nym-diary"))]
-    #[test]
-    fn history_aggregates_per_host_and_route() {
-        use zingolib::lightclient::indexer_history::{
-            AttemptKind, AttemptRoute, FailureKind, IndexerAttempt,
-        };
-
-        let attempt = |host: &str, route, unix_secs, outcome| IndexerAttempt {
-            unix_secs,
-            host: host.to_string(),
-            route,
-            kind: AttemptKind::Send,
-            millis: 10,
-            outcome,
-        };
-        let tunnel = Err(FailureKind::Unreachable);
-        let attempts = vec![
-            attempt("zec.rocks", AttemptRoute::Mixnet, 1_000, tunnel),
-            attempt("zec.rocks", AttemptRoute::Mixnet, 2_000, Ok(())),
-            attempt("zec.rocks", AttemptRoute::Clearnet, 1_500, Ok(())),
-            attempt("carover0.xyz", AttemptRoute::Mixnet, 1_800, tunnel),
-        ];
-
-        assert_eq!(
-            render_history(&attempts, 2_060),
-            "Indexer history (all sessions):\n  \
-             carover0.xyz: mixnet 0/1 ok, last failed 4m ago\n  \
-             zec.rocks: clearnet 1/1 ok, last ok 9m ago; mixnet 1/2 ok, last ok 1m ago"
-        );
-        assert_eq!(render_history(&[], 0), "No indexer history recorded yet.");
-    }
-
-    #[cfg(not(feature = "nym"))]
-    #[test]
-    fn feature_absent_renders_byte_identically_to_the_replaced_string() {
-        assert_eq!(
-            NymCommandError::FeatureAbsent.to_string(),
-            "This build has no Nym mixnet support. Rebuild zingo-cli with `--features nym`."
-        );
-    }
-
-    /// Pins the `nym status` mode strings via the pure renderer.
-    #[cfg(feature = "nym")]
-    #[test]
-    fn status_lines_render_byte_identically_to_the_replaced_strings() {
-        use zingolib::nym::MixnetMode;
-
-        assert_eq!(
-            render_status(MixnetMode::Unattached, None, None),
-            "Mixnet Mode: unattached. The mixnet has not been enabled, and no consent to \
-             clearnet has been given: send and price-fetch refuse. Run `nym on` to enable \
-             the mixnet, or `nym off` to use clearnet.",
-            "absence is not consent: unattached names refusal, never clearnet"
-        );
-        assert_eq!(
-            render_status(MixnetMode::SwitchedOff, None, None),
-            "Mixnet Mode: switched off (send and price-fetch use clearnet)"
-        );
-        assert_eq!(
-            render_status(MixnetMode::Bootstrapping, None, None),
-            "Mixnet Mode: bootstrapping (send and price-fetch are unavailable until ready)"
-        );
-        assert_eq!(
-            render_status(MixnetMode::Ready, Some("127.0.0.1:43210"), None),
-            "Mixnet Mode: ready (SOCKS5 127.0.0.1:43210)"
-        );
-        assert_eq!(
-            render_status(MixnetMode::Ready, None, None),
-            "Mixnet Mode: ready",
-            "ready with no address yet still renders (the route resolver, \
-             not the renderer, refuses that state)"
-        );
-        assert_eq!(
-            render_status(MixnetMode::Died, None, None),
-            "Mixnet Mode: died. The proxy exited unexpectedly. Send and price-fetch \
-             refuse and will not fall back to clearnet. Run `nym on` to restart the proxy.",
-            "a died proxy is reported distinctly from switched off, and tells the user how to \
-             recover"
-        );
-    }
-
-    /// HYPOTHESIS: live bootstrap progress reaches the `nym status` line, so
-    /// the connect race is narrated rather than an opaque wait. Falsified if
-    /// the detail is dropped by the renderer. The detail is shown only while
-    /// bootstrapping: a ready proxy has no bootstrap left to narrate.
-    #[cfg(feature = "nym")]
-    #[test]
-    fn bootstrap_detail_reaches_the_status_line_only_while_bootstrapping() {
-        use zingolib::nym::MixnetMode;
-
-        assert_eq!(
-            render_status(
-                MixnetMode::Bootstrapping,
-                None,
-                Some("attempt 2/10: 2 in flight, 0 failed")
-            ),
-            "Mixnet Mode: bootstrapping, attempt 2/10: 2 in flight, 0 failed \
-             (send and price-fetch are unavailable until ready)"
-        );
-        assert_eq!(
-            render_status(MixnetMode::Ready, Some("127.0.0.1:1"), Some("stale")),
-            "Mixnet Mode: ready (SOCKS5 127.0.0.1:1)",
-            "a stale detail must not leak into the ready line"
-        );
-    }
-
-    /// HYPOTHESIS: `nym status` always carries the IP-correlation disclaimer in
-    /// every mode, so a "ready" mixnet is never mistaken for end-to-end IP
-    /// protection while synchronization stays on clearnet (ZIP-0318). The mode
-    /// line is preserved verbatim as the first line. Falsified if the
-    /// disclaimer is dropped in any mode, no longer leads with the mode line,
-    /// or omits the sync/IP/indexer/balance risk it must name.
-    #[cfg(feature = "nym")]
-    #[test]
-    fn status_always_carries_the_ip_correlation_disclaimer() {
-        use zingolib::nym::MixnetMode;
-
-        for mode in [
-            MixnetMode::Unattached,
-            MixnetMode::SwitchedOff,
-            MixnetMode::Bootstrapping,
-            MixnetMode::Ready,
-            MixnetMode::Died,
-        ] {
-            let addr = Some("127.0.0.1:43210");
-            let out = render_status_with_disclaimer(mode, addr, None);
-            assert!(
-                out.starts_with(&render_status(mode, addr, None)),
-                "the mode line must lead the status output: {out}"
-            );
-            for phrase in [
-                "IP-correlation risk",
-                "synchronization",
-                "sync indexer",
-                "total balance",
-                "ZIP-0318",
-            ] {
-                assert!(
-                    out.contains(phrase),
-                    "the disclaimer must name {phrase:?} in mode {mode:?}: {out}"
-                );
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod offline_contract {
-    //! The Offline-mode contract at the command surface (issue #2286,
-    //! ADR 0006, ADR 0025). Every client here is genuinely Indexerless —
-    //! built by [`LightClient::new_for_test`] from a synthetic wallet, with
-    //! no server configured and no network object constructed — so these
-    //! tests run with zero traffic and prove two halves of one contract:
-    //!
-    //! - every wallet-local command completes offline, meaning connectivity
-    //!   is never the obstacle (a domain failure such as "nothing to
-    //!   shield" is legitimate; the Offline refusal is not); and
-    //! - every connectivity-requiring command refuses offline with the one
-    //!   typed refusal, [`zingolib::lightclient::error::LightClientError::Offline`],
-    //!   rendered through the command's own error channel — never a hang, a
-    //!   panic, or a silent clearnet fallback.
-    //!
-    //! The `change_server` pin lives at the REPL dispatch, not here: see
-    //! `offline_mode_refusal` and its tests in `crate::tests`.
-    //!
-    //! Deliberately untested, with the reasoning on record: `drain now`,
-    //! `split now`, and `migration catchup` refuse at the transmit stage,
-    //! whose pre-flight `transmit` and `quicksend` pin below (each extra
-    //! case would buy another proving run, not another guarantee); `nym on`
-    //! and `nym probe` currently carry NO offline gate (they would emit
-    //! traffic from an Offline session — a known gap tracked for the ADR
-    //! 0024 session driver), and the REPL-owned `servers` command likewise
-    //! probes the network unguarded.
-
-    use zingolib::lightclient::LightClient;
-    use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
-
-    use super::{CommandError, RT, get_commands};
-
-    /// The Display of `LightClientError::Offline`: the single refusal every
-    /// connectivity-requiring command must surface, and the string no
-    /// offline-capable command may ever emit.
-    const OFFLINE_REFUSAL: &str =
-        "Offline: no indexer configured. Call set_indexer_uri() to connect.";
-
-    /// An Indexerless client over an empty synthetic wallet.
-    fn offline_client() -> LightClient {
-        RT.block_on(LightClient::new_for_test(
-            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED).build(),
-        ))
-    }
-
-    /// An Indexerless client whose wallet holds a spendable orchard note
-    /// and a transparent coin, so proposing, planning, and shielding have
-    /// material to work with.
-    fn funded_offline_client() -> LightClient {
-        RT.block_on(LightClient::new_for_test(
-            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
-                .orchard_note(100_000_000)
-                .transparent_coin(50_000_000)
-                .build(),
-        ))
-    }
-
-    fn exec(
-        client: &mut LightClient,
-        command: &str,
-        args: &[&str],
-    ) -> Result<String, CommandError> {
-        get_commands()
-            .get(command)
-            .unwrap_or_else(|| panic!("command `{command}` is registered"))
-            .exec(args, client)
-    }
-
-    /// Asserts `command` succeeds offline and returns its output.
-    fn assert_works_offline(client: &mut LightClient, command: &str, args: &[&str]) -> String {
-        let output = exec(client, command, args)
-            .unwrap_or_else(|error| panic!("`{command}` must work offline: {error}"));
-        assert!(
-            !output.contains(OFFLINE_REFUSAL),
-            "`{command}` must not surface the Offline refusal: {output}"
-        );
-        output
-    }
-
-    /// Asserts connectivity is never `command`'s obstacle: it may succeed
-    /// or fail on domain grounds, but must not surface the Offline refusal.
-    fn assert_unblocked_offline(client: &mut LightClient, command: &str, args: &[&str]) -> String {
-        let rendered = match exec(client, command, args) {
-            Ok(output) => output,
-            Err(error) => error.to_string(),
-        };
-        assert!(
-            !rendered.contains(OFFLINE_REFUSAL),
-            "`{command}` must not be blocked by Offline mode: {rendered}"
-        );
-        rendered
-    }
-
-    /// Asserts `command` refuses offline through its `Err` channel with the
-    /// typed Offline refusal.
-    fn assert_refuses_offline_via_err(client: &mut LightClient, command: &str, args: &[&str]) {
-        let error = exec(client, command, args).expect_err(command);
-        assert!(
-            error.to_string().contains(OFFLINE_REFUSAL),
-            "`{command}` must refuse with the typed Offline error: {error}"
-        );
-    }
-
-    /// Asserts `command` refuses offline through its rendered `error` field
-    /// (the send family reports failure inside its JSON success string).
-    fn assert_refuses_offline_in_output(client: &mut LightClient, command: &str, args: &[&str]) {
-        let output = exec(client, command, args)
-            .unwrap_or_else(|error| panic!("`{command}` renders refusals into output: {error}"));
-        assert!(
-            output.contains(OFFLINE_REFUSAL),
-            "`{command}` must report the typed Offline refusal: {output}"
-        );
-    }
-
-    /// A fresh unified address from the wallet itself, so send-family tests
-    /// stay on the wallet's own chain.
-    fn own_unified_address(client: &mut LightClient) -> String {
-        let output = assert_works_offline(client, "new_address", &["o"]);
-        let parsed = json::parse(&output).expect("new_address returns JSON");
-        parsed["encoded_address"]
-            .as_str()
-            .expect("encoded_address is a string")
-            .to_string()
-    }
-
-    mod works_offline {
-        //! The offline-capable surface: every command here must complete
-        //! against an Indexerless client.
-
-        use super::*;
-
-        #[test]
-        fn version() {
-            let output = assert_works_offline(&mut offline_client(), "version", &[]);
-            assert!(!output.is_empty());
-        }
-
-        #[test]
-        fn help() {
-            let output = assert_works_offline(&mut offline_client(), "help", &[]);
-            assert!(output.contains("Wallet commands"), "{output}");
-        }
-
-        #[test]
-        fn parse_address_of_the_wallets_own() {
-            let mut client = offline_client();
-            let address = own_unified_address(&mut client);
-            let output = assert_works_offline(&mut client, "parse_address", &[&address]);
-            assert!(output.contains("success"), "{output}");
-        }
-
-        #[test]
-        fn parse_viewkey_of_the_exported_ufvk() {
-            let mut client = offline_client();
-            let exported = assert_works_offline(&mut client, "export_ufvk", &[]);
-            let ufvk = json::parse(&exported).expect("export_ufvk returns JSON")["ufvk"]
-                .as_str()
-                .expect("ufvk is a string")
-                .to_string();
-            let output = assert_works_offline(&mut client, "parse_viewkey", &[&ufvk]);
-            assert!(output.contains("success"), "{output}");
-        }
-
-        #[test]
-        fn addresses() {
-            let output = assert_works_offline(&mut offline_client(), "addresses", &[]);
-            json::parse(&output).expect("addresses returns JSON");
-        }
-
-        #[test]
-        fn t_addresses() {
-            let output = assert_works_offline(&mut offline_client(), "t_addresses", &[]);
-            json::parse(&output).expect("t_addresses returns JSON");
-        }
-
-        #[test]
-        fn new_address() {
-            let output = assert_works_offline(&mut offline_client(), "new_address", &["oz"]);
-            assert!(output.contains("encoded_address"), "{output}");
-        }
-
-        /// Funded, because the address-gap rule (a new transparent address
-        /// only after the latest one received funds) is a domain rule that
-        /// applies offline exactly as it does online.
-        #[test]
-        fn new_taddress() {
-            let output = assert_works_offline(&mut funded_offline_client(), "new_taddress", &[]);
-            assert!(output.contains("encoded_address"), "{output}");
-        }
-
-        #[test]
-        fn balance() {
-            let output = assert_works_offline(&mut funded_offline_client(), "balance", &[]);
-            assert!(!output.is_empty());
-        }
-
-        #[test]
-        fn spendable_balance() {
-            let output =
-                assert_works_offline(&mut funded_offline_client(), "spendable_balance", &[]);
-            assert!(output.contains("spendable_balance"), "{output}");
-        }
-
-        #[test]
-        fn max_send_value() {
-            let mut client = funded_offline_client();
-            let address = own_unified_address(&mut client);
-            let output = assert_works_offline(&mut client, "max_send_value", &[&address]);
-            assert!(output.contains("max_send_value"), "{output}");
-        }
-
-        #[test]
-        fn birthday() {
-            let output = assert_works_offline(&mut offline_client(), "birthday", &[]);
-            assert!(!output.is_empty());
-        }
-
-        #[test]
-        fn height_reports_the_wallets_own_view() {
-            let output = assert_works_offline(&mut offline_client(), "height", &[]);
-            assert!(output.contains("20"), "the synthetic tip is 20: {output}");
-        }
-
-        #[test]
-        fn notes() {
-            assert_works_offline(&mut funded_offline_client(), "notes", &[]);
-        }
-
-        #[test]
-        fn coins() {
-            assert_works_offline(&mut funded_offline_client(), "coins", &[]);
-        }
-
-        #[test]
-        fn transactions() {
-            assert_works_offline(&mut offline_client(), "transactions", &[]);
-        }
-
-        #[test]
-        fn value_transfers() {
-            assert_works_offline(&mut offline_client(), "value_transfers", &[]);
-        }
-
-        #[test]
-        fn messages() {
-            assert_works_offline(&mut offline_client(), "messages", &[]);
-        }
-
-        #[test]
-        fn sends_to_address() {
-            assert_works_offline(&mut offline_client(), "sends_to_address", &[]);
-        }
-
-        #[test]
-        fn value_to_address() {
-            assert_works_offline(&mut offline_client(), "value_to_address", &[]);
-        }
-
-        #[test]
-        fn memobytes_to_address() {
-            assert_works_offline(&mut offline_client(), "memobytes_to_address", &[]);
-        }
-
-        #[test]
-        fn wallet_kind() {
-            let output = assert_works_offline(&mut offline_client(), "wallet_kind", &[]);
-            assert!(output.contains("mnemonic"), "{output}");
-        }
-
-        #[test]
-        fn settings() {
-            assert_unblocked_offline(&mut offline_client(), "settings", &[]);
-        }
-
-        #[test]
-        fn recovery_info() {
-            let output = assert_works_offline(&mut offline_client(), "recovery_info", &[]);
-            assert!(!output.is_empty());
-        }
-
-        #[test]
-        fn export_ufvk() {
-            let output = assert_works_offline(&mut offline_client(), "export_ufvk", &[]);
-            assert!(output.contains("ufvk"), "{output}");
-        }
-
-        #[test]
-        fn check_address_recognizes_the_wallets_own() {
-            let mut client = offline_client();
-            let address = own_unified_address(&mut client);
-            let output = assert_works_offline(&mut client, "check_address", &[&address]);
-            assert!(output.contains("is_wallet_address"), "{output}");
-        }
-
-        #[test]
-        fn clear() {
-            let output = assert_works_offline(&mut offline_client(), "clear", &[]);
-            assert!(output.contains("success"), "{output}");
-        }
-
-        /// `sync status` reads wallet state only; on a synthetic wallet it
-        /// reports a wallet-shape error (no wallet blocks are fabricated),
-        /// which is a domain outcome — connectivity is never the obstacle.
-        #[test]
-        fn sync_status() {
-            assert_unblocked_offline(&mut offline_client(), "sync", &["status"]);
-        }
-
-        #[test]
-        fn sync_poll() {
-            let output = assert_works_offline(&mut offline_client(), "sync", &["poll"]);
-            assert_eq!(output, "Sync task has not been launched.");
-        }
-
-        #[test]
-        fn quit() {
-            let output = assert_works_offline(&mut offline_client(), "quit", &[]);
-            assert!(output.contains("quit successfully"), "{output}");
-        }
-
-        /// Proposing is an Indexerless capability (ADR 0006): `send` shows
-        /// the fee offline, for a later `calculate`/`transmit`.
-        #[test]
-        fn send_proposes_offline() {
-            let mut client = funded_offline_client();
-            let address = own_unified_address(&mut client);
-            let output = assert_works_offline(&mut client, "send", &[&address, "50000"]);
-            assert!(output.contains("fee"), "{output}");
-        }
-
-        #[test]
-        fn send_all_proposes_offline() {
-            let mut client = funded_offline_client();
-            let address = own_unified_address(&mut client);
-            let output = assert_works_offline(&mut client, "send_all", &[&address]);
-            assert!(output.contains("fee"), "{output}");
-        }
-
-        #[test]
-        fn shield_proposes_offline() {
-            let output = assert_works_offline(&mut funded_offline_client(), "shield", &[]);
-            assert!(output.contains("fee"), "{output}");
-        }
-
-        /// Offline signing (ADR 0006): `calculate` signs the stored
-        /// proposal with no Indexer, leaving Calculated transactions for a
-        /// connected `transmit`.
-        #[test]
-        fn calculate_signs_offline() {
-            let mut client = funded_offline_client();
-            let address = own_unified_address(&mut client);
-            assert_works_offline(&mut client, "send", &[&address, "50000"]);
-            let output = assert_works_offline(&mut client, "calculate", &[]);
-            assert!(output.contains("txids"), "{output}");
-        }
-
-        #[test]
-        fn drain_plan() {
-            let output = assert_works_offline(&mut funded_offline_client(), "drain", &["plan"]);
-            assert!(output.contains("transactions"), "{output}");
-        }
-
-        #[test]
-        fn split_plan() {
-            let output = assert_works_offline(&mut funded_offline_client(), "split", &["plan"]);
-            assert!(output.contains("split_rounds"), "{output}");
-        }
-
-        #[test]
-        fn migration_plan() {
-            let output = assert_works_offline(&mut funded_offline_client(), "migration", &["plan"]);
-            assert!(output.contains("plan_hash"), "{output}");
-        }
-
-        #[test]
-        fn migration_status() {
-            let output =
-                assert_works_offline(&mut funded_offline_client(), "migration", &["status"]);
-            assert!(output.contains("phase"), "{output}");
-        }
-
-        #[test]
-        fn migration_windows() {
-            assert_unblocked_offline(&mut funded_offline_client(), "migration", &["windows"]);
-        }
-
-        /// `nym status` reads the wallet's mode: an offline session never
-        /// bootstraps the mixnet, so a fresh client reports unattached.
-        #[cfg(feature = "nym")]
-        #[test]
-        fn nym_status_reports_unattached() {
-            let output = assert_works_offline(&mut offline_client(), "nym", &["status"]);
-            assert!(output.contains("unattached"), "{output}");
-        }
-
-        #[test]
-        fn remove_transaction_fails_on_the_txid_never_on_connectivity() {
-            let unknown_txid = "ab".repeat(32);
-            assert_unblocked_offline(
-                &mut offline_client(),
-                "remove_transaction",
-                &[&unknown_txid],
-            );
-        }
-
-        #[test]
-        fn delete_fails_on_the_file_never_on_connectivity() {
-            assert_unblocked_offline(&mut offline_client(), "delete", &[]);
-        }
-    }
-
-    mod refuses_offline {
-        //! The connectivity-requiring surface: every command here must
-        //! refuse offline with the typed Offline error, through its own
-        //! error channel.
-
-        use super::*;
-
-        #[test]
-        fn sync_run() {
-            assert_refuses_offline_via_err(&mut offline_client(), "sync", &["run"]);
-        }
-
-        #[test]
-        fn rescan() {
-            assert_refuses_offline_via_err(&mut offline_client(), "rescan", &[]);
-        }
-
-        /// `info` renders the typed failure at its presentation boundary:
-        /// the output IS the refusal, byte for byte.
-        #[test]
-        fn info() {
-            let output = exec(&mut offline_client(), "info", &[]).expect("info renders errors");
-            assert_eq!(output, OFFLINE_REFUSAL);
-        }
-
-        /// `confirm` pre-flights the Indexer before touching the stored
-        /// proposal, so the refusal needs no proposal and costs no proving.
-        #[test]
-        fn confirm() {
-            assert_refuses_offline_in_output(&mut offline_client(), "confirm", &[]);
-        }
-
-        /// `transmit` pre-flights the Indexer before resolving txids, so
-        /// even an unknown txid refuses on connectivity first.
-        #[test]
-        fn transmit() {
-            let txid = "ab".repeat(32);
-            assert_refuses_offline_in_output(&mut offline_client(), "transmit", &[&txid]);
-        }
-
-        /// `quicksend` proposes and signs offline (both Indexerless
-        /// capabilities), then refuses at the transmit stage: the wallet
-        /// does the work it can and leaks nothing.
-        #[test]
-        fn quicksend() {
-            let mut client = funded_offline_client();
-            let address = own_unified_address(&mut client);
-            assert_refuses_offline_in_output(&mut client, "quicksend", &[&address, "50000"]);
-        }
-
-        /// `quickshield` mirrors `quicksend`: the shield proposal and its
-        /// signing succeed offline, and the transmit stage refuses.
-        #[test]
-        fn quickshield() {
-            assert_refuses_offline_in_output(&mut funded_offline_client(), "quickshield", &[]);
-        }
-
-        /// `migrate` syncs before building anything, so the refusal
-        /// arrives from the sync pre-flight with no proving spent.
-        #[test]
-        fn migrate() {
-            assert_refuses_offline_via_err(&mut funded_offline_client(), "migrate", &[]);
-        }
-
-        #[test]
-        fn migration_continue() {
-            assert_refuses_offline_via_err(
-                &mut funded_offline_client(),
-                "migration",
-                &["continue"],
-            );
-        }
-
-        #[test]
-        fn migration_execute() {
-            assert_refuses_offline_via_err(&mut funded_offline_client(), "migration", &["execute"]);
-        }
-
-        #[test]
-        fn migration_auto() {
-            assert_refuses_offline_via_err(&mut funded_offline_client(), "migration", &["auto"]);
-        }
-
-        /// `current_price` is mixnet-only (ADR 0011): an offline session
-        /// never bootstraps the mixnet, so the fetch refuses from the
-        /// unattached mode — a typed refusal, zero traffic.
-        #[cfg(feature = "nym")]
-        #[test]
-        fn current_price_refuses_from_the_unattached_mixnet() {
-            let output = exec(&mut offline_client(), "current_price", &[])
-                .expect("current_price renders refusals");
-            assert!(
-                output.contains("error: the Nym mixnet is not enabled"),
-                "{output}"
-            );
-        }
-
-        /// Without the nym feature there is no price fetch at all: the
-        /// command says so instead of touching the network.
-        #[cfg(not(feature = "nym"))]
-        #[test]
-        fn current_price_has_no_fetch_to_offer() {
-            let output = exec(&mut offline_client(), "current_price", &[])
-                .expect("current_price explains the absent fetch");
-            assert!(output.contains("no price fetch"), "{output}");
-        }
-    }
+/// The crate's single sync-to-async dispatch seam (ADR 0030): string
+/// frontends call this, and the one `block_on` below is the only place
+/// command execution crosses from sync into async.
+#[allow(clippy::disallowed_methods)]
+pub fn do_user_command(
+    cmd: &str,
+    args: &[&str],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    RT.block_on(do_user_command_result(cmd, args, lightclient))
 }

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -1,0 +1,1064 @@
+#[cfg(test)]
+mod table_invariants {
+    //! Pins the properties [`super::super::COMMANDS`] relies on but the
+    //! compiler does not check: declaration order is the help listing's
+    //! order, and dispatch takes the first name match.
+
+    use super::super::COMMANDS;
+
+    /// HYPOTHESIS: the table's names are strictly increasing — sorted, so
+    /// the help listing stays alphabetical, and therefore unique, so no
+    /// row can shadow another at dispatch.
+    #[test]
+    fn names_are_strictly_increasing() {
+        for pair in COMMANDS.windows(2) {
+            assert!(
+                pair[0].name < pair[1].name,
+                "COMMANDS must stay sorted and duplicate-free: {:?} precedes {:?}",
+                pair[0].name,
+                pair[1].name
+            );
+        }
+    }
+
+    /// HYPOTHESIS: wherever a help text offers a Usage section, at least
+    /// one of its lines invokes the command by its minted name, so the
+    /// prose cannot silently drift from the table's single mint. The
+    /// duplication itself retires when clap generates usage from typed
+    /// arguments (the ratified follow-up arc); until then it is pinned.
+    #[test]
+    fn usage_lines_invoke_the_minted_name() {
+        for spec in COMMANDS {
+            let Some((_, usage)) = spec.help.split_once("Usage:") else {
+                continue;
+            };
+            assert!(
+                usage.lines().map(str::trim).any(|line| {
+                    line == spec.name || line.starts_with(&format!("{} ", spec.name))
+                }),
+                "`{}`'s Usage section never invokes it by its minted name:\n{}",
+                spec.name,
+                spec.help
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod transmit_heartbeat {
+    //! Paused-clock falsifiers for the transmit heartbeat's contract: silence
+    //! for fast transmissions, a narrated line on the ratified 20-40s cadence
+    //! for slow ones, always carrying the side channel's latest detail.
+    //!
+    //! Seam justification (ADR 0030): the `block_on` here is the one
+    //! `#[tokio::test]` generates to drive each async test body; a test
+    //! driver is a sync frontend, so it is an audited crossing.
+    #![allow(clippy::disallowed_methods)]
+
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use super::super::*;
+
+    /// HYPOTHESIS: a transmission finishing before the first tick emits
+    /// nothing, because the heartbeat must not add noise to a normal fast send.
+    #[tokio::test(start_paused = true)]
+    async fn a_fast_transmission_stays_silent() {
+        let lines: Arc<Mutex<Vec<String>>> = Arc::default();
+        let sink = lines.clone();
+        let out = with_transmit_heartbeat(
+            "confirm",
+            || Some("submitting".to_string()),
+            move |line| sink.lock().expect("line sink poisoned").push(line),
+            tokio::time::sleep(zingo_netutils::time::test::SIMULATED_TRANSMIT),
+        )
+        .await;
+        let () = out;
+        assert!(
+            lines.lock().expect("line sink poisoned").is_empty(),
+            "no heartbeat before the first interval"
+        );
+    }
+
+    /// HYPOTHESIS: a slow transmission is narrated on the interval cadence,
+    /// each line carrying the label, the side channel's latest detail, and
+    /// the elapsed seconds. Falsified if the wait stays silent or drops the
+    /// detail.
+    #[tokio::test(start_paused = true)]
+    async fn a_slow_transmission_heartbeats_the_latest_detail() {
+        let lines: Arc<Mutex<Vec<String>>> = Arc::default();
+        let sink = lines.clone();
+        with_transmit_heartbeat(
+            "confirm",
+            || Some("witness zec.rocks: submitting".to_string()),
+            move |line| sink.lock().expect("line sink poisoned").push(line),
+            tokio::time::sleep(Duration::from_secs(95)),
+        )
+        .await;
+        let lines = lines.lock().expect("line sink poisoned").clone();
+        assert_eq!(
+            lines,
+            vec![
+                "confirm: witness zec.rocks: submitting (30s elapsed)".to_string(),
+                "confirm: witness zec.rocks: submitting (60s elapsed)".to_string(),
+                "confirm: witness zec.rocks: submitting (90s elapsed)".to_string(),
+            ]
+        );
+    }
+
+    /// An empty side channel still heartbeats, falling back to a generic
+    /// line rather than skipping the tick.
+    #[tokio::test(start_paused = true)]
+    async fn an_empty_side_channel_still_heartbeats() {
+        let lines: Arc<Mutex<Vec<String>>> = Arc::default();
+        let sink = lines.clone();
+        with_transmit_heartbeat(
+            "transmit",
+            || None,
+            move |line| sink.lock().expect("line sink poisoned").push(line),
+            tokio::time::sleep(Duration::from_secs(35)),
+        )
+        .await;
+        assert_eq!(
+            lines.lock().expect("line sink poisoned").clone(),
+            vec!["transmit: transmitting (30s elapsed)".to_string()]
+        );
+    }
+}
+
+#[cfg(test)]
+mod migration_command_parsing {
+    //! Pins the pure argument parser and the byte-identity of the typed
+    //! errors' rendering with the in-band strings they replaced.
+
+    use super::super::*;
+
+    #[test]
+    fn start_parses_hash_and_per_bucket() {
+        let hash_hex = "11".repeat(32);
+        let parsed = parse_migration_args(&["start", &hash_hex, "--per-bucket", "3"])
+            .expect("well-formed arguments parse");
+        assert_eq!(
+            parsed,
+            MigrationSubCommand::Start {
+                plan_hash: [0x11; 32],
+                per_bucket: Some(3),
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_plan_hash_is_typed() {
+        assert!(matches!(
+            parse_migration_args(&["start", "abc"]),
+            Err(MigrationCommandError::MalformedPlanHash)
+        ));
+    }
+
+    #[test]
+    fn continue_parses_bare() {
+        assert_eq!(
+            parse_migration_args(&["continue"]).expect("bare continue parses"),
+            MigrationSubCommand::Continue
+        );
+    }
+
+    #[test]
+    fn windows_parses_bare() {
+        assert_eq!(
+            parse_migration_args(&["windows"]).expect("bare windows parses"),
+            MigrationSubCommand::Windows
+        );
+    }
+
+    #[test]
+    fn cadence_requires_a_count() {
+        assert_eq!(
+            parse_migration_args(&["cadence", "4"]).expect("well-formed cadence parses"),
+            MigrationSubCommand::Cadence { per_bucket: 4 }
+        );
+        assert!(matches!(
+            parse_migration_args(&["cadence"]),
+            Err(MigrationCommandError::MalformedCadence)
+        ));
+    }
+
+    #[test]
+    fn execute_defaults_spacing_to_thirty_seconds() {
+        assert_eq!(
+            parse_migration_args(&["execute"]).expect("bare execute parses"),
+            MigrationSubCommand::Execute {
+                spacing: std::time::Duration::from_secs(30),
+            }
+        );
+        assert_eq!(
+            parse_migration_args(&["execute", "5"]).expect("spaced execute parses"),
+            MigrationSubCommand::Execute {
+                spacing: std::time::Duration::from_secs(5),
+            }
+        );
+    }
+
+    #[test]
+    fn catchup_defaults_spacing_to_thirty_seconds() {
+        assert_eq!(
+            parse_migration_args(&["catchup"]).expect("bare catchup parses"),
+            MigrationSubCommand::Catchup {
+                spacing: std::time::Duration::from_secs(30),
+            }
+        );
+    }
+
+    #[test]
+    fn errors_render_byte_identically_to_the_replaced_strings() {
+        assert_eq!(
+            format!("Error: {}", MigrationCommandError::MissingSubCommand),
+            "Error: migration command expects a sub-command. Type \"help migration\" for usage."
+        );
+        assert_eq!(
+            format!("Error: {}", MigrationCommandError::MalformedPerBucket),
+            "Error: --per-bucket expects a positive integer."
+        );
+    }
+}
+
+#[cfg(test)]
+mod drain_and_split_command_parsing {
+    //! Pins the pure argument parsers of the mobile-parity migration
+    //! commands: `drain` and `split` accept exactly `plan` or `now`.
+
+    use super::super::*;
+
+    #[test]
+    fn drain_accepts_exactly_plan_or_now() {
+        assert_eq!(
+            parse_drain_args(&["plan"]).expect("drain plan parses"),
+            DrainSubCommand::Plan
+        );
+        assert_eq!(
+            parse_drain_args(&["now"]).expect("drain now parses"),
+            DrainSubCommand::Now
+        );
+        for junk in [&[][..], &["bogus"][..], &["now", "extra"][..]] {
+            assert!(matches!(
+                parse_drain_args(junk),
+                Err(MigrationCommandError::DrainUsage)
+            ));
+        }
+    }
+
+    #[test]
+    fn split_accepts_exactly_plan_or_now() {
+        assert_eq!(
+            parse_split_args(&["plan"]).expect("split plan parses"),
+            SplitSubCommand::Plan
+        );
+        assert_eq!(
+            parse_split_args(&["now"]).expect("split now parses"),
+            SplitSubCommand::Now
+        );
+        for junk in [&[][..], &["bogus"][..], &["plan", "extra"][..]] {
+            assert!(matches!(
+                parse_split_args(junk),
+                Err(MigrationCommandError::SplitUsage)
+            ));
+        }
+    }
+
+    #[test]
+    fn usage_errors_render_with_help_pointers() {
+        assert_eq!(
+            format!("Error: {}", MigrationCommandError::DrainUsage),
+            "Error: drain expects a sub-command: plan | now. Type \"help drain\" for usage."
+        );
+        assert_eq!(
+            format!("Error: {}", MigrationCommandError::SplitUsage),
+            "Error: split expects a sub-command: plan | now. Type \"help split\" for usage."
+        );
+    }
+}
+
+#[cfg(test)]
+mod nym_command_parsing {
+    //! Pins the pure argument parser and the byte-identity of the typed
+    //! errors' rendering with the in-band strings they replaced.
+
+    use super::super::*;
+
+    #[cfg(feature = "nym")]
+    #[test]
+    fn bare_and_status_both_parse_to_status() {
+        assert_eq!(
+            parse_nym_args(&[]).expect("a bare nym parses"),
+            NymSubCommand::Status
+        );
+        assert_eq!(
+            parse_nym_args(&["status"]).expect("nym status parses"),
+            NymSubCommand::Status
+        );
+    }
+
+    #[cfg(feature = "nym")]
+    #[test]
+    fn on_captures_the_optional_path() {
+        assert_eq!(
+            parse_nym_args(&["on"]).expect("bare nym on parses"),
+            NymSubCommand::On { path: None }
+        );
+        assert_eq!(
+            parse_nym_args(&["on", "/opt/nym-proxy"]).expect("nym on with a path parses"),
+            NymSubCommand::On {
+                path: Some("/opt/nym-proxy".to_string()),
+            }
+        );
+    }
+
+    #[cfg(feature = "nym")]
+    #[test]
+    fn unknown_subcommand_renders_byte_identically_to_the_replaced_string() {
+        assert_eq!(
+            parse_nym_args(&["bogus"])
+                .expect_err("an unknown subcommand is typed")
+                .to_string(),
+            "unknown nym subcommand 'bogus'. Use: nym status | nym on [path] | nym off | \
+             nym probe [uri] | nym history"
+        );
+    }
+
+    #[cfg(feature = "nym")]
+    #[test]
+    fn probe_parses_its_optional_target_and_rejects_junk() {
+        assert_eq!(
+            parse_nym_args(&["probe"]).expect("bare probe parses"),
+            NymSubCommand::Probe { target: None }
+        );
+        assert_eq!(
+            parse_nym_args(&["probe", "https://zec.rocks:443"]).expect("probe with a uri parses"),
+            NymSubCommand::Probe {
+                target: Some("https://zec.rocks:443".parse().expect("static uri")),
+            }
+        );
+        assert!(matches!(
+            parse_nym_args(&["probe", "not a uri"]),
+            Err(NymCommandError::InvalidProbeTarget(_))
+        ));
+        assert!(
+            matches!(
+                parse_nym_args(&["probe", "http://zec.rocks:9067"]),
+                Err(NymCommandError::InvalidProbeTarget(_))
+            ),
+            "a plaintext http target is refused: mixnet transmission is https-only"
+        );
+        assert_eq!(
+            parse_nym_args(&["history"]).expect("history parses"),
+            NymSubCommand::History
+        );
+    }
+
+    /// HYPOTHESIS: the paired-probe rendering makes a mixnet-specific failure
+    /// legible at a glance: clearnet ok beside mixnet FAILED. Falsified if
+    /// either leg's outcome, timing, or the not-ready skip is dropped.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn paired_probe_renders_both_legs_side_by_side() {
+        use zingo_net_diag::{NetOpFailure, NetOpStage};
+        use zingolib::nym::probe::{PairedProbe, ProbeLeg, ProbeSuccess};
+
+        let tip = ProbeSuccess {
+            chain: "main".to_string(),
+            height: 3_420_400,
+        };
+        let mixnet_specific = PairedProbe {
+            host: "carover0.xyz".to_string(),
+            clearnet: ProbeLeg {
+                outcome: Ok(tip.clone()),
+                millis: 210,
+            },
+            mixnet: Some(ProbeLeg {
+                outcome: Err(NetOpFailure {
+                    stage: NetOpStage::SocksHandshake,
+                    target: "carover0.xyz".to_string(),
+                    cause_chain: vec![
+                        "the mixnet exit could not reach carover0.xyz:9067 (timed out after 20.0s)"
+                            .to_string(),
+                    ],
+                }),
+                millis: 20_000,
+            }),
+        };
+        assert_eq!(
+            render_paired_probe(&mixnet_specific),
+            "carover0.xyz\n  clearnet: ok in 210ms: chain main, height 3420400\n  mixnet:   FAILED after 20000ms: failed at socks-handshake to carover0.xyz: the mixnet exit could not reach carover0.xyz:9067 (timed out after 20.0s)"
+        );
+
+        let proxy_not_ready = PairedProbe {
+            host: "zec.rocks".to_string(),
+            clearnet: ProbeLeg {
+                outcome: Ok(tip),
+                millis: 180,
+            },
+            mixnet: None,
+        };
+        assert_eq!(
+            render_paired_probe(&proxy_not_ready),
+            "zec.rocks\n  clearnet: ok in 180ms: chain main, height 3420400\n  mixnet:   skipped (mixnet proxy not ready)"
+        );
+    }
+
+    /// HYPOTHESIS: the history rendering aggregates per host and route with
+    /// the most recent outcome and its age. Falsified if counts mix routes
+    /// or the last outcome reflects file order rather than timestamps.
+    #[cfg(all(feature = "nym", feature = "nym-diary"))]
+    #[test]
+    fn history_aggregates_per_host_and_route() {
+        use zingolib::lightclient::indexer_history::{
+            AttemptKind, AttemptRoute, FailureKind, IndexerAttempt,
+        };
+
+        let attempt = |host: &str, route, unix_secs, outcome| IndexerAttempt {
+            unix_secs,
+            host: host.to_string(),
+            route,
+            kind: AttemptKind::Send,
+            millis: 10,
+            outcome,
+        };
+        let tunnel = Err(FailureKind::Unreachable);
+        let attempts = vec![
+            attempt("zec.rocks", AttemptRoute::Mixnet, 1_000, tunnel),
+            attempt("zec.rocks", AttemptRoute::Mixnet, 2_000, Ok(())),
+            attempt("zec.rocks", AttemptRoute::Clearnet, 1_500, Ok(())),
+            attempt("carover0.xyz", AttemptRoute::Mixnet, 1_800, tunnel),
+        ];
+
+        assert_eq!(
+            render_history(&attempts, 2_060),
+            "Indexer history (all sessions):\n  \
+             carover0.xyz: mixnet 0/1 ok, last failed 4m ago\n  \
+             zec.rocks: clearnet 1/1 ok, last ok 9m ago; mixnet 1/2 ok, last ok 1m ago"
+        );
+        assert_eq!(render_history(&[], 0), "No indexer history recorded yet.");
+    }
+
+    #[cfg(not(feature = "nym"))]
+    #[test]
+    fn feature_absent_renders_byte_identically_to_the_replaced_string() {
+        assert_eq!(
+            NymCommandError::FeatureAbsent.to_string(),
+            "This build has no Nym mixnet support. Rebuild zingo-cli with `--features nym`."
+        );
+    }
+
+    /// Pins the `nym status` mode strings via the pure renderer.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn status_lines_render_byte_identically_to_the_replaced_strings() {
+        use zingolib::nym::MixnetMode;
+
+        assert_eq!(
+            render_status(MixnetMode::Unattached, None, None),
+            "Mixnet Mode: unattached. The mixnet has not been enabled, and no consent to \
+             clearnet has been given: send and price-fetch refuse. Run `nym on` to enable \
+             the mixnet, or `nym off` to use clearnet.",
+            "absence is not consent: unattached names refusal, never clearnet"
+        );
+        assert_eq!(
+            render_status(MixnetMode::SwitchedOff, None, None),
+            "Mixnet Mode: switched off (send and price-fetch use clearnet)"
+        );
+        assert_eq!(
+            render_status(MixnetMode::Bootstrapping, None, None),
+            "Mixnet Mode: bootstrapping (send and price-fetch are unavailable until ready)"
+        );
+        assert_eq!(
+            render_status(MixnetMode::Ready, Some("127.0.0.1:43210"), None),
+            "Mixnet Mode: ready (SOCKS5 127.0.0.1:43210)"
+        );
+        assert_eq!(
+            render_status(MixnetMode::Ready, None, None),
+            "Mixnet Mode: ready",
+            "ready with no address yet still renders (the route resolver, \
+             not the renderer, refuses that state)"
+        );
+        assert_eq!(
+            render_status(MixnetMode::Died, None, None),
+            "Mixnet Mode: died. The proxy exited unexpectedly. Send and price-fetch \
+             refuse and will not fall back to clearnet. Run `nym on` to restart the proxy.",
+            "a died proxy is reported distinctly from switched off, and tells the user how to \
+             recover"
+        );
+    }
+
+    /// HYPOTHESIS: live bootstrap progress reaches the `nym status` line, so
+    /// the connect race is narrated rather than an opaque wait. Falsified if
+    /// the detail is dropped by the renderer. The detail is shown only while
+    /// bootstrapping: a ready proxy has no bootstrap left to narrate.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn bootstrap_detail_reaches_the_status_line_only_while_bootstrapping() {
+        use zingolib::nym::MixnetMode;
+
+        assert_eq!(
+            render_status(
+                MixnetMode::Bootstrapping,
+                None,
+                Some("attempt 2/10: 2 in flight, 0 failed")
+            ),
+            "Mixnet Mode: bootstrapping, attempt 2/10: 2 in flight, 0 failed \
+             (send and price-fetch are unavailable until ready)"
+        );
+        assert_eq!(
+            render_status(MixnetMode::Ready, Some("127.0.0.1:1"), Some("stale")),
+            "Mixnet Mode: ready (SOCKS5 127.0.0.1:1)",
+            "a stale detail must not leak into the ready line"
+        );
+    }
+
+    /// HYPOTHESIS: `nym status` always carries the IP-correlation disclaimer in
+    /// every mode, so a "ready" mixnet is never mistaken for end-to-end IP
+    /// protection while synchronization stays on clearnet (ZIP-0318). The mode
+    /// line is preserved verbatim as the first line. Falsified if the
+    /// disclaimer is dropped in any mode, no longer leads with the mode line,
+    /// or omits the sync/IP/indexer/balance risk it must name.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn status_always_carries_the_ip_correlation_disclaimer() {
+        use zingolib::nym::MixnetMode;
+
+        for mode in [
+            MixnetMode::Unattached,
+            MixnetMode::SwitchedOff,
+            MixnetMode::Bootstrapping,
+            MixnetMode::Ready,
+            MixnetMode::Died,
+        ] {
+            let addr = Some("127.0.0.1:43210");
+            let out = render_status_with_disclaimer(mode, addr, None);
+            assert!(
+                out.starts_with(&render_status(mode, addr, None)),
+                "the mode line must lead the status output: {out}"
+            );
+            for phrase in [
+                "IP-correlation risk",
+                "synchronization",
+                "sync indexer",
+                "total balance",
+                "ZIP-0318",
+            ] {
+                assert!(
+                    out.contains(phrase),
+                    "the disclaimer must name {phrase:?} in mode {mode:?}: {out}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod offline_contract {
+    //! The Offline-mode contract at the command surface (issue #2286,
+    //! ADR 0006, ADR 0025). Every client here is genuinely Indexerless —
+    //! built by [`LightClient::new_for_test`] from a synthetic wallet, with
+    //! no server configured and no network object constructed — so these
+    //! tests run with zero traffic and prove two halves of one contract:
+    //!
+    //! - every wallet-local command completes offline, meaning connectivity
+    //!   is never the obstacle (a domain failure such as "nothing to
+    //!   shield" is legitimate; the Offline refusal is not); and
+    //! - every connectivity-requiring command refuses offline with the one
+    //!   typed refusal, [`zingolib::lightclient::error::LightClientError::Offline`],
+    //!   carried through the command's `Err` channel (ADR 0031) — never a
+    //!   hang, a panic, or a silent clearnet fallback.
+    //!
+    //! The `change_server` pin lives at the REPL dispatch, not here: see
+    //! `offline_mode_refusal` and its tests in `crate::tests`.
+    //!
+    //! Deliberately untested, with the reasoning on record: `drain now`,
+    //! `split now`, and `migration catchup` refuse at the transmit stage,
+    //! whose pre-flight `transmit` and `quicksend` pin below (each extra
+    //! case would buy another proving run, not another guarantee); `nym on`
+    //! and `nym probe` currently carry NO offline gate (they would emit
+    //! traffic from an Offline session — a known gap tracked for the ADR
+    //! 0024 session driver), and the REPL-owned `servers` command likewise
+    //! probes the network unguarded.
+
+    #![allow(clippy::disallowed_methods)]
+
+    use zingolib::lightclient::LightClient;
+    use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+    use super::super::{CommandError, RT, do_user_command_result};
+
+    /// The Display of `LightClientError::Offline`: the single refusal every
+    /// connectivity-requiring command must surface, and the string no
+    /// offline-capable command may ever emit.
+    const OFFLINE_REFUSAL: &str =
+        "Offline: no indexer configured. Call set_indexer_uri() to connect.";
+
+    /// An Indexerless client over an empty synthetic wallet.
+    fn offline_client() -> LightClient {
+        RT.block_on(LightClient::new_for_test(
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED).build(),
+        ))
+    }
+
+    /// An Indexerless client whose wallet holds a spendable orchard note
+    /// and a transparent coin, so proposing, planning, and shielding have
+    /// material to work with.
+    fn funded_offline_client() -> LightClient {
+        RT.block_on(LightClient::new_for_test(
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+                .orchard_note(100_000_000)
+                .transparent_coin(50_000_000)
+                .build(),
+        ))
+    }
+
+    fn exec(
+        client: &mut LightClient,
+        command: &str,
+        args: &[&str],
+    ) -> Result<String, CommandError> {
+        RT.block_on(do_user_command_result(command, args, client))
+    }
+
+    /// Asserts `command` succeeds offline and returns its output.
+    fn assert_works_offline(client: &mut LightClient, command: &str, args: &[&str]) -> String {
+        let output = exec(client, command, args)
+            .unwrap_or_else(|error| panic!("`{command}` must work offline: {error}"));
+        assert!(
+            !output.contains(OFFLINE_REFUSAL),
+            "`{command}` must not surface the Offline refusal: {output}"
+        );
+        output
+    }
+
+    /// Asserts connectivity is never `command`'s obstacle: it may succeed
+    /// or fail on domain grounds, but must not surface the Offline refusal.
+    fn assert_unblocked_offline(client: &mut LightClient, command: &str, args: &[&str]) -> String {
+        let rendered = match exec(client, command, args) {
+            Ok(output) => output,
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            !rendered.contains(OFFLINE_REFUSAL),
+            "`{command}` must not be blocked by Offline mode: {rendered}"
+        );
+        rendered
+    }
+
+    /// Asserts `command` refuses offline through its `Err` channel with the
+    /// typed Offline refusal.
+    fn assert_refuses_offline_via_err(client: &mut LightClient, command: &str, args: &[&str]) {
+        let error = exec(client, command, args).expect_err(command);
+        assert!(
+            error.to_string().contains(OFFLINE_REFUSAL),
+            "`{command}` must refuse with the typed Offline error: {error}"
+        );
+    }
+
+    /// A fresh unified address from the wallet itself, so send-family tests
+    /// stay on the wallet's own chain.
+    fn own_unified_address(client: &mut LightClient) -> String {
+        let output = assert_works_offline(client, "new_address", &["o"]);
+        let parsed = json::parse(&output).expect("new_address returns JSON");
+        parsed["encoded_address"]
+            .as_str()
+            .expect("encoded_address is a string")
+            .to_string()
+    }
+
+    mod works_offline {
+        //! The offline-capable surface: every command here must complete
+        //! against an Indexerless client.
+
+        use super::*;
+
+        #[test]
+        fn version() {
+            let output = assert_works_offline(&mut offline_client(), "version", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn help() {
+            let output = assert_works_offline(&mut offline_client(), "help", &[]);
+            assert!(output.contains("Wallet commands"), "{output}");
+        }
+
+        #[test]
+        fn parse_address_of_the_wallets_own() {
+            let mut client = offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "parse_address", &[&address]);
+            assert!(output.contains("success"), "{output}");
+        }
+
+        #[test]
+        fn parse_viewkey_of_the_exported_ufvk() {
+            let mut client = offline_client();
+            let exported = assert_works_offline(&mut client, "export_ufvk", &[]);
+            let ufvk = json::parse(&exported).expect("export_ufvk returns JSON")["ufvk"]
+                .as_str()
+                .expect("ufvk is a string")
+                .to_string();
+            let output = assert_works_offline(&mut client, "parse_viewkey", &[&ufvk]);
+            assert!(output.contains("success"), "{output}");
+        }
+
+        #[test]
+        fn addresses() {
+            let output = assert_works_offline(&mut offline_client(), "addresses", &[]);
+            json::parse(&output).expect("addresses returns JSON");
+        }
+
+        #[test]
+        fn t_addresses() {
+            let output = assert_works_offline(&mut offline_client(), "t_addresses", &[]);
+            json::parse(&output).expect("t_addresses returns JSON");
+        }
+
+        #[test]
+        fn new_address() {
+            let output = assert_works_offline(&mut offline_client(), "new_address", &["oz"]);
+            assert!(output.contains("encoded_address"), "{output}");
+        }
+
+        /// Funded, because the address-gap rule (a new transparent address
+        /// only after the latest one received funds) is a domain rule that
+        /// applies offline exactly as it does online.
+        #[test]
+        fn new_taddress() {
+            let output = assert_works_offline(&mut funded_offline_client(), "new_taddress", &[]);
+            assert!(output.contains("encoded_address"), "{output}");
+        }
+
+        #[test]
+        fn balance() {
+            let output = assert_works_offline(&mut funded_offline_client(), "balance", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn spendable_balance() {
+            let output =
+                assert_works_offline(&mut funded_offline_client(), "spendable_balance", &[]);
+            assert!(output.contains("spendable_balance"), "{output}");
+        }
+
+        #[test]
+        fn max_send_value() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "max_send_value", &[&address]);
+            assert!(output.contains("max_send_value"), "{output}");
+        }
+
+        #[test]
+        fn birthday() {
+            let output = assert_works_offline(&mut offline_client(), "birthday", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn height_reports_the_wallets_own_view() {
+            let output = assert_works_offline(&mut offline_client(), "height", &[]);
+            assert!(output.contains("20"), "the synthetic tip is 20: {output}");
+        }
+
+        #[test]
+        fn notes() {
+            assert_works_offline(&mut funded_offline_client(), "notes", &[]);
+        }
+
+        #[test]
+        fn coins() {
+            assert_works_offline(&mut funded_offline_client(), "coins", &[]);
+        }
+
+        #[test]
+        fn transactions() {
+            assert_works_offline(&mut offline_client(), "transactions", &[]);
+        }
+
+        #[test]
+        fn value_transfers() {
+            assert_works_offline(&mut offline_client(), "value_transfers", &[]);
+        }
+
+        #[test]
+        fn messages() {
+            assert_works_offline(&mut offline_client(), "messages", &[]);
+        }
+
+        #[test]
+        fn sends_to_address() {
+            assert_works_offline(&mut offline_client(), "sends_to_address", &[]);
+        }
+
+        #[test]
+        fn value_to_address() {
+            assert_works_offline(&mut offline_client(), "value_to_address", &[]);
+        }
+
+        #[test]
+        fn memobytes_to_address() {
+            assert_works_offline(&mut offline_client(), "memobytes_to_address", &[]);
+        }
+
+        #[test]
+        fn wallet_kind() {
+            let output = assert_works_offline(&mut offline_client(), "wallet_kind", &[]);
+            assert!(output.contains("mnemonic"), "{output}");
+        }
+
+        #[test]
+        fn settings() {
+            assert_unblocked_offline(&mut offline_client(), "settings", &[]);
+        }
+
+        #[test]
+        fn recovery_info() {
+            let output = assert_works_offline(&mut offline_client(), "recovery_info", &[]);
+            assert!(!output.is_empty());
+        }
+
+        #[test]
+        fn export_ufvk() {
+            let output = assert_works_offline(&mut offline_client(), "export_ufvk", &[]);
+            assert!(output.contains("ufvk"), "{output}");
+        }
+
+        #[test]
+        fn check_address_recognizes_the_wallets_own() {
+            let mut client = offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "check_address", &[&address]);
+            assert!(output.contains("is_wallet_address"), "{output}");
+        }
+
+        #[test]
+        fn clear() {
+            let output = assert_works_offline(&mut offline_client(), "clear", &[]);
+            assert!(output.contains("success"), "{output}");
+        }
+
+        /// `sync status` reads wallet state only; on a synthetic wallet it
+        /// reports a wallet-shape error (no wallet blocks are fabricated),
+        /// which is a domain outcome — connectivity is never the obstacle.
+        #[test]
+        fn sync_status() {
+            assert_unblocked_offline(&mut offline_client(), "sync", &["status"]);
+        }
+
+        #[test]
+        fn sync_poll() {
+            let output = assert_works_offline(&mut offline_client(), "sync", &["poll"]);
+            assert_eq!(output, "Sync task has not been launched.");
+        }
+
+        #[test]
+        fn quit() {
+            let output = assert_works_offline(&mut offline_client(), "quit", &[]);
+            assert!(output.contains("quit successfully"), "{output}");
+        }
+
+        /// Proposing is an Indexerless capability (ADR 0006): `send` shows
+        /// the fee offline, for a later `calculate`/`transmit`.
+        #[test]
+        fn send_proposes_offline() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "send", &[&address, "50000"]);
+            assert!(output.contains("fee"), "{output}");
+        }
+
+        #[test]
+        fn send_all_proposes_offline() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            let output = assert_works_offline(&mut client, "send_all", &[&address]);
+            assert!(output.contains("fee"), "{output}");
+        }
+
+        #[test]
+        fn shield_proposes_offline() {
+            let output = assert_works_offline(&mut funded_offline_client(), "shield", &[]);
+            assert!(output.contains("fee"), "{output}");
+        }
+
+        /// Offline signing (ADR 0006): `calculate` signs the stored
+        /// proposal with no Indexer, leaving Calculated transactions for a
+        /// connected `transmit`.
+        #[test]
+        fn calculate_signs_offline() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            assert_works_offline(&mut client, "send", &[&address, "50000"]);
+            let output = assert_works_offline(&mut client, "calculate", &[]);
+            assert!(output.contains("txids"), "{output}");
+        }
+
+        #[test]
+        fn drain_plan() {
+            let output = assert_works_offline(&mut funded_offline_client(), "drain", &["plan"]);
+            assert!(output.contains("transactions"), "{output}");
+        }
+
+        #[test]
+        fn split_plan() {
+            let output = assert_works_offline(&mut funded_offline_client(), "split", &["plan"]);
+            assert!(output.contains("split_rounds"), "{output}");
+        }
+
+        #[test]
+        fn migration_plan() {
+            let output = assert_works_offline(&mut funded_offline_client(), "migration", &["plan"]);
+            assert!(output.contains("plan_hash"), "{output}");
+        }
+
+        #[test]
+        fn migration_status() {
+            let output =
+                assert_works_offline(&mut funded_offline_client(), "migration", &["status"]);
+            assert!(output.contains("phase"), "{output}");
+        }
+
+        #[test]
+        fn migration_windows() {
+            assert_unblocked_offline(&mut funded_offline_client(), "migration", &["windows"]);
+        }
+
+        /// `nym status` reads the wallet's mode: an offline session never
+        /// bootstraps the mixnet, so a fresh client reports unattached.
+        #[cfg(feature = "nym")]
+        #[test]
+        fn nym_status_reports_unattached() {
+            let output = assert_works_offline(&mut offline_client(), "nym", &["status"]);
+            assert!(output.contains("unattached"), "{output}");
+        }
+
+        #[test]
+        fn remove_transaction_fails_on_the_txid_never_on_connectivity() {
+            let unknown_txid = "ab".repeat(32);
+            assert_unblocked_offline(
+                &mut offline_client(),
+                "remove_transaction",
+                &[&unknown_txid],
+            );
+        }
+
+        #[test]
+        fn delete_fails_on_the_file_never_on_connectivity() {
+            assert_unblocked_offline(&mut offline_client(), "delete", &[]);
+        }
+    }
+
+    mod refuses_offline {
+        //! The connectivity-requiring surface: every command here must
+        //! refuse offline with the typed Offline error, through its `Err`
+        //! channel.
+
+        use super::*;
+
+        #[test]
+        fn sync_run() {
+            assert_refuses_offline_via_err(&mut offline_client(), "sync", &["run"]);
+        }
+
+        #[test]
+        fn rescan() {
+            assert_refuses_offline_via_err(&mut offline_client(), "rescan", &[]);
+        }
+
+        /// `info` carries the typed failure whole: the error's rendering IS
+        /// the refusal, byte for byte.
+        #[test]
+        fn info() {
+            let error = exec(&mut offline_client(), "info", &[]).expect_err("info refuses offline");
+            assert_eq!(error.to_string(), OFFLINE_REFUSAL);
+        }
+
+        /// `confirm` pre-flights the Indexer before touching the stored
+        /// proposal, so the refusal needs no proposal and costs no proving.
+        #[test]
+        fn confirm() {
+            assert_refuses_offline_via_err(&mut offline_client(), "confirm", &[]);
+        }
+
+        /// `transmit` pre-flights the Indexer before resolving txids, so
+        /// even an unknown txid refuses on connectivity first.
+        #[test]
+        fn transmit() {
+            let txid = "ab".repeat(32);
+            assert_refuses_offline_via_err(&mut offline_client(), "transmit", &[&txid]);
+        }
+
+        /// `quicksend` proposes and signs offline (both Indexerless
+        /// capabilities), then refuses at the transmit stage: the wallet
+        /// does the work it can and leaks nothing.
+        #[test]
+        fn quicksend() {
+            let mut client = funded_offline_client();
+            let address = own_unified_address(&mut client);
+            assert_refuses_offline_via_err(&mut client, "quicksend", &[&address, "50000"]);
+        }
+
+        /// `quickshield` mirrors `quicksend`: the shield proposal and its
+        /// signing succeed offline, and the transmit stage refuses.
+        #[test]
+        fn quickshield() {
+            assert_refuses_offline_via_err(&mut funded_offline_client(), "quickshield", &[]);
+        }
+
+        /// `migrate` syncs before building anything, so the refusal
+        /// arrives from the sync pre-flight with no proving spent.
+        #[test]
+        fn migrate() {
+            assert_refuses_offline_via_err(&mut funded_offline_client(), "migrate", &[]);
+        }
+
+        #[test]
+        fn migration_continue() {
+            assert_refuses_offline_via_err(
+                &mut funded_offline_client(),
+                "migration",
+                &["continue"],
+            );
+        }
+
+        #[test]
+        fn migration_execute() {
+            assert_refuses_offline_via_err(&mut funded_offline_client(), "migration", &["execute"]);
+        }
+
+        #[test]
+        fn migration_auto() {
+            assert_refuses_offline_via_err(&mut funded_offline_client(), "migration", &["auto"]);
+        }
+
+        /// `current_price` is mixnet-only (ADR 0011): an offline session
+        /// never bootstraps the mixnet, so the fetch refuses from the
+        /// unattached mode — a typed refusal, zero traffic.
+        #[cfg(feature = "nym")]
+        #[test]
+        fn current_price_refuses_from_the_unattached_mixnet() {
+            let error = exec(&mut offline_client(), "current_price", &[])
+                .expect_err("current_price refuses offline");
+            assert!(
+                error.to_string().contains("the Nym mixnet is not enabled"),
+                "{error}"
+            );
+        }
+
+        /// Without the nym feature there is no price fetch at all: the
+        /// command says so instead of touching the network.
+        #[cfg(not(feature = "nym"))]
+        #[test]
+        fn current_price_has_no_fetch_to_offer() {
+            let output = exec(&mut offline_client(), "current_price", &[])
+                .expect("current_price explains the absent fetch");
+            assert!(output.contains("no price fetch"), "{output}");
+        }
+    }
+}

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -19,6 +19,7 @@ mod server_select;
 
 use std::num::NonZeroU32;
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::sync::mpsc::{Receiver, Sender, channel};
 
 use clap::{self, Arg};
@@ -35,7 +36,7 @@ use zingolib::lightclient::{DEFAULT_REQUEST_TIMEOUT, LightClient};
 use zingolib::netutils::Indexer as _;
 use zingolib::wallet::WalletSettings;
 
-use crate::commands::{RT, ShortCircuitedCommand};
+use crate::commands::RT;
 
 pub(crate) mod version;
 
@@ -169,18 +170,19 @@ fn parse_ufvk(s: &str) -> Result<String, String> {
     }
 }
 
-/// Performs the per-prompt housekeeping on the command-loop thread, where
-/// the [`LightClient`] lives: polls the sync task, reports any save-task
-/// failure, and returns the sync indicator to embed in the interactive
-/// prompt: `" [Syncing X / Y outputs]"` while sync is in progress,
-/// `" [Synced X / X outputs]"` when fully synced, `" [Sync error]"` on
-/// failure, or `" [Sync stopped at X / Y outputs]"` when no sync task is
-/// running and the wallet is not fully synced.
+/// Performs the per-prompt housekeeping, awaited on the command-loop
+/// thread where the [`LightClient`] lives: polls the sync task, reports
+/// any save-task failure, and returns the sync indicator to embed in the
+/// interactive prompt: `" [Syncing X / Y outputs]"` while sync is in
+/// progress, `" [Synced X / X outputs]"` when fully synced,
+/// `" [Sync error]"` on failure, or `" [Sync stopped at X / Y outputs]"`
+/// when no sync task is running and the wallet is not fully synced.
 ///
 /// Every outcome is classified from typed values ([`PollReport`],
 /// [`pepper_sync::sync_status`], `check_save_error`), never by inspecting
-/// a command's output string.
-fn prompt_indicator(lightclient: &mut LightClient) -> String {
+/// a command's output string. Every line this function prints is
+/// narration, so all of it goes to stderr (ADR 0031).
+async fn prompt_indicator(lightclient: &mut LightClient) -> String {
     let indicator = match lightclient.poll_sync() {
         PollReport::Ready(Err(e)) => {
             // The doubled "Sync error: Error:" is deliberate: it reproduces
@@ -191,13 +193,13 @@ fn prompt_indicator(lightclient: &mut LightClient) -> String {
             " [Sync error]".to_string()
         }
         PollReport::Ready(Ok(sync_result)) => {
-            println!("{sync_result}");
-            synced_indicator(scan_progress(lightclient))
+            eprintln!("{sync_result}");
+            synced_indicator(scan_progress(lightclient).await)
         }
-        PollReport::NotReady => syncing_indicator(scan_progress(lightclient)),
-        PollReport::NoHandle => idle_indicator(scan_progress(lightclient)),
+        PollReport::NotReady => syncing_indicator(scan_progress(lightclient).await),
+        PollReport::NoHandle => idle_indicator(scan_progress(lightclient).await),
     };
-    if let Err(e) = RT.block_on(lightclient.check_save_error()) {
+    if let Err(e) = lightclient.check_save_error().await {
         eprintln!("Error: save failed. {e}\nRestarting save task...");
     }
     indicator
@@ -214,17 +216,15 @@ struct ScanProgress {
 
 /// Reads the wallet's scan progress, or `None` if sync status is
 /// unavailable.
-fn scan_progress(lightclient: &LightClient) -> Option<ScanProgress> {
-    RT.block_on(async {
-        pepper_sync::sync_status(&*lightclient.wallet().read().await)
-            .await
-            .ok()
-            .map(|status| ScanProgress {
-                outputs_scanned: status.total_outputs_scanned,
-                total_outputs: status.total_outputs,
-                complete: status.is_complete(),
-            })
-    })
+async fn scan_progress(lightclient: &LightClient) -> Option<ScanProgress> {
+    pepper_sync::sync_status(&*lightclient.wallet().read().await)
+        .await
+        .ok()
+        .map(|status| ScanProgress {
+            outputs_scanned: status.total_outputs_scanned,
+            total_outputs: status.total_outputs,
+            complete: status.is_complete(),
+        })
 }
 
 /// Formats a prompt indicator: `" [{labeled} X / Y outputs]"` when the
@@ -286,24 +286,30 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 
     log::debug!("Ready!");
 
-    let send_request = |request: Request| -> String {
+    let send_request = |request: Request| -> Result<String, String> {
         let description = match &request {
             Request::Command(cmd, _) => cmd.clone(),
             Request::PromptIndicator => "prompt indicator".to_string(),
         };
-        ch.transmitter.send(request).unwrap();
+        if ch.transmitter.send(request).is_err() {
+            let e = format!("Error executing command {description}: the command loop has exited");
+            eprintln!("{e}");
+            error!("{e}");
+            return Err(e);
+        }
         match ch.receiver.recv() {
-            Ok(s) => s,
+            Ok(response) => response,
             Err(e) => {
                 let e = format!("Error executing command {description}: {e}");
                 eprintln!("{e}");
                 error!("{e}");
-                String::new()
+                Err(e)
             }
         }
     };
-    let send_command =
-        |cmd: String, args: Vec<String>| -> String { send_request(Request::Command(cmd, args)) };
+    let send_command = |cmd: String, args: Vec<String>| -> Result<String, String> {
+        send_request(Request::Command(cmd, args))
+    };
 
     // The prompt's chain label comes from local config, not the server. An
     // `info` round trip here blocked the first prompt behind the cold mixnet
@@ -317,15 +323,13 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 
     loop {
         // Read the height first
-        let height = json::parse(&send_command(
-            "height".to_string(),
-            vec!["false".to_string()],
-        ))
-        .unwrap()["height"]
-            .as_i64()
-            .unwrap();
+        let height = send_command("height".to_string(), vec![])
+            .ok()
+            .and_then(|s| json::parse(&s).ok())
+            .and_then(|v| v["height"].as_i64())
+            .unwrap_or(0);
 
-        let sync_indicator = send_request(Request::PromptIndicator);
+        let sync_indicator = send_request(Request::PromptIndicator).unwrap_or_default();
 
         let readline = rl.readline(&format!(
             "({chain_name}) Block:{height}{sync_indicator} >> "
@@ -355,7 +359,10 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
                     continue;
                 }
 
-                println!("{}", send_command(cmd, args));
+                match send_command(cmd, args) {
+                    Ok(output) => println!("{output}"),
+                    Err(rendered) => eprintln!("{rendered}"),
+                }
 
                 // Special check for Quit command.
                 if line == "quit" || line == "exit" {
@@ -387,7 +394,8 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 /// a response by sniffing its text (the in-band-error problem of issue
 /// zingolabs/zingolib#2446).
 enum Request {
-    /// Execute a user command. The reply is the command's output.
+    /// Execute a user command. The reply is `Ok` with the command's
+    /// output, or `Err` with the rendered error line.
     Command(String, Vec<String>),
     /// Perform the per-prompt housekeeping (sync poll, save check) via
     /// typed calls on the loop thread. The reply is the sync indicator
@@ -395,23 +403,34 @@ enum Request {
     PromptIndicator,
 }
 
-/// A paired request/response channel for communicating with the background command loop.
+/// A paired request/response channel for communicating with the background
+/// command loop.
+///
+/// A response is `Ok` with the command's result, or `Err` with a fully
+/// rendered error line that already begins with `Error: `. The requester
+/// therefore learns of a failure from the variant, and never by reading
+/// the text (ADR 0031).
 struct CommandChannel {
     transmitter: Sender<Request>,
-    receiver: Receiver<String>,
+    receiver: Receiver<Result<String, String>>,
 }
 
 /// Spawns a background thread that listens for `(command, args)` messages,
 /// executes each command against the [`LightClient`], and sends the
-/// string response back through the returned [`CommandChannel`].
+/// response back through the returned [`CommandChannel`].
+///
+/// Each command crosses into async inside `commands::do_user_command`, and
+/// the per-prompt housekeeping crosses in the `block_on` below; the loop
+/// thread holds no other crossing (ADR 0030).
 ///
 /// The loop exits when it receives a `"quit"` or `"exit"` command.
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn command_loop(
     mut lightclient: LightClient,
     communication_mode: CommunicationMode,
 ) -> CommandChannel {
     let (command_transmitter, command_receiver) = channel::<Request>();
-    let (resp_transmitter, resp_receiver) = channel::<String>();
+    let (resp_transmitter, resp_receiver) = channel::<Result<String, String>>();
 
     std::thread::spawn(move || {
         while let Ok(request) = command_receiver.recv() {
@@ -419,19 +438,20 @@ pub(crate) fn command_loop(
                 Request::Command(cmd, args) => (cmd, args),
                 Request::PromptIndicator => {
                     resp_transmitter
-                        .send(prompt_indicator(&mut lightclient))
+                        .send(Ok(RT.block_on(prompt_indicator(&mut lightclient))))
                         .unwrap();
                     continue;
                 }
             };
             // The Offline-mode pin: this session never configures an Indexer.
             if let Some(refusal) = offline_mode_refusal(communication_mode, &cmd) {
-                resp_transmitter.send(refusal).unwrap();
+                resp_transmitter.send(Err(refusal)).unwrap();
                 continue;
             }
             let args: Vec<_> = args.iter().map(std::convert::AsRef::as_ref).collect();
 
-            let cmd_response = commands::do_user_command(&cmd, &args[..], &mut lightclient);
+            let cmd_response = commands::do_user_command(&cmd, &args[..], &mut lightclient)
+                .map_err(|e| format!("Error: {e}"));
             resp_transmitter.send(cmd_response).unwrap();
 
             if cmd == "quit" || cmd == "exit" {
@@ -740,9 +760,10 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
 
 /// Builds a `ClientConfig` from the filled config template.
 ///
-/// This is a pure function, with no I/O or side effects, and is the
-/// first testable seam inside the startup sequence.
-fn build_zingo_config(filled_template: &ConfigTemplate) -> std::io::Result<ClientConfig> {
+/// This is the first testable seam inside the startup sequence. Its only
+/// I/O is the chain-tip fetch that dates a brand-new wallet, which an
+/// Offline-mode session never performs.
+async fn build_zingo_config(filled_template: &ConfigTemplate) -> std::io::Result<ClientConfig> {
     let wallet_path = filled_template.data_dir.clone().join(DEFAULT_WALLET_NAME);
     let no_of_accounts = NonZeroU32::try_from(1).expect("hard-coded integer");
     let wallet_settings = WalletSettings {
@@ -773,19 +794,19 @@ fn build_zingo_config(filled_template: &ConfigTemplate) -> std::io::Result<Clien
         WalletConfig::Read
     } else {
         // Create client from a new wallet
-        println!("Creating a new wallet");
+        eprintln!("Creating a new wallet");
         let chain_height = match filled_template.server.clone() {
-            Some(server) => RT
-                .block_on(async move {
-                    zingolib::netutils::GrpcIndexer::new(server)
-                        .await
-                        .map_err(|e| format!("{e:?}"))?
-                        .get_latest_block(DEFAULT_REQUEST_TIMEOUT)
-                        .await
-                        .map(|block_id| block_id.height as u32)
-                        .map_err(|e| format!("{e:?}"))
-                })
-                .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?,
+            Some(server) => async move {
+                zingolib::netutils::GrpcIndexer::new(server)
+                    .await
+                    .map_err(|e| format!("{e:?}"))?
+                    .get_latest_block(DEFAULT_REQUEST_TIMEOUT)
+                    .await
+                    .map(|block_id| block_id.height as u32)
+                    .map_err(|e| format!("{e:?}"))
+            }
+            .await
+            .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?,
             // Offline mode has no Indexer to ask for the chain tip; a
             // user-supplied birthday stands in for it, and absent that the
             // Library Birthday is a safe floor: a new seed cannot predate
@@ -819,14 +840,21 @@ fn build_zingo_config(filled_template: &ConfigTemplate) -> std::io::Result<Clien
         .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn startup(filled_template: &ConfigTemplate) -> std::io::Result<CommandChannel> {
-    let config = build_zingo_config(filled_template)?;
+    let lightclient = RT.block_on(startup_async(filled_template))?;
+    Ok(command_loop(
+        lightclient,
+        filled_template.communication_mode,
+    ))
+}
 
-    let mut lightclient = RT.block_on(async move {
-        LightClient::new(config, false)
-            .await
-            .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))
-    })?;
+async fn startup_async(filled_template: &ConfigTemplate) -> std::io::Result<LightClient> {
+    let config = build_zingo_config(filled_template).await?;
+
+    let mut lightclient = LightClient::new(config, false)
+        .await
+        .map_err(|e| std::io::Error::other(format!("Failed to create lightclient. {e}")))?;
 
     if matches!(filled_template.mode, ModeOfOperation::Interactive) {
         // Print startup Messages
@@ -871,19 +899,22 @@ pub(crate) fn startup(filled_template: &ConfigTemplate) -> std::io::Result<Comma
         } else {
             MixnetStartPolicy::ForcedOn
         };
-        RT.block_on(lightclient.start_mixnet_session(
-            ProvisionStrategy::Spawn(commands::spawn_hints(
-                filled_template.nym_proxy_path.as_deref(),
-            )),
-            policy,
-        ))
-        .map_err(|e| {
-            std::io::Error::other(format!(
-                "Failed to start the Nym mixnet proxy: {e}. Mixnet Mode is required for a \
-                 connected session; install the nym-proxy binary, pass --nym-proxy <path>, set \
-                 $ZINGO_NYM_PROXY, or pass --no-mixnet to transmit over clearnet this session.",
-            ))
-        })?;
+        lightclient
+            .start_mixnet_session(
+                ProvisionStrategy::Spawn(commands::spawn_hints(
+                    filled_template.nym_proxy_path.as_deref(),
+                )),
+                policy,
+            )
+            .await
+            .map_err(|e| {
+                std::io::Error::other(format!(
+                    "Failed to start the Nym mixnet proxy: {e}. Mixnet Mode is required for a \
+                     connected session; install the nym-proxy binary, pass --nym-proxy <path>, \
+                     set $ZINGO_NYM_PROXY, or pass --no-mixnet to transmit over clearnet this \
+                     session.",
+                ))
+            })?;
         match policy {
             MixnetStartPolicy::OptedOutThisSession => info!(
                 "Mixnet Mode switched off by --no-mixnet; send and price-fetch use clearnet this \
@@ -900,7 +931,7 @@ pub(crate) fn startup(filled_template: &ConfigTemplate) -> std::io::Result<Comma
         // this consumer's own (ADR 0024, decision 8) — variant matching,
         // never prose matching.
         let mut status_rx = lightclient.subscribe_mixnet_status();
-        RT.spawn(async move {
+        tokio::spawn(async move {
             let mut last_mode = status_rx.borrow().mode;
             while status_rx.changed().await.is_ok() {
                 let status = status_rx.borrow_and_update().clone();
@@ -935,29 +966,25 @@ pub(crate) fn startup(filled_template: &ConfigTemplate) -> std::io::Result<Comma
     }
 
     if filled_template.sync {
-        let update = commands::do_user_command("sync", &["run"], &mut lightclient);
-        println!("{update}");
+        match commands::do_user_command_result("sync", &["run"], &mut lightclient).await {
+            Ok(update) => eprintln!("{update}"),
+            Err(e) => eprintln!("Error: {e}"),
+        }
     }
 
-    let update = commands::do_user_command("save", &["run"], &mut lightclient);
-    println!("{update}");
+    match commands::do_user_command_result("save", &["run"], &mut lightclient).await {
+        Ok(update) => eprintln!("{update}"),
+        Err(e) => eprintln!("Error: {e}"),
+    }
 
-    lightclient = RT.block_on(async move {
-        if filled_template.sync
-            && filled_template.waitsync
-            && let Err(e) = lightclient.await_sync().await
-        {
-            eprintln!("error: {e}");
-        }
+    if filled_template.sync
+        && filled_template.waitsync
+        && let Err(e) = lightclient.await_sync().await
+    {
+        eprintln!("error: {e}");
+    }
 
-        lightclient
-    });
-
-    // Start the command loop
-    Ok(command_loop(
-        lightclient,
-        filled_template.communication_mode,
-    ))
+    Ok(lightclient)
 }
 
 /// Falls back to the prefix-only salvage reader when the user asked for
@@ -986,46 +1013,68 @@ fn print_salvaged_recovery_info(
     Ok(())
 }
 
-fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io::Result<()> {
+fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io::Result<ExitCode> {
     let ch = match startup(cli_config) {
         Ok(ch) => ch,
         Err(startup_error) => {
             if let ModeOfOperation::Command { name, .. } = &cli_config.mode
                 && name == "recovery_info"
             {
-                return print_salvaged_recovery_info(cli_config, &startup_error);
+                return print_salvaged_recovery_info(cli_config, &startup_error)
+                    .map(|()| ExitCode::SUCCESS);
             }
             return Err(startup_error);
         }
     };
     match &cli_config.mode {
-        ModeOfOperation::Interactive => start_interactive(cli_config, ch),
+        ModeOfOperation::Interactive => {
+            start_interactive(cli_config, ch);
+            Ok(ExitCode::SUCCESS)
+        }
         ModeOfOperation::Command { name, args } => {
-            ch.transmitter
+            let exit_code = if ch
+                .transmitter
                 .send(Request::Command(name.clone(), args.clone()))
-                .unwrap();
-
-            match ch.receiver.recv() {
-                Ok(s) => println!("{s}"),
-                Err(e) => {
-                    let e = format!("Error executing command {name}: {e}");
-                    eprintln!("{e}");
-                    error!("{e}");
+                .is_err()
+            {
+                let e = format!("Error executing command {name}: the command loop has exited");
+                eprintln!("{e}");
+                error!("{e}");
+                ExitCode::FAILURE
+            } else {
+                match ch.receiver.recv() {
+                    Ok(Ok(output)) => {
+                        println!("{output}");
+                        ExitCode::SUCCESS
+                    }
+                    Ok(Err(rendered)) => {
+                        eprintln!("{rendered}");
+                        ExitCode::FAILURE
+                    }
+                    Err(e) => {
+                        let e = format!("Error executing command {name}: {e}");
+                        eprintln!("{e}");
+                        error!("{e}");
+                        ExitCode::FAILURE
+                    }
                 }
-            }
+            };
 
-            ch.transmitter
+            if ch
+                .transmitter
                 .send(Request::Command("quit".to_string(), vec![]))
-                .unwrap();
-            match ch.receiver.recv() {
-                Ok(s) => println!("{s}"),
-                Err(e) => {
-                    eprintln!("{e}");
+                .is_ok()
+            {
+                match ch.receiver.recv() {
+                    Ok(Ok(trailer)) => eprintln!("{trailer}"),
+                    Ok(Err(rendered)) => eprintln!("{rendered}"),
+                    Err(e) => eprintln!("{e}"),
                 }
             }
+
+            Ok(exit_code)
         }
     }
-    Ok(())
 }
 
 /// Returns `true` if the CLI will start the interactive REPL
@@ -1060,18 +1109,22 @@ pub fn help_output(matches: &clap::ArgMatches) -> Option<String> {
             .get_many::<String>("extra_args")
             .map(|v| v.cloned().collect())
             .unwrap_or_default();
-        Some(commands::HelpCommand::exec_without_lc(args))
+        Some(commands::format_help(
+            &args.iter().map(String::as_str).collect::<Vec<&str>>(),
+        ))
     } else {
         None
     }
 }
 
-/// Runs the CLI from pre-parsed arguments.
+/// Runs the CLI from pre-parsed arguments, returning the process exit code
+/// the session earned: `SUCCESS`, or `FAILURE` when a one-shot command
+/// fails (ADR 0031).
 ///
 /// This function never calls `std::process::exit` or reads `std::env::args`.
 /// The caller (the binary entry point) is responsible for parsing arguments,
 /// handling the help short-circuit, process-level setup, and error reporting.
-pub fn run_cli(matches: clap::ArgMatches) -> std::io::Result<()> {
+pub fn run_cli(matches: clap::ArgMatches) -> std::io::Result<ExitCode> {
     let mode = get_mode_of_operation(&matches);
     let communication_mode = get_communication_mode(&matches)?;
     let cli_config =

--- a/zingo-cli/src/main.rs
+++ b/zingo-cli/src/main.rs
@@ -81,11 +81,15 @@ fn handle_error(e: std::io::Error) {
     }
 }
 
-pub fn main() {
+pub fn main() -> std::process::ExitCode {
     zingolib::netutils::ensure_default_crypto_provider();
     let matches = parse_args_or_exit_for_help();
     init_tracing(&matches);
-    if let Err(e) = zingo_cli::run_cli(matches) {
-        handle_error(e);
+    match zingo_cli::run_cli(matches) {
+        Ok(code) => code,
+        Err(e) => {
+            handle_error(e);
+            std::process::ExitCode::FAILURE
+        }
     }
 }

--- a/zingo-cli/src/server_select.rs
+++ b/zingo-cli/src/server_select.rs
@@ -4,6 +4,11 @@
 //! `zingolib::netutils::indexers::MOST_UP_INDEXER_URIS` (the census) concurrently,
 //! measure response time, and return the responsive servers sorted
 //! from fastest to slowest.
+//!
+//! Probing is async: `select_servers` awaits its fan-out, and `resolve_server`
+//! is the module's only sync-to-async seam (ADR 0030). Every line this module
+//! prints is narration and goes to stderr, so stdout carries only command
+//! results (ADR 0031).
 
 use std::time::{Duration, Instant};
 
@@ -22,7 +27,8 @@ pub(crate) struct RankedServer {
 /// returns those that responded, sorted fastest to slowest.
 ///
 /// Uses a per-server timeout so one slow server doesn't block the rest.
-pub(crate) fn select_servers() -> Vec<RankedServer> {
+/// The probe narration goes to stderr (ADR 0031).
+pub(crate) async fn select_servers() -> Vec<RankedServer> {
     use zingolib::netutils::time::SERVER_RANKING_TIMEOUT;
 
     let uris: Vec<http::Uri> = MOST_UP_INDEXER_URIS
@@ -30,48 +36,45 @@ pub(crate) fn select_servers() -> Vec<RankedServer> {
         .filter_map(|s| s.parse::<http::Uri>().ok())
         .collect();
 
-    println!("No --server specified. Probing {} indexers...", uris.len());
+    eprintln!("No --server specified. Probing {} indexers...", uris.len());
 
-    let mut ranked: Vec<RankedServer> = RT.block_on(async {
-        let mut handles = Vec::new();
+    let mut handles = Vec::new();
 
-        for uri in uris {
-            handles.push(tokio::spawn(async move {
-                let start = Instant::now();
-                let mut indexer = match GrpcIndexer::new(uri.clone()).await {
-                    Ok(i) => i,
-                    Err(_) => return None,
-                };
-                match indexer.get_lightd_info(SERVER_RANKING_TIMEOUT).await {
-                    Ok(_info) => Some(RankedServer {
-                        uri,
-                        latency: start.elapsed(),
-                    }),
-                    _ => None,
-                }
-            }));
-        }
-
-        let mut results = Vec::new();
-        for handle in handles {
-            if let Ok(Some(ranked)) = handle.await {
-                results.push(ranked);
+    for uri in uris {
+        handles.push(tokio::spawn(async move {
+            let start = Instant::now();
+            let mut indexer = match GrpcIndexer::new(uri.clone()).await {
+                Ok(i) => i,
+                Err(_) => return None,
+            };
+            match indexer.get_lightd_info(SERVER_RANKING_TIMEOUT).await {
+                Ok(_info) => Some(RankedServer {
+                    uri,
+                    latency: start.elapsed(),
+                }),
+                _ => None,
             }
+        }));
+    }
+
+    let mut ranked: Vec<RankedServer> = Vec::new();
+    for handle in handles {
+        if let Ok(Some(server)) = handle.await {
+            ranked.push(server);
         }
-        results
-    });
+    }
 
     ranked.sort_by_key(|r| r.latency);
 
     if ranked.is_empty() {
         eprintln!("Warning: no indexers responded. Falling back to default.");
     } else {
-        println!(
+        eprintln!(
             "Selected server: {} ({:?})",
             ranked[0].uri, ranked[0].latency
         );
         for r in &ranked[1..] {
-            println!("  also available: {} ({:?})", r.uri, r.latency);
+            eprintln!("  also available: {} ({:?})", r.uri, r.latency);
         }
     }
 
@@ -83,6 +86,10 @@ pub(crate) fn select_servers() -> Vec<RankedServer> {
 /// If `--server` was provided explicitly, uses that URI and returns an
 /// empty ranked list. Otherwise, probes curated indexers with `get_info()`
 /// and returns the fastest responder along with the full ranked list.
+///
+/// This function is the module's audited sync-to-async seam: startup calls it
+/// synchronously, so it holds the module's only `block_on` (ADR 0030).
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn resolve_server(
     matches: &clap::ArgMatches,
 ) -> Result<(http::Uri, Vec<RankedServer>), http::uri::InvalidUri> {
@@ -92,7 +99,7 @@ pub(crate) fn resolve_server(
             vec![],
         ))
     } else {
-        let ranked = select_servers();
+        let ranked = RT.block_on(select_servers());
         let server = if let Some(best) = ranked.first() {
             best.uri.clone()
         } else {

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -586,9 +586,18 @@ mod config_template {
         ConfigTemplate::fill(mode, communication_mode, matches)
     }
 
+    /// Helper: build the ZingoConfig for a filled template. The builder is
+    /// async, so the tests hold their own crossing into the runtime.
+    #[allow(clippy::disallowed_methods)]
+    fn build(filled: &ConfigTemplate) -> zingolib::config::ClientConfig {
+        crate::commands::RT
+            .block_on(build_zingo_config(filled))
+            .unwrap()
+    }
+
     /// Helper: parse args, fill config, and build ZingoConfig in one step.
     fn fill_and_build(args: &[&str]) -> zingolib::config::ClientConfig {
-        build_zingo_config(&fill(args).unwrap()).unwrap()
+        build(&fill(args).unwrap())
     }
 
     mod offline {
@@ -636,7 +645,7 @@ mod config_template {
                 data_dir.to_str().unwrap(),
             ])
             .unwrap();
-            let config = build_zingo_config(&filled).unwrap();
+            let config = build(&filled);
             assert!(matches!(
                 config.wallet_config(),
                 zingolib::config::WalletConfig::NewSeed { chain_height, .. }
@@ -658,7 +667,7 @@ mod config_template {
                 data_dir.to_str().unwrap(),
             ])
             .unwrap();
-            let config = build_zingo_config(&filled).unwrap();
+            let config = build(&filled);
             assert!(matches!(
                 config.wallet_config(),
                 zingolib::config::WalletConfig::NewSeed { chain_height, .. }

--- a/zingo-cli/tests/log_file.rs
+++ b/zingo-cli/tests/log_file.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -94,10 +96,13 @@ fn interactive_mode_redirects_tracing_to_log_file() {
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.is_empty(),
-        "Expected empty stderr (tracing should go to log file), but got:\n{stderr}"
-    );
+    for level in ["INFO", "WARN", "ERROR", "DEBUG", "TRACE"] {
+        assert!(
+            !stderr.contains(&format!(" {level} ")),
+            "Tracing {level} lines should go to the log file, not stderr \
+             (stderr carries only Narration, ADR 0031). Got:\n{stderr}"
+        );
+    }
 }
 
 /// The error string that pepper_sync's `#[instrument(err)]` on

--- a/zingolib/CONTEXT.md
+++ b/zingolib/CONTEXT.md
@@ -169,6 +169,10 @@
 
 **Two-phase Send** — The standard send path: `propose_send` (or `propose_shield`) followed by `send_stored_proposal`. Allows the caller to inspect the Proposal (e.g. fees) before committing. Proposing pauses the sync engine and the client holds that pause (a **SyncPauseGuard**) while the Proposal is stored, so the state proposed against cannot shift before the send builds it. The pause ends with the Proposal: `send_stored_proposal(resume_sync: true)` and `clear_proposal` (the decline path) restore the engine's prior mode, `resume_sync: false` leaves it paused for the caller, and a proposing call that fails restores the engine on its way out. `quick_send` / `quick_shield` are single-shot convenience wrappers that hold the pause for the span of one call. The pause's outside view is the Privacy section's **Quiescence Signature**, which today carries send timing; see that entry for the de-correlation requirement.
 
+**Narration** — Human-facing progress reporting emitted while a long-running operation is in flight: the transmit path's latest progress line, a migration batch's build/send counts, server probing. Narration is presentation, never data: it carries no parse contract, its wording may change in any release, and in zingo-cli it travels only on stderr, because stdout carries exactly the command's result (see `docs/adr/0031`). The library publishes narration pull-style through progress handles; each frontend decides its own cadence and rendering. *Avoid*: parsing narration lines (typed frontends poll the progress handles; machine consumers read the stdout result).
+
+**Transmit Heartbeat** — zingo-cli's liveness tick during a Transmission, migration broadcast, drain, or split: while the operation blocks the session, the heartbeat prints the latest Narration line with elapsed time at a fixed cadence, proving the process is alive so a user does not kill a slow mixnet send mid-broadcast. An operation that finishes before the first tick stays silent, and a tick with no progress line yet available still fires with a generic line: the contract is liveness first, Narration when it exists.
+
 ---
 
 ## Balance


### PR DESCRIPTION
This PR realizes ADR 0030 and ADR 0031. Every zingo-cli command is now one row of a static spec table: its name is minted once from its body function's identifier, its capability is a typed `CommandBody` variant (a standalone body never receives the wallet; the REPL-owned `servers` cannot claim a body), and its async body runs below the crate's single sync-to-async seam, which a Clippy `disallowed-methods` rule enforces. This eliminates the nested-runtime panic class that review 4852724030 of PR #2592 reached through `network on`, along with the per-dispatch `HashMap` rebuild, the fifty `impl Command` scaffolds, and the hand-patched `servers` help line.

Breaking, per ADR 0031: a failing command renders once as `Error: …` on stderr and one-shot mode exits nonzero; stdout carries exactly the command's result, with the in-band `{"error": …}` JSON objects deleted; unknown commands are errors; and all narration (transmit heartbeat, server probing, save/sync notices, the quit trailer) moves to stderr. Consumers that parse stdout for errors or assert exit 0 must adapt — the known audit surface is the cli-wallet-harness work in PR #2453.

The command tests move to `commands/tests.rs` (169 passing, including new table invariants: names sorted and unique, and every usage section invokes its command's minted name), the non-test `commands.rs` shrinks from 3,316 lines to 2,867, and clap is bumped to 4.6.5 ahead of a follow-up branch that will delegate subcommand parsing, help, and usage errors to clap's derive API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
