### PR TITLE
feat(cli): network on narrates the bootstrap on an eight-second heartbeat

### DIFF
--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -40,24 +40,23 @@ pub static RT: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new
 
 use zingolib::netutils::time::TRANSMIT_HEARTBEAT_INTERVAL;
 
-async fn with_transmit_heartbeat<T>(
+async fn with_heartbeat<T>(
     label: &str,
+    interval: std::time::Duration,
+    fallback: &str,
     latest: impl Fn() -> Option<String>,
     mut emit: impl FnMut(String),
     operation: impl Future<Output = T>,
 ) -> T {
     let started = tokio::time::Instant::now();
-    let mut ticker = tokio::time::interval_at(
-        started + TRANSMIT_HEARTBEAT_INTERVAL,
-        TRANSMIT_HEARTBEAT_INTERVAL,
-    );
+    let mut ticker = tokio::time::interval_at(started + interval, interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut operation = std::pin::pin!(operation);
     loop {
         tokio::select! {
             output = &mut operation => return output,
             _ = ticker.tick() => {
-                let detail = latest().unwrap_or_else(|| "transmitting".to_string());
+                let detail = latest().unwrap_or_else(|| fallback.to_string());
                 emit(format!(
                     "{label}: {detail} ({}s elapsed)",
                     started.elapsed().as_secs()
@@ -65,6 +64,23 @@ async fn with_transmit_heartbeat<T>(
             }
         }
     }
+}
+
+async fn with_transmit_heartbeat<T>(
+    label: &str,
+    latest: impl Fn() -> Option<String>,
+    emit: impl FnMut(String),
+    operation: impl Future<Output = T>,
+) -> T {
+    with_heartbeat(
+        label,
+        TRANSMIT_HEARTBEAT_INTERVAL,
+        "transmitting",
+        latest,
+        emit,
+        operation,
+    )
+    .await
 }
 
 /// Runs `operation` under the transmit heartbeat with the stderr sink: the
@@ -1137,6 +1153,10 @@ pub enum NetworkCommandError {
         path: String,
         source: zingolib::nym::MixnetProxyError,
     },
+    /// The proxy spawned but its bootstrap reached a terminal failure while
+    /// the command waited; re-enabling spawns a fresh proxy.
+    #[error("the mixnet bootstrap failed: {report}. Re-enable with `network on`.")]
+    Bootstrap { report: String },
 }
 
 /// A parsed `network` command, its arguments parsed completely at the clap
@@ -1363,6 +1383,71 @@ fn render_status_with_disclaimer(
     )
 }
 
+/// The terminal readings of one bootstrap wait.
+#[cfg(feature = "nym")]
+#[derive(Debug, PartialEq, Eq)]
+enum BootstrapOutcome {
+    Ready,
+    Failed { report: String },
+}
+
+/// Waits on the status subscription until the bootstrap reaches a terminal
+/// mode, so `network on` reports an outcome instead of a promise to poll.
+#[cfg(feature = "nym")]
+async fn await_bootstrap_outcome(
+    mut rx: tokio::sync::watch::Receiver<zingolib::nym::MixnetStatus>,
+) -> BootstrapOutcome {
+    use zingolib::nym::MixnetMode;
+    let mut was_bootstrapping = false;
+    loop {
+        let status = rx.borrow_and_update().clone();
+        match status.mode {
+            MixnetMode::Ready => return BootstrapOutcome::Ready,
+            MixnetMode::Died => {
+                let cause = status
+                    .death
+                    .as_ref()
+                    .and_then(|death| death.detail.as_ref())
+                    .map(|detail| format!(": {detail}"))
+                    .unwrap_or_default();
+                return BootstrapOutcome::Failed {
+                    report: format!("the mixnet transport died{cause}"),
+                };
+            }
+            MixnetMode::Bootstrapping => was_bootstrapping = true,
+            MixnetMode::Unattached | MixnetMode::SwitchedOff if was_bootstrapping => {
+                return BootstrapOutcome::Failed {
+                    report: format!("the bootstrap ended in mode {}", status.mode),
+                };
+            }
+            MixnetMode::Unattached | MixnetMode::SwitchedOff => {}
+        }
+        if rx.changed().await.is_err() {
+            return BootstrapOutcome::Failed {
+                report: "the mixnet status channel closed".to_string(),
+            };
+        }
+    }
+}
+
+/// Runs `operation` under the bootstrap heartbeat with the stderr sink.
+#[cfg(feature = "nym")]
+async fn narrated_bootstrap<T>(
+    label: &str,
+    latest: impl Fn() -> Option<String>,
+    operation: impl Future<Output = T>,
+) -> T {
+    with_heartbeat(
+        label,
+        zingolib::netutils::time::BOOTSTRAP_HEARTBEAT_INTERVAL,
+        "bootstrapping",
+        latest,
+        |line| eprintln!("{line}"),
+        operation,
+    )
+    .await
+}
+
 /// The body of the `network` command; the command exists only with the
 /// mixnet transport compiled in (ADR 0026).
 #[cfg(feature = "nym")]
@@ -1404,16 +1489,42 @@ async fn network_command(
                     path: path.clone(),
                     source,
                 })?;
-            let enabling = format!(
-                "Mixnet Mode enabling; the nym proxy at '{path}' is bootstrapping. \
-                 Run `network status` to check readiness."
-            );
+            // Block until the bootstrap resolves, narrating on the
+            // bootstrap heartbeat so the caller watches progress instead
+            // of polling `network status` by hand. The wait is bounded:
+            // the supervisor's own lifecycle timeout flips a stuck
+            // bootstrap to died, and the outer timeout is the backstop.
+            let rx = lightclient.subscribe_mixnet_status();
+            let detail_rx = rx.clone();
+            let outcome = narrated_bootstrap(
+                "network on",
+                move || detail_rx.borrow().bootstrap_detail.clone(),
+                tokio::time::timeout(
+                    zingolib::netutils::time::NYM_LIFECYCLE_TIMEOUT,
+                    await_bootstrap_outcome(rx),
+                ),
+            )
+            .await;
+            let readiness = match outcome {
+                Ok(BootstrapOutcome::Ready) => format!(
+                    "Mixnet Mode ready; the nym proxy at '{path}' serves send and \
+                     price-fetch over the mixnet."
+                ),
+                Ok(BootstrapOutcome::Failed { report }) => {
+                    return Err(NetworkCommandError::Bootstrap { report });
+                }
+                Err(_elapsed) => format!(
+                    "Mixnet Mode still bootstrapping after {}s; run `network status` \
+                     to check readiness.",
+                    zingolib::netutils::time::NYM_LIFECYCLE_TIMEOUT.as_secs()
+                ),
+            };
             Ok(match went_online {
                 Some(server) => format!(
                     "WARNING: this consent act switched the session to ONLINE MODE \
-                     (this session only); indexer '{server}'. {enabling}"
+                     (this session only); indexer '{server}'. {readiness}"
                 ),
-                None => enabling,
+                None => readiness,
             })
         }
         NetworkSubCommand::Off => {

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -824,6 +824,132 @@ mod network_command_parsing {
     }
 }
 
+#[cfg(all(test, feature = "nym"))]
+mod bootstrap_wait {
+    //! Paused-clock falsifiers for the `network on` bootstrap wait: the
+    //! 8-second heartbeat cadence, and the outcome reader over the status
+    //! subscription.
+    //!
+    //! Seam justification (ADR 0030): the `block_on` here is the one
+    //! `#[tokio::test]` generates to drive each async test body; a test
+    //! driver is a sync frontend, so it is an audited crossing.
+    #![allow(clippy::disallowed_methods)]
+
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use zingolib::netutils::time::BOOTSTRAP_HEARTBEAT_INTERVAL;
+    use zingolib::nym::{MixnetMode, MixnetStatus};
+
+    use super::super::{BootstrapOutcome, await_bootstrap_outcome, with_heartbeat};
+
+    fn status(mode: MixnetMode) -> MixnetStatus {
+        MixnetStatus {
+            mode,
+            socks5_addr: None,
+            bootstrap_detail: None,
+            death: None,
+        }
+    }
+
+    /// HYPOTHESIS: a slow bootstrap is narrated every eight seconds, each
+    /// line carrying the latest detail and the elapsed seconds.
+    #[tokio::test(start_paused = true)]
+    async fn a_slow_bootstrap_heartbeats_on_the_eight_second_cadence() {
+        let lines: Arc<Mutex<Vec<String>>> = Arc::default();
+        let sink = lines.clone();
+        with_heartbeat(
+            "network on",
+            BOOTSTRAP_HEARTBEAT_INTERVAL,
+            "bootstrapping",
+            || Some("connecting to the gateway".to_string()),
+            move |line| sink.lock().expect("line sink poisoned").push(line),
+            tokio::time::sleep(Duration::from_secs(20)),
+        )
+        .await;
+        let lines = lines.lock().expect("line sink poisoned").clone();
+        assert_eq!(
+            lines,
+            vec![
+                "network on: connecting to the gateway (8s elapsed)".to_string(),
+                "network on: connecting to the gateway (16s elapsed)".to_string(),
+            ]
+        );
+    }
+
+    /// HYPOTHESIS: the wait resolves `Ready` when the subscription reaches
+    /// the ready mode, even from an initial unattached snapshot.
+    #[tokio::test]
+    async fn ready_resolves_the_wait() {
+        let (tx, rx) = tokio::sync::watch::channel(status(MixnetMode::Unattached));
+        let waiter = tokio::spawn(await_bootstrap_outcome(rx));
+        tokio::task::yield_now().await;
+        tx.send(status(MixnetMode::Bootstrapping))
+            .expect("the waiter holds the receiver");
+        tokio::task::yield_now().await;
+        tx.send(status(MixnetMode::Ready))
+            .expect("the waiter holds the receiver");
+        assert_eq!(
+            waiter.await.expect("the waiter must not panic"),
+            BootstrapOutcome::Ready
+        );
+    }
+
+    /// HYPOTHESIS: a death during the wait resolves `Failed` with the died
+    /// report rather than hanging until a timeout.
+    #[tokio::test]
+    async fn death_resolves_the_wait_as_failed() {
+        let (tx, rx) = tokio::sync::watch::channel(status(MixnetMode::Bootstrapping));
+        let waiter = tokio::spawn(await_bootstrap_outcome(rx));
+        tokio::task::yield_now().await;
+        tx.send(status(MixnetMode::Died))
+            .expect("the waiter holds the receiver");
+        let outcome = waiter.await.expect("the waiter must not panic");
+        assert_eq!(
+            outcome,
+            BootstrapOutcome::Failed {
+                report: "the mixnet transport died".to_string()
+            }
+        );
+    }
+
+    /// HYPOTHESIS: a fall back to unattached after bootstrapping began is a
+    /// failure, but the initial unattached snapshot is not — the wait must
+    /// survive subscribing before the driver flips to bootstrapping.
+    #[tokio::test]
+    async fn unattached_fails_only_after_bootstrapping_began() {
+        let (tx, rx) = tokio::sync::watch::channel(status(MixnetMode::Bootstrapping));
+        let waiter = tokio::spawn(await_bootstrap_outcome(rx));
+        tokio::task::yield_now().await;
+        tx.send(status(MixnetMode::Unattached))
+            .expect("the waiter holds the receiver");
+        let outcome = waiter.await.expect("the waiter must not panic");
+        assert_eq!(
+            outcome,
+            BootstrapOutcome::Failed {
+                report: "the bootstrap ended in mode unattached".to_string()
+            }
+        );
+    }
+
+    /// HYPOTHESIS: a closed status channel resolves `Failed` instead of
+    /// waiting forever on a sender that will never speak again.
+    #[tokio::test]
+    async fn a_closed_channel_resolves_the_wait_as_failed() {
+        let (tx, rx) = tokio::sync::watch::channel(status(MixnetMode::Bootstrapping));
+        let waiter = tokio::spawn(await_bootstrap_outcome(rx));
+        tokio::task::yield_now().await;
+        drop(tx);
+        let outcome = waiter.await.expect("the waiter must not panic");
+        assert_eq!(
+            outcome,
+            BootstrapOutcome::Failed {
+                report: "the mixnet status channel closed".to_string()
+            }
+        );
+    }
+}
+
 #[cfg(test)]
 mod offline_contract {
     //! The Offline-mode contract at the command surface (issue #2286,

--- a/zingo-netutils/src/time.rs
+++ b/zingo-netutils/src/time.rs
@@ -188,6 +188,11 @@ pub const CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// tick stays silent.
 pub const TRANSMIT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
+/// An interactive `network on` blocks while the nym proxy bootstraps, so the
+/// command prints the latest bootstrap progress line at this interval while
+/// it waits.
+pub const BOOTSTRAP_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(8);
+
 // ---------------------------------------------------------------------------
 // Diagnostics and server selection
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
In interactive mode, tracing goes to the log file. The mixnet narration task therefore speaks into that file while the user sits at the prompt. `network on` also returned immediately, with only a promise to poll `network status`.

The command now blocks until the bootstrap resolves. It prints a progress line every eight seconds. Each line carries the live bootstrap detail and the elapsed seconds. The cadence is the new named constant `BOOTSTRAP_HEARTBEAT_INTERVAL` in the netutils time module. The return value is the outcome: ready, a typed `Bootstrap` failure, or a bounded still-bootstrapping report after `NYM_LIFECYCLE_TIMEOUT`.

The transmit heartbeat generalizes to `with_heartbeat` with the interval and the fallback label as parameters. The transmit path delegates to it unchanged. A new pure `await_bootstrap_outcome` reads the status subscription. It treats unattached as failure only after it has observed bootstrapping, so subscribing before the driver flips modes cannot misreport.

Verified: zingo-cli passes 218/218 on the default shape and 193/193 on the opt-out shape. The netutils workspace passes 32/32. Clippy and fmt are clean in both workspaces. Five new tests pin the cadence, the ready path, the death path, the unattached race guard, and the closed-channel path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)