### PR TITLE
refactor(cli)!: delegate command parsing to clap derive grammars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -754,7 +754,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -997,7 +997,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1087,7 +1087,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2170,7 +2170,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2236,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2258,7 +2258,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2317,7 +2317,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -2331,7 +2331,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2697,7 +2697,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -2966,7 +2966,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3248,7 +3248,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3259,7 +3259,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3352,7 +3352,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3482,7 +3482,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3507,7 +3507,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
@@ -3580,7 +3580,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3751,7 +3751,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3852,7 +3852,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3963,7 +3963,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3974,7 +3974,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4205,7 +4205,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4221,7 +4221,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4303,7 +4303,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4688,7 +4688,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4708,7 +4708,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4729,7 +4729,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4762,7 +4762,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -525,6 +526,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3153,6 +3166,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ shellwords = "1"
 
 ### OS hooks
 chrono = "0.4"
-clap = "4"
+clap = { version = "4.6.5", features = ["derive"] }
 dirs = "6"
 memuse = "0.2"
 rand = "0.8"

--- a/docs/adr/0030-the-cli-crosses-sync-to-async-exactly-once.md
+++ b/docs/adr/0030-the-cli-crosses-sync-to-async-exactly-once.md
@@ -1,6 +1,7 @@
 ---
 status: accepted
 date: 2026-08-05
+amended: 2026-08-05
 ---
 
 # The CLI crosses sync to async exactly once, dispatching from a static command table
@@ -70,3 +71,21 @@ transmit heartbeat) becomes async-native and composable, which is what the
 `network on` consent flow of ADR 0026 needs. The failure contract for string
 frontends — what a failing command prints, and on which stream — is unblocked
 by this decision but is a separate ruling, recorded when ratified.
+
+## Amendment (2026-08-05): the clap grammar replaces the table
+
+The clap conversion (PR #2630) retired the registry machinery this record
+prescribes, having first built it as decided. The static `CommandSpec` slice,
+the `CommandBody` enum, and the `wallet!`/`standalone!` macros dissolved into
+a single `#[derive(clap::Subcommand)]` `CliCommand` enum: the variant
+identifier mints the command's name, typed fields carry its arguments, and
+dispatch is an exhaustive match, so the divergences the table was built to
+prevent remain impossible by construction. `do_user_command` is deleted; the
+command channel carries a parsed `CliCommand`, so no string dispatch exists
+below the seam at all.
+
+The core ruling stands unchanged. Command bodies are ordinary `async`
+functions returning typed results, the sync world crosses into async only at
+the audited seams — the command loop's two `block_on` calls, the startup
+driver, and the server-resolution entry — and the Clippy `disallowed-methods`
+rule continues to enforce the invariant everywhere else in the crate.

--- a/docs/adr/0030-the-cli-crosses-sync-to-async-exactly-once.md
+++ b/docs/adr/0030-the-cli-crosses-sync-to-async-exactly-once.md
@@ -80,12 +80,12 @@ the `CommandBody` enum, and the `wallet!`/`standalone!` macros dissolved into
 a single `#[derive(clap::Subcommand)]` `CliCommand` enum: the variant
 identifier mints the command's name, typed fields carry its arguments, and
 dispatch is an exhaustive match, so the divergences the table was built to
-prevent remain impossible by construction. `do_user_command` is deleted; the
+prevent remain impossible by construction. `do_user_command` is deleted. The
 command channel carries a parsed `CliCommand`, so no string dispatch exists
 below the seam at all.
 
 The core ruling stands unchanged. Command bodies are ordinary `async`
 functions returning typed results, the sync world crosses into async only at
-the audited seams — the command loop's two `block_on` calls, the startup
-driver, and the server-resolution entry — and the Clippy `disallowed-methods`
+the audited seams (the command loop's two `block_on` calls, the startup
+driver, and the server-resolution entry), and the Clippy `disallowed-methods`
 rule continues to enforce the invariant everywhere else in the crate.

--- a/docs/agents/pr2630-open-findings.md
+++ b/docs/agents/pr2630-open-findings.md
@@ -1,7 +1,7 @@
 # PR #2630: open review findings
 
 The multi-agent review of the clap conversion confirmed ten findings.
-Eight are resolved on the branch. The parse boundaries now refuse
+Nine are resolved on the branch. The parse boundaries now refuse
 misplaced session flags and malformed send payloads before any wallet
 work. A manual `Debug` impl renders only the variant identifier, so no
 memo or key can reach a `Debug` surface. The family enums carry
@@ -9,7 +9,11 @@ per-variant `about` metadata, their long help no longer advertises a
 nested `help`, the offline harness panics on a parse error instead of
 misreading it, the REPL reuses one cached clap model per session, the
 usage lines are pinned to the minted names, and the CHANGELOG and ADR
-prose follow the punctuation conventions.
+prose follow the punctuation conventions. The wallet-free set has one
+statement, `requires_wallet`: the help split derives from it over the
+module's one-sample-per-variant list, the `standalone_commands` array
+is gone, and a pin holds the rendered standalone section equal to the
+derived names.
 
 ## Open findings
 
@@ -20,15 +24,7 @@ prose follow the punctuation conventions.
    "Type 'help'" pointer is gone. `parse_command_tokens` still renders
    the clap error verbatim.
 
-2. **Wallet-free classification residue.** The green
-   `help_sections_agree_with_requires_wallet` pin catches a misfiled
-   command, but the classification still lives in three places:
-   `requires_wallet`, the `standalone_commands` array of dummy variant
-   values, and `format_help`'s name comparison. The array also needs
-   placeholder fields reconstructed whenever a standalone command gains
-   an argument.
-
-3. **`help` takes one token.** The family syntax now shows in
+2. **`help` takes one token.** The family syntax now shows in
    `help migration`, but the natural follow-up `help migration start`
    is still a parse error. The full argument syntax lives behind
    `migration start --help`.

--- a/docs/agents/pr2630-open-findings.md
+++ b/docs/agents/pr2630-open-findings.md
@@ -1,0 +1,40 @@
+# PR #2630: open review findings
+
+The multi-agent review of the clap conversion confirmed ten findings.
+Eight are resolved on the branch. The parse boundaries now refuse
+misplaced session flags and malformed send payloads before any wallet
+work. A manual `Debug` impl renders only the variant identifier, so no
+memo or key can reach a `Debug` surface. The family enums carry
+per-variant `about` metadata, their long help no longer advertises a
+nested `help`, the offline harness panics on a parse error instead of
+misreading it, the REPL reuses one cached clap model per session, the
+usage lines are pinned to the minted names, and the CHANGELOG and ADR
+prose follow the punctuation conventions.
+
+## Open findings
+
+1. **The REPL leaks clap's process-oriented text.** Typing `--help` at
+   the prompt prints the `CommandLine` struct's internal doc-comment as
+   the program description. A typo prints `Usage: zingo-cli <COMMAND>`,
+   naming a binary the prompt user is not typing, and the old
+   "Type 'help'" pointer is gone. `parse_command_tokens` still renders
+   the clap error verbatim.
+
+2. **Wallet-free classification residue.** The green
+   `help_sections_agree_with_requires_wallet` pin catches a misfiled
+   command, but the classification still lives in three places:
+   `requires_wallet`, the `standalone_commands` array of dummy variant
+   values, and `format_help`'s name comparison. The array also needs
+   placeholder fields reconstructed whenever a standalone command gains
+   an argument.
+
+3. **`help` takes one token.** The family syntax now shows in
+   `help migration`, but the natural follow-up `help migration start`
+   is still a parse error. The full argument syntax lives behind
+   `migration start --help`.
+
+## Pending decision
+
+The `nym_arguments_meet_the_absent_feature_not_the_grammar` pin doubles
+as a decision instrument. If the shared-grammar validation ruling
+stands, that pin is deleted rather than the code changed.

--- a/utils/gen_branch_wallet.sh
+++ b/utils/gen_branch_wallet.sh
@@ -9,7 +9,7 @@ WALLETDIR=$REPOROOT/zingocli/tests/data/wallets/v26/${GITBRANCH}/${CHAIN}
 
 if [[ "$CHAIN" = "regtest" ]]
 then 
-  COMMANDARGS="--data-dir=$WALLETDIR save --regtest"
+  COMMANDARGS="--data-dir=$WALLETDIR --chain=regtest save"
 elif [[ "$CHAIN" = "mainnet" ]]
 then
   COMMANDARGS="--data-dir=$WALLETDIR save"

--- a/utils/gen_branch_wallet.sh
+++ b/utils/gen_branch_wallet.sh
@@ -9,10 +9,10 @@ WALLETDIR=$REPOROOT/zingocli/tests/data/wallets/v26/${GITBRANCH}/${CHAIN}
 
 if [[ "$CHAIN" = "regtest" ]]
 then 
-  COMMANDARGS="--data-dir=$WALLETDIR --chain=regtest save"
+  COMMANDARGS="--data-dir=$WALLETDIR --chain=regtest save run"
 elif [[ "$CHAIN" = "mainnet" ]]
 then
-  COMMANDARGS="--data-dir=$WALLETDIR save"
+  COMMANDARGS="--data-dir=$WALLETDIR save run"
 else
   exit 99
 fi

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -34,9 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that alters no command's output (ADR 0030).
 - **Breaking.** Command-line parsing is clap's now. Every command and
   sub-command is a clap derive grammar: help and usage errors are generated,
-  so the hand-written parser messages and their byte-stability are gone;
-  arguments arrive typed, with txids, server URIs, output scopes, and
-  performance levels validated at the parse; and a malformed one-shot
+  so the hand-written parser messages and their byte-stability are gone.
+  Arguments arrive typed, with txids, server URIs, output scopes, and
+  performance levels validated at the parse. A malformed one-shot
   invocation fails with clap's usage error and exit code 2 before any wallet
   work begins, where it previously booted the wallet first.
 - **Breaking.** Command names are case-sensitive: the grammar knows
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unknown-command error before exiting, and a bare `save` refuses at the
   argument parse, since its sub-command is required.
 - The interactive prompt and one-shot mode parse through one grammar,
-  exactly once, at the process boundary; the command channel carries parsed
+  exactly once, at the process boundary. The command channel carries parsed
   values, so no string is re-parsed inside the process.
 
 ### Removed
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `get_commands`, `get_standalone_commands`, `get_wallet_commands`,
   `do_user_command`, and `do_user_command_result` functions are gone.
   Dispatch parses one clap derive grammar and matches its enum
-  exhaustively; no string entry point remains (ADR 0030).
+  exhaustively. No string entry point remains (ADR 0030).
 
 ## [0.4.0] - 2026-06-10
 

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -45,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   balance` binds the flag to the session, and a flag written after the
   command is a usage error with exit code 2, where the old parser accepted
   session flags in any position. A send-family memo beginning with a dash
-  needs the standard escape: `send <address> <zatoshis> -- "-memo"`.
+  needs the standard escape: `send <address> <zatoshis> -- "-memo"`, and a
+  `messages` filter beginning with a dash rides the same escape.
 - `zingo-cli --help` now lists every wallet command, and `help <command>`
   appends clap's generated usage and options to the command's description.
 - `exit` is a clean alias of `quit`, where it previously printed an

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -58,10 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - **Breaking.** The string-command plumbing left the library surface: the
   `Command` and `ShortCircuitedCommand` traits, `HelpCommand`, and the
-  `get_commands`, `get_standalone_commands`, `get_wallet_commands`, and
-  `do_user_command` functions are gone. Dispatch parses one clap derive
-  grammar and matches its enum exhaustively; `do_user_command_result`
-  remains the string entry point (ADR 0030).
+  `get_commands`, `get_standalone_commands`, `get_wallet_commands`,
+  `do_user_command`, and `do_user_command_result` functions are gone.
+  Dispatch parses one clap derive grammar and matches its enum
+  exhaustively; no string entry point remains (ADR 0030).
 
 ## [0.4.0] - 2026-06-10
 

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   work begins, where it previously booted the wallet first.
 - **Breaking.** Command names are case-sensitive: the grammar knows
   `balance`, never `BALANCE`, where the old dispatcher lowercased names.
+- **Breaking.** Session flags precede the command name: `zingo-cli --nosync
+  balance` binds the flag to the session, and a flag written after the
+  command is a usage error with exit code 2, where the old parser accepted
+  session flags in any position. A send-family memo beginning with a dash
+  needs the standard escape: `send <address> <zatoshis> -- "-memo"`.
 - `zingo-cli --help` now lists every wallet command, and `help <command>`
   appends clap's generated usage and options to the command's description.
 - `exit` is a clean alias of `quit`, where it previously printed an

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -32,14 +32,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bodies, and the crate crosses from sync to async at a single audited seam
   that a Clippy `disallowed-methods` rule enforces. This is an internal change
   that alters no command's output (ADR 0030).
+- **Breaking.** Command-line parsing is clap's now. Every command and
+  sub-command is a clap derive grammar: help and usage errors are generated,
+  so the hand-written parser messages and their byte-stability are gone;
+  arguments arrive typed, with txids, server URIs, output scopes, and
+  performance levels validated at the parse; and a malformed one-shot
+  invocation fails with clap's usage error and exit code 2 before any wallet
+  work begins, where it previously booted the wallet first.
+- **Breaking.** Command names are case-sensitive: the grammar knows
+  `balance`, never `BALANCE`, where the old dispatcher lowercased names.
+- `zingo-cli --help` now lists every wallet command, and `help <command>`
+  appends clap's generated usage and options to the command's description.
+- `exit` is a clean alias of `quit`, where it previously printed an
+  unknown-command error before exiting, and a bare `save` refuses at the
+  argument parse, since its sub-command is required.
+- The interactive prompt and one-shot mode parse through one grammar,
+  exactly once, at the process boundary; the command channel carries parsed
+  values, so no string is re-parsed inside the process.
 
 ### Removed
 - **Breaking.** The string-command plumbing left the library surface: the
   `Command` and `ShortCircuitedCommand` traits, `HelpCommand`, and the
   `get_commands`, `get_standalone_commands`, `get_wallet_commands`, and
-  `do_user_command_result` functions are gone. Dispatch now reads the static
-  command table of `CommandSpec` rows, and `do_user_command` remains the
-  string entry point (ADR 0030).
+  `do_user_command` functions are gone. Dispatch parses one clap derive
+  grammar and matches its enum exhaustively; `do_user_command_result`
+  remains the string entry point (ADR 0030).
 
 ## [0.4.0] - 2026-06-10
 

--- a/zingo-cli/clippy.toml
+++ b/zingo-cli/clippy.toml
@@ -1,4 +1,4 @@
 disallowed-methods = [
-    { path = "tokio::runtime::Runtime::block_on", reason = "ADR 0030: the CLI crosses sync to async only at audited seams (dispatch, the startup driver, server resolution); a new block_on needs an explicit allow and a seam justification" },
+    { path = "tokio::runtime::Runtime::block_on", reason = "ADR 0030 as amended: the CLI crosses sync to async only at audited seams (the command loop, the startup driver, server resolution); a new block_on needs an explicit allow and a seam justification" },
     { path = "tokio::runtime::Handle::block_on", reason = "ADR 0030: same invariant as Runtime::block_on" },
 ]

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1104,7 +1104,6 @@ pub enum NymCommandError {
 
 /// A parsed `nym` command, its arguments parsed completely at the clap
 /// derive grammar before any wallet access.
-#[cfg(feature = "nym")]
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum NymSubCommand {
     Status,
@@ -1121,7 +1120,6 @@ pub(crate) enum NymSubCommand {
 
 /// https-only: the mixnet leg refuses a plaintext target at dial time,
 /// so the grammar rejects it up front with a clear message.
-#[cfg(feature = "nym")]
 fn parse_probe_target(raw: &str) -> Result<http::Uri, String> {
     let uri = raw
         .parse::<http::Uri>()
@@ -1819,28 +1817,6 @@ async fn run_split(
     })
 }
 
-/// The `nym` help texts, held as consts because the command's grammar
-/// splits on the `nym` feature and both variants carry the same help.
-const NYM_ABOUT: &str = "Control the Nym mixnet transport (on/off/status/probe/history).";
-const NYM_LONG_ABOUT: &str = indoc! {r"
-    Control the Nym mixnet transport for send and price-fetch.
-
-    With Mixnet Mode on, both route over the mixnet and fail closed while it
-    bootstraps, never falling back to clearnet. Turning it off is a deliberate
-    choice to transmit over clearnet.
-
-    `status` reports off, bootstrapping or ready. `on` starts the nym-proxy
-    child, taking the binary from the given path, else $ZINGO_NYM_PROXY, else
-    one bundled beside this binary, else PATH. `off` reverts to clearnet.
-    `probe` runs GetLightdInfo over both routes side by side to tell whether a
-    failure is mixnet-specific, and its clearnet leg uses your real IP.
-    `history` shows per-indexer attempts across sessions, and needs the
-    nym-diary feature plus --indexer-diary.
-
-    Usage:
-    nym status | on [binary_path] | off | probe [uri] | history
-"};
-
 /// Every command the CLI dispatches, in alphabetical order: the single
 /// source of the dispatchable names, help texts, and typed arguments.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq)]
@@ -2080,10 +2056,7 @@ pub(crate) enum CliCommand {
             max_send_value { "address": "<address>", "zennies_for_zingo": <true|false> }
         "#}
     )]
-    MaxSendValue {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
+    MaxSendValue { args: Vec<String> },
     #[command(
         about = "Show by address memo_bytes transfers for this seed.",
         long_about = indoc! {r"
@@ -2106,7 +2079,10 @@ pub(crate) enum CliCommand {
             messages [address | string]
         "}
     )]
-    Messages { filter: Option<String> },
+    Messages {
+        #[arg(allow_hyphen_values = true)]
+        filter: Option<String>,
+    },
     #[command(
         about = "Migrate all Orchard funds to the Ironwood pool in one interactive run.",
         long_about = indoc! {r"
@@ -2226,15 +2202,31 @@ pub(crate) enum CliCommand {
         #[arg(value_enum)]
         scope: Option<OutputScope>,
     },
-    #[command(about = NYM_ABOUT, long_about = NYM_LONG_ABOUT)]
-    #[cfg(feature = "nym")]
+    #[command(
+        about = "Control the Nym mixnet transport (on/off/status/probe/history).",
+        long_about = indoc! {r"
+            Control the Nym mixnet transport for send and price-fetch.
+
+            With Mixnet Mode on, both route over the mixnet and fail closed while it
+            bootstraps, never falling back to clearnet. Turning it off is a deliberate
+            choice to transmit over clearnet.
+
+            `status` reports off, bootstrapping or ready. `on` starts the nym-proxy
+            child, taking the binary from the given path, else $ZINGO_NYM_PROXY, else
+            one bundled beside this binary, else PATH. `off` reverts to clearnet.
+            `probe` runs GetLightdInfo over both routes side by side to tell whether a
+            failure is mixnet-specific, and its clearnet leg uses your real IP.
+            `history` shows per-indexer attempts across sessions, and needs the
+            nym-diary feature plus --indexer-diary.
+
+            Usage:
+            nym status | on [binary_path] | off | probe [uri] | history
+        "}
+    )]
     Nym {
         #[command(subcommand)]
         sub: Option<NymSubCommand>,
     },
-    #[command(about = NYM_ABOUT, long_about = NYM_LONG_ABOUT)]
-    #[cfg(not(feature = "nym"))]
-    Nym,
     #[command(
         about = "Parse an address",
         long_about = concat!(
@@ -2284,10 +2276,7 @@ pub(crate) enum CliCommand {
             "\"\n",
         )
     )]
-    Quicksend {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
+    Quicksend { args: Vec<String> },
     #[command(
         about = "Shield transparent funds, fusing `shield` and `confirm`.",
         long_about = indoc! {r"
@@ -2381,10 +2370,7 @@ pub(crate) enum CliCommand {
             "    confirm\n",
         )
     )]
-    Send {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
+    Send { args: Vec<String> },
     #[command(
         about = "Propose a transfer of all shielded ZEC to one address, for 'confirm' to broadcast.",
         long_about = concat!(
@@ -2406,10 +2392,7 @@ pub(crate) enum CliCommand {
             "    confirm\n",
         )
     )]
-    SendAll {
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
+    SendAll { args: Vec<String> },
     #[command(
         about = "Show by address number of sends for this seed.",
         long_about = indoc! {r"
@@ -2586,6 +2569,27 @@ pub(crate) enum CliCommand {
     WalletKind,
 }
 
+impl CliCommand {
+    /// The command's minted name, derived from the variant identifier, so
+    /// a log line can carry the name and never the arguments.
+    pub(crate) fn name(&self) -> String {
+        let debug = format!("{self:?}");
+        let ident = debug.split([' ', '{', '(']).next().unwrap_or_default();
+        let mut name = String::with_capacity(ident.len() + 2);
+        for c in ident.chars() {
+            if c.is_ascii_uppercase() {
+                if !name.is_empty() {
+                    name.push('_');
+                }
+                name.push(c.to_ascii_lowercase());
+            } else {
+                name.push(c);
+            }
+        }
+        name
+    }
+}
+
 /// The whole command line one dispatch parses: a command name and its
 /// arguments, with no binary name in front, so the REPL and the one-shot
 /// entry share this grammar.
@@ -2686,7 +2690,7 @@ pub(crate) async fn dispatch_parsed(
         #[cfg(feature = "nym")]
         CliCommand::Nym { sub } => nym(sub, lightclient).await,
         #[cfg(not(feature = "nym"))]
-        CliCommand::Nym => nym(lightclient).await,
+        CliCommand::Nym { .. } => nym(lightclient).await,
         CliCommand::ParseAddress { address } => parse_address(&address),
         CliCommand::ParseViewkey { viewkey } => parse_viewkey(&viewkey),
         CliCommand::Quicksend { args } => quicksend(&args, lightclient).await,

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -88,6 +88,22 @@ async fn transmit_narrated<T>(
     narrated(label, move || progress.latest(), operation).await
 }
 
+/// [`transmit_narrated`] for the operations whose whole result is a list of
+/// transaction ids, rendered here so the sandwich exists once.
+async fn transmit_txids<T: ToString, E: std::fmt::Display>(
+    label: &str,
+    progress: TransmitProgressHandle,
+    operation: impl Future<Output = Result<impl IntoIterator<Item = T>, E>>,
+) -> Result<String, CommandError> {
+    match transmit_narrated(label, progress, operation).await {
+        Ok(txids) => {
+            let txids: Vec<T> = txids.into_iter().collect();
+            Ok(object! { "txids" => txids_json(&txids) }.pretty(JSON_INDENT))
+        }
+        Err(e) => Err(not_yet_typed(e)),
+    }
+}
+
 /// Typed failure of a CLI command, rendered to prose exactly once, on
 /// stderr, at the dispatch seam.
 #[derive(Debug, thiserror::Error)]
@@ -114,14 +130,25 @@ fn usage(command: &str, detail: impl std::fmt::Display) -> CommandError {
     ))
 }
 
+/// The indent width of every JSON object the CLI prints.
+const JSON_INDENT: u16 = 2;
+
+/// Wraps a failure's rendering in the transitional [`CommandError::NotYetTyped`] variant.
+fn not_yet_typed(e: impl std::fmt::Display) -> CommandError {
+    CommandError::NotYetTyped(e.to_string())
+}
+
 async fn addresses(lightclient: &mut LightClient) -> Result<String, CommandError> {
-    Ok(lightclient.unified_addresses_json().await.pretty(2))
+    Ok(lightclient
+        .unified_addresses_json()
+        .await
+        .pretty(JSON_INDENT))
 }
 
 async fn balance(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.account_balance(zip32::AccountId::ZERO).await {
         Ok(bal) => Ok(bal.to_string()),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -134,8 +161,8 @@ async fn calculate(lightclient: &mut LightClient) -> Result<String, CommandError
         Ok(txids) => Ok(object! {
             "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
         }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        .pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -160,6 +187,67 @@ async fn change_server(
     }
 }
 
+/// Renders the wallet's judgment of an address into the `check_address` JSON.
+fn address_check_json(address_ref: Option<WalletAddressRef>) -> json::JsonValue {
+    address_ref.map_or(
+        json::object! { "is_wallet_address" => "false".to_string() },
+        |address_ref| match address_ref {
+            WalletAddressRef::Unified {
+                account_id,
+                address_index,
+                has_orchard,
+                has_sapling,
+                has_transparent,
+                encoded_address,
+            } => json::object! {
+                "is_wallet_address" => "true".to_string(),
+                "address_type" => "unified".to_string(),
+                "address_index" => address_index,
+                "account_id" => u32::from(account_id),
+                "has_orchard" => has_orchard,
+                "has_sapling" => has_sapling,
+                "has_transparent" => has_transparent,
+                "encoded_address" => encoded_address,
+            },
+            WalletAddressRef::OrchardInternal {
+                account_id,
+                diversifier_index,
+                encoded_address,
+            } => json::object! {
+                "is_wallet_address" => "true".to_string(),
+                "address_type" => "orchard_internal".to_string(),
+                "account_id" => u32::from(account_id),
+                "diversifier_index" => u128::from(diversifier_index).to_string(),
+                "encoded_address" => encoded_address,
+            },
+            WalletAddressRef::SaplingExternal {
+                account_id,
+                diversifier_index,
+                encoded_address,
+            } => json::object! {
+                "is_wallet_address" => "true".to_string(),
+                "address_type" => "sapling".to_string(),
+                "account_id" => u32::from(account_id),
+                "diversifier_index" => u128::from(diversifier_index).to_string(),
+                "encoded_address" => encoded_address,
+            },
+            WalletAddressRef::Transparent {
+                account_id,
+                scope,
+                address_index,
+                encoded_address,
+            } => json::object! {
+                "is_wallet_address" => "true".to_string(),
+                "address_type" => "transparent".to_string(),
+                "account_id" => u32::from(account_id),
+                "scope" => scope.to_string(),
+                "address_index" => address_index.index(),
+                "encoded_address" => encoded_address,
+            },
+        },
+    )
+}
+
 async fn check_address(
     address: &str,
     lightclient: &mut LightClient,
@@ -170,88 +258,23 @@ async fn check_address(
         .await
         .is_address_derived_by_keys(address)
     {
-        Ok(address_ref) => Ok(address_ref
-            .map_or(
-                json::object! { "is_wallet_address" => "false".to_string() },
-                |address_ref| match address_ref {
-                    WalletAddressRef::Unified {
-                        account_id,
-                        address_index,
-                        has_orchard,
-                        has_sapling,
-                        has_transparent,
-                        encoded_address,
-                    } => json::object! {
-                        "is_wallet_address" => "true".to_string(),
-                        "address_type" => "unified".to_string(),
-                        "address_index" => address_index,
-                        "account_id" => u32::from(account_id),
-                        "has_orchard" => has_orchard,
-                        "has_sapling" => has_sapling,
-                        "has_transparent" => has_transparent,
-                        "encoded_address" => encoded_address,
-                    },
-                    WalletAddressRef::OrchardInternal {
-                        account_id,
-                        diversifier_index,
-                        encoded_address,
-                    } => json::object! {
-                        "is_wallet_address" => "true".to_string(),
-                        "address_type" => "orchard_internal".to_string(),
-                        "account_id" => u32::from(account_id),
-                        "diversifier_index" => u128::from(diversifier_index).to_string(),
-                        "encoded_address" => encoded_address,
-                    },
-                    WalletAddressRef::SaplingExternal {
-                        account_id,
-                        diversifier_index,
-                        encoded_address,
-                    } => json::object! {
-                        "is_wallet_address" => "true".to_string(),
-                        "address_type" => "sapling".to_string(),
-                        "account_id" => u32::from(account_id),
-                        "diversifier_index" => u128::from(diversifier_index).to_string(),
-                        "encoded_address" => encoded_address,
-                    },
-                    WalletAddressRef::Transparent {
-                        account_id,
-                        scope,
-                        address_index,
-                        encoded_address,
-                    } => json::object! {
-                        "is_wallet_address" => "true".to_string(),
-                        "address_type" => "transparent".to_string(),
-                        "account_id" => u32::from(account_id),
-                        "scope" => scope.to_string(),
-                        "address_index" => address_index.index(),
-                        "encoded_address" => encoded_address,
-                    },
-                },
-            )
-            .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Ok(address_ref) => Ok(address_check_json(address_ref).pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
 async fn clear(lightclient: &mut LightClient) -> Result<String, CommandError> {
     lightclient.wallet().write().await.clear_all();
-    Ok(object! { "result" => "success" }.pretty(2))
+    Ok(object! { "result" => "success" }.pretty(JSON_INDENT))
 }
 
 async fn confirm(lightclient: &mut LightClient) -> Result<String, CommandError> {
-    match transmit_narrated(
+    transmit_txids(
         "confirm",
         lightclient.transmit_progress_handle(),
         lightclient.send_stored_proposal(true),
     )
     .await
-    {
-        Ok(txids) => Ok(object! {
-            "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
-        }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-    }
 }
 
 #[cfg(feature = "nym")]
@@ -264,7 +287,7 @@ async fn current_price(lightclient: &mut LightClient) -> Result<String, CommandE
             fetch.round_trip.as_millis(),
             fetch.via_socks5
         )),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -283,8 +306,8 @@ async fn delete(lightclient: &mut LightClient) -> Result<String, CommandError> {
             "result" => "success",
             "wallet_path" => lightclient.wallet_path().to_str().expect("should be valid UTF-8"),
         }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        .pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -299,13 +322,13 @@ async fn export_ufvk(lightclient: &mut LightClient) -> Result<String, CommandErr
         .try_into()
     {
         Ok(ufvk) => ufvk,
-        Err(e) => return Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => return Err(not_yet_typed(e)),
     };
     Ok(object! {
         "ufvk" => ufvk.encode(&lightclient.chain_type()),
         "birthday" => lightclient.birthday()
     }
-    .pretty(2))
+    .pretty(JSON_INDENT))
 }
 
 async fn height(lightclient: &mut LightClient) -> Result<String, CommandError> {
@@ -320,7 +343,7 @@ async fn height(lightclient: &mut LightClient) -> Result<String, CommandError> {
                 .map_or(0, u32::from)
         )
     }
-    .pretty(2))
+    .pretty(JSON_INDENT))
 }
 
 fn help(command: Option<&str>) -> Result<String, CommandError> {
@@ -329,8 +352,8 @@ fn help(command: Option<&str>) -> Result<String, CommandError> {
 
 async fn info(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.info().await {
-        Ok(info) => Ok(json::JsonValue::from(info).pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Ok(info) => Ok(json::JsonValue::from(info).pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -351,15 +374,15 @@ async fn max_send_value(
         .max_send_value(address, zennies_for_zingo, zip32::AccountId::ZERO)
         .await
     {
-        Ok(bal) => Ok(object! { "max_send_value" => bal.into_u64() }.pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Ok(bal) => Ok(object! { "max_send_value" => bal.into_u64() }.pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
 async fn memobytes_to_address(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.do_total_memobytes_to_address().await {
-        Ok(total_memo_bytes) => Ok(json::JsonValue::from(total_memo_bytes).pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Ok(total_memo_bytes) => Ok(json::JsonValue::from(total_memo_bytes).pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -368,8 +391,8 @@ async fn messages(
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
     match lightclient.messages_containing(filter).await {
-        Ok(value_transfers) => Ok(json::JsonValue::from(value_transfers).pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Ok(value_transfers) => Ok(json::JsonValue::from(value_transfers).pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -415,38 +438,26 @@ async fn new_address(
             "has_transparent" => unified_address.has_transparent(),
             "encoded_address" => unified_address.encode(&chain_type),
         }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        .pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
-async fn new_taddress(lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn taddress(
+    lightclient: &mut LightClient,
+    enforce_gap: bool,
+) -> Result<String, CommandError> {
     let chain_type = lightclient.chain_type();
     let mut wallet = lightclient.wallet().write().await;
-    match wallet.generate_transparent_address(zip32::AccountId::ZERO, true) {
+    match wallet.generate_transparent_address(zip32::AccountId::ZERO, enforce_gap) {
         Ok((id, transparent_address)) => Ok(json::object! {
             "account" => u32::from(id.account_id()),
             "address_index" => id.address_index().index(),
             "scope" => id.scope().to_string(),
             "encoded_address" => transparent::encode_address(&chain_type, transparent_address),
         }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-    }
-}
-
-async fn new_taddress_allow_gap(lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let chain_type = lightclient.chain_type();
-    let mut wallet = lightclient.wallet().write().await;
-    match wallet.generate_transparent_address(zip32::AccountId::ZERO, false) {
-        Ok((id, transparent_address)) => Ok(json::object! {
-            "account" => u32::from(id.account_id()),
-            "address_index" => id.address_index().index(),
-            "scope" => id.scope().to_string(),
-            "encoded_address" => transparent::encode_address(&chain_type, transparent_address),
-        }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        .pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -468,7 +479,7 @@ async fn notes(
         "orchard_notes" => json::JsonValue::from(wallet.note_summaries::<OrchardNote>(all_notes)),
         "sapling_notes" => json::JsonValue::from(wallet.note_summaries::<SaplingNote>(all_notes)),
     }
-    .pretty(2))
+    .pretty(JSON_INDENT))
 }
 
 async fn coins(
@@ -481,7 +492,7 @@ async fn coins(
             lightclient.wallet().read().await.coin_summaries(all_coins)
         ),
     }
-    .pretty(2))
+    .pretty(JSON_INDENT))
 }
 
 async fn quicksend(
@@ -500,28 +511,21 @@ async fn quicksend(
     .await
     {
         Ok(reports) => Ok(object! {
-            "txids" => reports.iter().map(|report| report.txid.to_string()).collect::<Vec<_>>(),
+            "txids" => txids_json(&reports.iter().map(|report| report.txid).collect::<Vec<_>>()),
             "transmissions" => reports.iter().map(render_transmit_report).collect::<Vec<_>>(),
         }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        .pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
 async fn quickshield(lightclient: &mut LightClient) -> Result<String, CommandError> {
-    match transmit_narrated(
+    transmit_txids(
         "quickshield",
         lightclient.transmit_progress_handle(),
         lightclient.quick_shield(zip32::AccountId::ZERO),
     )
     .await
-    {
-        Ok(txids) => Ok(object! {
-            "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
-        }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-    }
 }
 
 async fn quit(lightclient: &mut LightClient) -> Result<String, CommandError> {
@@ -558,14 +562,14 @@ async fn remove_transaction(
         .remove_failed_transaction(txid)
     {
         Ok(()) => Ok("Successfully removed failed transaction.".to_string()),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
 async fn rescan(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.rescan().await {
         Ok(()) => Ok("Launching rescan...".to_string()),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -610,10 +614,10 @@ async fn send(
         .await
     {
         Ok(proposal) => match zingolib::data::proposal::total_fee(&proposal) {
-            Ok(fee) => Ok(object! { "fee" => fee.into_u64() }.pretty(2)),
-            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+            Ok(fee) => Ok(object! { "fee" => fee.into_u64() }.pretty(JSON_INDENT)),
+            Err(e) => Err(not_yet_typed(e)),
         },
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -629,24 +633,22 @@ async fn send_all(
         .await
     {
         Ok(proposal) => {
-            let amount = proposal::total_payment_amount(&proposal)
-                .map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
-            let fee = proposal::total_fee(&proposal)
-                .map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
+            let amount = proposal::total_payment_amount(&proposal).map_err(not_yet_typed)?;
+            let fee = proposal::total_fee(&proposal).map_err(not_yet_typed)?;
             Ok(object! {
                 "amount" => amount.into_u64(),
                 "fee" => fee.into_u64(),
             }
-            .pretty(2))
+            .pretty(JSON_INDENT))
         }
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
 async fn sends_to_address(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.do_total_spends_to_address().await {
-        Ok(total_spends) => Ok(json::JsonValue::from(total_spends).pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Ok(total_spends) => Ok(json::JsonValue::from(total_spends).pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -740,9 +742,9 @@ async fn shield(lightclient: &mut LightClient) -> Result<String, CommandError> {
                 "value_to_shield" => value_to_shield.into_u64(),
                 "fee" => fee.into_u64(),
             }
-            .pretty(2))
+            .pretty(JSON_INDENT))
         }
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -750,11 +752,11 @@ async fn spendable_balance(lightclient: &mut LightClient) -> Result<String, Comm
     let wallet = lightclient.wallet().read().await;
     let spendable_balance = wallet
         .shielded_spendable_balance(zip32::AccountId::ZERO, false)
-        .map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
+        .map_err(not_yet_typed)?;
     Ok(object! {
         "spendable_balance" => spendable_balance.into_u64(),
     }
-    .pretty(2))
+    .pretty(JSON_INDENT))
 }
 
 /// A parsed `sync` command, its arguments parsed completely at the clap
@@ -777,22 +779,22 @@ async fn sync(sub: SyncSubCommand, lightclient: &mut LightClient) -> Result<Stri
             } else {
                 match lightclient.sync().await {
                     Ok(()) => Ok("Launching sync task...".to_string()),
-                    Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+                    Err(e) => Err(not_yet_typed(e)),
                 }
             }
         }
         SyncSubCommand::Pause => match lightclient.pause_sync() {
             Ok(()) => Ok("Pausing sync task...".to_string()),
-            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+            Err(e) => Err(not_yet_typed(e)),
         },
         SyncSubCommand::Stop => match lightclient.stop_sync() {
             Ok(()) => Ok("Stopping sync task...".to_string()),
-            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+            Err(e) => Err(not_yet_typed(e)),
         },
         SyncSubCommand::Status => {
             match pepper_sync::sync_status(&*lightclient.wallet().read().await).await {
-                Ok(status) => Ok(json::JsonValue::from(status).pretty(2)),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+                Ok(status) => Ok(json::JsonValue::from(status).pretty(JSON_INDENT)),
+                Err(e) => Err(not_yet_typed(e)),
             }
         }
         SyncSubCommand::Poll => match lightclient.poll_sync() {
@@ -800,20 +802,23 @@ async fn sync(sub: SyncSubCommand, lightclient: &mut LightClient) -> Result<Stri
             PollReport::NotReady => Ok("Sync task is not complete.".to_string()),
             PollReport::Ready(result) => match result {
                 Ok(sync_result) => Ok(sync_result.to_string()),
-                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+                Err(e) => Err(not_yet_typed(e)),
             },
         },
     }
 }
 
 async fn t_addresses(lightclient: &mut LightClient) -> Result<String, CommandError> {
-    Ok(lightclient.transparent_addresses_json().await.pretty(2))
+    Ok(lightclient
+        .transparent_addresses_json()
+        .await
+        .pretty(JSON_INDENT))
 }
 
 async fn transactions(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.transaction_summaries(false).await {
         Ok(transactions) => Ok(transactions.to_string()),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -848,32 +853,25 @@ async fn transmit(
         ));
     };
 
-    match transmit_narrated(
+    transmit_txids(
         "transmit",
         lightclient.transmit_progress_handle(),
         lightclient.transmit_calculated(txids),
     )
     .await
-    {
-        Ok(txids) => Ok(object! {
-            "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
-        }
-        .pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-    }
 }
 
 async fn value_to_address(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.do_total_value_to_address().await {
-        Ok(total_values) => Ok(json::JsonValue::from(total_values).pretty(2)),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Ok(total_values) => Ok(json::JsonValue::from(total_values).pretty(JSON_INDENT)),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
 async fn value_transfers(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.value_transfers(false).await {
         Ok(value_transfers) => Ok(value_transfers.to_string()),
-        Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -1488,7 +1486,7 @@ async fn run_migrate(lightclient: &mut LightClient) -> Result<String, MigrationC
         "part_txids" => txids_json(&summary.part_txids),
         "residual" => summary.residual,
     }
-    .pretty(2))
+    .pretty(JSON_INDENT))
 }
 
 /// Runs one `migration` sub-command.
@@ -1509,7 +1507,7 @@ async fn run_migration(
                 "residual" => plan.residual,
                 "plan_hash" => hex::encode(migration::plan_hash(&plan)),
             }
-            .pretty(2)
+            .pretty(JSON_INDENT)
         }
         MigrationSubCommand::Start {
             plan_hash,
@@ -1538,7 +1536,7 @@ async fn run_migration(
                     "round" => round,
                     "split_txids" => txids_json(&txids),
                 }
-                .pretty(2),
+                .pretty(JSON_INDENT),
                 SplitStep::AwaitingConfirmation { pending } if pending.is_empty() => {
                     "Round confirmed; waiting for the anchor to reach its outputs. \
                      Sync and retry."
@@ -1547,7 +1545,7 @@ async fn run_migration(
                 SplitStep::AwaitingConfirmation { pending } => object! {
                     "awaiting_confirmation" => txids_json(&pending),
                 }
-                .pretty(2),
+                .pretty(JSON_INDENT),
                 SplitStep::SplittingComplete => {
                     "Note splitting complete; parts are scheduled.".to_string()
                 }
@@ -1590,7 +1588,7 @@ async fn run_migration(
                     .collect::<Vec<_>>(),
                 "halted" => report.halted,
             }
-            .pretty(2)
+            .pretty(JSON_INDENT)
         }
         MigrationSubCommand::Auto => {
             lightclient
@@ -1601,7 +1599,7 @@ async fn run_migration(
             if txids.is_empty() {
                 "No parts due yet.".to_string()
             } else {
-                object! { "broadcast" => txids_json(&txids) }.pretty(2)
+                object! { "broadcast" => txids_json(&txids) }.pretty(JSON_INDENT)
             }
         }
         MigrationSubCommand::Status => {
@@ -1630,7 +1628,7 @@ async fn run_migration(
                     "denominations" => batch.denominations.clone(),
                 }),
             }
-            .pretty(2)
+            .pretty(JSON_INDENT)
         }
         MigrationSubCommand::Windows => {
             let timeline = lightclient.window_timeline().await?;
@@ -1651,7 +1649,7 @@ async fn run_migration(
                         })
                         .collect::<Vec<_>>(),
                 }
-                .pretty(2),
+                .pretty(JSON_INDENT),
             }
         }
         MigrationSubCommand::Reconcile => {
@@ -1671,7 +1669,7 @@ async fn run_migration(
                     .map(|action| format!("{action:?}"))
                     .collect::<Vec<_>>(),
             }
-            .pretty(2)
+            .pretty(JSON_INDENT)
         }
         MigrationSubCommand::Catchup { spacing } => {
             let txids = transmit_narrated(
@@ -1683,7 +1681,7 @@ async fn run_migration(
             if txids.is_empty() {
                 "No overdue parts.".to_string()
             } else {
-                object! { "part_txids" => txids_json(&txids) }.pretty(2)
+                object! { "part_txids" => txids_json(&txids) }.pretty(JSON_INDENT)
             }
         }
         MigrationSubCommand::Cancel => {
@@ -1763,7 +1761,7 @@ async fn run_drain(
                 "fee" => plan.fee,
                 "residual" => plan.residual,
             }
-            .pretty(2)
+            .pretty(JSON_INDENT)
         }
         DrainSubCommand::Now => {
             let progress = lightclient.immediate_migration_progress_handle();
@@ -1779,7 +1777,7 @@ async fn run_drain(
                 "fee" => summary.fee,
                 "residual" => summary.residual,
             }
-            .pretty(2)
+            .pretty(JSON_INDENT)
         }
     })
 }
@@ -1803,7 +1801,7 @@ async fn run_split(
                 "parts" => plan.parts.clone(),
                 "residual" => plan.residual,
             }
-            .pretty(2)
+            .pretty(JSON_INDENT)
         }
         SplitSubCommand::Now => {
             let progress = lightclient.split_progress_handle();
@@ -1815,7 +1813,7 @@ async fn run_split(
             .await?
             {
                 SplitOutcome::Round { txids } => {
-                    object! { "split_txids" => txids_json(&txids) }.pretty(2)
+                    object! { "split_txids" => txids_json(&txids) }.pretty(JSON_INDENT)
                 }
                 SplitOutcome::AwaitingConfirmation => {
                     "A previous round has not confirmed yet; nothing was sent. Sync and retry."
@@ -2638,8 +2636,8 @@ pub(crate) async fn dispatch_parsed(
         CliCommand::Migrate => migrate(lightclient).await,
         CliCommand::Migration { sub } => migration(sub, lightclient).await,
         CliCommand::NewAddress { receivers } => new_address(receivers, lightclient).await,
-        CliCommand::NewTaddress => new_taddress(lightclient).await,
-        CliCommand::NewTaddressAllowGap => new_taddress_allow_gap(lightclient).await,
+        CliCommand::NewTaddress => taddress(lightclient, true).await,
+        CliCommand::NewTaddressAllowGap => taddress(lightclient, false).await,
         CliCommand::Notes { scope } => notes(scope, lightclient).await,
         #[cfg(feature = "nym")]
         CliCommand::Nym { sub } => nym(sub, lightclient).await,

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -2667,20 +2667,94 @@ static COMMAND_MODEL: std::sync::LazyLock<clap::Command> = std::sync::LazyLock::
     model
 });
 
-/// The wallet-free commands as values, so the section split in `help`
-/// derives its names from the grammar's own mint.
-fn standalone_commands() -> [CliCommand; 5] {
-    [
+/// One sample value per variant, held complete by the tests' set-equality
+/// pin, so derived listings cover the whole grammar.
+fn every_command() -> Vec<CliCommand> {
+    vec![
+        CliCommand::Addresses,
+        CliCommand::Balance,
+        CliCommand::Birthday,
+        CliCommand::Calculate,
+        CliCommand::ChangeServer { uri: None },
+        CliCommand::CheckAddress {
+            address: String::new(),
+        },
+        CliCommand::Clear,
+        CliCommand::Coins { scope: None },
+        CliCommand::Confirm,
+        CliCommand::CurrentPrice,
+        CliCommand::Delete,
+        CliCommand::Drain {
+            sub: DrainSubCommand::Plan,
+        },
+        CliCommand::ExportUfvk,
+        CliCommand::Height,
         CliCommand::Help { command: None },
+        CliCommand::Info,
+        CliCommand::MaxSendValue { args: Vec::new() },
+        CliCommand::MemobytesToAddress,
+        CliCommand::Messages { filter: None },
+        CliCommand::Migrate,
+        CliCommand::Migration {
+            sub: MigrationSubCommand::Plan,
+        },
+        CliCommand::NewAddress {
+            receivers: ReceiverSelection {
+                orchard: true,
+                sapling: false,
+            },
+        },
+        CliCommand::NewTaddress,
+        CliCommand::NewTaddressAllowGap,
+        CliCommand::Notes { scope: None },
+        CliCommand::Nym { sub: None },
         CliCommand::ParseAddress {
             address: String::new(),
         },
         CliCommand::ParseViewkey {
             viewkey: String::new(),
         },
+        CliCommand::Quicksend { args: Vec::new() },
+        CliCommand::Quickshield,
+        CliCommand::Quit,
+        CliCommand::RecoveryInfo,
+        CliCommand::RemoveTransaction {
+            txid: TxId::from_bytes([0; 32]),
+        },
+        CliCommand::Rescan,
+        CliCommand::Save {
+            sub: SaveSubCommand::Run,
+        },
+        CliCommand::Send { args: Vec::new() },
+        CliCommand::SendAll { args: Vec::new() },
+        CliCommand::SendsToAddress,
         CliCommand::Servers,
+        CliCommand::Settings { sub: None },
+        CliCommand::Shield,
+        CliCommand::SpendableBalance,
+        CliCommand::Split {
+            sub: SplitSubCommand::Plan,
+        },
+        CliCommand::Sync {
+            sub: SyncSubCommand::Status,
+        },
+        CliCommand::TAddresses,
+        CliCommand::Transactions,
+        CliCommand::Transmit { txids: Vec::new() },
+        CliCommand::ValueToAddress,
+        CliCommand::ValueTransfers,
         CliCommand::Version,
+        CliCommand::WalletKind,
     ]
+}
+
+/// The wallet-free commands, filtered from [`every_command`] by
+/// [`CliCommand::requires_wallet`], so the set has that single statement.
+fn wallet_free_commands() -> Vec<CliCommand> {
+    every_command()
+        .into_iter()
+        .filter(|command| !command.requires_wallet())
+        .collect()
 }
 
 /// Renders the two-section help listing, or one command's long help,
@@ -2688,9 +2762,8 @@ fn standalone_commands() -> [CliCommand; 5] {
 pub fn format_help(command: Option<&str>) -> String {
     let mut model = COMMAND_MODEL.clone();
     let Some(command) = command else {
-        let standalone_names: Vec<String> = standalone_commands()
+        let standalone_names: Vec<String> = wallet_free_commands()
             .iter()
-            .inspect(|command| debug_assert!(!command.requires_wallet()))
             .map(CliCommand::name)
             .collect();
         let listing = |standalone: bool| {

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -88,9 +88,8 @@ async fn transmit_narrated<T>(
     narrated(label, move || progress.latest(), operation).await
 }
 
-/// Typed failure of a CLI command. The dispatch seam renders these to
-/// prose exactly once, on stderr, for string frontends (ADR 0031). Typed
-/// frontends consume them directly via [`do_user_command_result`].
+/// Typed failure of a CLI command, rendered to prose exactly once, on
+/// stderr, at the dispatch seam.
 #[derive(Debug, thiserror::Error)]
 pub enum CommandError {
     #[error(transparent)]
@@ -2801,20 +2800,4 @@ pub(crate) async fn dispatch_parsed(
         CliCommand::Version => version(),
         CliCommand::WalletKind => wallet_kind(lightclient).await,
     }
-}
-
-/// Dispatches a user command given as a name and string arguments: the
-/// string frontend over [`parse_command_tokens`] and [`dispatch_parsed`],
-/// kept for callers that hold only strings.
-#[allow(dead_code)]
-pub async fn do_user_command_result(
-    cmd: &str,
-    args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
-    let tokens: Vec<String> = std::iter::once(cmd.to_ascii_lowercase())
-        .chain(args.iter().map(|arg| (*arg).to_string()))
-        .collect();
-    let command = parse_command_tokens(&tokens).map_err(CommandError::NotYetTyped)?;
-    dispatch_parsed(command, lightclient).await
 }

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -496,7 +496,10 @@ async fn migrate(args: &[&str], lightclient: &mut LightClient) -> Result<String,
 }
 
 async fn migration(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    Ok(run_migration(args, lightclient).await?)
+    use clap::Parser as _;
+    let MigrationCli { sub } = MigrationCli::try_parse_from(args.iter().copied())
+        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    Ok(run_migration(sub, lightclient).await?)
 }
 
 async fn new_address(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
@@ -698,30 +701,41 @@ async fn rescan(args: &[&str], lightclient: &mut LightClient) -> Result<String, 
     }
 }
 
+#[derive(clap::Parser, Debug, PartialEq, Eq)]
+#[command(name = "save", no_binary_name = true)]
+struct SaveCli {
+    #[command(subcommand)]
+    sub: SaveSubCommand,
+}
+
+/// A parsed `save` command. Arguments parse completely into this enum,
+/// at the clap derive grammar, before any wallet access.
+#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
+enum SaveSubCommand {
+    Run,
+    Check,
+    Shutdown,
+}
+
 async fn save(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if args.len() != 1 {
-        return Err(CommandError::NotYetTyped(
-            "save command expects 1 argument. Type \"help save\" for usage.".to_string(),
-        ));
-    }
-    match args[0] {
-        "run" => {
+    use clap::Parser as _;
+    let SaveCli { sub } = SaveCli::try_parse_from(args.iter().copied())
+        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    match sub {
+        SaveSubCommand::Run => {
             lightclient.save_task().await;
             Ok("Launching save task...".to_string())
         }
-        "check" => match lightclient.check_save_error().await {
+        SaveSubCommand::Check => match lightclient.check_save_error().await {
             Ok(()) => Ok(String::new()),
             Err(e) => Err(CommandError::NotYetTyped(format!(
                 "save failed. {e}\nRestarting save task..."
             ))),
         },
-        "shutdown" => match lightclient.shutdown_save_task().await {
+        SaveSubCommand::Shutdown => match lightclient.shutdown_save_task().await {
             Ok(()) => Ok("Save task shutdown successfully.".to_string()),
             Err(e) => Err(CommandError::NotYetTyped(format!("save failed. {e}"))),
         },
-        _ => Err(CommandError::NotYetTyped(
-            "invalid sub-command. Type \"help save\" for usage.".to_string(),
-        )),
     }
 }
 
@@ -872,15 +886,30 @@ async fn spendable_balance(
     .pretty(2))
 }
 
-async fn sync(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if args.len() != 1 {
-        return Err(CommandError::NotYetTyped(
-            "sync command expects 1 argument. Type \"help sync\" for usage.".to_string(),
-        ));
-    }
+#[derive(clap::Parser, Debug, PartialEq, Eq)]
+#[command(name = "sync", no_binary_name = true)]
+struct SyncCli {
+    #[command(subcommand)]
+    sub: SyncSubCommand,
+}
 
-    match args[0] {
-        "run" => {
+/// A parsed `sync` command. Arguments parse completely into this enum,
+/// at the clap derive grammar, before any wallet access.
+#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
+enum SyncSubCommand {
+    Run,
+    Pause,
+    Stop,
+    Status,
+    Poll,
+}
+
+async fn sync(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    use clap::Parser as _;
+    let SyncCli { sub } = SyncCli::try_parse_from(args.iter().copied())
+        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    match sub {
+        SyncSubCommand::Run => {
             if lightclient.sync_mode() == SyncMode::Paused {
                 lightclient.resume_sync().expect("sync should be paused");
                 Ok("Resuming sync task...".to_string())
@@ -891,19 +920,21 @@ async fn sync(args: &[&str], lightclient: &mut LightClient) -> Result<String, Co
                 }
             }
         }
-        "pause" => match lightclient.pause_sync() {
+        SyncSubCommand::Pause => match lightclient.pause_sync() {
             Ok(()) => Ok("Pausing sync task...".to_string()),
             Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
         },
-        "stop" => match lightclient.stop_sync() {
+        SyncSubCommand::Stop => match lightclient.stop_sync() {
             Ok(()) => Ok("Stopping sync task...".to_string()),
             Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
         },
-        "status" => match pepper_sync::sync_status(&*lightclient.wallet().read().await).await {
-            Ok(status) => Ok(json::JsonValue::from(status).pretty(2)),
-            Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
-        },
-        "poll" => match lightclient.poll_sync() {
+        SyncSubCommand::Status => {
+            match pepper_sync::sync_status(&*lightclient.wallet().read().await).await {
+                Ok(status) => Ok(json::JsonValue::from(status).pretty(2)),
+                Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
+            }
+        }
+        SyncSubCommand::Poll => match lightclient.poll_sync() {
             PollReport::NoHandle => Ok("Sync task has not been launched.".to_string()),
             PollReport::NotReady => Ok("Sync task is not complete.".to_string()),
             PollReport::Ready(result) => match result {
@@ -911,9 +942,6 @@ async fn sync(args: &[&str], lightclient: &mut LightClient) -> Result<String, Co
                 Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
             },
         },
-        _ => Err(CommandError::NotYetTyped(
-            "invalid sub-command. Type \"help sync\" for usage.".to_string(),
-        )),
     }
 }
 
@@ -1198,15 +1226,30 @@ fn parse_viewkey(args: &[&str]) -> Result<String, CommandError> {
 }
 
 async fn drain(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    Ok(run_drain(args, lightclient).await?)
+    use clap::Parser as _;
+    let DrainCli { sub } = DrainCli::try_parse_from(args.iter().copied())
+        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    Ok(run_drain(sub, lightclient).await?)
 }
 
 async fn split(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    Ok(run_split(args, lightclient).await?)
+    use clap::Parser as _;
+    let SplitCli { sub } = SplitCli::try_parse_from(args.iter().copied())
+        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    Ok(run_split(sub, lightclient).await?)
 }
 
+#[cfg(feature = "nym")]
 async fn nym(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    Ok(nym_command(args, lightclient).await?)
+    use clap::Parser as _;
+    let NymCli { sub } = NymCli::try_parse_from(args.iter().copied())
+        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    Ok(nym_command(sub.unwrap_or(NymSubCommand::Status), lightclient).await?)
+}
+
+#[cfg(not(feature = "nym"))]
+async fn nym(_args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Err(CommandError::Nym(NymCommandError::FeatureAbsent))
 }
 
 /// This consumer's platform hints for provisioning the `nym-proxy` binary:
@@ -1233,17 +1276,10 @@ pub(crate) fn resolve_proxy_path(explicit: Option<&str>) -> String {
 
 /// Typed failure of the `nym` command family. Each variant exists only in
 /// the build that can produce it, so the enum's shape follows the feature.
+/// The parse failures that once lived here are clap's now: arguments
+/// refuse at the derive grammar, before any wallet access.
 #[derive(Debug, thiserror::Error)]
 pub enum NymCommandError {
-    #[cfg(feature = "nym")]
-    #[error(
-        "unknown nym subcommand '{0}'. Use: nym status | nym on [path] | nym off | \
-         nym probe [uri] | nym history"
-    )]
-    UnknownSubCommand(String),
-    #[cfg(feature = "nym")]
-    #[error("'{0}' is not a valid indexer uri to probe")]
-    InvalidProbeTarget(String),
     #[cfg(not(feature = "nym"))]
     #[error("This build has no Nym mixnet support. Rebuild zingo-cli with `--features nym`.")]
     FeatureAbsent,
@@ -1255,48 +1291,43 @@ pub enum NymCommandError {
     },
 }
 
-/// A parsed `nym` command. Arguments parse completely into this
-/// enum before any wallet access.
 #[cfg(feature = "nym")]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(clap::Parser, Debug, PartialEq, Eq)]
+#[command(name = "nym", no_binary_name = true)]
+struct NymCli {
+    /// A bare `nym` reads as `nym status`.
+    #[command(subcommand)]
+    sub: Option<NymSubCommand>,
+}
+
+/// A parsed `nym` command. Arguments parse completely into this enum,
+/// at the clap derive grammar, before any wallet access.
+#[cfg(feature = "nym")]
+#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
 enum NymSubCommand {
     Status,
-    On { path: Option<String> },
+    On {
+        path: Option<String>,
+    },
     Off,
-    Probe { target: Option<http::Uri> },
+    Probe {
+        #[arg(value_parser = parse_probe_target)]
+        target: Option<http::Uri>,
+    },
     History,
 }
 
+/// https-only: the mixnet leg refuses a plaintext target at dial time,
+/// so the grammar rejects it up front with a clear message.
 #[cfg(feature = "nym")]
-fn parse_nym_args(args: &[&str]) -> Result<NymSubCommand, NymCommandError> {
-    match args.first().copied() {
-        None | Some("status") => Ok(NymSubCommand::Status),
-        Some("on") => Ok(NymSubCommand::On {
-            path: args.get(1).map(|path| path.to_string()),
-        }),
-        Some("off") => Ok(NymSubCommand::Off),
-        Some("probe") => {
-            let target = args
-                .get(1)
-                .map(|raw| {
-                    let uri = raw
-                        .parse::<http::Uri>()
-                        .map_err(|_| NymCommandError::InvalidProbeTarget((*raw).to_string()))?;
-                    // https-only: the mixnet leg refuses a plaintext target at
-                    // dial time, so reject it up front with a clear message.
-                    if uri.scheme_str() != Some("https") {
-                        return Err(NymCommandError::InvalidProbeTarget(format!(
-                            "{raw} (indexers must be https)"
-                        )));
-                    }
-                    Ok(uri)
-                })
-                .transpose()?;
-            Ok(NymSubCommand::Probe { target })
-        }
-        Some("history") => Ok(NymSubCommand::History),
-        Some(other) => Err(NymCommandError::UnknownSubCommand(other.to_string())),
+fn parse_probe_target(raw: &str) -> Result<http::Uri, String> {
+    let uri = raw
+        .parse::<http::Uri>()
+        .map_err(|_| "not a valid indexer uri to probe".to_string())?;
+    if uri.scheme_str() != Some("https") {
+        return Err("indexers must be https".to_string());
     }
+    Ok(uri)
 }
 
 #[cfg(feature = "nym")]
@@ -1489,10 +1520,10 @@ fn render_status_with_disclaimer(
 /// The body of the `nym` command when the mixnet transport is compiled in.
 #[cfg(feature = "nym")]
 async fn nym_command(
-    args: &[&str],
+    sub: NymSubCommand,
     lightclient: &mut LightClient,
 ) -> Result<String, NymCommandError> {
-    match parse_nym_args(args)? {
+    match sub {
         NymSubCommand::Status => Ok(render_status_with_disclaimer(
             lightclient.mixnet_mode(),
             lightclient.mixnet_socks5_addr().as_deref(),
@@ -1528,15 +1559,6 @@ async fn nym_command(
         }
         NymSubCommand::History => Ok(nym_history_command(lightclient)),
     }
-}
-
-/// The body of the `nym` command when the mixnet transport is not compiled in.
-#[cfg(not(feature = "nym"))]
-async fn nym_command(
-    _args: &[&str],
-    _lightclient: &mut LightClient,
-) -> Result<String, NymCommandError> {
-    Err(NymCommandError::FeatureAbsent)
 }
 
 /// One transmitted transaction's attestation as JSON: the route it
@@ -1578,46 +1600,36 @@ fn render_migration_phase(phase: &MigrationPhase) -> String {
 }
 
 /// Typed failure of the migration command family, following the audit Issue-Q
-/// pattern PR #2464 established: the discriminant lives in the type,
-/// argument parsing happens before any wallet access, and prose is
-/// produced at exactly one rendering site per command. Each Display
-/// message is byte-identical to the in-band string it replaced, so no
-/// frontend observes the change.
+/// pattern PR #2464 established: the discriminant lives in the type, and
+/// prose is produced at exactly one rendering site per command. The parse
+/// failures that once lived here are clap's now: arguments refuse at the
+/// derive grammar, before any wallet access.
 #[derive(Debug, thiserror::Error)]
 pub enum MigrationCommandError {
     #[error("migrate command expects no arguments. Type \"help migrate\" for usage.")]
     UnexpectedArguments,
-    #[error("migration command expects a sub-command. Type \"help migration\" for usage.")]
-    MissingSubCommand,
-    #[error("invalid sub-command. Type \"help migration\" for usage.")]
-    InvalidSubCommand,
-    #[error("migration start expects the plan hash printed by \"migration plan\".")]
-    MissingPlanHash,
-    #[error("the plan hash must be 64 hex characters.")]
-    MalformedPlanHash,
-    #[error("--per-bucket expects a positive integer.")]
-    MalformedPerBucket,
-    #[error("cadence expects the number of parts per broadcast window.")]
-    MalformedCadence,
-    #[error("spacing must be a number of seconds.")]
-    MalformedSpacing,
-    #[error("drain expects a sub-command: plan | now. Type \"help drain\" for usage.")]
-    DrainUsage,
-    #[error("split expects a sub-command: plan | now. Type \"help split\" for usage.")]
-    SplitUsage,
     #[error("sync failed: {0}")]
     Sync(zingolib::lightclient::error::LightClientError),
     #[error("{0}")]
     Client(#[from] zingolib::lightclient::error::LightClientError),
 }
 
-/// A parsed migration command. Arguments parse completely
-/// into this enum before any wallet access.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(clap::Parser, Debug, PartialEq, Eq)]
+#[command(name = "migration", no_binary_name = true)]
+struct MigrationCli {
+    #[command(subcommand)]
+    sub: MigrationSubCommand,
+}
+
+/// A parsed migration command. Arguments parse completely into this
+/// enum, at the clap derive grammar, before any wallet access.
+#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
 enum MigrationSubCommand {
     Plan,
     Start {
+        #[arg(value_parser = parse_plan_hash)]
         plan_hash: [u8; 32],
+        #[arg(long)]
         per_bucket: Option<u32>,
     },
     Continue,
@@ -1625,6 +1637,7 @@ enum MigrationSubCommand {
         per_bucket: u32,
     },
     Execute {
+        #[arg(value_name = "spacing_seconds", default_value = "30", value_parser = parse_spacing)]
         spacing: std::time::Duration,
     },
     Auto,
@@ -1632,78 +1645,24 @@ enum MigrationSubCommand {
     Windows,
     Reconcile,
     Catchup {
+        #[arg(value_name = "spacing_seconds", default_value = "30", value_parser = parse_spacing)]
         spacing: std::time::Duration,
     },
     Cancel,
 }
 
-/// Pure parser for the migration command family's arguments.
-fn parse_migration_args(args: &[&str]) -> Result<MigrationSubCommand, MigrationCommandError> {
-    let Some(sub_command) = args.first() else {
-        return Err(MigrationCommandError::MissingSubCommand);
-    };
-    match *sub_command {
-        "plan" => Ok(MigrationSubCommand::Plan),
-        "start" => {
-            let hash_hex = args.get(1).ok_or(MigrationCommandError::MissingPlanHash)?;
-            let plan_hash: [u8; 32] = hex::decode(hash_hex)
-                .ok()
-                .and_then(|bytes| bytes.try_into().ok())
-                .ok_or(MigrationCommandError::MalformedPlanHash)?;
-            let mut per_bucket = None;
-            let mut remaining = args[2..].iter();
-            while let Some(arg) = remaining.next() {
-                if *arg == "--per-bucket" {
-                    per_bucket = Some(
-                        remaining
-                            .next()
-                            .and_then(|value| value.parse::<u32>().ok())
-                            .ok_or(MigrationCommandError::MalformedPerBucket)?,
-                    );
-                }
-            }
-            Ok(MigrationSubCommand::Start {
-                plan_hash,
-                per_bucket,
-            })
-        }
-        "continue" => Ok(MigrationSubCommand::Continue),
-        "cadence" => {
-            let per_bucket = args
-                .get(1)
-                .and_then(|value| value.parse::<u32>().ok())
-                .ok_or(MigrationCommandError::MalformedCadence)?;
-            Ok(MigrationSubCommand::Cadence { per_bucket })
-        }
-        "execute" => {
-            let spacing = match args.get(1) {
-                Some(seconds) => std::time::Duration::from_secs(
-                    seconds
-                        .parse::<u64>()
-                        .map_err(|_| MigrationCommandError::MalformedSpacing)?,
-                ),
-                None => std::time::Duration::from_secs(30),
-            };
-            Ok(MigrationSubCommand::Execute { spacing })
-        }
-        "auto" => Ok(MigrationSubCommand::Auto),
-        "status" => Ok(MigrationSubCommand::Status),
-        "windows" => Ok(MigrationSubCommand::Windows),
-        "reconcile" => Ok(MigrationSubCommand::Reconcile),
-        "catchup" => {
-            let spacing = match args.get(1) {
-                Some(seconds) => std::time::Duration::from_secs(
-                    seconds
-                        .parse::<u64>()
-                        .map_err(|_| MigrationCommandError::MalformedSpacing)?,
-                ),
-                None => std::time::Duration::from_secs(30),
-            };
-            Ok(MigrationSubCommand::Catchup { spacing })
-        }
-        "cancel" => Ok(MigrationSubCommand::Cancel),
-        _ => Err(MigrationCommandError::InvalidSubCommand),
-    }
+fn parse_plan_hash(hash_hex: &str) -> Result<[u8; 32], String> {
+    hex::decode(hash_hex)
+        .ok()
+        .and_then(|bytes| bytes.try_into().ok())
+        .ok_or_else(|| "the plan hash must be 64 hex characters".to_string())
+}
+
+fn parse_spacing(seconds: &str) -> Result<std::time::Duration, String> {
+    seconds
+        .parse::<u64>()
+        .map(std::time::Duration::from_secs)
+        .map_err(|_| "spacing must be a number of seconds".to_string())
 }
 
 /// Renders displayable ids as a JSON array of strings.
@@ -1740,10 +1699,10 @@ async fn run_migrate(
 
 /// Runs one `migration` sub-command.
 async fn run_migration(
-    args: &[&str],
+    sub: MigrationSubCommand,
     lightclient: &mut LightClient,
 ) -> Result<String, MigrationCommandError> {
-    Ok(match parse_migration_args(args)? {
+    Ok(match sub {
         MigrationSubCommand::Plan => {
             let plan = lightclient
                 .plan_ironwood_migration(zip32::AccountId::ZERO)
@@ -1940,36 +1899,32 @@ async fn run_migration(
     })
 }
 
-/// A parsed `drain` sub-command.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(clap::Parser, Debug, PartialEq, Eq)]
+#[command(name = "drain", no_binary_name = true)]
+struct DrainCli {
+    #[command(subcommand)]
+    sub: DrainSubCommand,
+}
+
+/// A parsed `drain` sub-command, at the clap derive grammar.
+#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
 enum DrainSubCommand {
     Plan,
     Now,
 }
 
-/// Pure parser for the drain command's arguments.
-fn parse_drain_args(args: &[&str]) -> Result<DrainSubCommand, MigrationCommandError> {
-    match args {
-        ["plan"] => Ok(DrainSubCommand::Plan),
-        ["now"] => Ok(DrainSubCommand::Now),
-        _ => Err(MigrationCommandError::DrainUsage),
-    }
+#[derive(clap::Parser, Debug, PartialEq, Eq)]
+#[command(name = "split", no_binary_name = true)]
+struct SplitCli {
+    #[command(subcommand)]
+    sub: SplitSubCommand,
 }
 
-/// A parsed `split` sub-command.
-#[derive(Debug, PartialEq, Eq)]
+/// A parsed `split` sub-command, at the clap derive grammar.
+#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
 enum SplitSubCommand {
     Plan,
     Now,
-}
-
-/// Pure parser for the split command's arguments.
-fn parse_split_args(args: &[&str]) -> Result<SplitSubCommand, MigrationCommandError> {
-    match args {
-        ["plan"] => Ok(SplitSubCommand::Plan),
-        ["now"] => Ok(SplitSubCommand::Now),
-        _ => Err(MigrationCommandError::SplitUsage),
-    }
 }
 
 /// Renders an in-flight execute batch snapshot as the heartbeat's detail
@@ -2014,10 +1969,10 @@ fn split_progress_line(status: &SplitStatus) -> String {
 ///
 /// Returns the summary as JSON.
 async fn run_drain(
-    args: &[&str],
+    sub: DrainSubCommand,
     lightclient: &mut LightClient,
 ) -> Result<String, MigrationCommandError> {
-    Ok(match parse_drain_args(args)? {
+    Ok(match sub {
         DrainSubCommand::Plan => {
             let plan = lightclient
                 .plan_immediate_migration(zip32::AccountId::ZERO)
@@ -2055,10 +2010,10 @@ async fn run_drain(
 /// round, writing progress lines to stderr while it runs. It returns the
 /// round's txids, or a message explaining why nothing was sent.
 async fn run_split(
-    args: &[&str],
+    sub: SplitSubCommand,
     lightclient: &mut LightClient,
 ) -> Result<String, MigrationCommandError> {
-    Ok(match parse_split_args(args)? {
+    Ok(match sub {
         SplitSubCommand::Plan => {
             let plan = lightclient.plan_note_split(zip32::AccountId::ZERO).await?;
             object! {

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1,11 +1,12 @@
 //! Command definitions and dispatch for zingo-cli.
 //!
-//! Every command is one row of [`COMMANDS`], the static spec table: its
-//! name, help texts, wallet requirement, and the async function that runs
-//! it. The sync world crosses into async exactly once, at
-//! [`do_user_command`] (ADR 0030), and a failure leaves a command only as
-//! a [`CommandError`], never as error prose in the result channel
-//! (ADR 0031).
+//! Every command is one variant of [`CliCommand`], the clap derive
+//! grammar: its name is minted from the variant identifier, its help texts
+//! are its `about` and `long_about`, and its arguments parse into typed
+//! payloads before any body runs. The sync world crosses into async
+//! exactly once, at [`do_user_command`] (ADR 0030), and a failure leaves a
+//! command only as a [`CommandError`], never as error prose in the result
+//! channel (ADR 0031).
 
 mod error;
 #[cfg(test)]
@@ -14,7 +15,6 @@ mod utils;
 
 use std::convert::TryInto;
 use std::num::NonZeroU32;
-use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
@@ -27,6 +27,7 @@ use tokio::runtime::Runtime;
 use zcash_address::unified::{Container, Encoding, Ufvk};
 use zcash_keys::address::Address;
 use zcash_keys::keys::UnifiedFullViewingKey;
+use zcash_protocol::TxId;
 use zcash_protocol::consensus::NetworkType;
 use zcash_protocol::value::Zatoshis;
 
@@ -104,8 +105,6 @@ pub enum CommandError {
     Migration(#[from] MigrationCommandError),
     #[error(transparent)]
     Nym(#[from] NymCommandError),
-    #[error("Unknown command : {0}. Type 'help' for a list of commands")]
-    UnknownCommand(String),
     #[error("the `{0}` command runs only at the interactive prompt")]
     ReplOnly(&'static str),
     /// Transitional quarantine for commands whose failure prose is not
@@ -124,102 +123,22 @@ fn usage(command: &str, detail: impl std::fmt::Display) -> CommandError {
     ))
 }
 
-/// The future a wallet command's body returns: boxed so every row of the
-/// spec table shares one type, borrowing the arguments and the client.
-type CommandFuture<'a> = Pin<Box<dyn Future<Output = Result<String, CommandError>> + 'a>>;
-
-type WalletRunFn = for<'a> fn(&'a [&'a str], &'a mut LightClient) -> CommandFuture<'a>;
-
-/// What runs a command, and therefore what it may touch and where `help`
-/// lists it. A `Standalone` body never receives the wallet, so its
-/// wallet-freedom is enforced by construction; `Repl` marks a command the
-/// interactive REPL dispatches itself, holding state this seam does not.
-enum CommandBody {
-    /// Wallet-free and synchronous; listed under "Standalone commands".
-    Standalone(fn(&[&str]) -> Result<String, CommandError>),
-    /// Needs the loaded wallet; listed under "Wallet commands".
-    Wallet(WalletRunFn),
-    /// Owned by the interactive REPL; listed under "Standalone commands".
-    Repl,
-}
-
-/// One row of the command table: the single source of a command's name,
-/// help texts, and body. The name is minted once, by the `wallet!` and
-/// `standalone!` macros, from the body function's identifier.
-pub struct CommandSpec {
-    pub name: &'static str,
-    help: &'static str,
-    short_help: &'static str,
-    body: CommandBody,
-}
-
-macro_rules! wallet {
-    (
-        $body:ident,
-        short_help: $short_help:expr,
-        help: $help:expr,
-    ) => {
-        CommandSpec {
-            name: stringify!($body),
-            help: $help,
-            short_help: $short_help,
-            body: CommandBody::Wallet({
-                fn wrap<'a>(
-                    args: &'a [&'a str],
-                    lightclient: &'a mut LightClient,
-                ) -> CommandFuture<'a> {
-                    Box::pin($body(args, lightclient))
-                }
-                wrap
-            }),
-        }
-    };
-}
-
-macro_rules! standalone {
-    (
-        $body:ident,
-        short_help: $short_help:expr,
-        help: $help:expr,
-    ) => {
-        CommandSpec {
-            name: stringify!($body),
-            help: $help,
-            short_help: $short_help,
-            body: CommandBody::Standalone($body),
-        }
-    };
-}
-
-/// The help text of the named command, for bodies that echo their own
-/// usage. Empty for a name not in the table.
-fn help_for(name: &str) -> &'static str {
-    COMMANDS
-        .iter()
-        .find(|spec| spec.name == name)
-        .map(|spec| spec.help)
-        .unwrap_or_default()
-}
-
-async fn addresses(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn addresses(lightclient: &mut LightClient) -> Result<String, CommandError> {
     Ok(lightclient.unified_addresses_json().await.pretty(2))
 }
 
-async fn balance(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn balance(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.account_balance(zip32::AccountId::ZERO).await {
         Ok(bal) => Ok(bal.to_string()),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-async fn birthday(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn birthday(lightclient: &mut LightClient) -> Result<String, CommandError> {
     Ok(lightclient.birthday().to_string())
 }
 
-async fn calculate(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if !args.is_empty() {
-        return Err(usage("calculate", error::CommandError::InvalidArguments));
-    }
+async fn calculate(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.calculate_stored_proposal().await {
         Ok(txids) => Ok(object! {
             "txids" => txids.iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
@@ -229,48 +148,36 @@ async fn calculate(args: &[&str], lightclient: &mut LightClient) -> Result<Strin
     }
 }
 
+/// The `change_server` argument: an empty string names the default uri,
+/// as it did when the body parsed the argument itself.
+fn parse_server_uri(raw: &str) -> Result<http::Uri, String> {
+    if raw.is_empty() {
+        return Ok(http::Uri::default());
+    }
+    http::Uri::from_str(raw).map_err(|_| "invalid server uri".to_string())
+}
+
 async fn change_server(
-    args: &[&str],
+    uri: Option<http::Uri>,
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
-    async fn set(lightclient: &mut LightClient, uri: http::Uri) -> Result<String, CommandError> {
-        match lightclient.set_indexer_uri(uri).await {
-            Ok(()) => Ok("server set".to_string()),
-            Err(e) => Err(CommandError::NotYetTyped(format!(
-                "failed to set server: {e}"
-            ))),
-        }
-    }
-    match args.len() {
-        0 => set(lightclient, http::Uri::default()).await,
-        1 => match http::Uri::from_str(args[0]) {
-            Ok(uri) => set(lightclient, uri).await,
-            Err(_) => match args[0] {
-                "" => set(lightclient, http::Uri::default()).await,
-                _ => Err(CommandError::NotYetTyped("invalid server uri".to_string())),
-            },
-        },
-        _ => Err(CommandError::NotYetTyped(
-            help_for("change_server").to_string(),
-        )),
+    match lightclient.set_indexer_uri(uri.unwrap_or_default()).await {
+        Ok(()) => Ok("server set".to_string()),
+        Err(e) => Err(CommandError::NotYetTyped(format!(
+            "failed to set server: {e}"
+        ))),
     }
 }
 
 async fn check_address(
-    args: &[&str],
+    address: &str,
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
-    if args.len() != 1 {
-        return Err(CommandError::NotYetTyped(
-            "no address specified. try 'help check_address' for correct usage and examples."
-                .to_string(),
-        ));
-    }
     match lightclient
         .wallet()
         .read()
         .await
-        .is_address_derived_by_keys(args[0])
+        .is_address_derived_by_keys(address)
     {
         Ok(address_ref) => Ok(address_ref
             .map_or(
@@ -335,15 +242,12 @@ async fn check_address(
     }
 }
 
-async fn clear(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn clear(lightclient: &mut LightClient) -> Result<String, CommandError> {
     lightclient.wallet().write().await.clear_all();
     Ok(object! { "result" => "success" }.pretty(2))
 }
 
-async fn confirm(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if !args.is_empty() {
-        return Err(usage("confirm", error::CommandError::InvalidArguments));
-    }
+async fn confirm(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match transmit_narrated(
         "confirm",
         lightclient.transmit_progress_handle(),
@@ -360,10 +264,7 @@ async fn confirm(args: &[&str], lightclient: &mut LightClient) -> Result<String,
 }
 
 #[cfg(feature = "nym")]
-async fn current_price(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn current_price(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.update_current_price().await {
         Ok(fetch) => Ok(format!(
             "current price: {} USD (source: {}, rtt: {} ms, fetched over the mixnet via {})",
@@ -377,10 +278,7 @@ async fn current_price(
 }
 
 #[cfg(not(feature = "nym"))]
-async fn current_price(
-    _args: &[&str],
-    _lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn current_price(_lightclient: &mut LightClient) -> Result<String, CommandError> {
     Ok(
         "This build has no price fetch: price travels only over the Nym mixnet (ADR 0011). \
          Rebuild zingo-cli with `--features nym`."
@@ -388,7 +286,7 @@ async fn current_price(
     )
 }
 
-async fn delete(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn delete(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.delete_wallet_file().await {
         Ok(()) => Ok(object! {
             "result" => "success",
@@ -399,10 +297,7 @@ async fn delete(_args: &[&str], lightclient: &mut LightClient) -> Result<String,
     }
 }
 
-async fn export_ufvk(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn export_ufvk(lightclient: &mut LightClient) -> Result<String, CommandError> {
     let ufvk: UnifiedFullViewingKey = match lightclient
         .wallet()
         .read()
@@ -422,7 +317,7 @@ async fn export_ufvk(
     .pretty(2))
 }
 
-async fn height(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn height(lightclient: &mut LightClient) -> Result<String, CommandError> {
     Ok(object! {
         "height" => json::JsonValue::from(
             lightclient
@@ -437,23 +332,31 @@ async fn height(_args: &[&str], lightclient: &mut LightClient) -> Result<String,
     .pretty(2))
 }
 
-fn help(args: &[&str]) -> Result<String, CommandError> {
-    Ok(format_help(args))
+fn help(command: Option<&str>) -> Result<String, CommandError> {
+    Ok(format_help(command))
 }
 
-async fn info(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn info(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.info().await {
         Ok(info) => Ok(json::JsonValue::from(info).pretty(2)),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
+/// The send family's arguments as the `utils::parse_*` grammars take them.
+/// Those grammars are a JSON-or-positional hybrid clap does not own yet, so
+/// the four send-family commands carry their arguments as strings and parse
+/// on their first line (documented compromise, clap arc Milestone 2).
+fn as_strs(args: &[String]) -> Vec<&str> {
+    args.iter().map(String::as_str).collect()
+}
+
 async fn max_send_value(
-    args: &[&str],
+    args: &[String],
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
     let (address, zennies_for_zingo) =
-        utils::parse_max_send_value_args(args).map_err(|e| usage("max_send_value", e))?;
+        utils::parse_max_send_value_args(&as_strs(args)).map_err(|e| usage("max_send_value", e))?;
     match lightclient
         .max_send_value(address, zennies_for_zingo, zip32::AccountId::ZERO)
         .await
@@ -463,58 +366,56 @@ async fn max_send_value(
     }
 }
 
-async fn memobytes_to_address(
-    args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
-    if args.len() > 1 {
-        return Err(CommandError::NotYetTyped(format!(
-            "didn't understand arguments\n{}",
-            help_for("memobytes_to_address")
-        )));
-    }
+async fn memobytes_to_address(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.do_total_memobytes_to_address().await {
         Ok(total_memo_bytes) => Ok(json::JsonValue::from(total_memo_bytes).pretty(2)),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-async fn messages(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if args.len() > 1 {
-        return Err(CommandError::NotYetTyped(
-            "invalid arguments\nTry 'help messages' for correct usage and examples".to_string(),
-        ));
-    }
-    match lightclient.messages_containing(args.first().copied()).await {
+async fn messages(
+    filter: Option<&str>,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    match lightclient.messages_containing(filter).await {
         Ok(value_transfers) => Ok(json::JsonValue::from(value_transfers).pretty(2)),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-async fn migrate(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    Ok(run_migrate(args, lightclient).await?)
+async fn migrate(lightclient: &mut LightClient) -> Result<String, CommandError> {
+    Ok(run_migrate(lightclient).await?)
 }
 
-async fn migration(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    use clap::Parser as _;
-    let MigrationCli { sub } = MigrationCli::try_parse_from(args.iter().copied())
-        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+async fn migration(
+    sub: MigrationSubCommand,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     Ok(run_migration(sub, lightclient).await?)
 }
 
-async fn new_address(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if args.len() != 1 || (!args[0].contains('o') && !args[0].contains('z')) {
-        return Err(CommandError::NotYetTyped(format!(
-            "No address type specified\n{}",
-            help_for("new_address")
-        )));
+/// The `new_address` argument: `o`, `z`, or both, naming the receivers the
+/// new unified address carries. Transparent receivers are `new_taddress`'s.
+fn parse_receiver_selection(raw: &str) -> Result<ReceiverSelection, String> {
+    if raw.is_empty()
+        || raw
+            .chars()
+            .any(|receiver| receiver != 'o' && receiver != 'z')
+    {
+        return Err("the address type must be o, z, or oz".to_string());
     }
+    Ok(ReceiverSelection {
+        orchard: raw.contains('o'),
+        sapling: raw.contains('z'),
+    })
+}
+
+async fn new_address(
+    receivers: ReceiverSelection,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     let chain_type = lightclient.chain_type();
     let mut wallet = lightclient.wallet().write().await;
-    let receivers = ReceiverSelection {
-        orchard: args[0].contains('o'),
-        sapling: args[0].contains('z'),
-    };
     match wallet.generate_unified_address(receivers, zip32::AccountId::ZERO) {
         Ok((id, unified_address)) => Ok(json::object! {
             "account" => u32::from(zip32::AccountId::ZERO), // used concrete type instead of u32 to simplify upgrading CLI to multi-account
@@ -529,10 +430,7 @@ async fn new_address(args: &[&str], lightclient: &mut LightClient) -> Result<Str
     }
 }
 
-async fn new_taddress(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn new_taddress(lightclient: &mut LightClient) -> Result<String, CommandError> {
     let chain_type = lightclient.chain_type();
     let mut wallet = lightclient.wallet().write().await;
     match wallet.generate_transparent_address(zip32::AccountId::ZERO, true) {
@@ -547,10 +445,7 @@ async fn new_taddress(
     }
 }
 
-async fn new_taddress_allow_gap(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn new_taddress_allow_gap(lightclient: &mut LightClient) -> Result<String, CommandError> {
     let chain_type = lightclient.chain_type();
     let mut wallet = lightclient.wallet().write().await;
     match wallet.generate_transparent_address(zip32::AccountId::ZERO, false) {
@@ -565,19 +460,18 @@ async fn new_taddress_allow_gap(
     }
 }
 
-async fn notes(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let all_notes = match args {
-        [] => false,
-        ["all"] => true,
-        [a] => {
-            return Err(CommandError::NotYetTyped(format!(
-                "Invalid argument \"{a}\". Specify 'all' to include spent notes"
-            )));
-        }
-        _ => {
-            return Err(CommandError::NotYetTyped(help_for("notes").to_string()));
-        }
-    };
+/// The one optional argument of `notes` and `coins`: `all`, widening the
+/// listing to the spent outputs.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum OutputScope {
+    All,
+}
+
+async fn notes(
+    scope: Option<OutputScope>,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let all_notes = scope.is_some();
     let wallet = lightclient.wallet().read().await;
     Ok(json::object! {
         "ironwood_notes" => json::JsonValue::from(wallet.note_summaries::<IronwoodNote>(all_notes)),
@@ -587,19 +481,11 @@ async fn notes(args: &[&str], lightclient: &mut LightClient) -> Result<String, C
     .pretty(2))
 }
 
-async fn coins(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let all_coins = match args {
-        [] => false,
-        ["all"] => true,
-        [a] => {
-            return Err(CommandError::NotYetTyped(format!(
-                "Invalid argument \"{a}\". Specify 'all' to include spent coins"
-            )));
-        }
-        _ => {
-            return Err(CommandError::NotYetTyped(help_for("coins").to_string()));
-        }
-    };
+async fn coins(
+    scope: Option<OutputScope>,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let all_coins = scope.is_some();
     Ok(json::object! {
         "transparent_coins" => json::JsonValue::from(
             lightclient.wallet().read().await.coin_summaries(all_coins)
@@ -608,8 +494,8 @@ async fn coins(args: &[&str], lightclient: &mut LightClient) -> Result<String, C
     .pretty(2))
 }
 
-async fn quicksend(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let receivers = utils::parse_send_args(args).map_err(|e| usage("quicksend", e))?;
+async fn quicksend(args: &[String], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let receivers = utils::parse_send_args(&as_strs(args)).map_err(|e| usage("quicksend", e))?;
     let request = zingolib::data::receivers::transaction_request_from_receivers(receivers)
         .map_err(|e| usage("quicksend", e))?;
     match transmit_narrated(
@@ -628,10 +514,7 @@ async fn quicksend(args: &[&str], lightclient: &mut LightClient) -> Result<Strin
     }
 }
 
-async fn quickshield(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if !args.is_empty() {
-        return Err(usage("shield", error::CommandError::InvalidArguments));
-    }
+async fn quickshield(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match transmit_narrated(
         "quickshield",
         lightclient.transmit_progress_handle(),
@@ -647,7 +530,7 @@ async fn quickshield(args: &[&str], lightclient: &mut LightClient) -> Result<Str
     }
 }
 
-async fn quit(_args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn quit(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.shutdown_save_task().await {
         Ok(()) => eprintln!("Save task shutdown successfully."),
         Err(e) => eprintln!("Error: save failed. {e}"),
@@ -655,10 +538,7 @@ async fn quit(_args: &[&str], lightclient: &mut LightClient) -> Result<String, C
     Ok("Zingo CLI quit successfully.".to_string())
 }
 
-async fn recovery_info(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn recovery_info(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.wallet().read().await.recovery_info() {
         Some(backup_info) => Ok(backup_info.to_string()),
         None => Err(CommandError::NotYetTyped(
@@ -667,17 +547,16 @@ async fn recovery_info(
     }
 }
 
+/// A transaction id argument, hex-encoded as `calculate` and the wallet's
+/// listings print it.
+fn parse_txid(raw: &str) -> Result<TxId, String> {
+    txid_from_hex_encoded_str(raw).map_err(|e| e.to_string())
+}
+
 async fn remove_transaction(
-    args: &[&str],
+    txid: TxId,
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
-    if args.len() != 1 {
-        return Err(CommandError::NotYetTyped(
-            "remove command expects 1 argument. Type \"help remove\" for usage.".to_string(),
-        ));
-    }
-    let txid =
-        txid_from_hex_encoded_str(args[0]).map_err(|e| CommandError::NotYetTyped(e.to_string()))?;
     match lightclient
         .wallet()
         .write()
@@ -689,23 +568,11 @@ async fn remove_transaction(
     }
 }
 
-async fn rescan(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if !args.is_empty() {
-        return Err(CommandError::NotYetTyped(
-            "rescan command expects no arguments. Type \"rescan help\" for usage.".to_string(),
-        ));
-    }
+async fn rescan(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.rescan().await {
         Ok(()) => Ok("Launching rescan...".to_string()),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
-}
-
-#[derive(clap::Parser, Debug, PartialEq, Eq)]
-#[command(name = "save", no_binary_name = true)]
-struct SaveCli {
-    #[command(subcommand)]
-    sub: SaveSubCommand,
 }
 
 /// A parsed `save` command. Arguments parse completely into this enum,
@@ -717,10 +584,7 @@ enum SaveSubCommand {
     Shutdown,
 }
 
-async fn save(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    use clap::Parser as _;
-    let SaveCli { sub } = SaveCli::try_parse_from(args.iter().copied())
-        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+async fn save(sub: SaveSubCommand, lightclient: &mut LightClient) -> Result<String, CommandError> {
     match sub {
         SaveSubCommand::Run => {
             lightclient.save_task().await;
@@ -739,8 +603,8 @@ async fn save(args: &[&str], lightclient: &mut LightClient) -> Result<String, Co
     }
 }
 
-async fn send(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let receivers = utils::parse_send_args(args).map_err(|e| usage("send", e))?;
+async fn send(args: &[String], lightclient: &mut LightClient) -> Result<String, CommandError> {
+    let receivers = utils::parse_send_args(&as_strs(args)).map_err(|e| usage("send", e))?;
     let request = zingolib::data::receivers::transaction_request_from_receivers(receivers)
         .map_err(|e| usage("send", e))?;
     match lightclient
@@ -755,9 +619,9 @@ async fn send(args: &[&str], lightclient: &mut LightClient) -> Result<String, Co
     }
 }
 
-async fn send_all(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn send_all(args: &[String], lightclient: &mut LightClient) -> Result<String, CommandError> {
     let (address, zennies_for_zingo, memo) =
-        utils::parse_send_all_args(args).map_err(|e| usage("sendall", e))?;
+        utils::parse_send_all_args(&as_strs(args)).map_err(|e| usage("sendall", e))?;
     match lightclient
         .propose_send_all(address, zennies_for_zingo, memo, zip32::AccountId::ZERO)
         .await
@@ -777,26 +641,56 @@ async fn send_all(args: &[&str], lightclient: &mut LightClient) -> Result<String
     }
 }
 
-async fn sends_to_address(
-    args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
-    if args.len() > 1 {
-        return Err(CommandError::NotYetTyped(format!(
-            "didn't understand arguments\n{}",
-            help_for("sends_to_address")
-        )));
-    }
+async fn sends_to_address(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.do_total_spends_to_address().await {
         Ok(total_spends) => Ok(json::JsonValue::from(total_spends).pretty(2)),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-async fn settings(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
+/// A parsed `settings` command: which setting to write, and its value.
+/// Absent, the command reads the settings out instead. The grammar owns
+/// every value, so a malformed one refuses before the wallet lock is taken.
+#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
+#[command(rename_all = "snake_case")]
+enum SettingsSubCommand {
+    Performance {
+        #[arg(value_enum)]
+        level: PerformanceLevelArg,
+    },
+    MinConfirmations {
+        count: NonZeroU32,
+    },
+}
+
+/// The sync performance levels as a clap grammar. [`PerformanceLevel`] is
+/// pepper-sync's, so the CLI mints the value names and converts.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum PerformanceLevelArg {
+    Low,
+    Medium,
+    High,
+    Maximum,
+}
+
+impl From<PerformanceLevelArg> for PerformanceLevel {
+    fn from(level: PerformanceLevelArg) -> Self {
+        match level {
+            PerformanceLevelArg::Low => PerformanceLevel::Low,
+            PerformanceLevelArg::Medium => PerformanceLevel::Medium,
+            PerformanceLevelArg::High => PerformanceLevel::High,
+            PerformanceLevelArg::Maximum => PerformanceLevel::Maximum,
+        }
+    }
+}
+
+async fn settings(
+    sub: Option<SettingsSubCommand>,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     let mut wallet = lightclient.wallet().write().await;
 
-    if args.is_empty() {
+    let Some(sub) = sub else {
         return Ok(format!(
             r"
 performance: {}
@@ -805,33 +699,15 @@ min confirmations: {}
             wallet.wallet_settings.sync_config.performance_level,
             wallet.wallet_settings.min_confirmations,
         ));
-    }
-
-    let invalid_arguments = || {
-        CommandError::NotYetTyped(
-            "invalid arguments\nTry 'help settings' for correct usage and examples".to_string(),
-        )
     };
-    match args[0] {
-        "performance" => {
-            wallet.wallet_settings.sync_config.performance_level =
-                match args.get(1).copied().ok_or_else(invalid_arguments)? {
-                    "low" => PerformanceLevel::Low,
-                    "medium" => PerformanceLevel::Medium,
-                    "high" => PerformanceLevel::High,
-                    "maximum" => PerformanceLevel::Maximum,
-                    _ => return Err(invalid_arguments()),
-                }
+
+    match sub {
+        SettingsSubCommand::Performance { level } => {
+            wallet.wallet_settings.sync_config.performance_level = level.into();
         }
-        "min_confirmations" => {
-            let min_confirmations = args
-                .get(1)
-                .and_then(|value| value.parse::<u32>().ok())
-                .and_then(|m| NonZeroU32::try_from(m).ok())
-                .ok_or_else(invalid_arguments)?;
-            wallet.wallet_settings.min_confirmations = min_confirmations;
+        SettingsSubCommand::MinConfirmations { count } => {
+            wallet.wallet_settings.min_confirmations = count;
         }
-        _ => return Err(invalid_arguments()),
     }
 
     wallet.mark_dirty();
@@ -839,10 +715,7 @@ min confirmations: {}
     Ok("Successfully updated settings.".to_string())
 }
 
-async fn shield(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    if !args.is_empty() {
-        return Err(usage("shield", error::CommandError::InvalidArguments));
-    }
+async fn shield(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.propose_shield(zip32::AccountId::ZERO).await {
         Ok(proposal) => {
             if proposal.steps().len() != 1 {
@@ -872,10 +745,7 @@ async fn shield(args: &[&str], lightclient: &mut LightClient) -> Result<String, 
     }
 }
 
-async fn spendable_balance(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn spendable_balance(lightclient: &mut LightClient) -> Result<String, CommandError> {
     let wallet = lightclient.wallet().read().await;
     let spendable_balance = wallet
         .shielded_spendable_balance(zip32::AccountId::ZERO, false)
@@ -884,13 +754,6 @@ async fn spendable_balance(
         "spendable_balance" => spendable_balance.into_u64(),
     }
     .pretty(2))
-}
-
-#[derive(clap::Parser, Debug, PartialEq, Eq)]
-#[command(name = "sync", no_binary_name = true)]
-struct SyncCli {
-    #[command(subcommand)]
-    sub: SyncSubCommand,
 }
 
 /// A parsed `sync` command. Arguments parse completely into this enum,
@@ -904,10 +767,7 @@ enum SyncSubCommand {
     Poll,
 }
 
-async fn sync(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    use clap::Parser as _;
-    let SyncCli { sub } = SyncCli::try_parse_from(args.iter().copied())
-        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+async fn sync(sub: SyncSubCommand, lightclient: &mut LightClient) -> Result<String, CommandError> {
     match sub {
         SyncSubCommand::Run => {
             if lightclient.sync_mode() == SyncMode::Paused {
@@ -945,30 +805,22 @@ async fn sync(args: &[&str], lightclient: &mut LightClient) -> Result<String, Co
     }
 }
 
-async fn t_addresses(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn t_addresses(lightclient: &mut LightClient) -> Result<String, CommandError> {
     Ok(lightclient.transparent_addresses_json().await.pretty(2))
 }
 
-async fn transactions(
-    args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
-    if !args.is_empty() {
-        return Err(CommandError::NotYetTyped(
-            "invalid arguments\nTry 'help transactions' for correct usage and examples".to_string(),
-        ));
-    }
+async fn transactions(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.transaction_summaries(false).await {
         Ok(transactions) => Ok(transactions.to_string()),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-async fn transmit(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let txids = if args.is_empty() {
+async fn transmit(
+    requested: Vec<TxId>,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let txids = if requested.is_empty() {
         // All Calculated transactions, ordered by target height and
         // then txid for determinism.
         let wallet = lightclient.wallet().read().await;
@@ -986,10 +838,7 @@ async fn transmit(args: &[&str], lightclient: &mut LightClient) -> Result<String
         calculated.sort_by_key(|&(height, txid)| (height, txid.as_ref().to_owned()));
         calculated.into_iter().map(|(_, txid)| txid).collect()
     } else {
-        args.iter()
-            .map(|arg| txid_from_hex_encoded_str(arg))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| usage("transmit", e))?
+        requested
     };
 
     let Some(txids) = nonempty::NonEmpty::from_vec(txids) else {
@@ -1013,40 +862,25 @@ async fn transmit(args: &[&str], lightclient: &mut LightClient) -> Result<String
     }
 }
 
-async fn value_to_address(
-    args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
-    if args.len() > 1 {
-        return Err(CommandError::NotYetTyped(format!(
-            "didn't understand arguments\n{}",
-            help_for("value_to_address")
-        )));
-    }
+async fn value_to_address(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.do_total_value_to_address().await {
         Ok(total_values) => Ok(json::JsonValue::from(total_values).pretty(2)),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-async fn value_transfers(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn value_transfers(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.value_transfers(false).await {
         Ok(value_transfers) => Ok(value_transfers.to_string()),
         Err(e) => Err(CommandError::NotYetTyped(e.to_string())),
     }
 }
 
-fn version(_args: &[&str]) -> Result<String, CommandError> {
+fn version() -> Result<String, CommandError> {
     Ok(zingolib::git_description().to_string())
 }
 
-async fn wallet_kind(
-    _args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+async fn wallet_kind(lightclient: &mut LightClient) -> Result<String, CommandError> {
     if lightclient.mnemonic_phrase().is_some() {
         return Ok(object! {"kind" => "Loaded from mnemonic (seed or phrase)",
                 "transparent" => true,
@@ -1089,12 +923,7 @@ async fn wallet_kind(
     )
 }
 
-fn parse_address(args: &[&str]) -> Result<String, CommandError> {
-    if args.len() > 1 || args.is_empty() {
-        return Err(CommandError::NotYetTyped(
-            help_for("parse_address").to_string(),
-        ));
-    }
+fn parse_address(address: &str) -> Result<String, CommandError> {
     fn make_decoded_chain_pair(
         address: &str,
     ) -> Option<(
@@ -1110,7 +939,7 @@ fn parse_address(args: &[&str]) -> Result<String, CommandError> {
         .find_map(|chain| Address::decode(chain, address).zip(Some(*chain)))
     }
     Ok(
-        if let Some((recipient_address, chain_name)) = make_decoded_chain_pair(args[0]) {
+        if let Some((recipient_address, chain_name)) = make_decoded_chain_pair(address) {
             #[allow(unreachable_patterns)]
             let chain_name_string = match chain_name {
                 zingolib::config::ChainType::Mainnet => "main",
@@ -1177,78 +1006,73 @@ fn parse_address(args: &[&str]) -> Result<String, CommandError> {
     )
 }
 
-fn parse_viewkey(args: &[&str]) -> Result<String, CommandError> {
-    match args.len() {
-        1 => Ok(json::stringify_pretty(
-            match Ufvk::decode(args[0]) {
-                Ok((network, ufvk)) => {
-                    let mut pools_available = vec![];
-                    for fvk in ufvk.items_as_parsed() {
-                        match fvk {
-                            zcash_address::unified::Fvk::Orchard(_) => {
-                                pools_available.push("orchard");
-                            }
-                            zcash_address::unified::Fvk::Sapling(_) => {
-                                pools_available.push("sapling");
-                            }
-                            zcash_address::unified::Fvk::P2pkh(_) => {
-                                pools_available.push("transparent");
-                            }
-                            zcash_address::unified::Fvk::Unknown { .. } => pools_available
-                                .push("Unknown future protocol. Perhaps you're using old software"),
+fn parse_viewkey(viewkey: &str) -> Result<String, CommandError> {
+    Ok(json::stringify_pretty(
+        match Ufvk::decode(viewkey) {
+            Ok((network, ufvk)) => {
+                let mut pools_available = vec![];
+                for fvk in ufvk.items_as_parsed() {
+                    match fvk {
+                        zcash_address::unified::Fvk::Orchard(_) => {
+                            pools_available.push("orchard");
                         }
-                    }
-                    object! {
-                        "status" => "success",
-                        "chain_name" => match network {
-                            NetworkType::Main => "main",
-                            NetworkType::Test => "test",
-                            NetworkType::Regtest => "regtest",
-                        },
-                        "address_kind" => "ufvk",
-                        "pools_available" => pools_available,
+                        zcash_address::unified::Fvk::Sapling(_) => {
+                            pools_available.push("sapling");
+                        }
+                        zcash_address::unified::Fvk::P2pkh(_) => {
+                            pools_available.push("transparent");
+                        }
+                        zcash_address::unified::Fvk::Unknown { .. } => pools_available
+                            .push("Unknown future protocol. Perhaps you're using old software"),
                     }
                 }
-                Err(_) => {
-                    object! {
-                        "status" => "Invalid viewkey",
-                        "chain_name" => json::JsonValue::Null,
-                        "address_kind" => json::JsonValue::Null
-                    }
+                object! {
+                    "status" => "success",
+                    "chain_name" => match network {
+                        NetworkType::Main => "main",
+                        NetworkType::Test => "test",
+                        NetworkType::Regtest => "regtest",
+                    },
+                    "address_kind" => "ufvk",
+                    "pools_available" => pools_available,
                 }
-            },
-            4,
-        )),
-        _ => Err(CommandError::NotYetTyped(
-            help_for("parse_viewkey").to_string(),
-        )),
-    }
+            }
+            Err(_) => {
+                object! {
+                    "status" => "Invalid viewkey",
+                    "chain_name" => json::JsonValue::Null,
+                    "address_kind" => json::JsonValue::Null
+                }
+            }
+        },
+        4,
+    ))
 }
 
-async fn drain(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    use clap::Parser as _;
-    let DrainCli { sub } = DrainCli::try_parse_from(args.iter().copied())
-        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+async fn drain(
+    sub: DrainSubCommand,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     Ok(run_drain(sub, lightclient).await?)
 }
 
-async fn split(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    use clap::Parser as _;
-    let SplitCli { sub } = SplitCli::try_parse_from(args.iter().copied())
-        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+async fn split(
+    sub: SplitSubCommand,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     Ok(run_split(sub, lightclient).await?)
 }
 
 #[cfg(feature = "nym")]
-async fn nym(args: &[&str], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    use clap::Parser as _;
-    let NymCli { sub } = NymCli::try_parse_from(args.iter().copied())
-        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+async fn nym(
+    sub: Option<NymSubCommand>,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     Ok(nym_command(sub.unwrap_or(NymSubCommand::Status), lightclient).await?)
 }
 
 #[cfg(not(feature = "nym"))]
-async fn nym(_args: &[&str], _lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn nym(_lightclient: &mut LightClient) -> Result<String, CommandError> {
     Err(CommandError::Nym(NymCommandError::FeatureAbsent))
 }
 
@@ -1289,15 +1113,6 @@ pub enum NymCommandError {
         path: String,
         source: zingolib::nym::MixnetProxyError,
     },
-}
-
-#[cfg(feature = "nym")]
-#[derive(clap::Parser, Debug, PartialEq, Eq)]
-#[command(name = "nym", no_binary_name = true)]
-struct NymCli {
-    /// A bare `nym` reads as `nym status`.
-    #[command(subcommand)]
-    sub: Option<NymSubCommand>,
 }
 
 /// A parsed `nym` command. Arguments parse completely into this enum,
@@ -1606,19 +1421,10 @@ fn render_migration_phase(phase: &MigrationPhase) -> String {
 /// derive grammar, before any wallet access.
 #[derive(Debug, thiserror::Error)]
 pub enum MigrationCommandError {
-    #[error("migrate command expects no arguments. Type \"help migrate\" for usage.")]
-    UnexpectedArguments,
     #[error("sync failed: {0}")]
     Sync(zingolib::lightclient::error::LightClientError),
     #[error("{0}")]
     Client(#[from] zingolib::lightclient::error::LightClientError),
-}
-
-#[derive(clap::Parser, Debug, PartialEq, Eq)]
-#[command(name = "migration", no_binary_name = true)]
-struct MigrationCli {
-    #[command(subcommand)]
-    sub: MigrationSubCommand,
 }
 
 /// A parsed migration command. Arguments parse completely into this
@@ -1676,13 +1482,7 @@ fn txids_json<T: ToString>(txids: &[T]) -> json::JsonValue {
 
 /// Runs the `migrate` command. Its errors cross the dispatch seam as
 /// [`CommandError::Migration`].
-async fn run_migrate(
-    args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, MigrationCommandError> {
-    if !args.is_empty() {
-        return Err(MigrationCommandError::UnexpectedArguments);
-    }
+async fn run_migrate(lightclient: &mut LightClient) -> Result<String, MigrationCommandError> {
     let summary = transmit_narrated(
         "migrate",
         lightclient.transmit_progress_handle(),
@@ -1899,25 +1699,11 @@ async fn run_migration(
     })
 }
 
-#[derive(clap::Parser, Debug, PartialEq, Eq)]
-#[command(name = "drain", no_binary_name = true)]
-struct DrainCli {
-    #[command(subcommand)]
-    sub: DrainSubCommand,
-}
-
 /// A parsed `drain` sub-command, at the clap derive grammar.
 #[derive(clap::Subcommand, Debug, PartialEq, Eq)]
 enum DrainSubCommand {
     Plan,
     Now,
-}
-
-#[derive(clap::Parser, Debug, PartialEq, Eq)]
-#[command(name = "split", no_binary_name = true)]
-struct SplitCli {
-    #[command(subcommand)]
-    sub: SplitSubCommand,
 }
 
 /// A parsed `split` sub-command, at the clap derive grammar.
@@ -2049,42 +1835,66 @@ async fn run_split(
     })
 }
 
-/// Every command, in alphabetical order: the single source of the
-/// dispatchable names, help texts, and bodies (ADR 0030). `help` renders
-/// its listing straight from this table, so declaration order is display
-/// order.
-static COMMANDS: &[CommandSpec] = &[
-    wallet! {
-        addresses,
-        short_help: "List unified addresses in the wallet.",
-        help: indoc! {r"
+/// The `nym` help texts, held as consts because the command's grammar
+/// splits on the `nym` feature and both variants carry the same help.
+const NYM_ABOUT: &str = "Control the Nym mixnet transport (on/off/status/probe/history).";
+const NYM_LONG_ABOUT: &str = indoc! {r"
+    Control the Nym mixnet transport for send and price-fetch.
+
+    With Mixnet Mode on, both route over the mixnet and fail closed while it
+    bootstraps, never falling back to clearnet. Turning it off is a deliberate
+    choice to transmit over clearnet.
+
+    `status` reports off, bootstrapping or ready. `on` starts the nym-proxy
+    child, taking the binary from the given path, else $ZINGO_NYM_PROXY, else
+    one bundled beside this binary, else PATH. `off` reverts to clearnet.
+    `probe` runs GetLightdInfo over both routes side by side to tell whether a
+    failure is mixnet-specific, and its clearnet leg uses your real IP.
+    `history` shows per-indexer attempts across sessions, and needs the
+    nym-diary feature plus --indexer-diary.
+
+    Usage:
+    nym status | on [binary_path] | off | probe [uri] | history
+"};
+
+/// Every command the CLI dispatches, in alphabetical order: the single
+/// source of the dispatchable names, help texts, and typed arguments
+/// (ADR 0030). Each name is minted from its variant identifier, and `help`
+/// renders its listing from this grammar's clap model, so declaration
+/// order is display order.
+#[derive(clap::Subcommand, Debug)]
+#[command(rename_all = "snake_case")]
+enum CliCommand {
+    #[command(
+        about = "List unified addresses in the wallet.",
+        long_about = indoc! {r"
             List the wallet's unified addresses.
 
             Usage:
             addresses
-        "},
-    },
-    wallet! {
-        balance,
-        short_help: "Return the wallet ZEC balance for each pool (account 0).",
-        help: indoc! {r"
+        "}
+    )]
+    Addresses,
+    #[command(
+        about = "Return the wallet ZEC balance for each pool (account 0).",
+        long_about = indoc! {r"
             Return the wallet ZEC balance for each pool (account 0).
-        "},
-    },
-    wallet! {
-        birthday,
-        short_help: "Returns block height wallet was created",
-        help: indoc! {r"
+        "}
+    )]
+    Balance,
+    #[command(
+        about = "Returns block height wallet was created",
+        long_about = indoc! {r"
             Print the height the wallet was created at.
 
             Usage:
             birthday
-        "},
-    },
-    wallet! {
-        calculate,
-        short_help: "Sign the latest proposal without transmitting it.",
-        help: concat!(
+        "}
+    )]
+    Birthday,
+    #[command(
+        about = "Sign the latest proposal without transmitting it.",
+        long_about = concat!(
             "Sign the latest proposal without transmitting it, for offline signing. No\n",
             "Indexer needed. The transactions are stored Calculated, for 'transmit' to send\n",
             "later. Needs a proposal from 'send', 'send_all' or 'shield' first.\n",
@@ -2106,12 +1916,12 @@ static COMMANDS: &[CommandSpec] = &[
             "\"\n",
             "    calculate\n",
             "    transmit\n",
-        ),
-    },
-    wallet! {
-        change_server,
-        short_help: "Change indexer server",
-        help: concat!(
+        )
+    )]
+    Calculate,
+    #[command(
+        about = "Change indexer server",
+        long_about = concat!(
             "Change the indexer server.\n",
             "\n",
             "Usage:\n",
@@ -2121,42 +1931,48 @@ static COMMANDS: &[CommandSpec] = &[
             "change_server ",
             crate::examples::server_uri!(),
             "\n",
-        ),
+        )
+    )]
+    ChangeServer {
+        #[arg(value_parser = parse_server_uri)]
+        uri: Option<http::Uri>,
     },
-    wallet! {
-        check_address,
-        short_help: "Checks if the given encoded address is derived by the wallet's keys.",
-        help: indoc! {r"
+    #[command(
+        about = "Checks if the given encoded address is derived by the wallet's keys.",
+        long_about = indoc! {r"
             Check whether an encoded address derives from the wallet's keys.
 
             Usage:
             check_address <encoded_address>
-        "},
-    },
-    wallet! {
-        clear,
-        short_help: "Clear the wallet state, rolling back the wallet to an empty state.",
-        help: indoc! {r"
+        "}
+    )]
+    CheckAddress { address: String },
+    #[command(
+        about = "Clear the wallet state, rolling back the wallet to an empty state.",
+        long_about = indoc! {r"
             Drop every note, coin and transaction, leaving the wallet to sync from scratch.
 
             Usage:
             clear
-        "},
-    },
-    wallet! {
-        coins,
-        short_help: "Show the wallet's coins (transparent outputs).",
-        help: indoc! {r"
+        "}
+    )]
+    Clear,
+    #[command(
+        about = "Show the wallet's coins (transparent outputs).",
+        long_about = indoc! {r"
             Show the wallet's coins (transparent outputs). `all` includes spent ones.
 
             Usage:
             coins [all]
-        "},
+        "}
+    )]
+    Coins {
+        #[arg(value_enum)]
+        scope: Option<OutputScope>,
     },
-    wallet! {
-        confirm,
-        short_help: "Build and transmit the latest proposal, then resume sync.",
-        help: concat!(
+    #[command(
+        about = "Build and transmit the latest proposal, then resume sync.",
+        long_about = concat!(
             "Build and transmit the latest proposal, then resume sync. Needs a proposal\n",
             "from 'send', 'send_all' or 'shield' first.\n",
             "\n",
@@ -2171,12 +1987,12 @@ static COMMANDS: &[CommandSpec] = &[
             crate::examples::memo!(),
             "\"\n",
             "    confirm\n",
-        ),
-    },
-    wallet! {
-        current_price,
-        short_help: "Updates and returns current price of ZEC.",
-        help: indoc! {r"
+        )
+    )]
+    Confirm,
+    #[command(
+        about = "Updates and returns current price of ZEC.",
+        long_about = indoc! {r"
             Fetch the current ZEC price over the Nym mixnet. USD only.
 
             The fetch races all three price sources (gemini, kraken,
@@ -2191,22 +2007,22 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             current_price
-        "},
-    },
-    wallet! {
-        delete,
-        short_help: "Delete wallet file from disk",
-        help: indoc! {r"
+        "}
+    )]
+    CurrentPrice,
+    #[command(
+        about = "Delete wallet file from disk",
+        long_about = indoc! {r"
             Delete the wallet file from disk.
 
             Usage:
             delete
-        "},
-    },
-    wallet! {
-        drain,
-        short_help: "Send all Orchard funds into the Ironwood pool now (immediate ZIP 318 path).",
-        help: indoc! {r"
+        "}
+    )]
+    Delete,
+    #[command(
+        about = "Send all Orchard funds into the Ironwood pool now (immediate ZIP 318 path).",
+        long_about = indoc! {r"
             Send every spendable Orchard note into the Ironwood pool now, ZIP 318's
             immediate path.
 
@@ -2223,53 +2039,56 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             drain plan | now
-        "},
+        "}
+    )]
+    Drain {
+        #[command(subcommand)]
+        sub: DrainSubCommand,
     },
-    wallet! {
-        export_ufvk,
-        short_help: "Export unified full viewing key for the wallet.",
-        help: indoc! {r"
+    #[command(
+        about = "Export unified full viewing key for the wallet.",
+        long_about = indoc! {r"
             Export the wallet's unified full viewing key. To back up spend capability,
             use `recovery_info` instead.
 
             Usage:
             export_ufvk
-        "},
-    },
-    wallet! {
-        height,
-        short_help: "Print the chain height as of the wallet's last request to the server.",
-        help: indoc! {r"
+        "}
+    )]
+    ExportUfvk,
+    #[command(
+        about = "Print the chain height as of the wallet's last request to the server.",
+        long_about = indoc! {r"
             Print the chain height as of the wallet's last request to the server.
 
             Usage:
             height
-        "},
-    },
-    standalone! {
-        help,
-        short_help: "Lists all available commands",
-        help: indoc! {r"
+        "}
+    )]
+    Height,
+    #[command(
+        about = "Lists all available commands",
+        long_about = indoc! {r"
             List every command, or show one command's help.
 
             Usage:
             help [command]
-        "},
-    },
-    wallet! {
-        info,
-        short_help: "Get the indexer server's info",
-        help: indoc! {r"
+        "}
+    )]
+    Help { command: Option<String> },
+    #[command(
+        about = "Get the indexer server's info",
+        long_about = indoc! {r"
             Print the connected indexer's info.
 
             Usage:
             info
-        "},
-    },
-    wallet! {
-        max_send_value,
-        short_help: "Print the most the wallet can send to a given address.",
-        help: indoc! {r#"
+        "}
+    )]
+    Info,
+    #[command(
+        about = "Print the most the wallet can send to a given address.",
+        long_about = indoc! {r#"
             Print the most the wallet can send to an address: shielded spendable
             balance less the fee. Mid-sync this can trail the confirmed balance.
             `zennies_for_zingo` also budgets 1_000_000 ZAT to the ZingoLabs developer
@@ -2278,22 +2097,25 @@ static COMMANDS: &[CommandSpec] = &[
             Usage:
             max_send_value <address>
             max_send_value { "address": "<address>", "zennies_for_zingo": <true|false> }
-        "#},
+        "#}
+    )]
+    MaxSendValue {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
-    wallet! {
-        memobytes_to_address,
-        short_help: "Show by address memo_bytes transfers for this seed.",
-        help: indoc! {r"
+    #[command(
+        about = "Show by address memo_bytes transfers for this seed.",
+        long_about = indoc! {r"
             Print total memo bytes sent, keyed by address.
 
             Usage:
             memobytes_to_address
-        "},
-    },
-    wallet! {
-        messages,
-        short_help: "List memos for this wallet.",
-        help: indoc! {r"
+        "}
+    )]
+    MemobytesToAddress,
+    #[command(
+        about = "List memos for this wallet.",
+        long_about = indoc! {r"
             List the wallet's memo-bearing value transfers. An address filters to that
             correspondent, any other string filters to memos containing it, and no
             argument shows every memo. Received messages are matched on the memo's
@@ -2301,12 +2123,12 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             messages [address | string]
-        "},
-    },
-    wallet! {
-        migrate,
-        short_help: "Migrate all Orchard funds to the Ironwood pool in one interactive run.",
-        help: indoc! {r"
+        "}
+    )]
+    Messages { filter: Option<String> },
+    #[command(
+        about = "Migrate all Orchard funds to the Ironwood pool in one interactive run.",
+        long_about = indoc! {r"
             Migrate all Orchard funds to the Ironwood pool in one interactive run.
 
             Runs ZIP 318's two phases back to back: note-splitting rounds of Orchard
@@ -2320,12 +2142,12 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             migrate
-        "},
-    },
-    wallet! {
-        migration,
-        short_help: "Drive the scheduled Orchard to Ironwood migration",
-        help: indoc! {r"
+        "}
+    )]
+    Migrate,
+    #[command(
+        about = "Drive the scheduled Orchard to Ironwood migration",
+        long_about = indoc! {r"
             Drive the scheduled Orchard to Ironwood migration (ZIP 318).
 
             `plan` computes the plan (rounds, parts, fees, residual dust) from the
@@ -2365,33 +2187,39 @@ static COMMANDS: &[CommandSpec] = &[
             migration execute [spacing_seconds]
             migration catchup [spacing_seconds]
             migration continue | auto | status | windows | reconcile | cancel
-        "},
+        "}
+    )]
+    Migration {
+        #[command(subcommand)]
+        sub: MigrationSubCommand,
     },
-    wallet! {
-        new_address,
-        short_help: "Create a new unified address.",
-        help: indoc! {r"
+    #[command(
+        about = "Create a new unified address.",
+        long_about = indoc! {r"
             Create a new unified address, with an orchard receiver, a sapling one, or
             both. No transparent receivers: use `new_taddress` for those.
 
             Usage:
             new_address o | z | oz
-        "},
+        "}
+    )]
+    NewAddress {
+        #[arg(value_parser = parse_receiver_selection)]
+        receivers: ReceiverSelection,
     },
-    wallet! {
-        new_taddress,
-        short_help: "Create a new transparent address.",
-        help: indoc! {r"
+    #[command(
+        about = "Create a new transparent address.",
+        long_about = indoc! {r"
             Create a new transparent address.
 
             Usage:
             new_taddress
-        "},
-    },
-    wallet! {
-        new_taddress_allow_gap,
-        short_help: "Create a new transparent address (even if the last one did not receive any funds).",
-        help: indoc! {r#"
+        "}
+    )]
+    NewTaddress,
+    #[command(
+        about = "Create a new transparent address (even if the last one did not receive any funds).",
+        long_about = indoc! {r#"
             Create a new transparent address even if the last one never received funds.
 
             This bypasses the no-gap rule, which exists because recovery from seed may
@@ -2401,44 +2229,34 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             new_taddress_allow_gap
-        "#},
-    },
-    wallet! {
-        notes,
-        short_help: "Show the wallet's notes (shielded outputs).",
-        help: indoc! {r"
+        "#}
+    )]
+    NewTaddressAllowGap,
+    #[command(
+        about = "Show the wallet's notes (shielded outputs).",
+        long_about = indoc! {r"
             Show the wallet's notes (shielded outputs). `all` includes spent ones.
 
             Usage:
             notes [all]
-        "},
+        "}
+    )]
+    Notes {
+        #[arg(value_enum)]
+        scope: Option<OutputScope>,
     },
-    wallet! {
-        nym,
-        short_help: "Control the Nym mixnet transport (on/off/status/probe/history).",
-        help: indoc! {r"
-            Control the Nym mixnet transport for send and price-fetch.
-
-            With Mixnet Mode on, both route over the mixnet and fail closed while it
-            bootstraps, never falling back to clearnet. Turning it off is a deliberate
-            choice to transmit over clearnet.
-
-            `status` reports off, bootstrapping or ready. `on` starts the nym-proxy
-            child, taking the binary from the given path, else $ZINGO_NYM_PROXY, else
-            one bundled beside this binary, else PATH. `off` reverts to clearnet.
-            `probe` runs GetLightdInfo over both routes side by side to tell whether a
-            failure is mixnet-specific, and its clearnet leg uses your real IP.
-            `history` shows per-indexer attempts across sessions, and needs the
-            nym-diary feature plus --indexer-diary.
-
-            Usage:
-            nym status | on [binary_path] | off | probe [uri] | history
-        "},
+    #[command(about = NYM_ABOUT, long_about = NYM_LONG_ABOUT)]
+    #[cfg(feature = "nym")]
+    Nym {
+        #[command(subcommand)]
+        sub: Option<NymSubCommand>,
     },
-    standalone! {
-        parse_address,
-        short_help: "Parse an address",
-        help: concat!(
+    #[command(about = NYM_ABOUT, long_about = NYM_LONG_ABOUT)]
+    #[cfg(not(feature = "nym"))]
+    Nym,
+    #[command(
+        about = "Parse an address",
+        long_about = concat!(
             "Parse an address.\n",
             "\n",
             "Usage:\n",
@@ -2448,12 +2266,12 @@ static COMMANDS: &[CommandSpec] = &[
             "parse_address ",
             crate::examples::transparent_address!(),
             "\n",
-        ),
-    },
-    standalone! {
-        parse_viewkey,
-        short_help: "Parse a view_key.",
-        help: concat!(
+        )
+    )]
+    ParseAddress { address: String },
+    #[command(
+        about = "Parse a view_key.",
+        long_about = concat!(
             "Parse a viewing key.\n",
             "\n",
             "Usage:\n",
@@ -2463,12 +2281,12 @@ static COMMANDS: &[CommandSpec] = &[
             "parse_viewkey ",
             crate::examples::unified_viewing_key!(),
             "\n",
-        ),
-    },
-    wallet! {
-        quicksend,
-        short_help: "Send ZEC, fusing `send` and `confirm`.",
-        help: concat!(
+        )
+    )]
+    ParseViewkey { viewkey: String },
+    #[command(
+        about = "Send ZEC, fusing `send` and `confirm`.",
+        long_about = concat!(
             "Send ZEC, fusing `send` and `confirm`. The fee comes out of your balance\n",
             "and you never see it before the transaction goes out.\n",
             "\n",
@@ -2483,34 +2301,37 @@ static COMMANDS: &[CommandSpec] = &[
             " \"",
             crate::examples::memo!(),
             "\"\n",
-        ),
+        )
+    )]
+    Quicksend {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
-    wallet! {
-        quickshield,
-        short_help: "Shield transparent funds, fusing `shield` and `confirm`.",
-        help: indoc! {r"
+    #[command(
+        about = "Shield transparent funds, fusing `shield` and `confirm`.",
+        long_about = indoc! {r"
             Shield transparent funds into the ironwood pool, fusing `shield` and
             `confirm`. The fee comes out of your balance and you never see it before
             the transaction goes out.
 
             Usage:
                 quickshield
-        "},
-    },
-    wallet! {
-        quit,
-        short_help: "Quit the light client, saving state to disk.",
-        help: indoc! {r"
+        "}
+    )]
+    Quickshield,
+    #[command(
+        about = "Quit the light client, saving state to disk.",
+        long_about = indoc! {r"
             Quit the light client, saving state to disk.
 
             Usage:
             quit
-        "},
-    },
-    wallet! {
-        recovery_info,
-        short_help: "Print the wallet's seed phrase, birthday and account count.",
-        help: indoc! {r"
+        "}
+    )]
+    Quit,
+    #[command(
+        about = "Print the wallet's seed phrase, birthday and account count.",
+        long_about = indoc! {r"
             Print the wallet's seed phrase, birthday and account count.
 
             The seed phrase recovers the whole wallet. Save it carefully, share it with
@@ -2518,44 +2339,50 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             recovery_info
-        "},
-    },
-    wallet! {
-        remove_transaction,
-        short_help: "Remove a failed transaction from the wallet.",
-        help: indoc! {r"
+        "}
+    )]
+    RecoveryInfo,
+    #[command(
+        about = "Remove a failed transaction from the wallet.",
+        long_about = indoc! {r"
             Remove a failed transaction from the wallet. Manual on purpose, so a failed
             send keeps its memos until you decide to drop them.
 
             Usage:
             remove_transaction <txid>
-        "},
+        "}
+    )]
+    RemoveTransaction {
+        #[arg(value_parser = parse_txid)]
+        txid: TxId,
     },
-    wallet! {
-        rescan,
-        short_help: "Clear all chain-derived wallet data and sync again from the birthday.",
-        help: indoc! {r"
+    #[command(
+        about = "Clear all chain-derived wallet data and sync again from the birthday.",
+        long_about = indoc! {r"
             Clear all chain-derived wallet data and sync again from the birthday.
 
             Usage:
             rescan
-        "},
-    },
-    wallet! {
-        save,
-        short_help: "Launch the save task. Not meant to be called by hand.",
-        help: indoc! {r"
+        "}
+    )]
+    Rescan,
+    #[command(
+        about = "Launch the save task. Not meant to be called by hand.",
+        long_about = indoc! {r"
             Launch the task that persists the wallet as its state changes. Not meant to
             be called by hand.
 
             Usage:
             save run | check | shutdown
-        "},
+        "}
+    )]
+    Save {
+        #[command(subcommand)]
+        sub: SaveSubCommand,
     },
-    wallet! {
-        send,
-        short_help: "Propose a transfer of ZEC, for 'confirm' to broadcast.",
-        help: concat!(
+    #[command(
+        about = "Propose a transfer of ZEC, for 'confirm' to broadcast.",
+        long_about = concat!(
             "Propose a transfer of ZEC. Shows the fee, then 'confirm' broadcasts it.\n",
             "\n",
             "Usage:\n",
@@ -2570,12 +2397,15 @@ static COMMANDS: &[CommandSpec] = &[
             crate::examples::memo!(),
             "\"\n",
             "    confirm\n",
-        ),
+        )
+    )]
+    Send {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
-    wallet! {
-        send_all,
-        short_help: "Propose a transfer of all shielded ZEC to one address, for 'confirm' to broadcast.",
-        help: concat!(
+    #[command(
+        about = "Propose a transfer of all shielded ZEC to one address, for 'confirm' to broadcast.",
+        long_about = concat!(
             "Propose a transfer of every shielded ZEC to one address. Shows the fee,\n",
             "then 'confirm' broadcasts it. `zennies_for_zingo` adds 1_000_000 ZAT to the\n",
             "zingolabs developer address per transaction.\n",
@@ -2592,28 +2422,30 @@ static COMMANDS: &[CommandSpec] = &[
             crate::examples::send_all_memo!(),
             "\"\n",
             "    confirm\n",
-        ),
+        )
+    )]
+    SendAll {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
-    wallet! {
-        sends_to_address,
-        short_help: "Show by address number of sends for this seed.",
-        help: indoc! {r"
+    #[command(
+        about = "Show by address number of sends for this seed.",
+        long_about = indoc! {r"
             Print the number of sends, keyed by address.
 
             Usage:
             sends_to_address
-        "},
-    },
-    CommandSpec {
-        name: "servers",
-        short_help: "Show ranked indexer servers and response times",
-        help: "Show ranked indexer servers and their get_info() response times.\nUsage: servers",
-        body: CommandBody::Repl,
-    },
-    wallet! {
-        settings,
-        short_help: "Show or set wallet settings.",
-        help: indoc! {r"
+        "}
+    )]
+    SendsToAddress,
+    #[command(
+        about = "Show ranked indexer servers and response times",
+        long_about = "Show ranked indexer servers and their get_info() response times.\nUsage: servers"
+    )]
+    Servers,
+    #[command(
+        about = "Show or set wallet settings.",
+        long_about = indoc! {r"
             Show or set wallet settings. With no argument, prints them all. To set one,
             name it and give a value.
 
@@ -2623,33 +2455,36 @@ static COMMANDS: &[CommandSpec] = &[
             Usage:
             settings
             settings performance high
-        "},
+        "}
+    )]
+    Settings {
+        #[command(subcommand)]
+        sub: Option<SettingsSubCommand>,
     },
-    wallet! {
-        shield,
-        short_help: "Propose a shield of transparent funds, for 'confirm' to broadcast.",
-        help: indoc! {r"
+    #[command(
+        about = "Propose a shield of transparent funds, for 'confirm' to broadcast.",
+        long_about = indoc! {r"
             Propose a shield of transparent funds into the ironwood pool. Shows the
             fee, then 'confirm' broadcasts it.
 
             Usage:
                 shield
-        "},
-    },
-    wallet! {
-        spendable_balance,
-        short_help: "Display the wallet's spendable balance.",
-        help: indoc! {r"
+        "}
+    )]
+    Shield,
+    #[command(
+        about = "Display the wallet's spendable balance.",
+        long_about = indoc! {r"
             Print the wallet's spendable balance.
 
             Usage:
             spendable_balance
-        "},
-    },
-    wallet! {
-        split,
-        short_help: "Split Orchard notes into ZIP 318 part sizes, one round per call.",
-        help: indoc! {r"
+        "}
+    )]
+    SpendableBalance,
+    #[command(
+        about = "Split Orchard notes into ZIP 318 part sizes, one round per call.",
+        long_about = indoc! {r"
             Resize the wallet's Orchard notes into ZIP 318 part sizes, one round of
             Orchard self-sends per call.
 
@@ -2667,12 +2502,15 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             split plan | now
-        "},
+        "}
+    )]
+    Split {
+        #[command(subcommand)]
+        sub: SplitSubCommand,
     },
-    wallet! {
-        sync,
-        short_help: "Sync the wallet to the latest state of the blockchain.",
-        help: indoc! {r"
+    #[command(
+        about = "Sync the wallet to the latest state of the blockchain.",
+        long_about = indoc! {r"
             Sync the wallet to the chain tip.
 
             `run` starts or resumes. `pause` halts scanning. `stop` shuts sync down
@@ -2681,32 +2519,35 @@ static COMMANDS: &[CommandSpec] = &[
 
             Usage:
             sync run | pause | stop | status | poll
-        "},
+        "}
+    )]
+    Sync {
+        #[command(subcommand)]
+        sub: SyncSubCommand,
     },
-    wallet! {
-        t_addresses,
-        short_help: "List transparent addresses in the wallet.",
-        help: indoc! {r"
+    #[command(
+        about = "List transparent addresses in the wallet.",
+        long_about = indoc! {r"
             List the wallet's transparent addresses.
 
             Usage:
             t_addresses
-        "},
-    },
-    wallet! {
-        transactions,
-        short_help: "List the wallet's transaction summaries by block height.",
-        help: indoc! {r"
+        "}
+    )]
+    TAddresses,
+    #[command(
+        about = "List the wallet's transaction summaries by block height.",
+        long_about = indoc! {r"
             List the wallet's transaction summaries by block height.
 
             Usage:
             transactions
-        "},
-    },
-    wallet! {
-        transmit,
-        short_help: "Transmit calculated transactions to the Indexer.",
-        help: concat!(
+        "}
+    )]
+    Transactions,
+    #[command(
+        about = "Transmit calculated transactions to the Indexer.",
+        long_about = concat!(
             "Transmit calculated transactions to the Indexer. With no arguments, sends\n",
             "every Calculated transaction in target-height order. Pass txids in the order\n",
             "'calculate' printed them to fix the order yourself, which multi-step proposals\n",
@@ -2719,93 +2560,173 @@ static COMMANDS: &[CommandSpec] = &[
             "    transmit [txid ...]\n",
             "Example:\n",
             "    transmit\n",
-        ),
+        )
+    )]
+    Transmit {
+        #[arg(value_parser = parse_txid)]
+        txids: Vec<TxId>,
     },
-    wallet! {
-        value_to_address,
-        short_help: "Show by address value transfers for this seed.",
-        help: indoc! {r"
+    #[command(
+        about = "Show by address value transfers for this seed.",
+        long_about = indoc! {r"
             Print total value sent, keyed by address.
 
             Usage:
             value_to_address
-        "},
-    },
-    wallet! {
-        value_transfers,
-        short_help: "List all value transfers for this wallet.",
-        help: indoc! {r"
+        "}
+    )]
+    ValueToAddress,
+    #[command(
+        about = "List all value transfers for this wallet.",
+        long_about = indoc! {r"
             List the wallet's value transfers, each one a transaction's notes to a
             single receiver.
 
             Usage:
             value_transfers
-        "},
-    },
-    standalone! {
-        version,
-        short_help: "Get version of build code",
-        help: indoc! {r"
+        "}
+    )]
+    ValueTransfers,
+    #[command(
+        about = "Get version of build code",
+        long_about = indoc! {r"
             Print the build's git describe --dirty.
-        "},
-    },
-    wallet! {
-        wallet_kind,
-        short_help: "Displays the kind of wallet currently loaded",
-        help: indoc! {r"
+        "}
+    )]
+    Version,
+    #[command(
+        about = "Displays the kind of wallet currently loaded",
+        long_about = indoc! {r"
             Print the loaded wallet's kind. For a UFVK, lists the supported pools.
             Spend-capable wallets always spend from all three.
-            "},
-    },
+            "}
+    )]
+    WalletKind,
+}
+
+/// The whole command line one dispatch parses: a command name and its
+/// arguments, with no binary name in front, so the REPL and the one-shot
+/// entry share this grammar.
+#[derive(clap::Parser, Debug)]
+#[command(no_binary_name = true, disable_help_subcommand = true)]
+struct CommandLine {
+    #[command(subcommand)]
+    command: CliCommand,
+}
+
+/// The commands `help` lists under "Standalone commands (no wallet
+/// required)": those whose bodies never touch the wallet, plus the
+/// REPL-owned `servers`. Every other command is a wallet command.
+const STANDALONE_COMMANDS: &[&str] = &[
+    "help",
+    "parse_address",
+    "parse_viewkey",
+    "servers",
+    "version",
 ];
 
-/// Renders the help listing (no arguments) or one command's help text,
-/// straight from [`COMMANDS`].
-pub fn format_help(args: &[&str]) -> String {
-    match args.len() {
-        0 => {
-            let mut lines = Vec::new();
-            lines.push("Standalone commands (no wallet required):".to_string());
-            lines.extend(
-                COMMANDS
-                    .iter()
-                    .filter(|spec| !matches!(spec.body, CommandBody::Wallet(_)))
-                    .map(|spec| format!("  {} - {}", spec.name, spec.short_help)),
-            );
-            lines.push(String::new());
-            lines.push("Wallet commands:".to_string());
-            lines.extend(
-                COMMANDS
-                    .iter()
-                    .filter(|spec| matches!(spec.body, CommandBody::Wallet(_)))
-                    .map(|spec| format!("  {} - {}", spec.name, spec.short_help)),
-            );
-            lines.join("\n")
-        }
-        1 => match COMMANDS.iter().find(|spec| spec.name == args[0]) {
-            Some(spec) => spec.help.to_string(),
-            None => format!("Command {} not found", args[0]),
-        },
-        _ => "Usage: help [command_name]".to_string(),
+/// Renders the two-section help listing, or one command's long help,
+/// from [`CommandLine`]'s clap model.
+pub fn format_help(command: Option<&str>) -> String {
+    use clap::CommandFactory as _;
+
+    let mut model = CommandLine::command();
+    let Some(command) = command else {
+        let listing = |standalone: bool| {
+            model
+                .get_subcommands()
+                .filter(|sub| STANDALONE_COMMANDS.contains(&sub.get_name()) == standalone)
+                .map(|sub| {
+                    format!(
+                        "  {} - {}",
+                        sub.get_name(),
+                        sub.get_about().map(ToString::to_string).unwrap_or_default()
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut lines = vec!["Standalone commands (no wallet required):".to_string()];
+        lines.extend(listing(true));
+        lines.push(String::new());
+        lines.push("Wallet commands:".to_string());
+        lines.extend(listing(false));
+        return lines.join("\n");
+    };
+    match model.find_subcommand_mut(command) {
+        Some(sub) => sub.render_long_help().to_string(),
+        None => format!("Command {command} not found"),
     }
 }
 
-/// Dispatches a user command by name through [`COMMANDS`], exposing the
-/// typed success/failure crossing. Unknown names and the REPL-owned
-/// `servers` command return typed errors (ADR 0031).
+/// Dispatches a user command by parsing it with [`CommandLine`], exposing
+/// the typed success/failure crossing. A name the grammar does not know
+/// and the REPL-owned `servers` command return typed errors (ADR 0031).
 pub async fn do_user_command_result(
     cmd: &str,
     args: &[&str],
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
-    let lowered = cmd.to_ascii_lowercase();
-    match COMMANDS.iter().find(|spec| spec.name == lowered) {
-        Some(spec) => match spec.body {
-            CommandBody::Standalone(run) => run(args),
-            CommandBody::Wallet(run) => run(args, lightclient).await,
-            CommandBody::Repl => Err(CommandError::ReplOnly(spec.name)),
-        },
-        None => Err(CommandError::UnknownCommand(cmd.to_string())),
+    use clap::Parser as _;
+
+    let line =
+        std::iter::once(cmd.to_ascii_lowercase()).chain(args.iter().map(|arg| (*arg).to_string()));
+    let CommandLine { command } = CommandLine::try_parse_from(line)
+        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    match command {
+        CliCommand::Addresses => addresses(lightclient).await,
+        CliCommand::Balance => balance(lightclient).await,
+        CliCommand::Birthday => birthday(lightclient).await,
+        CliCommand::Calculate => calculate(lightclient).await,
+        CliCommand::ChangeServer { uri } => change_server(uri, lightclient).await,
+        CliCommand::CheckAddress { address } => check_address(&address, lightclient).await,
+        CliCommand::Clear => clear(lightclient).await,
+        CliCommand::Coins { scope } => coins(scope, lightclient).await,
+        CliCommand::Confirm => confirm(lightclient).await,
+        CliCommand::CurrentPrice => current_price(lightclient).await,
+        CliCommand::Delete => delete(lightclient).await,
+        CliCommand::Drain { sub } => drain(sub, lightclient).await,
+        CliCommand::ExportUfvk => export_ufvk(lightclient).await,
+        CliCommand::Height => height(lightclient).await,
+        CliCommand::Help { command: named } => help(named.as_deref()),
+        CliCommand::Info => info(lightclient).await,
+        CliCommand::MaxSendValue { args } => max_send_value(&args, lightclient).await,
+        CliCommand::MemobytesToAddress => memobytes_to_address(lightclient).await,
+        CliCommand::Messages { filter } => messages(filter.as_deref(), lightclient).await,
+        CliCommand::Migrate => migrate(lightclient).await,
+        CliCommand::Migration { sub } => migration(sub, lightclient).await,
+        CliCommand::NewAddress { receivers } => new_address(receivers, lightclient).await,
+        CliCommand::NewTaddress => new_taddress(lightclient).await,
+        CliCommand::NewTaddressAllowGap => new_taddress_allow_gap(lightclient).await,
+        CliCommand::Notes { scope } => notes(scope, lightclient).await,
+        #[cfg(feature = "nym")]
+        CliCommand::Nym { sub } => nym(sub, lightclient).await,
+        #[cfg(not(feature = "nym"))]
+        CliCommand::Nym => nym(lightclient).await,
+        CliCommand::ParseAddress { address } => parse_address(&address),
+        CliCommand::ParseViewkey { viewkey } => parse_viewkey(&viewkey),
+        CliCommand::Quicksend { args } => quicksend(&args, lightclient).await,
+        CliCommand::Quickshield => quickshield(lightclient).await,
+        CliCommand::Quit => quit(lightclient).await,
+        CliCommand::RecoveryInfo => recovery_info(lightclient).await,
+        CliCommand::RemoveTransaction { txid } => remove_transaction(txid, lightclient).await,
+        CliCommand::Rescan => rescan(lightclient).await,
+        CliCommand::Save { sub } => save(sub, lightclient).await,
+        CliCommand::Send { args } => send(&args, lightclient).await,
+        CliCommand::SendAll { args } => send_all(&args, lightclient).await,
+        CliCommand::SendsToAddress => sends_to_address(lightclient).await,
+        CliCommand::Servers => Err(CommandError::ReplOnly("servers")),
+        CliCommand::Settings { sub } => settings(sub, lightclient).await,
+        CliCommand::Shield => shield(lightclient).await,
+        CliCommand::SpendableBalance => spendable_balance(lightclient).await,
+        CliCommand::Split { sub } => split(sub, lightclient).await,
+        CliCommand::Sync { sub } => sync(sub, lightclient).await,
+        CliCommand::TAddresses => t_addresses(lightclient).await,
+        CliCommand::Transactions => transactions(lightclient).await,
+        CliCommand::Transmit { txids } => transmit(txids, lightclient).await,
+        CliCommand::ValueToAddress => value_to_address(lightclient).await,
+        CliCommand::ValueTransfers => value_transfers(lightclient).await,
+        CliCommand::Version => version(),
+        CliCommand::WalletKind => wallet_kind(lightclient).await,
     }
 }
 

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -3,10 +3,12 @@
 //! Every command is one variant of [`CliCommand`], the clap derive
 //! grammar: its name is minted from the variant identifier, its help texts
 //! are its `about` and `long_about`, and its arguments parse into typed
-//! payloads before any body runs. The sync world crosses into async
-//! exactly once, at [`do_user_command`] (ADR 0030), and a failure leaves a
-//! command only as a [`CommandError`], never as error prose in the result
-//! channel (ADR 0031).
+//! payloads before any body runs. A command is parsed once, as early as
+//! the process can parse it, and travels to [`dispatch_parsed`] as a
+//! [`CliCommand`]; the sync world crosses into async at the two audited
+//! seams in the crate root, the command loop and startup (ADR 0030). A
+//! failure leaves a command only as a [`CommandError`], never as error
+//! prose in the result channel (ADR 0031).
 
 mod error;
 #[cfg(test)]
@@ -463,7 +465,7 @@ async fn new_taddress_allow_gap(lightclient: &mut LightClient) -> Result<String,
 /// The one optional argument of `notes` and `coins`: `all`, widening the
 /// listing to the spent outputs.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-enum OutputScope {
+pub(crate) enum OutputScope {
     All,
 }
 
@@ -577,8 +579,8 @@ async fn rescan(lightclient: &mut LightClient) -> Result<String, CommandError> {
 
 /// A parsed `save` command. Arguments parse completely into this enum,
 /// at the clap derive grammar, before any wallet access.
-#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
-enum SaveSubCommand {
+#[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SaveSubCommand {
     Run,
     Check,
     Shutdown,
@@ -651,9 +653,9 @@ async fn sends_to_address(lightclient: &mut LightClient) -> Result<String, Comma
 /// A parsed `settings` command: which setting to write, and its value.
 /// Absent, the command reads the settings out instead. The grammar owns
 /// every value, so a malformed one refuses before the wallet lock is taken.
-#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
+#[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 #[command(rename_all = "snake_case")]
-enum SettingsSubCommand {
+pub(crate) enum SettingsSubCommand {
     Performance {
         #[arg(value_enum)]
         level: PerformanceLevelArg,
@@ -666,7 +668,7 @@ enum SettingsSubCommand {
 /// The sync performance levels as a clap grammar. [`PerformanceLevel`] is
 /// pepper-sync's, so the CLI mints the value names and converts.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-enum PerformanceLevelArg {
+pub(crate) enum PerformanceLevelArg {
     Low,
     Medium,
     High,
@@ -758,8 +760,8 @@ async fn spendable_balance(lightclient: &mut LightClient) -> Result<String, Comm
 
 /// A parsed `sync` command. Arguments parse completely into this enum,
 /// at the clap derive grammar, before any wallet access.
-#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
-enum SyncSubCommand {
+#[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SyncSubCommand {
     Run,
     Pause,
     Stop,
@@ -1118,8 +1120,8 @@ pub enum NymCommandError {
 /// A parsed `nym` command. Arguments parse completely into this enum,
 /// at the clap derive grammar, before any wallet access.
 #[cfg(feature = "nym")]
-#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
-enum NymSubCommand {
+#[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum NymSubCommand {
     Status,
     On {
         path: Option<String>,
@@ -1429,8 +1431,8 @@ pub enum MigrationCommandError {
 
 /// A parsed migration command. Arguments parse completely into this
 /// enum, at the clap derive grammar, before any wallet access.
-#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
-enum MigrationSubCommand {
+#[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum MigrationSubCommand {
     Plan,
     Start {
         #[arg(value_parser = parse_plan_hash)]
@@ -1700,15 +1702,15 @@ async fn run_migration(
 }
 
 /// A parsed `drain` sub-command, at the clap derive grammar.
-#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
-enum DrainSubCommand {
+#[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DrainSubCommand {
     Plan,
     Now,
 }
 
 /// A parsed `split` sub-command, at the clap derive grammar.
-#[derive(clap::Subcommand, Debug, PartialEq, Eq)]
-enum SplitSubCommand {
+#[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SplitSubCommand {
     Plan,
     Now,
 }
@@ -1862,9 +1864,9 @@ const NYM_LONG_ABOUT: &str = indoc! {r"
 /// (ADR 0030). Each name is minted from its variant identifier, and `help`
 /// renders its listing from this grammar's clap model, so declaration
 /// order is display order.
-#[derive(clap::Subcommand, Debug)]
+#[derive(clap::Subcommand, Clone, Debug, PartialEq)]
 #[command(rename_all = "snake_case")]
-enum CliCommand {
+pub(crate) enum CliCommand {
     #[command(
         about = "List unified addresses in the wallet.",
         long_about = indoc! {r"
@@ -2320,9 +2322,10 @@ enum CliCommand {
     )]
     Quickshield,
     #[command(
+        alias = "exit",
         about = "Quit the light client, saving state to disk.",
         long_about = indoc! {r"
-            Quit the light client, saving state to disk.
+            Quit the light client, saving state to disk. `exit` is an alias.
 
             Usage:
             quit
@@ -2658,20 +2661,25 @@ pub fn format_help(command: Option<&str>) -> String {
     }
 }
 
-/// Dispatches a user command by parsing it with [`CommandLine`], exposing
-/// the typed success/failure crossing. A name the grammar does not know
-/// and the REPL-owned `servers` command return typed errors (ADR 0031).
-pub async fn do_user_command_result(
-    cmd: &str,
-    args: &[&str],
-    lightclient: &mut LightClient,
-) -> Result<String, CommandError> {
+/// Parses one command line into a [`CliCommand`], rendering a refusal as
+/// clap prints it. The REPL parses each line here, so a malformed line
+/// never reaches the command loop.
+pub(crate) fn parse_command_tokens(tokens: &[String]) -> Result<CliCommand, String> {
     use clap::Parser as _;
 
-    let line =
-        std::iter::once(cmd.to_ascii_lowercase()).chain(args.iter().map(|arg| (*arg).to_string()));
-    let CommandLine { command } = CommandLine::try_parse_from(line)
-        .map_err(|error| CommandError::NotYetTyped(error.to_string()))?;
+    CommandLine::try_parse_from(tokens)
+        .map(|CommandLine { command }| command)
+        .map_err(|error| error.to_string())
+}
+
+/// Dispatches an already-parsed command against the wallet: the exhaustive
+/// match every frontend reaches, whether it parsed its command at the REPL,
+/// at the process's own argument parse, or from a string. The REPL-owned
+/// `servers` command returns a typed error (ADR 0031).
+pub(crate) async fn dispatch_parsed(
+    command: CliCommand,
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     match command {
         CliCommand::Addresses => addresses(lightclient).await,
         CliCommand::Balance => balance(lightclient).await,
@@ -2730,14 +2738,22 @@ pub async fn do_user_command_result(
     }
 }
 
-/// The crate's single sync-to-async dispatch seam (ADR 0030): string
-/// frontends call this, and the one `block_on` below is the only place
-/// command execution crosses from sync into async.
-#[allow(clippy::disallowed_methods)]
-pub fn do_user_command(
+/// Dispatches a user command given as a name and string arguments: the
+/// string frontend over [`parse_command_tokens`] and [`dispatch_parsed`].
+/// A name the grammar does not know refuses here, before any wallet
+/// access, as a typed error (ADR 0031). No in-process caller remains, now
+/// that every channel carries a parsed command; this surface serves a
+/// frontend that holds only strings, and the offline-contract tests drive
+/// it.
+#[allow(dead_code)]
+pub async fn do_user_command_result(
     cmd: &str,
     args: &[&str],
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
-    RT.block_on(do_user_command_result(cmd, args, lightclient))
+    let tokens: Vec<String> = std::iter::once(cmd.to_ascii_lowercase())
+        .chain(args.iter().map(|arg| (*arg).to_string()))
+        .collect();
+    let command = parse_command_tokens(&tokens).map_err(CommandError::NotYetTyped)?;
+    dispatch_parsed(command, lightclient).await
 }

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1838,9 +1838,6 @@ pub(crate) enum CliCommand {
         about = "List unified addresses in the wallet.",
         long_about = indoc! {r"
             List the wallet's unified addresses.
-
-            Usage:
-            addresses
         "}
     )]
     Addresses,
@@ -1855,9 +1852,6 @@ pub(crate) enum CliCommand {
         about = "Returns block height wallet was created",
         long_about = indoc! {r"
             Print the height the wallet was created at.
-
-            Usage:
-            birthday
         "}
     )]
     Birthday,
@@ -1873,8 +1867,6 @@ pub(crate) enum CliCommand {
             "Treat a Calculated transaction as live value in flight until it is transmitted,\n",
             "expires, or another transaction spends its inputs.\n",
             "\n",
-            "Usage:\n",
-            "    calculate\n",
             "Example:\n",
             "    send ",
             crate::examples::sapling_address!(),
@@ -1893,9 +1885,6 @@ pub(crate) enum CliCommand {
         long_about = concat!(
             "Change the indexer server.\n",
             "\n",
-            "Usage:\n",
-            "change_server <server_uri>\n",
-            "\n",
             "Example:\n",
             "change_server ",
             crate::examples::server_uri!(),
@@ -1910,9 +1899,6 @@ pub(crate) enum CliCommand {
         about = "Checks if the given encoded address is derived by the wallet's keys.",
         long_about = indoc! {r"
             Check whether an encoded address derives from the wallet's keys.
-
-            Usage:
-            check_address <encoded_address>
         "}
     )]
     CheckAddress { address: String },
@@ -1920,9 +1906,6 @@ pub(crate) enum CliCommand {
         about = "Clear the wallet state, rolling back the wallet to an empty state.",
         long_about = indoc! {r"
             Drop every note, coin and transaction, leaving the wallet to sync from scratch.
-
-            Usage:
-            clear
         "}
     )]
     Clear,
@@ -1930,9 +1913,6 @@ pub(crate) enum CliCommand {
         about = "Show the wallet's coins (transparent outputs).",
         long_about = indoc! {r"
             Show the wallet's coins (transparent outputs). `all` includes spent ones.
-
-            Usage:
-            coins [all]
         "}
     )]
     Coins {
@@ -1945,8 +1925,6 @@ pub(crate) enum CliCommand {
             "Build and transmit the latest proposal, then resume sync. Needs a proposal\n",
             "from 'send', 'send_all' or 'shield' first.\n",
             "\n",
-            "Usage:\n",
-            "    confirm\n",
             "Example:\n",
             "    send ",
             crate::examples::sapling_address!(),
@@ -1973,9 +1951,6 @@ pub(crate) enum CliCommand {
             switched off — the clearnet consent covers sends, never price,
             because the price source is a third party outside the Zcash
             ecosystem. A build without the `nym` feature has no price fetch.
-
-            Usage:
-            current_price
         "}
     )]
     CurrentPrice,
@@ -1983,9 +1958,6 @@ pub(crate) enum CliCommand {
         about = "Delete wallet file from disk",
         long_about = indoc! {r"
             Delete the wallet file from disk.
-
-            Usage:
-            delete
         "}
     )]
     Delete,
@@ -2005,9 +1977,6 @@ pub(crate) enum CliCommand {
             `now` builds, signs and broadcasts. Sync first, since like any send this
             does not synchronize. Safe to repeat: a partial failure leaves the unsent
             notes spendable and a second run sends only the remainder.
-
-            Usage:
-            drain plan | now
         "}
     )]
     Drain {
@@ -2019,9 +1988,6 @@ pub(crate) enum CliCommand {
         long_about = indoc! {r"
             Export the wallet's unified full viewing key. To back up spend capability,
             use `recovery_info` instead.
-
-            Usage:
-            export_ufvk
         "}
     )]
     ExportUfvk,
@@ -2029,9 +1995,6 @@ pub(crate) enum CliCommand {
         about = "Print the chain height as of the wallet's last request to the server.",
         long_about = indoc! {r"
             Print the chain height as of the wallet's last request to the server.
-
-            Usage:
-            height
         "}
     )]
     Height,
@@ -2039,9 +2002,6 @@ pub(crate) enum CliCommand {
         about = "Lists all available commands",
         long_about = indoc! {r"
             List every command, or show one command's help.
-
-            Usage:
-            help [command]
         "}
     )]
     Help { command: Option<String> },
@@ -2049,33 +2009,27 @@ pub(crate) enum CliCommand {
         about = "Get the indexer server's info",
         long_about = indoc! {r"
             Print the connected indexer's info.
-
-            Usage:
-            info
         "}
     )]
     Info,
     #[command(
         about = "Print the most the wallet can send to a given address.",
-        long_about = indoc! {r#"
+        long_about = indoc! {r"
             Print the most the wallet can send to an address: shielded spendable
             balance less the fee. Mid-sync this can trail the confirmed balance.
             `zennies_for_zingo` also budgets 1_000_000 ZAT to the ZingoLabs developer
             address.
-
-            Usage:
-            max_send_value <address>
-            max_send_value { "address": "<address>", "zennies_for_zingo": <true|false> }
-        "#}
+        "},
+        override_usage = concat!(
+            "max_send_value <address>\n",
+            "       max_send_value { \"address\": \"<address>\", \"zennies_for_zingo\": <true|false> }",
+        )
     )]
     MaxSendValue { args: Vec<String> },
     #[command(
         about = "Show by address memo_bytes transfers for this seed.",
         long_about = indoc! {r"
             Print total memo bytes sent, keyed by address.
-
-            Usage:
-            memobytes_to_address
         "}
     )]
     MemobytesToAddress,
@@ -2086,9 +2040,6 @@ pub(crate) enum CliCommand {
             correspondent, any other string filters to memos containing it, and no
             argument shows every memo. Received messages are matched on the memo's
             reply-to address.
-
-            Usage:
-            messages [address | string]
         "}
     )]
     Messages {
@@ -2108,9 +2059,6 @@ pub(crate) enum CliCommand {
             alongside synchronization, so the server can correlate them with this
             wallet's activity. The `migration` command spreads them across
             anchor-height buckets instead.
-
-            Usage:
-            migrate
         "}
     )]
     Migrate,
@@ -2148,14 +2096,6 @@ pub(crate) enum CliCommand {
             with this wallet's activity.
             `cancel` abandons the migration. Confirmed parts stand, pending ones are
             dropped and their notes released.
-
-            Usage:
-            migration plan
-            migration start <plan_hash> [--per-bucket N]
-            migration cadence <N>
-            migration execute [spacing_seconds]
-            migration catchup [spacing_seconds]
-            migration continue | auto | status | windows | reconcile | cancel
         "}
     )]
     Migration {
@@ -2167,47 +2107,35 @@ pub(crate) enum CliCommand {
         long_about = indoc! {r"
             Create a new unified address, with an orchard receiver, a sapling one, or
             both. No transparent receivers: use `new_taddress` for those.
-
-            Usage:
-            new_address o | z | oz
         "}
     )]
     NewAddress {
-        #[arg(value_parser = parse_receiver_selection)]
+        #[arg(value_name = "o|z|oz", value_parser = parse_receiver_selection)]
         receivers: ReceiverSelection,
     },
     #[command(
         about = "Create a new transparent address.",
         long_about = indoc! {r"
             Create a new transparent address.
-
-            Usage:
-            new_taddress
         "}
     )]
     NewTaddress,
     #[command(
         about = "Create a new transparent address (even if the last one did not receive any funds).",
-        long_about = indoc! {r#"
+        long_about = indoc! {r"
             Create a new transparent address even if the last one never received funds.
 
             This bypasses the no-gap rule, which exists because recovery from seed may
             not discover addresses beyond a gap. Funds sent to skipped addresses can go
             missing after a restore unless you rescan or raise the gap limit, so you are
             taking on tracking the unused ones yourself.
-
-            Usage:
-            new_taddress_allow_gap
-        "#}
+        "}
     )]
     NewTaddressAllowGap,
     #[command(
         about = "Show the wallet's notes (shielded outputs).",
         long_about = indoc! {r"
             Show the wallet's notes (shielded outputs). `all` includes spent ones.
-
-            Usage:
-            notes [all]
         "}
     )]
     Notes {
@@ -2230,9 +2158,6 @@ pub(crate) enum CliCommand {
             failure is mixnet-specific, and its clearnet leg uses your real IP.
             `history` shows per-indexer attempts across sessions, and needs the
             nym-diary feature plus --indexer-diary.
-
-            Usage:
-            nym status | on [binary_path] | off | probe [uri] | history
         "}
     )]
     Nym {
@@ -2243,9 +2168,6 @@ pub(crate) enum CliCommand {
         about = "Parse an address",
         long_about = concat!(
             "Parse an address.\n",
-            "\n",
-            "Usage:\n",
-            "parse_address <address>\n",
             "\n",
             "Example\n",
             "parse_address ",
@@ -2258,9 +2180,6 @@ pub(crate) enum CliCommand {
         about = "Parse a view_key.",
         long_about = concat!(
             "Parse a viewing key.\n",
-            "\n",
-            "Usage:\n",
-            "parse_viewkey <viewing_key>\n",
             "\n",
             "Example\n",
             "parse_viewkey ",
@@ -2275,9 +2194,6 @@ pub(crate) enum CliCommand {
             "Send ZEC, fusing `send` and `confirm`. The fee comes out of your balance\n",
             "and you never see it before the transaction goes out.\n",
             "\n",
-            "Usage:\n",
-            "    quicksend <address> <zatoshis> \"<optional memo>\"\n",
-            "    quicksend '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
             "Example:\n",
             "    quicksend ",
             crate::examples::sapling_address!(),
@@ -2286,6 +2202,10 @@ pub(crate) enum CliCommand {
             " \"",
             crate::examples::memo!(),
             "\"\n",
+        ),
+        override_usage = concat!(
+            "quicksend <address> <zatoshis> \"<optional memo>\"\n",
+            "       quicksend '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'",
         )
     )]
     Quicksend { args: Vec<String> },
@@ -2295,9 +2215,6 @@ pub(crate) enum CliCommand {
             Shield transparent funds into the ironwood pool, fusing `shield` and
             `confirm`. The fee comes out of your balance and you never see it before
             the transaction goes out.
-
-            Usage:
-                quickshield
         "}
     )]
     Quickshield,
@@ -2306,9 +2223,6 @@ pub(crate) enum CliCommand {
         about = "Quit the light client, saving state to disk.",
         long_about = indoc! {r"
             Quit the light client, saving state to disk. `exit` is an alias.
-
-            Usage:
-            quit
         "}
     )]
     Quit,
@@ -2319,9 +2233,6 @@ pub(crate) enum CliCommand {
 
             The seed phrase recovers the whole wallet. Save it carefully, share it with
             nobody.
-
-            Usage:
-            recovery_info
         "}
     )]
     RecoveryInfo,
@@ -2330,9 +2241,6 @@ pub(crate) enum CliCommand {
         long_about = indoc! {r"
             Remove a failed transaction from the wallet. Manual on purpose, so a failed
             send keeps its memos until you decide to drop them.
-
-            Usage:
-            remove_transaction <txid>
         "}
     )]
     RemoveTransaction {
@@ -2343,9 +2251,6 @@ pub(crate) enum CliCommand {
         about = "Clear all chain-derived wallet data and sync again from the birthday.",
         long_about = indoc! {r"
             Clear all chain-derived wallet data and sync again from the birthday.
-
-            Usage:
-            rescan
         "}
     )]
     Rescan,
@@ -2354,9 +2259,6 @@ pub(crate) enum CliCommand {
         long_about = indoc! {r"
             Launch the task that persists the wallet as its state changes. Not meant to
             be called by hand.
-
-            Usage:
-            save run | check | shutdown
         "}
     )]
     Save {
@@ -2368,9 +2270,6 @@ pub(crate) enum CliCommand {
         long_about = concat!(
             "Propose a transfer of ZEC. Shows the fee, then 'confirm' broadcasts it.\n",
             "\n",
-            "Usage:\n",
-            "    send <address> <zatoshis> \"<optional memo>\"\n",
-            "    send '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'\n",
             "Example:\n",
             "    send ",
             crate::examples::sapling_address!(),
@@ -2380,6 +2279,10 @@ pub(crate) enum CliCommand {
             crate::examples::memo!(),
             "\"\n",
             "    confirm\n",
+        ),
+        override_usage = concat!(
+            "send <address> <zatoshis> \"<optional memo>\"\n",
+            "       send '[{\"address\":\"<address>\", \"amount\":<zatoshis>, \"memo\":\"<optional memo>\"}, ...]'",
         )
     )]
     Send { args: Vec<String> },
@@ -2392,9 +2295,6 @@ pub(crate) enum CliCommand {
             "\n",
             "Skips transparent funds: shield those first, see `help shield`.\n",
             "\n",
-            "Usage:\n",
-            "    send_all <address> \"<optional memo>\"\n",
-            "    send_all '{ \"address\": \"<address>\", \"memo\": \"<optional memo>\", \"zennies_for_zingo\": <true|false> }'\n",
             "Example:\n",
             "    send_all ",
             crate::examples::sapling_address!(),
@@ -2402,6 +2302,10 @@ pub(crate) enum CliCommand {
             crate::examples::send_all_memo!(),
             "\"\n",
             "    confirm\n",
+        ),
+        override_usage = concat!(
+            "send_all <address> \"<optional memo>\"\n",
+            "       send_all '{ \"address\": \"<address>\", \"memo\": \"<optional memo>\", \"zennies_for_zingo\": <true|false> }'",
         )
     )]
     SendAll { args: Vec<String> },
@@ -2409,15 +2313,12 @@ pub(crate) enum CliCommand {
         about = "Show by address number of sends for this seed.",
         long_about = indoc! {r"
             Print the number of sends, keyed by address.
-
-            Usage:
-            sends_to_address
         "}
     )]
     SendsToAddress,
     #[command(
         about = "Show ranked indexer servers and response times",
-        long_about = "Show ranked indexer servers and their get_info() response times.\nUsage: servers"
+        long_about = "Show ranked indexer servers and their get_info() response times."
     )]
     Servers,
     #[command(
@@ -2428,10 +2329,6 @@ pub(crate) enum CliCommand {
 
             performance        low | medium | high | maximum
             min_confirmations  1 or greater
-
-            Usage:
-            settings
-            settings performance high
         "}
     )]
     Settings {
@@ -2443,9 +2340,6 @@ pub(crate) enum CliCommand {
         long_about = indoc! {r"
             Propose a shield of transparent funds into the ironwood pool. Shows the
             fee, then 'confirm' broadcasts it.
-
-            Usage:
-                shield
         "}
     )]
     Shield,
@@ -2453,9 +2347,6 @@ pub(crate) enum CliCommand {
         about = "Display the wallet's spendable balance.",
         long_about = indoc! {r"
             Print the wallet's spendable balance.
-
-            Usage:
-            spendable_balance
         "}
     )]
     SpendableBalance,
@@ -2476,9 +2367,6 @@ pub(crate) enum CliCommand {
             `now` runs one round. Sync first, and again between rounds until each
             round's self-sends confirm. It reports when a prior round is still
             confirming and when splitting is done.
-
-            Usage:
-            split plan | now
         "}
     )]
     Split {
@@ -2493,9 +2381,6 @@ pub(crate) enum CliCommand {
             `run` starts or resumes. `pause` halts scanning. `stop` shuts sync down
             early. `status` reports progress. `poll` returns the result once complete,
             and is not meant to be called by hand.
-
-            Usage:
-            sync run | pause | stop | status | poll
         "}
     )]
     Sync {
@@ -2506,9 +2391,6 @@ pub(crate) enum CliCommand {
         about = "List transparent addresses in the wallet.",
         long_about = indoc! {r"
             List the wallet's transparent addresses.
-
-            Usage:
-            t_addresses
         "}
     )]
     TAddresses,
@@ -2516,9 +2398,6 @@ pub(crate) enum CliCommand {
         about = "List the wallet's transaction summaries by block height.",
         long_about = indoc! {r"
             List the wallet's transaction summaries by block height.
-
-            Usage:
-            transactions
         "}
     )]
     Transactions,
@@ -2533,8 +2412,6 @@ pub(crate) enum CliCommand {
             "Anything you leave untransmitted stays live value in flight until it expires or\n",
             "its inputs are spent.\n",
             "\n",
-            "Usage:\n",
-            "    transmit [txid ...]\n",
             "Example:\n",
             "    transmit\n",
         )
@@ -2547,9 +2424,6 @@ pub(crate) enum CliCommand {
         about = "Show by address value transfers for this seed.",
         long_about = indoc! {r"
             Print total value sent, keyed by address.
-
-            Usage:
-            value_to_address
         "}
     )]
     ValueToAddress,
@@ -2558,9 +2432,6 @@ pub(crate) enum CliCommand {
         long_about = indoc! {r"
             List the wallet's value transfers, each one a transaction's notes to a
             single receiver.
-
-            Usage:
-            value_transfers
         "}
     )]
     ValueTransfers,

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1128,12 +1128,13 @@ pub(crate) enum NymSubCommand {
     History,
 }
 
-/// https-only: the mixnet leg refuses a plaintext target at dial time,
-/// so the grammar rejects it up front with a clear message.
+/// https-only in a mixnet build, so the grammar refuses a plaintext target
+/// up front, while a build without the feature defers to the typed refusal.
 fn parse_probe_target(raw: &str) -> Result<http::Uri, String> {
     let uri = raw
         .parse::<http::Uri>()
         .map_err(|_| "not a valid indexer uri to probe".to_string())?;
+    #[cfg(feature = "nym")]
     if uri.scheme_str() != Some("https") {
         return Err("indexers must be https".to_string());
     }
@@ -2040,10 +2041,7 @@ pub(crate) enum CliCommand {
             reply-to address.
         "}
     )]
-    Messages {
-        #[arg(allow_hyphen_values = true)]
-        filter: Option<String>,
-    },
+    Messages { filter: Option<String> },
     #[command(
         about = "Migrate all Orchard funds to the Ironwood pool in one interactive run.",
         long_about = indoc! {r"
@@ -2527,6 +2525,22 @@ impl CliCommand {
             | CliCommand::WalletKind => true,
         }
     }
+
+    /// Runs the send family's deferred string grammar eagerly, so both
+    /// parse boundaries refuse a malformed payload before any wallet work.
+    pub(crate) fn validate_deferred_grammar(&self) -> Result<(), String> {
+        match self {
+            CliCommand::Send { args } | CliCommand::Quicksend { args } => {
+                utils::parse_send_args(&as_strs(args)).map(|_| ())
+            }
+            CliCommand::SendAll { args } => utils::parse_send_all_args(&as_strs(args)).map(|_| ()),
+            CliCommand::MaxSendValue { args } => {
+                utils::parse_max_send_value_args(&as_strs(args)).map(|_| ())
+            }
+            _ => return Ok(()),
+        }
+        .map_err(|e| usage(&self.name(), e).to_string())
+    }
 }
 
 /// The whole command line one dispatch parses: a command name and its
@@ -2603,6 +2617,7 @@ pub(crate) fn parse_command_tokens(tokens: &[String]) -> Result<CliCommand, Stri
     CommandLine::try_parse_from(tokens)
         .map(|CommandLine { command }| command)
         .map_err(|error| error.to_string())
+        .and_then(|command| command.validate_deferred_grammar().map(|()| command))
 }
 
 /// Dispatches an already-parsed command against the wallet: the exhaustive

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -2601,6 +2601,64 @@ impl CliCommand {
         }
         name
     }
+
+    /// True when the command's body touches the wallet, deciding which
+    /// section of `help` lists the command.
+    pub(crate) fn requires_wallet(&self) -> bool {
+        match self {
+            CliCommand::Help { .. }
+            | CliCommand::ParseAddress { .. }
+            | CliCommand::ParseViewkey { .. }
+            | CliCommand::Servers
+            | CliCommand::Version => false,
+            CliCommand::Addresses
+            | CliCommand::Balance
+            | CliCommand::Birthday
+            | CliCommand::Calculate
+            | CliCommand::ChangeServer { .. }
+            | CliCommand::CheckAddress { .. }
+            | CliCommand::Clear
+            | CliCommand::Coins { .. }
+            | CliCommand::Confirm
+            | CliCommand::CurrentPrice
+            | CliCommand::Delete
+            | CliCommand::Drain { .. }
+            | CliCommand::ExportUfvk
+            | CliCommand::Height
+            | CliCommand::Info
+            | CliCommand::MaxSendValue { .. }
+            | CliCommand::MemobytesToAddress
+            | CliCommand::Messages { .. }
+            | CliCommand::Migrate
+            | CliCommand::Migration { .. }
+            | CliCommand::NewAddress { .. }
+            | CliCommand::NewTaddress
+            | CliCommand::NewTaddressAllowGap
+            | CliCommand::Notes { .. }
+            | CliCommand::Nym { .. }
+            | CliCommand::Quicksend { .. }
+            | CliCommand::Quickshield
+            | CliCommand::Quit
+            | CliCommand::RecoveryInfo
+            | CliCommand::RemoveTransaction { .. }
+            | CliCommand::Rescan
+            | CliCommand::Save { .. }
+            | CliCommand::Send { .. }
+            | CliCommand::SendAll { .. }
+            | CliCommand::SendsToAddress
+            | CliCommand::Settings { .. }
+            | CliCommand::Shield
+            | CliCommand::SpendableBalance
+            | CliCommand::Split { .. }
+            | CliCommand::Sync { .. }
+            | CliCommand::TAddresses
+            | CliCommand::Transactions
+            | CliCommand::Transmit { .. }
+            | CliCommand::ValueToAddress
+            | CliCommand::ValueTransfers
+            | CliCommand::WalletKind => true,
+        }
+    }
 }
 
 /// The whole command line one dispatch parses: a command name and its
@@ -2613,16 +2671,21 @@ struct CommandLine {
     command: CliCommand,
 }
 
-/// The commands `help` lists under "Standalone commands (no wallet
-/// required)": those whose bodies never touch the wallet, plus the
-/// REPL-owned `servers`.
-const STANDALONE_COMMANDS: &[&str] = &[
-    "help",
-    "parse_address",
-    "parse_viewkey",
-    "servers",
-    "version",
-];
+/// The wallet-free commands as values, so the section split in `help`
+/// derives its names from the grammar's own mint.
+fn standalone_commands() -> [CliCommand; 5] {
+    [
+        CliCommand::Help { command: None },
+        CliCommand::ParseAddress {
+            address: String::new(),
+        },
+        CliCommand::ParseViewkey {
+            viewkey: String::new(),
+        },
+        CliCommand::Servers,
+        CliCommand::Version,
+    ]
+}
 
 /// Renders the two-section help listing, or one command's long help,
 /// from [`CommandLine`]'s clap model.
@@ -2631,10 +2694,17 @@ pub fn format_help(command: Option<&str>) -> String {
 
     let mut model = CommandLine::command();
     let Some(command) = command else {
+        let standalone_names: Vec<String> = standalone_commands()
+            .iter()
+            .inspect(|command| debug_assert!(!command.requires_wallet()))
+            .map(CliCommand::name)
+            .collect();
         let listing = |standalone: bool| {
             model
                 .get_subcommands()
-                .filter(|sub| STANDALONE_COMMANDS.contains(&sub.get_name()) == standalone)
+                .filter(|sub| {
+                    standalone_names.iter().any(|name| name == sub.get_name()) == standalone
+                })
                 .map(|sub| {
                     format!(
                         "  {} - {}",

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1,14 +1,4 @@
 //! Command definitions and dispatch for zingo-cli.
-//!
-//! Every command is one variant of [`CliCommand`], the clap derive
-//! grammar: its name is minted from the variant identifier, its help texts
-//! are its `about` and `long_about`, and its arguments parse into typed
-//! payloads before any body runs. A command is parsed once, as early as
-//! the process can parse it, and travels to [`dispatch_parsed`] as a
-//! [`CliCommand`]; the sync world crosses into async at the two audited
-//! seams in the crate root, the command loop and startup (ADR 0030). A
-//! failure leaves a command only as a [`CommandError`], never as error
-//! prose in the result channel (ADR 0031).
 
 mod error;
 #[cfg(test)]
@@ -345,10 +335,8 @@ async fn info(lightclient: &mut LightClient) -> Result<String, CommandError> {
     }
 }
 
-/// The send family's arguments as the `utils::parse_*` grammars take them.
-/// Those grammars are a JSON-or-positional hybrid clap does not own yet, so
-/// the four send-family commands carry their arguments as strings and parse
-/// on their first line (documented compromise, clap arc Milestone 2).
+/// Borrows the send family's arguments for the `utils::parse_*` grammars,
+/// a JSON-or-positional hybrid clap does not own yet.
 fn as_strs(args: &[String]) -> Vec<&str> {
     args.iter().map(String::as_str).collect()
 }
@@ -397,7 +385,7 @@ async fn migration(
 }
 
 /// The `new_address` argument: `o`, `z`, or both, naming the receivers the
-/// new unified address carries. Transparent receivers are `new_taddress`'s.
+/// new unified address carries (transparent receivers are `new_taddress`'s).
 fn parse_receiver_selection(raw: &str) -> Result<ReceiverSelection, String> {
     if raw.is_empty()
         || raw
@@ -577,8 +565,8 @@ async fn rescan(lightclient: &mut LightClient) -> Result<String, CommandError> {
     }
 }
 
-/// A parsed `save` command. Arguments parse completely into this enum,
-/// at the clap derive grammar, before any wallet access.
+/// A parsed `save` command, its arguments parsed completely at the clap
+/// derive grammar before any wallet access.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum SaveSubCommand {
     Run,
@@ -650,9 +638,8 @@ async fn sends_to_address(lightclient: &mut LightClient) -> Result<String, Comma
     }
 }
 
-/// A parsed `settings` command: which setting to write, and its value.
-/// Absent, the command reads the settings out instead. The grammar owns
-/// every value, so a malformed one refuses before the wallet lock is taken.
+/// A parsed `settings` command, naming which setting to write and its
+/// value, or reading the settings out when no setting is named.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 #[command(rename_all = "snake_case")]
 pub(crate) enum SettingsSubCommand {
@@ -665,8 +652,8 @@ pub(crate) enum SettingsSubCommand {
     },
 }
 
-/// The sync performance levels as a clap grammar. [`PerformanceLevel`] is
-/// pepper-sync's, so the CLI mints the value names and converts.
+/// The sync performance levels as a clap grammar, minting CLI value names
+/// for pepper-sync's [`PerformanceLevel`] and converting.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PerformanceLevelArg {
     Low,
@@ -758,8 +745,8 @@ async fn spendable_balance(lightclient: &mut LightClient) -> Result<String, Comm
     .pretty(2))
 }
 
-/// A parsed `sync` command. Arguments parse completely into this enum,
-/// at the clap derive grammar, before any wallet access.
+/// A parsed `sync` command, its arguments parsed completely at the clap
+/// derive grammar before any wallet access.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum SyncSubCommand {
     Run,
@@ -1100,10 +1087,8 @@ pub(crate) fn resolve_proxy_path(explicit: Option<&str>) -> String {
     zingolib::nym::provision::resolve_proxy_path(&spawn_hints(explicit))
 }
 
-/// Typed failure of the `nym` command family. Each variant exists only in
-/// the build that can produce it, so the enum's shape follows the feature.
-/// The parse failures that once lived here are clap's now: arguments
-/// refuse at the derive grammar, before any wallet access.
+/// Typed failure of the `nym` command family, each variant existing only
+/// in the build that can produce it.
 #[derive(Debug, thiserror::Error)]
 pub enum NymCommandError {
     #[cfg(not(feature = "nym"))]
@@ -1117,8 +1102,8 @@ pub enum NymCommandError {
     },
 }
 
-/// A parsed `nym` command. Arguments parse completely into this enum,
-/// at the clap derive grammar, before any wallet access.
+/// A parsed `nym` command, its arguments parsed completely at the clap
+/// derive grammar before any wallet access.
 #[cfg(feature = "nym")]
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum NymSubCommand {
@@ -1416,11 +1401,8 @@ fn render_migration_phase(phase: &MigrationPhase) -> String {
     }
 }
 
-/// Typed failure of the migration command family, following the audit Issue-Q
-/// pattern PR #2464 established: the discriminant lives in the type, and
-/// prose is produced at exactly one rendering site per command. The parse
-/// failures that once lived here are clap's now: arguments refuse at the
-/// derive grammar, before any wallet access.
+/// Typed failure of the migration command family: the discriminant lives in
+/// the type, and prose is produced at exactly one rendering site per command.
 #[derive(Debug, thiserror::Error)]
 pub enum MigrationCommandError {
     #[error("sync failed: {0}")]
@@ -1429,8 +1411,8 @@ pub enum MigrationCommandError {
     Client(#[from] zingolib::lightclient::error::LightClientError),
 }
 
-/// A parsed migration command. Arguments parse completely into this
-/// enum, at the clap derive grammar, before any wallet access.
+/// A parsed migration command, its arguments parsed completely at the clap
+/// derive grammar before any wallet access.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum MigrationSubCommand {
     Plan,
@@ -1860,10 +1842,7 @@ const NYM_LONG_ABOUT: &str = indoc! {r"
 "};
 
 /// Every command the CLI dispatches, in alphabetical order: the single
-/// source of the dispatchable names, help texts, and typed arguments
-/// (ADR 0030). Each name is minted from its variant identifier, and `help`
-/// renders its listing from this grammar's clap model, so declaration
-/// order is display order.
+/// source of the dispatchable names, help texts, and typed arguments.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq)]
 #[command(rename_all = "snake_case")]
 pub(crate) enum CliCommand {
@@ -2619,7 +2598,7 @@ struct CommandLine {
 
 /// The commands `help` lists under "Standalone commands (no wallet
 /// required)": those whose bodies never touch the wallet, plus the
-/// REPL-owned `servers`. Every other command is a wallet command.
+/// REPL-owned `servers`.
 const STANDALONE_COMMANDS: &[&str] = &[
     "help",
     "parse_address",
@@ -2662,8 +2641,7 @@ pub fn format_help(command: Option<&str>) -> String {
 }
 
 /// Parses one command line into a [`CliCommand`], rendering a refusal as
-/// clap prints it. The REPL parses each line here, so a malformed line
-/// never reaches the command loop.
+/// clap prints it, so a malformed REPL line never reaches the command loop.
 pub(crate) fn parse_command_tokens(tokens: &[String]) -> Result<CliCommand, String> {
     use clap::Parser as _;
 
@@ -2674,8 +2652,7 @@ pub(crate) fn parse_command_tokens(tokens: &[String]) -> Result<CliCommand, Stri
 
 /// Dispatches an already-parsed command against the wallet: the exhaustive
 /// match every frontend reaches, whether it parsed its command at the REPL,
-/// at the process's own argument parse, or from a string. The REPL-owned
-/// `servers` command returns a typed error (ADR 0031).
+/// at the process's own argument parse, or from a string.
 pub(crate) async fn dispatch_parsed(
     command: CliCommand,
     lightclient: &mut LightClient,
@@ -2739,12 +2716,8 @@ pub(crate) async fn dispatch_parsed(
 }
 
 /// Dispatches a user command given as a name and string arguments: the
-/// string frontend over [`parse_command_tokens`] and [`dispatch_parsed`].
-/// A name the grammar does not know refuses here, before any wallet
-/// access, as a typed error (ADR 0031). No in-process caller remains, now
-/// that every channel carries a parsed command; this surface serves a
-/// frontend that holds only strings, and the offline-contract tests drive
-/// it.
+/// string frontend over [`parse_command_tokens`] and [`dispatch_parsed`],
+/// kept for callers that hold only strings.
 #[allow(dead_code)]
 pub async fn do_user_command_result(
     cmd: &str,

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -577,8 +577,11 @@ async fn rescan(lightclient: &mut LightClient) -> Result<String, CommandError> {
 /// derive grammar before any wallet access.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum SaveSubCommand {
+    #[command(about = "Launch the task that persists the wallet as its state changes")]
     Run,
+    #[command(about = "Check the save task for a recorded failure, restarting it on one")]
     Check,
+    #[command(about = "Shut the save task down")]
     Shutdown,
 }
 
@@ -657,11 +660,14 @@ async fn sends_to_address(lightclient: &mut LightClient) -> Result<String, Comma
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 #[command(rename_all = "snake_case")]
 pub(crate) enum SettingsSubCommand {
+    #[command(about = "Set the sync performance level")]
     Performance {
         #[arg(value_enum)]
         level: PerformanceLevelArg,
     },
+    #[command(about = "Set how many confirmations a note needs to be spendable")]
     MinConfirmations {
+        #[arg(value_name = "count")]
         count: NonZeroU32,
     },
 }
@@ -763,10 +769,15 @@ async fn spendable_balance(lightclient: &mut LightClient) -> Result<String, Comm
 /// derive grammar before any wallet access.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum SyncSubCommand {
+    #[command(about = "Start the sync task, or resume it when paused")]
     Run,
+    #[command(about = "Pause the sync task's scanning")]
     Pause,
+    #[command(about = "Shut the sync task down early")]
     Stop,
+    #[command(about = "Report sync progress")]
     Status,
+    #[command(about = "Report the finished sync's result. Not meant to be called by hand")]
     Poll,
 }
 
@@ -1116,15 +1127,21 @@ pub enum NymCommandError {
 /// derive grammar before any wallet access.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum NymSubCommand {
+    #[command(about = "Report the mixnet state: off, bootstrapping, or ready")]
     Status,
+    #[command(about = "Start the nym-proxy child and route transmissions through the mixnet")]
     On {
+        #[arg(value_name = "proxy_path")]
         path: Option<String>,
     },
+    #[command(about = "Stop the proxy and revert transmissions to clearnet")]
     Off,
+    #[command(about = "Compare GetLightdInfo over the clearnet and mixnet routes")]
     Probe {
-        #[arg(value_parser = parse_probe_target)]
+        #[arg(value_name = "indexer_uri", value_parser = parse_probe_target)]
         target: Option<http::Uri>,
     },
+    #[command(about = "Show per-indexer attempts across sessions")]
     History,
 }
 
@@ -1424,29 +1441,41 @@ pub enum MigrationCommandError {
 /// derive grammar before any wallet access.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum MigrationSubCommand {
+    #[command(about = "Compute the plan and print its hash, sending nothing")]
     Plan,
+    #[command(about = "Record consent to the plan with that hash and begin")]
     Start {
-        #[arg(value_parser = parse_plan_hash)]
+        #[arg(value_name = "plan_hash_hex", value_parser = parse_plan_hash)]
         plan_hash: [u8; 32],
-        #[arg(long)]
+        #[arg(long, value_name = "parts")]
         per_bucket: Option<u32>,
     },
+    #[command(about = "Sync, then drive one splitting step")]
     Continue,
+    #[command(about = "Reset parts-per-window and redraw the schedule")]
     Cadence {
+        #[arg(value_name = "parts")]
         per_bucket: u32,
     },
+    #[command(about = "Sync, then send every part owed right now in one spaced batch")]
     Execute {
         #[arg(value_name = "spacing_seconds", default_value = "30", value_parser = parse_spacing)]
         spacing: std::time::Duration,
     },
+    #[command(about = "Sync, then broadcast whatever the current window has due")]
     Auto,
+    #[command(about = "Report the balance, phase, part counts, and coming windows")]
     Status,
+    #[command(about = "List each window's block range, position, and confirmations")]
     Windows,
+    #[command(about = "Check the schedule against the chain and apply what is safe")]
     Reconcile,
+    #[command(about = "Send overdue parts now, spaced by the given seconds")]
     Catchup {
         #[arg(value_name = "spacing_seconds", default_value = "30", value_parser = parse_spacing)]
         spacing: std::time::Duration,
     },
+    #[command(about = "Abandon the migration, keeping its confirmed parts")]
     Cancel,
 }
 
@@ -1695,14 +1724,18 @@ async fn run_migration(
 /// A parsed `drain` sub-command, at the clap derive grammar.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum DrainSubCommand {
+    #[command(about = "Preview the drain from current wallet state, sending nothing")]
     Plan,
+    #[command(about = "Build, sign, and broadcast the drain")]
     Now,
 }
 
 /// A parsed `split` sub-command, at the clap derive grammar.
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum SplitSubCommand {
+    #[command(about = "Preview the remaining rounds, sending nothing")]
     Plan,
+    #[command(about = "Run one splitting round")]
     Now,
 }
 
@@ -1830,7 +1863,7 @@ async fn run_split(
 
 /// Every command the CLI dispatches, in alphabetical order: the single
 /// source of the dispatchable names, help texts, and typed arguments.
-#[derive(clap::Subcommand, Clone, Debug, PartialEq)]
+#[derive(clap::Subcommand, Clone, PartialEq)]
 #[command(rename_all = "snake_case")]
 pub(crate) enum CliCommand {
     #[command(
@@ -2449,11 +2482,68 @@ pub(crate) enum CliCommand {
 }
 
 impl CliCommand {
+    /// The variant's bare identifier, the single source `Debug` and `name`
+    /// render, so neither can materialize an argument.
+    fn ident(&self) -> &'static str {
+        match self {
+            CliCommand::Addresses => "Addresses",
+            CliCommand::Balance => "Balance",
+            CliCommand::Birthday => "Birthday",
+            CliCommand::Calculate => "Calculate",
+            CliCommand::ChangeServer { .. } => "ChangeServer",
+            CliCommand::CheckAddress { .. } => "CheckAddress",
+            CliCommand::Clear => "Clear",
+            CliCommand::Coins { .. } => "Coins",
+            CliCommand::Confirm => "Confirm",
+            CliCommand::CurrentPrice => "CurrentPrice",
+            CliCommand::Delete => "Delete",
+            CliCommand::Drain { .. } => "Drain",
+            CliCommand::ExportUfvk => "ExportUfvk",
+            CliCommand::Height => "Height",
+            CliCommand::Help { .. } => "Help",
+            CliCommand::Info => "Info",
+            CliCommand::MaxSendValue { .. } => "MaxSendValue",
+            CliCommand::MemobytesToAddress => "MemobytesToAddress",
+            CliCommand::Messages { .. } => "Messages",
+            CliCommand::Migrate => "Migrate",
+            CliCommand::Migration { .. } => "Migration",
+            CliCommand::NewAddress { .. } => "NewAddress",
+            CliCommand::NewTaddress => "NewTaddress",
+            CliCommand::NewTaddressAllowGap => "NewTaddressAllowGap",
+            CliCommand::Notes { .. } => "Notes",
+            CliCommand::Nym { .. } => "Nym",
+            CliCommand::ParseAddress { .. } => "ParseAddress",
+            CliCommand::ParseViewkey { .. } => "ParseViewkey",
+            CliCommand::Quicksend { .. } => "Quicksend",
+            CliCommand::Quickshield => "Quickshield",
+            CliCommand::Quit => "Quit",
+            CliCommand::RecoveryInfo => "RecoveryInfo",
+            CliCommand::RemoveTransaction { .. } => "RemoveTransaction",
+            CliCommand::Rescan => "Rescan",
+            CliCommand::Save { .. } => "Save",
+            CliCommand::Send { .. } => "Send",
+            CliCommand::SendAll { .. } => "SendAll",
+            CliCommand::SendsToAddress => "SendsToAddress",
+            CliCommand::Servers => "Servers",
+            CliCommand::Settings { .. } => "Settings",
+            CliCommand::Shield => "Shield",
+            CliCommand::SpendableBalance => "SpendableBalance",
+            CliCommand::Split { .. } => "Split",
+            CliCommand::Sync { .. } => "Sync",
+            CliCommand::TAddresses => "TAddresses",
+            CliCommand::Transactions => "Transactions",
+            CliCommand::Transmit { .. } => "Transmit",
+            CliCommand::ValueToAddress => "ValueToAddress",
+            CliCommand::ValueTransfers => "ValueTransfers",
+            CliCommand::Version => "Version",
+            CliCommand::WalletKind => "WalletKind",
+        }
+    }
+
     /// The command's minted name, derived from the variant identifier, so
     /// a log line can carry the name and never the arguments.
     pub(crate) fn name(&self) -> String {
-        let debug = format!("{self:?}");
-        let ident = debug.split([' ', '{', '(']).next().unwrap_or_default();
+        let ident = self.ident();
         let mut name = String::with_capacity(ident.len() + 2);
         for c in ident.chars() {
             if c.is_ascii_uppercase() {
@@ -2543,15 +2633,39 @@ impl CliCommand {
     }
 }
 
+/// Renders only the variant identifier, so memos and key material among
+/// the arguments never reach a `Debug` surface.
+impl std::fmt::Debug for CliCommand {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.ident())
+    }
+}
+
 /// The whole command line one dispatch parses: a command name and its
 /// arguments, with no binary name in front, so the REPL and the one-shot
 /// entry share this grammar.
 #[derive(clap::Parser, Debug)]
-#[command(no_binary_name = true, disable_help_subcommand = true)]
+#[command(
+    name = "",
+    no_binary_name = true,
+    disable_help_subcommand = true,
+    about = "Enter one command per line. `help` lists the commands.",
+    override_usage = "<COMMAND> [ARGS]"
+)]
 struct CommandLine {
     #[command(subcommand)]
     command: CliCommand,
 }
+
+/// [`CommandLine`]'s clap model, built once and cloned per use, so a REPL
+/// line never pays the grammar's construction again.
+static COMMAND_MODEL: std::sync::LazyLock<clap::Command> = std::sync::LazyLock::new(|| {
+    use clap::CommandFactory as _;
+
+    let mut model = CommandLine::command();
+    model.build();
+    model
+});
 
 /// The wallet-free commands as values, so the section split in `help`
 /// derives its names from the grammar's own mint.
@@ -2572,9 +2686,7 @@ fn standalone_commands() -> [CliCommand; 5] {
 /// Renders the two-section help listing, or one command's long help,
 /// from [`CommandLine`]'s clap model.
 pub fn format_help(command: Option<&str>) -> String {
-    use clap::CommandFactory as _;
-
-    let mut model = CommandLine::command();
+    let mut model = COMMAND_MODEL.clone();
     let Some(command) = command else {
         let standalone_names: Vec<String> = standalone_commands()
             .iter()
@@ -2612,9 +2724,12 @@ pub fn format_help(command: Option<&str>) -> String {
 /// Parses one command line into a [`CliCommand`], rendering a refusal as
 /// clap prints it, so a malformed REPL line never reaches the command loop.
 pub(crate) fn parse_command_tokens(tokens: &[String]) -> Result<CliCommand, String> {
-    use clap::Parser as _;
+    use clap::FromArgMatches as _;
 
-    CommandLine::try_parse_from(tokens)
+    COMMAND_MODEL
+        .clone()
+        .try_get_matches_from(tokens)
+        .and_then(|matches| CommandLine::from_arg_matches(&matches))
         .map(|CommandLine { command }| command)
         .map_err(|error| error.to_string())
         .and_then(|command| command.validate_deferred_grammar().map(|()| command))

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -98,7 +98,7 @@ pub enum CommandError {
     #[error(transparent)]
     Nym(#[from] NymCommandError),
     #[error("the `{0}` command runs only at the interactive prompt")]
-    ReplOnly(&'static str),
+    ReplOnly(String),
     /// Transitional quarantine for commands whose failure prose is not
     /// yet typed: the message is stored WITHOUT the "Error: " prefix
     /// (the renderer adds it). Every construction site is a candidate
@@ -342,11 +342,12 @@ fn as_strs(args: &[String]) -> Vec<&str> {
 }
 
 async fn max_send_value(
+    name: &str,
     args: &[String],
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
     let (address, zennies_for_zingo) =
-        utils::parse_max_send_value_args(&as_strs(args)).map_err(|e| usage("max_send_value", e))?;
+        utils::parse_max_send_value_args(&as_strs(args)).map_err(|e| usage(name, e))?;
     match lightclient
         .max_send_value(address, zennies_for_zingo, zip32::AccountId::ZERO)
         .await
@@ -484,12 +485,16 @@ async fn coins(
     .pretty(2))
 }
 
-async fn quicksend(args: &[String], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let receivers = utils::parse_send_args(&as_strs(args)).map_err(|e| usage("quicksend", e))?;
+async fn quicksend(
+    name: &str,
+    args: &[String],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let receivers = utils::parse_send_args(&as_strs(args)).map_err(|e| usage(name, e))?;
     let request = zingolib::data::receivers::transaction_request_from_receivers(receivers)
-        .map_err(|e| usage("quicksend", e))?;
+        .map_err(|e| usage(name, e))?;
     match transmit_narrated(
-        "quicksend",
+        name,
         lightclient.transmit_progress_handle(),
         lightclient.quick_send_reported(request, zip32::AccountId::ZERO, true),
     )
@@ -593,10 +598,14 @@ async fn save(sub: SaveSubCommand, lightclient: &mut LightClient) -> Result<Stri
     }
 }
 
-async fn send(args: &[String], lightclient: &mut LightClient) -> Result<String, CommandError> {
-    let receivers = utils::parse_send_args(&as_strs(args)).map_err(|e| usage("send", e))?;
+async fn send(
+    name: &str,
+    args: &[String],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
+    let receivers = utils::parse_send_args(&as_strs(args)).map_err(|e| usage(name, e))?;
     let request = zingolib::data::receivers::transaction_request_from_receivers(receivers)
-        .map_err(|e| usage("send", e))?;
+        .map_err(|e| usage(name, e))?;
     match lightclient
         .propose_send(request, zip32::AccountId::ZERO)
         .await
@@ -609,9 +618,13 @@ async fn send(args: &[String], lightclient: &mut LightClient) -> Result<String, 
     }
 }
 
-async fn send_all(args: &[String], lightclient: &mut LightClient) -> Result<String, CommandError> {
+async fn send_all(
+    name: &str,
+    args: &[String],
+    lightclient: &mut LightClient,
+) -> Result<String, CommandError> {
     let (address, zennies_for_zingo, memo) =
-        utils::parse_send_all_args(&as_strs(args)).map_err(|e| usage("sendall", e))?;
+        utils::parse_send_all_args(&as_strs(args)).map_err(|e| usage(name, e))?;
     match lightclient
         .propose_send_all(address, zennies_for_zingo, memo, zip32::AccountId::ZERO)
         .await
@@ -2661,6 +2674,7 @@ pub(crate) async fn dispatch_parsed(
     command: CliCommand,
     lightclient: &mut LightClient,
 ) -> Result<String, CommandError> {
+    let name = command.name();
     match command {
         CliCommand::Addresses => addresses(lightclient).await,
         CliCommand::Balance => balance(lightclient).await,
@@ -2678,7 +2692,7 @@ pub(crate) async fn dispatch_parsed(
         CliCommand::Height => height(lightclient).await,
         CliCommand::Help { command: named } => help(named.as_deref()),
         CliCommand::Info => info(lightclient).await,
-        CliCommand::MaxSendValue { args } => max_send_value(&args, lightclient).await,
+        CliCommand::MaxSendValue { args } => max_send_value(&name, &args, lightclient).await,
         CliCommand::MemobytesToAddress => memobytes_to_address(lightclient).await,
         CliCommand::Messages { filter } => messages(filter.as_deref(), lightclient).await,
         CliCommand::Migrate => migrate(lightclient).await,
@@ -2693,17 +2707,17 @@ pub(crate) async fn dispatch_parsed(
         CliCommand::Nym { .. } => nym(lightclient).await,
         CliCommand::ParseAddress { address } => parse_address(&address),
         CliCommand::ParseViewkey { viewkey } => parse_viewkey(&viewkey),
-        CliCommand::Quicksend { args } => quicksend(&args, lightclient).await,
+        CliCommand::Quicksend { args } => quicksend(&name, &args, lightclient).await,
         CliCommand::Quickshield => quickshield(lightclient).await,
         CliCommand::Quit => quit(lightclient).await,
         CliCommand::RecoveryInfo => recovery_info(lightclient).await,
         CliCommand::RemoveTransaction { txid } => remove_transaction(txid, lightclient).await,
         CliCommand::Rescan => rescan(lightclient).await,
         CliCommand::Save { sub } => save(sub, lightclient).await,
-        CliCommand::Send { args } => send(&args, lightclient).await,
-        CliCommand::SendAll { args } => send_all(&args, lightclient).await,
+        CliCommand::Send { args } => send(&name, &args, lightclient).await,
+        CliCommand::SendAll { args } => send_all(&name, &args, lightclient).await,
         CliCommand::SendsToAddress => sends_to_address(lightclient).await,
-        CliCommand::Servers => Err(CommandError::ReplOnly("servers")),
+        CliCommand::Servers => Err(CommandError::ReplOnly(name)),
         CliCommand::Settings { sub } => settings(sub, lightclient).await,
         CliCommand::Shield => shield(lightclient).await,
         CliCommand::SpendableBalance => spendable_balance(lightclient).await,

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -5,91 +5,8 @@ mod table_invariants {
     //! order, and no two variants mint the same name.
 
     use clap::CommandFactory as _;
-    use zcash_protocol::TxId;
 
-    use super::super::{
-        CliCommand, CommandLine, DrainSubCommand, MigrationSubCommand, SaveSubCommand,
-        SplitSubCommand, SyncSubCommand, format_help, parse_receiver_selection,
-        standalone_commands,
-    };
-
-    /// One sample per variant, held complete by the set-equality test below,
-    /// so the totality tests cover the whole grammar.
-    fn every_command() -> Vec<CliCommand> {
-        vec![
-            CliCommand::Addresses,
-            CliCommand::Balance,
-            CliCommand::Birthday,
-            CliCommand::Calculate,
-            CliCommand::ChangeServer { uri: None },
-            CliCommand::CheckAddress {
-                address: String::new(),
-            },
-            CliCommand::Clear,
-            CliCommand::Coins { scope: None },
-            CliCommand::Confirm,
-            CliCommand::CurrentPrice,
-            CliCommand::Delete,
-            CliCommand::Drain {
-                sub: DrainSubCommand::Plan,
-            },
-            CliCommand::ExportUfvk,
-            CliCommand::Height,
-            CliCommand::Help { command: None },
-            CliCommand::Info,
-            CliCommand::MaxSendValue { args: Vec::new() },
-            CliCommand::MemobytesToAddress,
-            CliCommand::Messages { filter: None },
-            CliCommand::Migrate,
-            CliCommand::Migration {
-                sub: MigrationSubCommand::Plan,
-            },
-            CliCommand::NewAddress {
-                receivers: parse_receiver_selection("o").expect("a valid receiver selection"),
-            },
-            CliCommand::NewTaddress,
-            CliCommand::NewTaddressAllowGap,
-            CliCommand::Notes { scope: None },
-            CliCommand::Nym { sub: None },
-            CliCommand::ParseAddress {
-                address: String::new(),
-            },
-            CliCommand::ParseViewkey {
-                viewkey: String::new(),
-            },
-            CliCommand::Quicksend { args: Vec::new() },
-            CliCommand::Quickshield,
-            CliCommand::Quit,
-            CliCommand::RecoveryInfo,
-            CliCommand::RemoveTransaction {
-                txid: TxId::from_bytes([0; 32]),
-            },
-            CliCommand::Rescan,
-            CliCommand::Save {
-                sub: SaveSubCommand::Run,
-            },
-            CliCommand::Send { args: Vec::new() },
-            CliCommand::SendAll { args: Vec::new() },
-            CliCommand::SendsToAddress,
-            CliCommand::Servers,
-            CliCommand::Settings { sub: None },
-            CliCommand::Shield,
-            CliCommand::SpendableBalance,
-            CliCommand::Split {
-                sub: SplitSubCommand::Plan,
-            },
-            CliCommand::Sync {
-                sub: SyncSubCommand::Status,
-            },
-            CliCommand::TAddresses,
-            CliCommand::Transactions,
-            CliCommand::Transmit { txids: Vec::new() },
-            CliCommand::ValueToAddress,
-            CliCommand::ValueTransfers,
-            CliCommand::Version,
-            CliCommand::WalletKind,
-        ]
-    }
+    use super::super::{CliCommand, CommandLine, every_command, format_help};
 
     /// HYPOTHESIS: the derived names of one-sample-per-variant equal the
     /// clap model's subcommand names exactly, so `name` can never diverge
@@ -178,22 +95,6 @@ mod table_invariants {
             assert!(
                 model.find_subcommand(expected).is_some(),
                 "`{expected}` must be a minted name"
-            );
-        }
-    }
-
-    /// HYPOTHESIS: every standalone sample is wallet-free by
-    /// `requires_wallet` and its derived name is minted, so `help` cannot
-    /// misfile or misname a section entry.
-    #[test]
-    fn the_standalone_set_is_wallet_free_and_minted() {
-        let model = CommandLine::command();
-        for command in standalone_commands() {
-            assert!(!command.requires_wallet());
-            assert!(
-                model.find_subcommand(command.name()).is_some(),
-                "`{}` must be a minted name",
-                command.name()
             );
         }
     }
@@ -1540,10 +1441,33 @@ mod finding_pins {
     use zingolib::lightclient::LightClient;
     use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
 
-    use super::super::{CliCommand, RT, format_help, parse_command_tokens};
+    use super::super::{CliCommand, RT, format_help, parse_command_tokens, wallet_free_commands};
 
     fn tokens(words: &[&str]) -> Vec<String> {
         words.iter().map(|word| String::from(*word)).collect()
+    }
+
+    /// HYPOTHESIS: the standalone help section derives from
+    /// `requires_wallet` alone: its rendered entries are exactly the
+    /// derived wallet-free names, so no second statement of the set
+    /// exists to drift.
+    #[test]
+    fn the_standalone_section_derives_from_requires_wallet() {
+        let listing = format_help(None);
+        let wallet_header = listing
+            .find("Wallet commands:")
+            .expect("the listing carries a wallet section");
+        let rendered: Vec<String> = listing[..wallet_header]
+            .lines()
+            .filter_map(|line| line.strip_prefix("  "))
+            .filter_map(|entry| entry.split(" - ").next())
+            .map(String::from)
+            .collect();
+        let derived: Vec<String> = wallet_free_commands()
+            .iter()
+            .map(CliCommand::name)
+            .collect();
+        assert_eq!(rendered, derived);
     }
 
     const FAMILIES: [&str; 7] = [

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -6,7 +6,7 @@ mod table_invariants {
 
     use clap::CommandFactory as _;
 
-    use super::super::{CliCommand, CommandLine};
+    use super::super::{CliCommand, CommandLine, standalone_commands};
 
     /// HYPOTHESIS: `name` derives exactly the minted subcommand name, so a
     /// log line names the command without carrying its arguments.
@@ -27,6 +27,22 @@ mod table_invariants {
             assert!(
                 model.find_subcommand(expected).is_some(),
                 "`{expected}` must be a minted name"
+            );
+        }
+    }
+
+    /// HYPOTHESIS: every standalone sample is wallet-free by
+    /// `requires_wallet` and its derived name is minted, so `help` cannot
+    /// misfile or misname a section entry.
+    #[test]
+    fn the_standalone_set_is_wallet_free_and_minted() {
+        let model = CommandLine::command();
+        for command in standalone_commands() {
+            assert!(!command.requires_wallet());
+            assert!(
+                model.find_subcommand(command.name()).is_some(),
+                "`{}` must be a minted name",
+                command.name()
             );
         }
     }

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -596,15 +596,17 @@ mod typed_argument_parsing {
         assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
     }
 
-    /// HYPOTHESIS: a memo filter may begin with a dash.
+    /// HYPOTHESIS: a memo filter beginning with a dash rides the standard
+    /// `--` escape, while a bare flag-shaped token refuses.
     #[test]
-    fn a_dash_leading_messages_filter_parses() {
+    fn a_dash_leading_messages_filter_rides_the_escape() {
         assert_eq!(
-            parse(&["messages", "-1ZEC"]).expect("a dash-leading filter parses"),
+            parse(&["messages", "--", "-1ZEC"]).expect("an escaped dash-leading filter parses"),
             CliCommand::Messages {
                 filter: Some("-1ZEC".to_string()),
             }
         );
+        assert!(parse(&["messages", "-1ZEC"]).is_err());
     }
 
     /// HYPOTHESIS: every advertised `nym` subcommand parses in every build,
@@ -1489,9 +1491,10 @@ mod pure_helpers {
 }
 
 #[cfg(test)]
-mod open_finding_reds {
-    //! Red by design: each test asserts a contract the CHANGELOG documents
-    //! and fails until its open review finding is fixed.
+mod finding_pins {
+    //! Pins the contracts the review findings demanded, kept green by the
+    //! fixes that closed them.
+    #![allow(clippy::disallowed_methods)]
 
     use zingolib::lightclient::LightClient;
     use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -6,7 +6,30 @@ mod table_invariants {
 
     use clap::CommandFactory as _;
 
-    use super::super::CommandLine;
+    use super::super::{CliCommand, CommandLine};
+
+    /// HYPOTHESIS: `name` derives exactly the minted subcommand name, so a
+    /// log line names the command without carrying its arguments.
+    #[test]
+    fn name_matches_the_mint_and_drops_the_arguments() {
+        let model = CommandLine::command();
+        for (command, expected) in [
+            (CliCommand::Quit, "quit"),
+            (
+                CliCommand::SendAll {
+                    args: vec!["a-secret-memo".to_string()],
+                },
+                "send_all",
+            ),
+            (CliCommand::NewTaddressAllowGap, "new_taddress_allow_gap"),
+        ] {
+            assert_eq!(command.name(), expected);
+            assert!(
+                model.find_subcommand(expected).is_some(),
+                "`{expected}` must be a minted name"
+            );
+        }
+    }
 
     /// HYPOTHESIS: the grammar's minted names are strictly increasing —
     /// sorted, so the help listing stays alphabetical, and therefore
@@ -422,6 +445,57 @@ mod typed_argument_parsing {
     fn an_unknown_command_refuses_at_the_parse() {
         assert!(parse(&["bogus"]).is_err());
         assert!(parse(&[]).is_err());
+    }
+
+    /// HYPOTHESIS: a flag-shaped token after send-family arguments refuses
+    /// at the parse instead of becoming the transaction's memo.
+    #[test]
+    fn a_flag_after_send_arguments_refuses_at_the_parse() {
+        for family in ["send", "send_all", "quicksend", "max_send_value"] {
+            assert!(
+                parse(&[family, "zs1exampleaddress", "50000", "--nosync"]).is_err(),
+                "`{family}` must refuse a flag-shaped trailing token"
+            );
+        }
+    }
+
+    /// HYPOTHESIS: the standard `--` escape carries a dash-leading memo
+    /// into the send arguments.
+    #[test]
+    fn the_escape_carries_a_dash_leading_memo() {
+        assert_eq!(
+            parse(&["send", "zs1exampleaddress", "50000", "--", "-memo"])
+                .expect("an escaped dash-leading memo parses"),
+            CliCommand::Send {
+                args: ["zs1exampleaddress", "50000", "-memo"]
+                    .map(String::from)
+                    .to_vec(),
+            }
+        );
+    }
+
+    /// HYPOTHESIS: a memo filter may begin with a dash.
+    #[test]
+    fn a_dash_leading_messages_filter_parses() {
+        assert_eq!(
+            parse(&["messages", "-1ZEC"]).expect("a dash-leading filter parses"),
+            CliCommand::Messages {
+                filter: Some("-1ZEC".to_string()),
+            }
+        );
+    }
+
+    /// HYPOTHESIS: every advertised `nym` subcommand parses in every build,
+    /// so a build without the feature refuses with the typed error instead
+    /// of a usage error.
+    #[test]
+    fn nym_subcommands_parse_in_every_build() {
+        assert_eq!(
+            parse(&["nym", "status"]).expect("nym status parses"),
+            CliCommand::Nym {
+                sub: Some(NymSubCommand::Status),
+            }
+        );
     }
 }
 

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -819,7 +819,7 @@ mod offline_contract {
     use zingolib::lightclient::LightClient;
     use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
 
-    use super::super::{CommandError, RT, do_user_command_result};
+    use super::super::{CommandError, RT, dispatch_parsed, parse_command_tokens};
 
     /// The Display of `LightClientError::Offline`: the single refusal every
     /// connectivity-requiring command must surface, and the string no
@@ -851,7 +851,12 @@ mod offline_contract {
         command: &str,
         args: &[&str],
     ) -> Result<String, CommandError> {
-        RT.block_on(do_user_command_result(command, args, client))
+        let tokens: Vec<String> = std::iter::once(command)
+            .chain(args.iter().copied())
+            .map(String::from)
+            .collect();
+        let parsed = parse_command_tokens(&tokens).map_err(CommandError::NotYetTyped)?;
+        RT.block_on(dispatch_parsed(parsed, client))
     }
 
     /// Asserts `command` succeeds offline and returns its output.

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -1275,3 +1275,70 @@ mod offline_contract {
         }
     }
 }
+
+#[cfg(test)]
+mod pure_helpers {
+    //! Runtime-free checks of the pure rendering vocabulary: every function
+    //! here takes already-fetched values and returns its whole result.
+
+    use zingolib::wallet::keys::WalletAddressRef;
+
+    use super::super::{JSON_INDENT, address_check_json, not_yet_typed, txids_json};
+
+    /// HYPOTHESIS: the wrapper stores the rendering verbatim, without an
+    /// "Error: " prefix, so the edge renderer adds it exactly once.
+    #[test]
+    fn not_yet_typed_renders_the_message_unprefixed() {
+        assert_eq!(
+            not_yet_typed("no such wallet file").to_string(),
+            "no such wallet file"
+        );
+    }
+
+    /// HYPOTHESIS: the ids render as a flat JSON array of their string
+    /// forms, in the order given.
+    #[test]
+    fn txids_json_renders_a_flat_ordered_array() {
+        assert_eq!(
+            txids_json(&["first", "second"]).dump(),
+            r#"["first","second"]"#
+        );
+    }
+
+    /// HYPOTHESIS: an underived address renders as the single
+    /// is_wallet_address=false field, with no address fields to mislead.
+    #[test]
+    fn address_check_json_renders_the_underived_case_bare() {
+        assert_eq!(
+            address_check_json(None).dump(),
+            r#"{"is_wallet_address":"false"}"#
+        );
+    }
+
+    /// HYPOTHESIS: a derived unified address renders its type, index, and
+    /// receiver flags alongside the encoding.
+    #[test]
+    fn address_check_json_renders_a_unified_derivation() {
+        let rendered = address_check_json(Some(WalletAddressRef::Unified {
+            account_id: zip32::AccountId::ZERO,
+            address_index: Some(3),
+            has_orchard: true,
+            has_sapling: false,
+            has_transparent: true,
+            encoded_address: "u1mocked".to_string(),
+        }))
+        .pretty(JSON_INDENT);
+        for expected in [
+            r#""is_wallet_address": "true""#,
+            r#""address_type": "unified""#,
+            r#""address_index": 3"#,
+            r#""account_id": 0"#,
+            r#""has_orchard": true"#,
+            r#""has_sapling": false"#,
+            r#""has_transparent": true"#,
+            r#""encoded_address": "u1mocked""#,
+        ] {
+            assert!(rendered.contains(expected), "{rendered}");
+        }
+    }
+}

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -130,6 +130,35 @@ mod table_invariants {
         }
     }
 
+    /// HYPOTHESIS: every rendered usage line, hand-written or generated,
+    /// invokes its command by the minted name, so an `override_usage`
+    /// cannot drift from a renamed variant.
+    #[test]
+    fn usage_lines_invoke_the_minted_name() {
+        let mut model = CommandLine::command();
+        let names: Vec<String> = model
+            .get_subcommands()
+            .map(|sub| sub.get_name().to_string())
+            .collect();
+        for name in names {
+            let usage = model
+                .find_subcommand_mut(&name)
+                .expect("the name was just minted")
+                .render_usage()
+                .to_string();
+            for line in usage.lines() {
+                let line = line.trim().trim_start_matches("Usage:").trim_start();
+                if line.is_empty() {
+                    continue;
+                }
+                assert!(
+                    line == name || line.starts_with(&format!("{name} ")),
+                    "`{name}`'s usage line drifts from the mint: {line}"
+                );
+            }
+        }
+    }
+
     /// HYPOTHESIS: `name` derives exactly the minted subcommand name, so a
     /// log line names the command without carrying its arguments.
     #[test]
@@ -963,7 +992,9 @@ mod offline_contract {
             .chain(args.iter().copied())
             .map(String::from)
             .collect();
-        let parsed = parse_command_tokens(&tokens).map_err(CommandError::NotYetTyped)?;
+        let parsed = parse_command_tokens(&tokens).unwrap_or_else(|error| {
+            panic!("`{command}` must parse before its offline contract can be judged: {error}")
+        });
         RT.block_on(dispatch_parsed(parsed, client))
     }
 
@@ -990,6 +1021,16 @@ mod offline_contract {
             "`{command}` must not be blocked by Offline mode: {rendered}"
         );
         rendered
+    }
+
+    /// HYPOTHESIS: `assert_unblocked_offline` rejects an invocation that
+    /// never reached dispatch, so a parse error cannot pass as an
+    /// offline-capable command.
+    #[test]
+    #[should_panic(expected = "must parse")]
+    fn a_parse_error_cannot_pass_as_unblocked() {
+        let mut client = offline_client();
+        assert_unblocked_offline(&mut client, "balance", &["surplus-argument"]);
     }
 
     /// Asserts `command` refuses offline through its `Err` channel with the
@@ -1499,10 +1540,76 @@ mod finding_pins {
     use zingolib::lightclient::LightClient;
     use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
 
-    use super::super::{RT, parse_command_tokens};
+    use super::super::{CliCommand, RT, format_help, parse_command_tokens};
 
     fn tokens(words: &[&str]) -> Vec<String> {
         words.iter().map(|word| String::from(*word)).collect()
+    }
+
+    const FAMILIES: [&str; 7] = [
+        "save",
+        "settings",
+        "sync",
+        "nym",
+        "migration",
+        "drain",
+        "split",
+    ];
+
+    /// HYPOTHESIS: no family's long help advertises a nested `help` that
+    /// the grammar refuses.
+    #[test]
+    fn family_long_help_never_advertises_nested_help() {
+        for family in FAMILIES {
+            let help = format_help(Some(family));
+            assert!(
+                !help
+                    .lines()
+                    .any(|line| line.split_whitespace().next() == Some("help")),
+                "`{family}` long help advertises a nested help:\n{help}"
+            );
+            assert!(
+                parse_command_tokens(&tokens(&[family, "help"])).is_err(),
+                "`{family} help` must stay refused while unadvertised"
+            );
+        }
+    }
+
+    /// HYPOTHESIS: a REPL refusal speaks in the prompt's terms, never
+    /// naming the binary or its process-oriented usage.
+    #[test]
+    fn repl_refusals_never_name_the_binary() {
+        for line in [
+            &["no_such_command"][..],
+            &["balance", "--bogus"][..],
+            &["save"][..],
+        ] {
+            let error = parse_command_tokens(&tokens(line)).expect_err("must refuse");
+            assert!(!error.contains("zingo-cli"), "{line:?} refused as: {error}");
+        }
+    }
+
+    /// HYPOTHESIS: every family sub-command carries an about line, so
+    /// `help <family>` lists no bare names.
+    #[test]
+    fn family_sub_commands_all_carry_abouts() {
+        for family in FAMILIES {
+            let help = format_help(Some(family));
+            let listing = help
+                .split("Commands:")
+                .nth(1)
+                .unwrap_or_else(|| panic!("`{family}` long help lists its sub-commands"));
+            for entry in listing
+                .lines()
+                .skip(1)
+                .take_while(|line| !line.trim().is_empty())
+            {
+                assert!(
+                    entry.split_whitespace().count() > 1,
+                    "`{family}` lists a bare sub-command: {entry}"
+                );
+            }
+        }
     }
 
     #[allow(dead_code)]
@@ -1530,6 +1637,33 @@ mod finding_pins {
             parse_command_tokens(&tokens(&["messages", "--nosync"])).is_err(),
             "a post-command session flag must be refused, never read as a memo filter"
         );
+    }
+
+    /// HYPOTHESIS: a command's Debug rendering, the string the name
+    /// derivation materializes on the heap, never carries memos or key
+    /// material out of the arguments.
+    #[test]
+    fn debug_rendering_never_materializes_memos_or_keys() {
+        let memo = "SENTINEL-MEMO-must-not-materialize";
+        let key = "SENTINEL-UFVK-must-not-materialize";
+        let send = CliCommand::Send {
+            args: vec![
+                String::from("zs1exampleaddress"),
+                String::from("50000"),
+                String::from(memo),
+            ],
+        };
+        let viewkey = CliCommand::ParseViewkey {
+            viewkey: String::from(key),
+        };
+        for (command, sentinel) in [(send, memo), (viewkey, key)] {
+            let rendered = format!("{command:?}");
+            assert!(
+                !rendered.contains(sentinel),
+                "`{}` renders its secret argument onto the heap: {rendered}",
+                command.name()
+            );
+        }
     }
 
     /// HYPOTHESIS: in a build without the nym feature, a nym invocation

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -30,9 +30,7 @@ mod table_invariants {
 
     /// HYPOTHESIS: wherever a long help offers a Usage section, at least
     /// one of its lines invokes the command by its minted name, so the
-    /// prose cannot silently drift from the grammar's single mint. The
-    /// duplication itself retires when clap generates usage from typed
-    /// arguments (the ratified follow-up arc); until then it is pinned.
+    /// prose cannot silently drift from the grammar's single mint.
     #[test]
     fn usage_lines_invoke_the_minted_name() {
         let model = CommandLine::command();
@@ -141,8 +139,6 @@ mod transmit_heartbeat {
 mod migration_command_parsing {
     //! Pins the clap derive grammar of the `migration` family: typed
     //! outcomes, the spacing defaults, and refusal at the parse boundary.
-    //! The byte-identity pins of the retired hand parser retired with it:
-    //! generated prose replaced the pinned strings (clap arc, ratified).
 
     use clap::Parser as _;
 

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -66,30 +66,6 @@ mod table_invariants {
             );
         }
     }
-
-    /// HYPOTHESIS: wherever a long help offers a Usage section, at least
-    /// one of its lines invokes the command by its minted name, so the
-    /// prose cannot silently drift from the grammar's single mint.
-    #[test]
-    fn usage_lines_invoke_the_minted_name() {
-        let model = CommandLine::command();
-        for sub in model.get_subcommands() {
-            let Some(long_about) = sub.get_long_about().map(ToString::to_string) else {
-                continue;
-            };
-            let Some((_, usage)) = long_about.split_once("Usage:") else {
-                continue;
-            };
-            let name = sub.get_name();
-            assert!(
-                usage
-                    .lines()
-                    .map(str::trim)
-                    .any(|line| line == name || line.starts_with(&format!("{name} "))),
-                "`{name}`'s Usage section never invokes it by its minted name:\n{long_about}"
-            );
-        }
-    }
 }
 
 #[cfg(test)]

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -5,8 +5,130 @@ mod table_invariants {
     //! order, and no two variants mint the same name.
 
     use clap::CommandFactory as _;
+    use zcash_protocol::TxId;
 
-    use super::super::{CliCommand, CommandLine, standalone_commands};
+    use super::super::{
+        CliCommand, CommandLine, DrainSubCommand, MigrationSubCommand, SaveSubCommand,
+        SplitSubCommand, SyncSubCommand, format_help, parse_receiver_selection,
+        standalone_commands,
+    };
+
+    /// One sample per variant, held complete by the set-equality test below,
+    /// so the totality tests cover the whole grammar.
+    fn every_command() -> Vec<CliCommand> {
+        vec![
+            CliCommand::Addresses,
+            CliCommand::Balance,
+            CliCommand::Birthday,
+            CliCommand::Calculate,
+            CliCommand::ChangeServer { uri: None },
+            CliCommand::CheckAddress {
+                address: String::new(),
+            },
+            CliCommand::Clear,
+            CliCommand::Coins { scope: None },
+            CliCommand::Confirm,
+            CliCommand::CurrentPrice,
+            CliCommand::Delete,
+            CliCommand::Drain {
+                sub: DrainSubCommand::Plan,
+            },
+            CliCommand::ExportUfvk,
+            CliCommand::Height,
+            CliCommand::Help { command: None },
+            CliCommand::Info,
+            CliCommand::MaxSendValue { args: Vec::new() },
+            CliCommand::MemobytesToAddress,
+            CliCommand::Messages { filter: None },
+            CliCommand::Migrate,
+            CliCommand::Migration {
+                sub: MigrationSubCommand::Plan,
+            },
+            CliCommand::NewAddress {
+                receivers: parse_receiver_selection("o").expect("a valid receiver selection"),
+            },
+            CliCommand::NewTaddress,
+            CliCommand::NewTaddressAllowGap,
+            CliCommand::Notes { scope: None },
+            CliCommand::Nym { sub: None },
+            CliCommand::ParseAddress {
+                address: String::new(),
+            },
+            CliCommand::ParseViewkey {
+                viewkey: String::new(),
+            },
+            CliCommand::Quicksend { args: Vec::new() },
+            CliCommand::Quickshield,
+            CliCommand::Quit,
+            CliCommand::RecoveryInfo,
+            CliCommand::RemoveTransaction {
+                txid: TxId::from_bytes([0; 32]),
+            },
+            CliCommand::Rescan,
+            CliCommand::Save {
+                sub: SaveSubCommand::Run,
+            },
+            CliCommand::Send { args: Vec::new() },
+            CliCommand::SendAll { args: Vec::new() },
+            CliCommand::SendsToAddress,
+            CliCommand::Servers,
+            CliCommand::Settings { sub: None },
+            CliCommand::Shield,
+            CliCommand::SpendableBalance,
+            CliCommand::Split {
+                sub: SplitSubCommand::Plan,
+            },
+            CliCommand::Sync {
+                sub: SyncSubCommand::Status,
+            },
+            CliCommand::TAddresses,
+            CliCommand::Transactions,
+            CliCommand::Transmit { txids: Vec::new() },
+            CliCommand::ValueToAddress,
+            CliCommand::ValueTransfers,
+            CliCommand::Version,
+            CliCommand::WalletKind,
+        ]
+    }
+
+    /// HYPOTHESIS: the derived names of one-sample-per-variant equal the
+    /// clap model's subcommand names exactly, so `name` can never diverge
+    /// from the mint and the sample list can never go stale.
+    #[test]
+    fn every_variant_names_the_mint() {
+        let model = CommandLine::command();
+        let mut derived: Vec<String> = every_command().iter().map(CliCommand::name).collect();
+        derived.sort();
+        let mut minted: Vec<String> = model
+            .get_subcommands()
+            .map(|sub| sub.get_name().to_string())
+            .collect();
+        minted.sort();
+        assert_eq!(derived, minted);
+    }
+
+    /// HYPOTHESIS: `help` files every command in the section
+    /// `requires_wallet` dictates, proven by the rendered listing itself
+    /// rather than any debug-only assertion.
+    #[test]
+    fn help_sections_agree_with_requires_wallet() {
+        let listing = format_help(None);
+        let wallet_header = listing
+            .find("Wallet commands:")
+            .expect("the listing carries a wallet section");
+        for command in every_command() {
+            let name = command.name();
+            let entry = format!("  {name} - ");
+            let position = listing
+                .find(&entry)
+                .unwrap_or_else(|| panic!("`{name}` must appear in the help listing"));
+            assert_eq!(
+                position > wallet_header,
+                command.requires_wallet(),
+                "`{name}` sits in the wrong help section"
+            );
+        }
+    }
 
     /// HYPOTHESIS: `name` derives exactly the minted subcommand name, so a
     /// log line names the command without carrying its arguments.
@@ -466,6 +588,14 @@ mod typed_argument_parsing {
         );
     }
 
+    /// HYPOTHESIS: `--help` on `messages` renders help, never a filter,
+    /// because defined flags outrank hyphen values.
+    #[test]
+    fn messages_help_outranks_the_hyphen_filter() {
+        let error = parse(&["messages", "--help"]).expect_err("--help renders help");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
     /// HYPOTHESIS: a memo filter may begin with a dash.
     #[test]
     fn a_dash_leading_messages_filter_parses() {
@@ -868,6 +998,21 @@ mod offline_contract {
             error.to_string().contains(OFFLINE_REFUSAL),
             "`{command}` must refuse with the typed Offline error: {error}"
         );
+    }
+
+    /// A build without the nym feature answers a well-formed `nym`
+    /// subcommand with the typed feature-absent refusal, not a usage error.
+    #[cfg(not(feature = "nym"))]
+    #[test]
+    fn nym_refuses_with_the_typed_feature_absent_error() {
+        use super::super::NymCommandError;
+
+        let mut client = offline_client();
+        let error = exec(&mut client, "nym", &["status"]).expect_err("nym status must refuse");
+        assert!(matches!(
+            error,
+            CommandError::Nym(NymCommandError::FeatureAbsent)
+        ));
     }
 
     /// A fresh unified address from the wallet itself, so send-family tests
@@ -1340,5 +1485,64 @@ mod pure_helpers {
         ] {
             assert!(rendered.contains(expected), "{rendered}");
         }
+    }
+}
+
+#[cfg(test)]
+mod open_finding_reds {
+    //! Red by design: each test asserts a contract the CHANGELOG documents
+    //! and fails until its open review finding is fixed.
+
+    use zingolib::lightclient::LightClient;
+    use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
+
+    use super::super::{RT, parse_command_tokens};
+
+    fn tokens(words: &[&str]) -> Vec<String> {
+        words.iter().map(|word| String::from(*word)).collect()
+    }
+
+    #[allow(dead_code)]
+    fn offline_client() -> LightClient {
+        RT.block_on(LightClient::new_for_test(
+            SyntheticWalletBuilder::new(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED).build(),
+        ))
+    }
+
+    /// HYPOTHESIS: a malformed one-shot send fails at the parse, so no
+    /// wallet work can begin on a mistyped amount.
+    #[test]
+    fn a_non_numeric_send_amount_refuses_at_the_parse() {
+        assert!(
+            parse_command_tokens(&tokens(&["send", "zs1exampleaddress", "one-hundred"])).is_err(),
+            "a non-numeric amount must be a parse error, not a body error"
+        );
+    }
+
+    /// HYPOTHESIS: a session flag written after `messages` is a usage
+    /// error, as the CHANGELOG's flag-ordering rule promises.
+    #[test]
+    fn a_session_flag_after_messages_refuses_at_the_parse() {
+        assert!(
+            parse_command_tokens(&tokens(&["messages", "--nosync"])).is_err(),
+            "a post-command session flag must be refused, never read as a memo filter"
+        );
+    }
+
+    /// HYPOTHESIS: in a build without the nym feature, a nym invocation
+    /// with arguments explains the feature is absent instead of grading
+    /// the arguments for a transport that was never compiled.
+    #[cfg(not(feature = "nym"))]
+    #[test]
+    fn nym_arguments_meet_the_absent_feature_not_the_grammar() {
+        use super::super::{CommandError, dispatch_parsed};
+        let rendered = match parse_command_tokens(&tokens(&["nym", "probe", "http://x.com"]))
+            .map_err(CommandError::NotYetTyped)
+            .and_then(|parsed| RT.block_on(dispatch_parsed(parsed, &mut offline_client())))
+        {
+            Ok(output) => output,
+            Err(error) => error.to_string(),
+        };
+        assert!(rendered.contains("no Nym mixnet support"), "{rendered}");
     }
 }

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -128,18 +128,24 @@ mod transmit_heartbeat {
 
 #[cfg(test)]
 mod migration_command_parsing {
-    //! Pins the pure argument parser and the byte-identity of the typed
-    //! errors' rendering with the in-band strings they replaced.
+    //! Pins the clap derive grammar of the `migration` family: typed
+    //! outcomes, the spacing defaults, and refusal at the parse boundary.
+    //! The byte-identity pins of the retired hand parser retired with it:
+    //! generated prose replaced the pinned strings (clap arc, ratified).
+
+    use clap::Parser as _;
 
     use super::super::*;
+
+    fn parse(args: &[&str]) -> Result<MigrationSubCommand, clap::Error> {
+        MigrationCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub)
+    }
 
     #[test]
     fn start_parses_hash_and_per_bucket() {
         let hash_hex = "11".repeat(32);
-        let parsed = parse_migration_args(&["start", &hash_hex, "--per-bucket", "3"])
-            .expect("well-formed arguments parse");
         assert_eq!(
-            parsed,
+            parse(&["start", &hash_hex, "--per-bucket", "3"]).expect("well-formed arguments parse"),
             MigrationSubCommand::Start {
                 plan_hash: [0x11; 32],
                 per_bucket: Some(3),
@@ -148,17 +154,14 @@ mod migration_command_parsing {
     }
 
     #[test]
-    fn malformed_plan_hash_is_typed() {
-        assert!(matches!(
-            parse_migration_args(&["start", "abc"]),
-            Err(MigrationCommandError::MalformedPlanHash)
-        ));
+    fn malformed_plan_hash_is_refused_at_parse() {
+        assert!(parse(&["start", "abc"]).is_err());
     }
 
     #[test]
     fn continue_parses_bare() {
         assert_eq!(
-            parse_migration_args(&["continue"]).expect("bare continue parses"),
+            parse(&["continue"]).expect("bare continue parses"),
             MigrationSubCommand::Continue
         );
     }
@@ -166,7 +169,7 @@ mod migration_command_parsing {
     #[test]
     fn windows_parses_bare() {
         assert_eq!(
-            parse_migration_args(&["windows"]).expect("bare windows parses"),
+            parse(&["windows"]).expect("bare windows parses"),
             MigrationSubCommand::Windows
         );
     }
@@ -174,25 +177,22 @@ mod migration_command_parsing {
     #[test]
     fn cadence_requires_a_count() {
         assert_eq!(
-            parse_migration_args(&["cadence", "4"]).expect("well-formed cadence parses"),
+            parse(&["cadence", "4"]).expect("well-formed cadence parses"),
             MigrationSubCommand::Cadence { per_bucket: 4 }
         );
-        assert!(matches!(
-            parse_migration_args(&["cadence"]),
-            Err(MigrationCommandError::MalformedCadence)
-        ));
+        assert!(parse(&["cadence"]).is_err());
     }
 
     #[test]
     fn execute_defaults_spacing_to_thirty_seconds() {
         assert_eq!(
-            parse_migration_args(&["execute"]).expect("bare execute parses"),
+            parse(&["execute"]).expect("bare execute parses"),
             MigrationSubCommand::Execute {
                 spacing: std::time::Duration::from_secs(30),
             }
         );
         assert_eq!(
-            parse_migration_args(&["execute", "5"]).expect("spaced execute parses"),
+            parse(&["execute", "5"]).expect("spaced execute parses"),
             MigrationSubCommand::Execute {
                 spacing: std::time::Duration::from_secs(5),
             }
@@ -202,7 +202,7 @@ mod migration_command_parsing {
     #[test]
     fn catchup_defaults_spacing_to_thirty_seconds() {
         assert_eq!(
-            parse_migration_args(&["catchup"]).expect("bare catchup parses"),
+            parse(&["catchup"]).expect("bare catchup parses"),
             MigrationSubCommand::Catchup {
                 spacing: std::time::Duration::from_secs(30),
             }
@@ -210,91 +210,77 @@ mod migration_command_parsing {
     }
 
     #[test]
-    fn errors_render_byte_identically_to_the_replaced_strings() {
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::MissingSubCommand),
-            "Error: migration command expects a sub-command. Type \"help migration\" for usage."
-        );
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::MalformedPerBucket),
-            "Error: --per-bucket expects a positive integer."
-        );
+    fn missing_and_unknown_subcommands_are_refused_at_parse() {
+        assert!(parse(&[]).is_err());
+        assert!(parse(&["bogus"]).is_err());
     }
 }
 
 #[cfg(test)]
 mod drain_and_split_command_parsing {
-    //! Pins the pure argument parsers of the mobile-parity migration
-    //! commands: `drain` and `split` accept exactly `plan` or `now`.
+    //! Pins the clap derive grammars of the mobile-parity migration
+    //! commands: `drain` and `split` accept exactly `plan` or `now`,
+    //! refusing everything else at the parse boundary.
+
+    use clap::Parser as _;
 
     use super::super::*;
 
     #[test]
     fn drain_accepts_exactly_plan_or_now() {
+        let parse =
+            |args: &[&str]| DrainCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub);
         assert_eq!(
-            parse_drain_args(&["plan"]).expect("drain plan parses"),
+            parse(&["plan"]).expect("drain plan parses"),
             DrainSubCommand::Plan
         );
         assert_eq!(
-            parse_drain_args(&["now"]).expect("drain now parses"),
+            parse(&["now"]).expect("drain now parses"),
             DrainSubCommand::Now
         );
         for junk in [&[][..], &["bogus"][..], &["now", "extra"][..]] {
-            assert!(matches!(
-                parse_drain_args(junk),
-                Err(MigrationCommandError::DrainUsage)
-            ));
+            assert!(parse(junk).is_err());
         }
     }
 
     #[test]
     fn split_accepts_exactly_plan_or_now() {
+        let parse =
+            |args: &[&str]| SplitCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub);
         assert_eq!(
-            parse_split_args(&["plan"]).expect("split plan parses"),
+            parse(&["plan"]).expect("split plan parses"),
             SplitSubCommand::Plan
         );
         assert_eq!(
-            parse_split_args(&["now"]).expect("split now parses"),
+            parse(&["now"]).expect("split now parses"),
             SplitSubCommand::Now
         );
         for junk in [&[][..], &["bogus"][..], &["plan", "extra"][..]] {
-            assert!(matches!(
-                parse_split_args(junk),
-                Err(MigrationCommandError::SplitUsage)
-            ));
+            assert!(parse(junk).is_err());
         }
-    }
-
-    #[test]
-    fn usage_errors_render_with_help_pointers() {
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::DrainUsage),
-            "Error: drain expects a sub-command: plan | now. Type \"help drain\" for usage."
-        );
-        assert_eq!(
-            format!("Error: {}", MigrationCommandError::SplitUsage),
-            "Error: split expects a sub-command: plan | now. Type \"help split\" for usage."
-        );
     }
 }
 
 #[cfg(test)]
 mod nym_command_parsing {
-    //! Pins the pure argument parser and the byte-identity of the typed
-    //! errors' rendering with the in-band strings they replaced.
+    //! Pins the clap derive grammar of the `nym` family and the pure
+    //! renderers whose strings every frontend shares.
 
     use super::super::*;
 
     #[cfg(feature = "nym")]
+    fn parse(args: &[&str]) -> Result<Option<NymSubCommand>, clap::Error> {
+        use clap::Parser as _;
+        NymCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub)
+    }
+
+    #[cfg(feature = "nym")]
     #[test]
-    fn bare_and_status_both_parse_to_status() {
+    fn bare_parses_to_no_subcommand_and_status_to_status() {
+        assert_eq!(parse(&[]).expect("a bare nym parses"), None);
         assert_eq!(
-            parse_nym_args(&[]).expect("a bare nym parses"),
-            NymSubCommand::Status
-        );
-        assert_eq!(
-            parse_nym_args(&["status"]).expect("nym status parses"),
-            NymSubCommand::Status
+            parse(&["status"]).expect("nym status parses"),
+            Some(NymSubCommand::Status)
         );
     }
 
@@ -302,56 +288,44 @@ mod nym_command_parsing {
     #[test]
     fn on_captures_the_optional_path() {
         assert_eq!(
-            parse_nym_args(&["on"]).expect("bare nym on parses"),
-            NymSubCommand::On { path: None }
+            parse(&["on"]).expect("bare nym on parses"),
+            Some(NymSubCommand::On { path: None })
         );
         assert_eq!(
-            parse_nym_args(&["on", "/opt/nym-proxy"]).expect("nym on with a path parses"),
-            NymSubCommand::On {
+            parse(&["on", "/opt/nym-proxy"]).expect("nym on with a path parses"),
+            Some(NymSubCommand::On {
                 path: Some("/opt/nym-proxy".to_string()),
-            }
+            })
         );
     }
 
     #[cfg(feature = "nym")]
     #[test]
-    fn unknown_subcommand_renders_byte_identically_to_the_replaced_string() {
-        assert_eq!(
-            parse_nym_args(&["bogus"])
-                .expect_err("an unknown subcommand is typed")
-                .to_string(),
-            "unknown nym subcommand 'bogus'. Use: nym status | nym on [path] | nym off | \
-             nym probe [uri] | nym history"
-        );
+    fn unknown_subcommands_are_refused_at_parse() {
+        assert!(parse(&["bogus"]).is_err());
     }
 
     #[cfg(feature = "nym")]
     #[test]
     fn probe_parses_its_optional_target_and_rejects_junk() {
         assert_eq!(
-            parse_nym_args(&["probe"]).expect("bare probe parses"),
-            NymSubCommand::Probe { target: None }
+            parse(&["probe"]).expect("bare probe parses"),
+            Some(NymSubCommand::Probe { target: None })
         );
         assert_eq!(
-            parse_nym_args(&["probe", "https://zec.rocks:443"]).expect("probe with a uri parses"),
-            NymSubCommand::Probe {
+            parse(&["probe", "https://zec.rocks:443"]).expect("probe with a uri parses"),
+            Some(NymSubCommand::Probe {
                 target: Some("https://zec.rocks:443".parse().expect("static uri")),
-            }
+            })
         );
-        assert!(matches!(
-            parse_nym_args(&["probe", "not a uri"]),
-            Err(NymCommandError::InvalidProbeTarget(_))
-        ));
+        assert!(parse(&["probe", "not a uri"]).is_err());
         assert!(
-            matches!(
-                parse_nym_args(&["probe", "http://zec.rocks:9067"]),
-                Err(NymCommandError::InvalidProbeTarget(_))
-            ),
+            parse(&["probe", "http://zec.rocks:9067"]).is_err(),
             "a plaintext http target is refused: mixnet transmission is https-only"
         );
         assert_eq!(
-            parse_nym_args(&["history"]).expect("history parses"),
-            NymSubCommand::History
+            parse(&["history"]).expect("history parses"),
+            Some(NymSubCommand::History)
         );
     }
 

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -1,44 +1,55 @@
 #[cfg(test)]
 mod table_invariants {
-    //! Pins the properties [`super::super::COMMANDS`] relies on but the
+    //! Pins the properties [`super::super::CliCommand`] relies on but the
     //! compiler does not check: declaration order is the help listing's
-    //! order, and dispatch takes the first name match.
+    //! order, and no two variants mint the same name.
 
-    use super::super::COMMANDS;
+    use clap::CommandFactory as _;
 
-    /// HYPOTHESIS: the table's names are strictly increasing — sorted, so
-    /// the help listing stays alphabetical, and therefore unique, so no
-    /// row can shadow another at dispatch.
+    use super::super::CommandLine;
+
+    /// HYPOTHESIS: the grammar's minted names are strictly increasing —
+    /// sorted, so the help listing stays alphabetical, and therefore
+    /// unique, so no variant can shadow another at dispatch.
     #[test]
     fn names_are_strictly_increasing() {
-        for pair in COMMANDS.windows(2) {
+        let model = CommandLine::command();
+        let names: Vec<&str> = model
+            .get_subcommands()
+            .map(clap::Command::get_name)
+            .collect();
+        for pair in names.windows(2) {
             assert!(
-                pair[0].name < pair[1].name,
-                "COMMANDS must stay sorted and duplicate-free: {:?} precedes {:?}",
-                pair[0].name,
-                pair[1].name
+                pair[0] < pair[1],
+                "CliCommand must stay sorted and duplicate-free: {:?} precedes {:?}",
+                pair[0],
+                pair[1]
             );
         }
     }
 
-    /// HYPOTHESIS: wherever a help text offers a Usage section, at least
+    /// HYPOTHESIS: wherever a long help offers a Usage section, at least
     /// one of its lines invokes the command by its minted name, so the
-    /// prose cannot silently drift from the table's single mint. The
+    /// prose cannot silently drift from the grammar's single mint. The
     /// duplication itself retires when clap generates usage from typed
     /// arguments (the ratified follow-up arc); until then it is pinned.
     #[test]
     fn usage_lines_invoke_the_minted_name() {
-        for spec in COMMANDS {
-            let Some((_, usage)) = spec.help.split_once("Usage:") else {
+        let model = CommandLine::command();
+        for sub in model.get_subcommands() {
+            let Some(long_about) = sub.get_long_about().map(ToString::to_string) else {
                 continue;
             };
+            let Some((_, usage)) = long_about.split_once("Usage:") else {
+                continue;
+            };
+            let name = sub.get_name();
             assert!(
-                usage.lines().map(str::trim).any(|line| {
-                    line == spec.name || line.starts_with(&format!("{} ", spec.name))
-                }),
-                "`{}`'s Usage section never invokes it by its minted name:\n{}",
-                spec.name,
-                spec.help
+                usage
+                    .lines()
+                    .map(str::trim)
+                    .any(|line| line == name || line.starts_with(&format!("{name} "))),
+                "`{name}`'s Usage section never invokes it by its minted name:\n{long_about}"
             );
         }
     }
@@ -138,7 +149,11 @@ mod migration_command_parsing {
     use super::super::*;
 
     fn parse(args: &[&str]) -> Result<MigrationSubCommand, clap::Error> {
-        MigrationCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub)
+        let line = std::iter::once("migration").chain(args.iter().copied());
+        CommandLine::try_parse_from(line).map(|line| match line.command {
+            CliCommand::Migration { sub } => sub,
+            other => panic!("`migration` must parse to the migration family: {other:?}"),
+        })
     }
 
     #[test]
@@ -228,8 +243,13 @@ mod drain_and_split_command_parsing {
 
     #[test]
     fn drain_accepts_exactly_plan_or_now() {
-        let parse =
-            |args: &[&str]| DrainCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub);
+        let parse = |args: &[&str]| {
+            let line = std::iter::once("drain").chain(args.iter().copied());
+            CommandLine::try_parse_from(line).map(|line| match line.command {
+                CliCommand::Drain { sub } => sub,
+                other => panic!("`drain` must parse to the drain family: {other:?}"),
+            })
+        };
         assert_eq!(
             parse(&["plan"]).expect("drain plan parses"),
             DrainSubCommand::Plan
@@ -245,8 +265,13 @@ mod drain_and_split_command_parsing {
 
     #[test]
     fn split_accepts_exactly_plan_or_now() {
-        let parse =
-            |args: &[&str]| SplitCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub);
+        let parse = |args: &[&str]| {
+            let line = std::iter::once("split").chain(args.iter().copied());
+            CommandLine::try_parse_from(line).map(|line| match line.command {
+                CliCommand::Split { sub } => sub,
+                other => panic!("`split` must parse to the split family: {other:?}"),
+            })
+        };
         assert_eq!(
             parse(&["plan"]).expect("split plan parses"),
             SplitSubCommand::Plan
@@ -262,6 +287,149 @@ mod drain_and_split_command_parsing {
 }
 
 #[cfg(test)]
+mod typed_argument_parsing {
+    //! Pins the typed payloads the top-level grammar owns: the arguments
+    //! that once reached a body as `&[&str]` now refuse, or arrive whole,
+    //! at the parse boundary.
+
+    use clap::Parser as _;
+
+    use super::super::*;
+
+    fn parse(args: &[&str]) -> Result<CliCommand, clap::Error> {
+        CommandLine::try_parse_from(args.iter().copied()).map(|line| line.command)
+    }
+
+    /// HYPOTHESIS: `settings` parses its whole grammar before the body
+    /// takes the wallet lock, so a malformed level or confirmation count
+    /// never reaches the wallet.
+    #[test]
+    fn settings_parses_before_it_takes_the_wallet_lock() {
+        assert!(matches!(
+            parse(&["settings"]).expect("a bare settings parses"),
+            CliCommand::Settings { sub: None }
+        ));
+        assert!(matches!(
+            parse(&["settings", "performance", "high"]).expect("a level parses"),
+            CliCommand::Settings {
+                sub: Some(SettingsSubCommand::Performance {
+                    level: PerformanceLevelArg::High
+                })
+            }
+        ));
+        assert!(matches!(
+            parse(&["settings", "min_confirmations", "3"]).expect("a count parses"),
+            CliCommand::Settings {
+                sub: Some(SettingsSubCommand::MinConfirmations { .. })
+            }
+        ));
+        for junk in [
+            &["settings", "bogus"][..],
+            &["settings", "performance"][..],
+            &["settings", "performance", "blazing"][..],
+            &["settings", "min_confirmations", "0"][..],
+            &["settings", "min_confirmations", "many"][..],
+        ] {
+            assert!(parse(junk).is_err(), "{junk:?} must refuse at the parse");
+        }
+    }
+
+    /// HYPOTHESIS: `notes` and `coins` take `all` and nothing else.
+    #[test]
+    fn the_spent_output_scope_is_all_or_nothing() {
+        assert!(matches!(
+            parse(&["notes", "all"]).expect("notes all parses"),
+            CliCommand::Notes {
+                scope: Some(OutputScope::All)
+            }
+        ));
+        assert!(matches!(
+            parse(&["coins"]).expect("bare coins parses"),
+            CliCommand::Coins { scope: None }
+        ));
+        assert!(parse(&["notes", "spent"]).is_err());
+        assert!(parse(&["coins", "all", "extra"]).is_err());
+    }
+
+    /// HYPOTHESIS: `new_address` takes the receivers as a type, so a
+    /// receiver set the wallet cannot build refuses at the parse.
+    #[test]
+    fn new_address_parses_its_receivers() {
+        assert!(matches!(
+            parse(&["new_address", "oz"]).expect("oz parses"),
+            CliCommand::NewAddress {
+                receivers: ReceiverSelection {
+                    orchard: true,
+                    sapling: true,
+                }
+            }
+        ));
+        assert!(matches!(
+            parse(&["new_address", "z"]).expect("z parses"),
+            CliCommand::NewAddress {
+                receivers: ReceiverSelection {
+                    orchard: false,
+                    sapling: true,
+                }
+            }
+        ));
+        for junk in [
+            &["new_address"][..],
+            &["new_address", "t"][..],
+            &["new_address", "o", "z"][..],
+        ] {
+            assert!(parse(junk).is_err(), "{junk:?} must refuse at the parse");
+        }
+    }
+
+    /// HYPOTHESIS: the transaction-id arguments arrive decoded, so a
+    /// malformed id never reaches the wallet.
+    #[test]
+    fn transaction_ids_parse_at_the_boundary() {
+        let txid = "ab".repeat(32);
+        assert!(matches!(
+            parse(&["transmit"]).expect("a bare transmit parses"),
+            CliCommand::Transmit { txids } if txids.is_empty()
+        ));
+        assert!(matches!(
+            parse(&["transmit", &txid, &txid]).expect("two txids parse"),
+            CliCommand::Transmit { txids } if txids.len() == 2
+        ));
+        assert!(parse(&["transmit", "nonsense"]).is_err());
+        assert!(parse(&["remove_transaction", "nonsense"]).is_err());
+        assert!(parse(&["remove_transaction"]).is_err());
+    }
+
+    /// HYPOTHESIS: `change_server` takes a uri, and an empty argument
+    /// still names the default one.
+    #[test]
+    fn change_server_parses_its_uri() {
+        assert!(matches!(
+            parse(&["change_server"]).expect("a bare change_server parses"),
+            CliCommand::ChangeServer { uri: None }
+        ));
+        assert!(matches!(
+            parse(&["change_server", ""]).expect("an empty uri parses"),
+            CliCommand::ChangeServer { uri: Some(uri) } if uri == http::Uri::default()
+        ));
+        assert!(matches!(
+            parse(&["change_server", "https://zec.rocks:443"]).expect("a uri parses"),
+            CliCommand::ChangeServer { uri: Some(_) }
+        ));
+        assert!(parse(&["change_server", "zec rocks"]).is_err());
+    }
+
+    /// HYPOTHESIS: a name the grammar does not know refuses at the parse,
+    /// where clap's unknown-subcommand error replaces the hand-written
+    /// one the table used to raise.
+    #[test]
+    fn an_unknown_command_refuses_at_the_parse() {
+        assert!(parse(&["bogus"]).is_err());
+        assert!(parse(&[]).is_err());
+    }
+}
+
+#[cfg(test)]
 mod nym_command_parsing {
     //! Pins the clap derive grammar of the `nym` family and the pure
     //! renderers whose strings every frontend shares.
@@ -271,7 +439,11 @@ mod nym_command_parsing {
     #[cfg(feature = "nym")]
     fn parse(args: &[&str]) -> Result<Option<NymSubCommand>, clap::Error> {
         use clap::Parser as _;
-        NymCli::try_parse_from(args.iter().copied()).map(|cli| cli.sub)
+        let line = std::iter::once("nym").chain(args.iter().copied());
+        CommandLine::try_parse_from(line).map(|line| match line.command {
+            CliCommand::Nym { sub } => sub,
+            other => panic!("`nym` must parse to the nym family: {other:?}"),
+        })
     }
 
     #[cfg(feature = "nym")]

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -1105,13 +1105,10 @@ pub fn log_file_path(matches: &clap::ArgMatches) -> PathBuf {
 /// the text and exiting the process.
 pub fn help_output(matches: &clap::ArgMatches) -> Option<String> {
     if matches.get_one::<String>("COMMAND").map(String::as_str) == Some("help") {
-        let args: Vec<String> = matches
+        let named = matches
             .get_many::<String>("extra_args")
-            .map(|v| v.cloned().collect())
-            .unwrap_or_default();
-        Some(commands::format_help(
-            &args.iter().map(String::as_str).collect::<Vec<&str>>(),
-        ))
+            .and_then(|mut args| args.next());
+        Some(commands::format_help(named.map(String::as_str)))
     } else {
         None
     }

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -288,7 +288,7 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 
     let send_request = |request: Request| -> Result<String, String> {
         let description = match &request {
-            Request::Command(command) => format!("{command:?}"),
+            Request::Command(command) => command.name(),
             Request::PromptIndicator => "prompt indicator".to_string(),
         };
         if ch.transmitter.send(request).is_err() {
@@ -1030,7 +1030,7 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io
             Ok(ExitCode::SUCCESS)
         }
         ModeOfOperation::Command { command } => {
-            let description = format!("{command:?}");
+            let description = command.name();
             let exit_code = if ch
                 .transmitter
                 .send(Request::Command(command.clone()))

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -42,9 +42,7 @@ pub(crate) mod version;
 
 /// Builds the clap `Command` definition for the CLI: the session's options
 /// followed by every dispatchable command, so a one-shot command parses
-/// into its typed form here, before any wallet work begins. Augmenting
-/// carries the command grammar's own description onto this app, so the
-/// session's description is restated afterwards to win.
+/// into its typed form here, before any wallet work begins.
 pub fn build_clap_app() -> clap::Command {
     use clap::Subcommand as _;
 
@@ -397,9 +395,8 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 /// a response by sniffing its text (the in-band-error problem of issue
 /// zingolabs/zingolib#2446).
 enum Request {
-    /// Execute a user command, already parsed by the sender. The reply is
-    /// `Ok` with the command's output, or `Err` with the rendered error
-    /// line.
+    /// Execute a user command, already parsed by the sender, replying `Ok`
+    /// with the command's output or `Err` with the rendered error line.
     Command(commands::CliCommand),
     /// Perform the per-prompt housekeeping (sync poll, save check) via
     /// typed calls on the loop thread. The reply is the sync indicator
@@ -419,15 +416,9 @@ struct CommandChannel {
     receiver: Receiver<Result<String, String>>,
 }
 
-/// Spawns a background thread that listens for parsed-command messages,
-/// executes each command against the [`LightClient`], and sends the
-/// response back through the returned [`CommandChannel`].
-///
-/// Both of this thread's crossings into async are the `block_on` calls
-/// below, one for command dispatch and one for the per-prompt
-/// housekeeping; the loop thread holds no other crossing (ADR 0030).
-///
-/// The loop exits when it receives [`commands::CliCommand::Quit`].
+/// Spawns a background thread that executes each parsed-command message
+/// against the [`LightClient`] and replies through the returned
+/// [`CommandChannel`], exiting on [`commands::CliCommand::Quit`].
 #[allow(clippy::disallowed_methods)]
 pub(crate) fn command_loop(
     mut lightclient: LightClient,
@@ -478,23 +469,17 @@ pub(crate) fn command_loop(
 enum ModeOfOperation {
     /// Start the interactive REPL.
     Interactive,
-    /// Execute a single command and exit. The command arrives already
-    /// parsed, from the same grammar the REPL uses.
+    /// Execute a single command and exit, the command arriving already
+    /// parsed from the same grammar the REPL uses.
     Command {
         /// The parsed command to execute.
         command: commands::CliCommand,
     },
 }
 
-/// Determines the mode of operation from parsed CLI arguments.
-///
-/// Returns [`ModeOfOperation::Command`] if a command is given, or
-/// [`ModeOfOperation::Interactive`] when no command is given. The command
-/// is rebuilt from the matches by clap, so a malformed one has already
-/// been refused by the argument parse that produced them.
-///
-/// The `help` command is handled separately before this function is called,
-/// so it will never appear as a [`ModeOfOperation::Command`].
+/// Determines the mode of operation from parsed CLI arguments:
+/// [`ModeOfOperation::Command`] when a command is given, or
+/// [`ModeOfOperation::Interactive`] when none is.
 fn get_mode_of_operation(matches: &clap::ArgMatches) -> ModeOfOperation {
     use clap::FromArgMatches as _;
 
@@ -517,11 +502,10 @@ enum CommunicationMode {
     Offline,
 }
 
-/// The Offline-mode pin at the REPL dispatch (issue #2286): an Offline
-/// session never configures an Indexer, so `change_server` is refused
-/// before it reaches command execution. Returns the refusal to send in
-/// place of executing `command`, or `None` when the command may proceed.
-/// Pure, so the pin is testable without a REPL thread.
+/// The Offline-mode pin at the REPL dispatch: returns the refusal to send
+/// in place of executing `command` (an Offline session never configures an
+/// Indexer, so `change_server` is refused), or `None` when the command may
+/// proceed.
 fn offline_mode_refusal(
     communication_mode: CommunicationMode,
     command: &commands::CliCommand,

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -40,9 +40,16 @@ use crate::commands::RT;
 
 pub(crate) mod version;
 
-/// Builds the clap `Command` definition for the CLI.
+/// Builds the clap `Command` definition for the CLI: the session's options
+/// followed by every dispatchable command, so a one-shot command parses
+/// into its typed form here, before any wallet work begins. Augmenting
+/// carries the command grammar's own description onto this app, so the
+/// session's description is restated afterwards to win.
 pub fn build_clap_app() -> clap::Command {
-    clap::Command::new("Zingo CLI").version(version::VERSION)
+    use clap::Subcommand as _;
+
+    let session_options = clap::Command::new("Zingo CLI").version(version::VERSION)
+            .disable_help_subcommand(true)
             .arg(Arg::new("nosync")
                 .help("By default, zingo-cli will sync the wallet at startup. Pass --nosync to prevent the automatic sync at startup.")
                 .long("nosync")
@@ -119,18 +126,13 @@ For a NEW wallet created in Offline mode it is instead an optional override of t
             .arg(Arg::new("log-file")
                 .long("log-file")
                 .value_name("PATH")
-                .help("Path to the log file for interactive mode. Defaults to .zingo-cli/cli.log"))
-            .arg(Arg::new("COMMAND")
-                .help("Command to execute. If a command is not specified, zingo-cli will start in interactive mode.")
-                .required(false)
-                .index(1))
-            .arg(Arg::new("extra_args")
-                .help("Params to execute command with. Run the 'help' command to get usage help.")
-                .required(false)
-                .num_args(1..)
-                .index(2)
-                .action(clap::ArgAction::Append)
+                .help("Path to the log file for interactive mode. Defaults to .zingo-cli/cli.log"));
+    commands::CliCommand::augment_subcommands(session_options)
+        .about(
+            "A command-line light wallet for Zcash. Runs the given command and exits, or \
+             starts the interactive prompt when given none.",
         )
+        .long_about(None)
 }
 
 /// Custom function to parse a string into an `http::Uri`
@@ -288,7 +290,7 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 
     let send_request = |request: Request| -> Result<String, String> {
         let description = match &request {
-            Request::Command(cmd, _) => cmd.clone(),
+            Request::Command(command) => format!("{command:?}"),
             Request::PromptIndicator => "prompt indicator".to_string(),
         };
         if ch.transmitter.send(request).is_err() {
@@ -307,10 +309,6 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
             }
         }
     };
-    let send_command = |cmd: String, args: Vec<String>| -> Result<String, String> {
-        send_request(Request::Command(cmd, args))
-    };
-
     // The prompt's chain label comes from local config, not the server. An
     // `info` round trip here blocked the first prompt behind the cold mixnet
     // tunnel (up to MIXNET_ROUND_TRIP_BOUND), and an offline session got a
@@ -323,7 +321,7 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 
     loop {
         // Read the height first
-        let height = send_command("height".to_string(), vec![])
+        let height = send_request(Request::Command(commands::CliCommand::Height))
             .ok()
             .and_then(|s| json::parse(&s).ok())
             .and_then(|v| v["height"].as_i64())
@@ -339,33 +337,38 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
                 rl.add_history_entry(line.as_str())
                     .expect("Ability to add history entry");
                 // Parse command line arguments
-                let mut cmd_args = if let Ok(args) = shellwords::split(&line) {
-                    args
-                } else {
+                let Ok(tokens) = shellwords::split(&line) else {
                     println!("Mismatched Quotes");
                     continue;
                 };
 
-                if cmd_args.is_empty() {
+                if tokens.is_empty() {
                     continue;
                 }
 
-                let cmd = cmd_args.remove(0);
-                let args: Vec<String> = cmd_args;
+                let command = match commands::parse_command_tokens(&tokens) {
+                    Ok(command) => command,
+                    Err(rendered) => {
+                        eprintln!("{rendered}");
+                        continue;
+                    }
+                };
 
                 // CLI-only commands that don't need the LightClient.
-                if cmd == "servers" {
+                if matches!(command, commands::CliCommand::Servers) {
                     println!("{}", format_ranked_servers(cli_config));
                     continue;
                 }
 
-                match send_command(cmd, args) {
+                // Special check for Quit command.
+                let is_quit = matches!(command, commands::CliCommand::Quit);
+
+                match send_request(Request::Command(command)) {
                     Ok(output) => println!("{output}"),
                     Err(rendered) => eprintln!("{rendered}"),
                 }
 
-                // Special check for Quit command.
-                if line == "quit" || line == "exit" {
+                if is_quit {
                     break;
                 }
             }
@@ -394,9 +397,10 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
 /// a response by sniffing its text (the in-band-error problem of issue
 /// zingolabs/zingolib#2446).
 enum Request {
-    /// Execute a user command. The reply is `Ok` with the command's
-    /// output, or `Err` with the rendered error line.
-    Command(String, Vec<String>),
+    /// Execute a user command, already parsed by the sender. The reply is
+    /// `Ok` with the command's output, or `Err` with the rendered error
+    /// line.
+    Command(commands::CliCommand),
     /// Perform the per-prompt housekeeping (sync poll, save check) via
     /// typed calls on the loop thread. The reply is the sync indicator
     /// to embed in the interactive prompt.
@@ -415,15 +419,15 @@ struct CommandChannel {
     receiver: Receiver<Result<String, String>>,
 }
 
-/// Spawns a background thread that listens for `(command, args)` messages,
+/// Spawns a background thread that listens for parsed-command messages,
 /// executes each command against the [`LightClient`], and sends the
 /// response back through the returned [`CommandChannel`].
 ///
-/// Each command crosses into async inside `commands::do_user_command`, and
-/// the per-prompt housekeeping crosses in the `block_on` below; the loop
-/// thread holds no other crossing (ADR 0030).
+/// Both of this thread's crossings into async are the `block_on` calls
+/// below, one for command dispatch and one for the per-prompt
+/// housekeeping; the loop thread holds no other crossing (ADR 0030).
 ///
-/// The loop exits when it receives a `"quit"` or `"exit"` command.
+/// The loop exits when it receives [`commands::CliCommand::Quit`].
 #[allow(clippy::disallowed_methods)]
 pub(crate) fn command_loop(
     mut lightclient: LightClient,
@@ -434,8 +438,8 @@ pub(crate) fn command_loop(
 
     std::thread::spawn(move || {
         while let Ok(request) = command_receiver.recv() {
-            let (cmd, args) = match request {
-                Request::Command(cmd, args) => (cmd, args),
+            let command = match request {
+                Request::Command(command) => command,
                 Request::PromptIndicator => {
                     resp_transmitter
                         .send(Ok(RT.block_on(prompt_indicator(&mut lightclient))))
@@ -444,17 +448,18 @@ pub(crate) fn command_loop(
                 }
             };
             // The Offline-mode pin: this session never configures an Indexer.
-            if let Some(refusal) = offline_mode_refusal(communication_mode, &cmd) {
+            if let Some(refusal) = offline_mode_refusal(communication_mode, &command) {
                 resp_transmitter.send(Err(refusal)).unwrap();
                 continue;
             }
-            let args: Vec<_> = args.iter().map(std::convert::AsRef::as_ref).collect();
+            let is_quit = matches!(command, commands::CliCommand::Quit);
 
-            let cmd_response = commands::do_user_command(&cmd, &args[..], &mut lightclient)
+            let cmd_response = RT
+                .block_on(commands::dispatch_parsed(command, &mut lightclient))
                 .map_err(|e| format!("Error: {e}"));
             resp_transmitter.send(cmd_response).unwrap();
 
-            if cmd == "quit" || cmd == "exit" {
+            if is_quit {
                 info!("Quit");
                 break;
             }
@@ -473,35 +478,30 @@ pub(crate) fn command_loop(
 enum ModeOfOperation {
     /// Start the interactive REPL.
     Interactive,
-    /// Execute a single command and exit.
+    /// Execute a single command and exit. The command arrives already
+    /// parsed, from the same grammar the REPL uses.
     Command {
-        /// The command name (e.g. "balance", "send").
-        name: String,
-        /// Additional positional arguments for the command.
-        args: Vec<String>,
+        /// The parsed command to execute.
+        command: commands::CliCommand,
     },
 }
 
 /// Determines the mode of operation from parsed CLI arguments.
 ///
 /// Returns [`ModeOfOperation::Command`] if a command is given, or
-/// [`ModeOfOperation::Interactive`] when no command is given.
+/// [`ModeOfOperation::Interactive`] when no command is given. The command
+/// is rebuilt from the matches by clap, so a malformed one has already
+/// been refused by the argument parse that produced them.
 ///
 /// The `help` command is handled separately before this function is called,
 /// so it will never appear as a [`ModeOfOperation::Command`].
 fn get_mode_of_operation(matches: &clap::ArgMatches) -> ModeOfOperation {
-    if let Some(cmd_name) = matches.get_one::<String>("COMMAND") {
-        let args = matches
-            .get_many::<String>("extra_args")
-            .map(|v| v.cloned().collect())
-            .unwrap_or_default();
-        ModeOfOperation::Command {
-            name: cmd_name.clone(),
-            args,
-        }
-    } else {
-        ModeOfOperation::Interactive
-    }
+    use clap::FromArgMatches as _;
+
+    commands::CliCommand::from_arg_matches(matches)
+        .map_or(ModeOfOperation::Interactive, |command| {
+            ModeOfOperation::Command { command }
+        })
 }
 
 /// Whether the CLI communicates with a remote indexer or operates locally.
@@ -520,10 +520,15 @@ enum CommunicationMode {
 /// The Offline-mode pin at the REPL dispatch (issue #2286): an Offline
 /// session never configures an Indexer, so `change_server` is refused
 /// before it reaches command execution. Returns the refusal to send in
-/// place of executing `cmd`, or `None` when the command may proceed.
+/// place of executing `command`, or `None` when the command may proceed.
 /// Pure, so the pin is testable without a REPL thread.
-fn offline_mode_refusal(communication_mode: CommunicationMode, cmd: &str) -> Option<String> {
-    (communication_mode == CommunicationMode::Offline && cmd == "change_server").then(|| {
+fn offline_mode_refusal(
+    communication_mode: CommunicationMode,
+    command: &commands::CliCommand,
+) -> Option<String> {
+    (communication_mode == CommunicationMode::Offline
+        && matches!(command, commands::CliCommand::ChangeServer { .. }))
+    .then(|| {
         "Error: this session is in Offline mode; no Indexer may be configured. \
          Restart without --offline to change servers."
             .to_string()
@@ -966,13 +971,19 @@ async fn startup_async(filled_template: &ConfigTemplate) -> std::io::Result<Ligh
     }
 
     if filled_template.sync {
-        match commands::do_user_command_result("sync", &["run"], &mut lightclient).await {
+        let sync_run = commands::CliCommand::Sync {
+            sub: commands::SyncSubCommand::Run,
+        };
+        match commands::dispatch_parsed(sync_run, &mut lightclient).await {
             Ok(update) => eprintln!("{update}"),
             Err(e) => eprintln!("Error: {e}"),
         }
     }
 
-    match commands::do_user_command_result("save", &["run"], &mut lightclient).await {
+    let save_run = commands::CliCommand::Save {
+        sub: commands::SaveSubCommand::Run,
+    };
+    match commands::dispatch_parsed(save_run, &mut lightclient).await {
         Ok(update) => eprintln!("{update}"),
         Err(e) => eprintln!("Error: {e}"),
     }
@@ -1017,9 +1028,12 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io
     let ch = match startup(cli_config) {
         Ok(ch) => ch,
         Err(startup_error) => {
-            if let ModeOfOperation::Command { name, .. } = &cli_config.mode
-                && name == "recovery_info"
-            {
+            if matches!(
+                &cli_config.mode,
+                ModeOfOperation::Command {
+                    command: commands::CliCommand::RecoveryInfo
+                }
+            ) {
                 return print_salvaged_recovery_info(cli_config, &startup_error)
                     .map(|()| ExitCode::SUCCESS);
             }
@@ -1031,13 +1045,15 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io
             start_interactive(cli_config, ch);
             Ok(ExitCode::SUCCESS)
         }
-        ModeOfOperation::Command { name, args } => {
+        ModeOfOperation::Command { command } => {
+            let description = format!("{command:?}");
             let exit_code = if ch
                 .transmitter
-                .send(Request::Command(name.clone(), args.clone()))
+                .send(Request::Command(command.clone()))
                 .is_err()
             {
-                let e = format!("Error executing command {name}: the command loop has exited");
+                let e =
+                    format!("Error executing command {description}: the command loop has exited");
                 eprintln!("{e}");
                 error!("{e}");
                 ExitCode::FAILURE
@@ -1052,7 +1068,7 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io
                         ExitCode::FAILURE
                     }
                     Err(e) => {
-                        let e = format!("Error executing command {name}: {e}");
+                        let e = format!("Error executing command {description}: {e}");
                         eprintln!("{e}");
                         error!("{e}");
                         ExitCode::FAILURE
@@ -1062,7 +1078,7 @@ fn dispatch_command_or_start_interactive(cli_config: &ConfigTemplate) -> std::io
 
             if ch
                 .transmitter
-                .send(Request::Command("quit".to_string(), vec![]))
+                .send(Request::Command(commands::CliCommand::Quit))
                 .is_ok()
             {
                 match ch.receiver.recv() {
@@ -1104,13 +1120,11 @@ pub fn log_file_path(matches: &clap::ArgMatches) -> PathBuf {
 /// or `None` for all other modes. The caller is responsible for printing
 /// the text and exiting the process.
 pub fn help_output(matches: &clap::ArgMatches) -> Option<String> {
-    if matches.get_one::<String>("COMMAND").map(String::as_str) == Some("help") {
-        let named = matches
-            .get_many::<String>("extra_args")
-            .and_then(|mut args| args.next());
-        Some(commands::format_help(named.map(String::as_str)))
-    } else {
-        None
+    match get_mode_of_operation(matches) {
+        ModeOfOperation::Command {
+            command: commands::CliCommand::Help { command: named },
+        } => Some(commands::format_help(named.as_deref())),
+        _ => None,
     }
 }
 

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -1121,6 +1121,12 @@ pub fn help_output(matches: &clap::ArgMatches) -> Option<String> {
 /// handling the help short-circuit, process-level setup, and error reporting.
 pub fn run_cli(matches: clap::ArgMatches) -> std::io::Result<ExitCode> {
     let mode = get_mode_of_operation(&matches);
+    if let ModeOfOperation::Command { command } = &mode
+        && let Err(refusal) = command.validate_deferred_grammar()
+    {
+        eprintln!("{refusal}");
+        return Ok(ExitCode::from(2));
+    }
     let communication_mode = get_communication_mode(&matches)?;
     let cli_config =
         ConfigTemplate::fill(mode, communication_mode, matches).map_err(std::io::Error::other)?;

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -10,6 +10,7 @@ fn parse(args: &[&str]) -> clap::ArgMatches {
 
 mod mode_of_operation {
     use super::*;
+    use crate::commands::CliCommand;
     use crate::{ModeOfOperation, get_mode_of_operation};
 
     fn assert_interactive(args: &[&str]) {
@@ -20,14 +21,11 @@ mod mode_of_operation {
         );
     }
 
-    fn assert_command(args: &[&str], expected_name: &str, expected_args: &[&str]) {
+    fn assert_command(args: &[&str], expected: CliCommand) {
         let matches = parse(args);
         assert_eq!(
             get_mode_of_operation(&matches),
-            ModeOfOperation::Command {
-                name: expected_name.to_string(),
-                args: expected_args.iter().map(|s| s.to_string()).collect(),
-            }
+            ModeOfOperation::Command { command: expected }
         );
     }
 
@@ -38,7 +36,7 @@ mod mode_of_operation {
 
     #[test]
     fn command_without_extra_args() {
-        assert_command(&[examples::BIN_NAME, "balance"], "balance", &[]);
+        assert_command(&[examples::BIN_NAME, "balance"], CliCommand::Balance);
     }
 
     #[test]
@@ -50,8 +48,12 @@ mod mode_of_operation {
                 examples::SAPLING_ADDRESS,
                 examples::AMOUNT_ZATOSHIS,
             ],
-            "send",
-            &[examples::SAPLING_ADDRESS, examples::AMOUNT_ZATOSHIS],
+            CliCommand::Send {
+                args: vec![
+                    examples::SAPLING_ADDRESS.to_string(),
+                    examples::AMOUNT_ZATOSHIS.to_string(),
+                ],
+            },
         );
     }
 
@@ -60,7 +62,10 @@ mod mode_of_operation {
         // `help` is handled by `parse_args_or_exit_for_help` in main.rs before
         // `get_mode_of_operation` is called, but if it were passed through
         // it would produce a normal Command variant.
-        assert_command(&[examples::BIN_NAME, "help"], "help", &[]);
+        assert_command(
+            &[examples::BIN_NAME, "help"],
+            CliCommand::Help { command: None },
+        );
     }
 
     #[test]
@@ -70,15 +75,20 @@ mod mode_of_operation {
 
     #[test]
     fn flags_do_not_affect_mode_command() {
-        assert_command(&[examples::BIN_NAME, "--nosync", "balance"], "balance", &[]);
+        assert_command(
+            &[examples::BIN_NAME, "--nosync", "balance"],
+            CliCommand::Balance,
+        );
     }
 
     mod commands {
         use super::*;
+        use crate::commands::{SaveSubCommand, SyncSubCommand};
+        use zingolib::wallet::keys::unified::ReceiverSelection;
 
-        /// Assert that a command with no extra args parses correctly.
-        fn assert_no_arg_command(name: &str) {
-            assert_command(&[examples::BIN_NAME, name], name, &[]);
+        /// Assert that a command with no arguments parses to its variant.
+        fn assert_no_arg_command(name: &str, expected: CliCommand) {
+            assert_command(&[examples::BIN_NAME, name], expected);
         }
 
         #[test]
@@ -91,12 +101,13 @@ mod mode_of_operation {
                     examples::AMOUNT_ZATOSHIS,
                     examples::MEMO,
                 ],
-                "send",
-                &[
-                    examples::SAPLING_ADDRESS,
-                    examples::AMOUNT_ZATOSHIS,
-                    examples::MEMO,
-                ],
+                CliCommand::Send {
+                    args: vec![
+                        examples::SAPLING_ADDRESS.to_string(),
+                        examples::AMOUNT_ZATOSHIS.to_string(),
+                        examples::MEMO.to_string(),
+                    ],
+                },
             );
         }
 
@@ -109,8 +120,12 @@ mod mode_of_operation {
                     examples::SAPLING_ADDRESS,
                     examples::SEND_ALL_MEMO,
                 ],
-                "send_all",
-                &[examples::SAPLING_ADDRESS, examples::SEND_ALL_MEMO],
+                CliCommand::SendAll {
+                    args: vec![
+                        examples::SAPLING_ADDRESS.to_string(),
+                        examples::SEND_ALL_MEMO.to_string(),
+                    ],
+                },
             );
         }
 
@@ -124,12 +139,13 @@ mod mode_of_operation {
                     examples::AMOUNT_ZATOSHIS,
                     examples::MEMO,
                 ],
-                "quicksend",
-                &[
-                    examples::SAPLING_ADDRESS,
-                    examples::AMOUNT_ZATOSHIS,
-                    examples::MEMO,
-                ],
+                CliCommand::Quicksend {
+                    args: vec![
+                        examples::SAPLING_ADDRESS.to_string(),
+                        examples::AMOUNT_ZATOSHIS.to_string(),
+                        examples::MEMO.to_string(),
+                    ],
+                },
             );
         }
 
@@ -141,8 +157,9 @@ mod mode_of_operation {
                     "parse_address",
                     examples::TRANSPARENT_ADDRESS,
                 ],
-                "parse_address",
-                &[examples::TRANSPARENT_ADDRESS],
+                CliCommand::ParseAddress {
+                    address: examples::TRANSPARENT_ADDRESS.to_string(),
+                },
             );
         }
 
@@ -154,8 +171,9 @@ mod mode_of_operation {
                     "parse_viewkey",
                     examples::UNIFIED_VIEWING_KEY,
                 ],
-                "parse_viewkey",
-                &[examples::UNIFIED_VIEWING_KEY],
+                CliCommand::ParseViewkey {
+                    viewkey: examples::UNIFIED_VIEWING_KEY.to_string(),
+                },
             );
         }
 
@@ -163,137 +181,173 @@ mod mode_of_operation {
         fn change_server() {
             assert_command(
                 &[examples::BIN_NAME, "change_server", examples::SERVER_URI],
-                "change_server",
-                &[examples::SERVER_URI],
+                CliCommand::ChangeServer {
+                    uri: Some(examples::SERVER_URI.parse().expect("a valid example uri")),
+                },
             );
         }
 
         #[test]
         fn sync() {
-            assert_command(&[examples::BIN_NAME, "sync", "run"], "sync", &["run"]);
+            assert_command(
+                &[examples::BIN_NAME, "sync", "run"],
+                CliCommand::Sync {
+                    sub: SyncSubCommand::Run,
+                },
+            );
         }
 
         #[test]
         fn new_address() {
             assert_command(
                 &[examples::BIN_NAME, "new_address", "o"],
-                "new_address",
-                &["o"],
+                CliCommand::NewAddress {
+                    receivers: ReceiverSelection {
+                        orchard: true,
+                        sapling: false,
+                    },
+                },
             );
         }
 
         #[test]
         fn balance() {
-            assert_no_arg_command("balance");
+            assert_no_arg_command("balance", CliCommand::Balance);
         }
 
         #[test]
         fn confirm() {
-            assert_no_arg_command("confirm");
+            assert_no_arg_command("confirm", CliCommand::Confirm);
         }
 
         #[test]
         fn calculate() {
-            assert_no_arg_command("calculate");
+            assert_no_arg_command("calculate", CliCommand::Calculate);
         }
 
         #[test]
         fn transmit() {
-            assert_no_arg_command("transmit");
+            assert_no_arg_command("transmit", CliCommand::Transmit { txids: vec![] });
         }
 
         #[test]
         fn transmit_with_txids() {
+            let txid = zingolib::utils::conversion::txid_from_hex_encoded_str(examples::TXID)
+                .expect("a valid example txid");
             assert_command(
                 &[examples::BIN_NAME, "transmit", examples::TXID],
-                "transmit",
-                &[examples::TXID],
+                CliCommand::Transmit { txids: vec![txid] },
             );
         }
 
         #[test]
         fn shield() {
-            assert_no_arg_command("shield");
+            assert_no_arg_command("shield", CliCommand::Shield);
         }
 
         #[test]
         fn height() {
-            assert_no_arg_command("height");
+            assert_no_arg_command("height", CliCommand::Height);
         }
 
         #[test]
         fn info() {
-            assert_no_arg_command("info");
+            assert_no_arg_command("info", CliCommand::Info);
         }
 
         #[test]
         fn addresses() {
-            assert_no_arg_command("addresses");
+            assert_no_arg_command("addresses", CliCommand::Addresses);
         }
 
+        /// `save` names its sub-command: the grammar requires one, so the
+        /// process's own argument parse refuses a bare `save`.
         #[test]
         fn save() {
-            assert_no_arg_command("save");
+            assert_command(
+                &[examples::BIN_NAME, "save", "run"],
+                CliCommand::Save {
+                    sub: SaveSubCommand::Run,
+                },
+            );
         }
 
         #[test]
         fn quit() {
-            assert_no_arg_command("quit");
+            assert_no_arg_command("quit", CliCommand::Quit);
+        }
+
+        /// `exit` is an alias of `quit`, so it parses to the same variant
+        /// and the one-shot flow quits cleanly instead of erroring.
+        #[test]
+        fn exit_is_an_alias_of_quit() {
+            assert_no_arg_command("exit", CliCommand::Quit);
         }
 
         #[test]
         fn notes() {
-            assert_no_arg_command("notes");
+            assert_no_arg_command("notes", CliCommand::Notes { scope: None });
         }
 
         #[test]
         fn version() {
-            assert_no_arg_command("version");
+            assert_no_arg_command("version", CliCommand::Version);
         }
 
         #[test]
         fn rescan() {
-            assert_no_arg_command("rescan");
+            assert_no_arg_command("rescan", CliCommand::Rescan);
         }
 
         #[test]
         fn export_ufvk() {
-            assert_no_arg_command("export_ufvk");
+            assert_no_arg_command("export_ufvk", CliCommand::ExportUfvk);
         }
 
         #[test]
         fn settings() {
-            assert_no_arg_command("settings");
+            assert_no_arg_command("settings", CliCommand::Settings { sub: None });
         }
 
         #[test]
         fn value_transfers() {
-            assert_no_arg_command("value_transfers");
+            assert_no_arg_command("value_transfers", CliCommand::ValueTransfers);
         }
 
         #[test]
         fn transactions() {
-            assert_no_arg_command("transactions");
+            assert_no_arg_command("transactions", CliCommand::Transactions);
         }
 
         #[test]
         fn quickshield() {
-            assert_no_arg_command("quickshield");
+            assert_no_arg_command("quickshield", CliCommand::Quickshield);
         }
 
         #[test]
         fn wallet_kind() {
-            assert_no_arg_command("wallet_kind");
+            assert_no_arg_command("wallet_kind", CliCommand::WalletKind);
         }
 
         #[test]
         fn birthday() {
-            assert_no_arg_command("birthday");
+            assert_no_arg_command("birthday", CliCommand::Birthday);
         }
 
         #[test]
         fn delete() {
-            assert_no_arg_command("delete");
+            assert_no_arg_command("delete", CliCommand::Delete);
+        }
+
+        /// A command the grammar does not know now refuses at the process's
+        /// own argument parse, before any wallet work begins.
+        #[test]
+        fn an_unknown_command_refuses_at_the_argument_parse() {
+            assert!(
+                build_clap_app()
+                    .try_get_matches_from([examples::BIN_NAME, "nonesuch"])
+                    .is_err()
+            );
         }
     }
 }
@@ -740,8 +794,7 @@ mod config_template {
             assert_eq!(
                 config.mode,
                 ModeOfOperation::Command {
-                    name: "balance".to_string(),
-                    args: vec![],
+                    command: crate::commands::CliCommand::Balance,
                 }
             );
         }
@@ -909,12 +962,16 @@ mod offline_mode_pin {
     //! Offline session may never configure an Indexer. The command-surface
     //! half lives in `commands::offline_contract`.
 
+    use crate::commands::CliCommand;
     use crate::{CommunicationMode, offline_mode_refusal};
 
     #[test]
     fn offline_mode_refuses_change_server_before_dispatch() {
-        let refusal = offline_mode_refusal(CommunicationMode::Offline, "change_server")
-            .expect("an Offline session must refuse change_server");
+        let refusal = offline_mode_refusal(
+            CommunicationMode::Offline,
+            &CliCommand::ChangeServer { uri: None },
+        )
+        .expect("an Offline session must refuse change_server");
         assert_eq!(
             refusal,
             "Error: this session is in Offline mode; no Indexer may be configured. \
@@ -925,12 +982,15 @@ mod offline_mode_pin {
     #[test]
     fn online_mode_and_other_commands_pass_the_pin() {
         assert_eq!(
-            offline_mode_refusal(CommunicationMode::Online, "change_server"),
+            offline_mode_refusal(
+                CommunicationMode::Online,
+                &CliCommand::ChangeServer { uri: None }
+            ),
             None,
             "an Online session may change servers"
         );
         assert_eq!(
-            offline_mode_refusal(CommunicationMode::Offline, "balance"),
+            offline_mode_refusal(CommunicationMode::Offline, &CliCommand::Balance),
             None,
             "the pin refuses exactly one command, never the local surface"
         );

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -34,6 +34,24 @@ mod mode_of_operation {
         assert_interactive(&[examples::BIN_NAME]);
     }
 
+    /// A session flag binds before the command name and refuses after it.
+    #[test]
+    fn session_flags_precede_the_command_name() {
+        let matches = parse(&[examples::BIN_NAME, "--nosync", "balance"]);
+        assert!(matches.get_flag("nosync"));
+        assert_eq!(
+            get_mode_of_operation(&matches),
+            ModeOfOperation::Command {
+                command: CliCommand::Balance
+            }
+        );
+        assert!(
+            build_clap_app()
+                .try_get_matches_from([examples::BIN_NAME, "balance", "--nosync"])
+                .is_err()
+        );
+    }
+
     #[test]
     fn command_without_extra_args() {
         assert_command(&[examples::BIN_NAME, "balance"], CliCommand::Balance);


### PR DESCRIPTION
This PR delegates zingo-cli's input processing to clap's derive API, completing the arc ratified after PR #2626. Four commits, each gate-green under both feature configurations:

1. **Family grammars** (`c80eae1f7`): the migration, nym, drain, split, sync, and save families parse through `#[derive(clap::Parser)]` grammars with typed fields — the plan hash as `[u8; 32]`, spacings as `Duration`s with defaults in the grammar, the probe target as an https-only `http::Uri`. Ten parse-error variants leave the typed error enums; those refusals belong to the grammars now. The byte-identity parser tests retire deliberately with the hand parsers whose strings they pinned.
2. **The table absorbed** (`715cea930`): the static `CommandSpec` table, `CommandBody`, and the name-minting macros dissolve into one alphabetical `#[derive(clap::Subcommand)] CliCommand` enum; dispatch is an exhaustive match, so a variant without a body or a body without a name cannot compile. Bodies take parsed inputs only, and `settings` gains a real subgrammar so no argument is ever inspected under the wallet lock. The send family keeps a trailing string payload for its JSON-or-positional hybrid, the one documented compromise.
3. **Parse once at the boundary** (`b61a83b95`): the outer app absorbs `CliCommand` as real subcommands, so a one-shot command parses in main's argument pass — malformed invocations fail with clap's usage error, exit code 2, before any wallet work — and `zingo-cli --help` lists every command. The REPL parses each line locally, so parse errors never cross the command channel, which now carries the parsed `CliCommand`. `do_user_command` is deleted; `do_user_command_result` remains the string entry point.
4. **CHANGELOG** (`4b583a0f7`), including a correction to the Unreleased entry from #2626 whose `do_user_command`/`do_user_command_result` roles this arc inverts.

Breaking, and recorded in the CHANGELOG: generated help and error prose replaces the pinned hand-parser strings; usage errors exit 2 pre-startup; command names are case-sensitive; `exit` cleanly aliases `quit`; a bare `save` refuses at the parse.

Deferred follow-ups, tracked in `.agent-plans/clap-commands-arc.md`: retiring the hand-written Usage prose from the long help now that clap generates usage (and the invariant test pinning it); a revision of ADR 0030's registry description, which this arc makes historical; the send-family grammar absorption; and the worker's failure interpolations naming commands by their `Debug` rendering.

The branch also rides the post-#2629 base, so the lockfile story is clean: clap's derive feature adds `clap_derive` and syn 3 (both proc-macro, compile-time only), and the workspace otherwise holds a single syn 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
