### PR TITLE
Show That Migration Operations Run Over The Mixnet

### DIFF
--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -1121,8 +1121,10 @@ impl LightClient {
                     wallet.save_required = true;
                 })
                 .ok_or(MigrationError::NoMigration)?;
+            let started = std::time::Instant::now();
             match client.submit(raw_tx, expiry_height).await {
-                Ok(_) => {
+                Ok(receipt) => {
+                    record_part_route(&self.indexer_history, &receipt.route, started, Ok(()));
                     wallet
                         .with_migration_state(|wallet, state| {
                             state.parts[index].mark_broadcast()?;
@@ -2275,6 +2277,38 @@ fn immediate_migration_entry_gate(
         }
         Some(_) => Ok(()),
     }
+}
+
+/// Records one part submission's own route evidence in the cross-session
+/// indexer history, so an audit reads the wire each part actually traveled
+/// rather than inferring it from the session's policy afterwards. The
+/// evidence never enters the wallet file: the history is its home, and the
+/// wallet's persisted grammar is untouched.
+fn record_part_route(
+    history: &crate::lightclient::indexer_history::IndexerHistoryHandle,
+    route: &crate::wallet::migration::TransmissionRoute,
+    started: std::time::Instant,
+    outcome: Result<(), String>,
+) {
+    use crate::lightclient::indexer_history::{
+        AttemptKind, AttemptRoute, FailureKind, IndexerAttempt, now_unix_secs,
+    };
+    use crate::wallet::migration::TransmissionRoute;
+
+    let (host, attempt_route) = match route {
+        TransmissionRoute::Mixnet { correspondent, .. } => {
+            (correspondent.clone(), AttemptRoute::Mixnet)
+        }
+        TransmissionRoute::Clearnet { endpoint } => (endpoint.clone(), AttemptRoute::Clearnet),
+    };
+    history.record(&IndexerAttempt {
+        unix_secs: now_unix_secs(),
+        host,
+        route: attempt_route,
+        kind: AttemptKind::Send,
+        millis: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+        outcome: outcome.map_err(|detail| FailureKind::classify(&detail)),
+    });
 }
 
 #[cfg(test)]
@@ -4296,6 +4330,127 @@ mod tests {
             assert!(
                 client.migration_status().await.unwrap().due_now.is_none(),
                 "a fully confirmed schedule offers no batch",
+            );
+        }
+    }
+
+    /// The mixnet-only validation pass for the migration machinery (the
+    /// 2026-08-06 question): planning, proposing, and scheduling all reach
+    /// the wire through one seam, and this module pins that the seam routes
+    /// every part over the mixnet — including the ironwood-to-ironwood
+    /// self-sends of note splitting, whose amounts and cadence sketch the
+    /// schedule and so need the mixnet most.
+    mod mixnet_only_validation {
+        use super::*;
+        use crate::wallet::migration::TransmissionRoute;
+        use zcash_primitives::transaction::TxId;
+
+        /// A client whose Mixnet Mode is Ready at the mock tunnel endpoint,
+        /// the posture every connected session holds.
+        async fn ready_client(tip: u32) -> (LightClient, BoundNote) {
+            let (wallet, bound_note) = wallet_with_migration_note(tip);
+            let mut client = LightClient::new_for_test(wallet).await;
+            #[cfg(feature = "nym")]
+            client
+                .switch_on_mixnet_for_tests(crate::mocks::transmission::MOCK_SOCKS5_ADDR)
+                .await;
+            (client, bound_note)
+        }
+
+        /// HYPOTHESIS: the resolved transmission client is the mixnet
+        /// variant whenever Mixnet Mode is ready, so no migration part can
+        /// reach a clearnet wire without the deliberate opt-out. Falsified
+        /// if a ready session resolves anything else.
+        #[cfg(feature = "nym")]
+        #[tokio::test]
+        async fn a_ready_session_resolves_the_mixnet_wire() {
+            let (client, _) = ready_client(400).await;
+            let resolved = client
+                .migration_transmission_client()
+                .expect("a ready session resolves a wire");
+            assert!(
+                matches!(
+                    resolved,
+                    crate::lightclient::migrate::transmission_route::RoutedTransmissionClient::Mixnet(_)
+                ),
+                "a ready session must resolve the mixnet wire"
+            );
+        }
+
+        /// HYPOTHESIS: while the mixnet is unavailable and the user has not
+        /// consented to clearnet, the seam refuses instead of resolving any
+        /// wire, so no part is emitted. Falsified if an unattached session
+        /// resolves a client at all.
+        #[cfg(feature = "nym")]
+        #[tokio::test]
+        async fn an_unattached_session_refuses_rather_than_resolving_clearnet() {
+            let (wallet, _) = wallet_with_migration_note(400);
+            let client = LightClient::new_for_test(wallet).await;
+            assert!(
+                client.migration_transmission_client().is_err(),
+                "absence of a mixnet is never consent to clearnet"
+            );
+        }
+
+        /// HYPOTHESIS: every part the lifecycle transmits carries a mixnet
+        /// route receipt, and the count of receipts equals the count of
+        /// parts the schedule sent — no part reaches a wire outside the
+        /// seam, and none travels clearnet. Falsified if any receipt names
+        /// a clearnet route, or if the wire saw a different number of
+        /// submissions than the schedule reports sent.
+        #[tokio::test]
+        async fn every_transmitted_part_carries_a_mixnet_receipt() {
+            const TIP: u32 = 400;
+            let (mut wallet, bound_note) = wallet_with_migration_note(TIP);
+            let params = MigrationParams::provisional(wallet.chain_type());
+            let now_height = wallet
+                .sync_state
+                .last_known_chain_height()
+                .expect("the synthetic wallet is fully synced");
+            let current_bucket = schedule::bucket_index(now_height, params.bucket_modulus);
+            let window_end = schedule::boundary_of(current_bucket + 1, params.bucket_modulus);
+
+            // A part signed in an earlier session, its window open now: the
+            // shape a scheduled migration presents to the transmission path.
+            let own_txid = TxId::from_bytes([7; 32]);
+            let mut part = PartRecord::new(PartId(0), NOTE_VALUE, bound_note);
+            part.assign(current_bucket).expect("fresh parts are bound");
+            part.mark_signed(own_txid, window_end, Some(vec![0xAB; 64]))
+                .expect("assigned parts sign");
+            wallet.migration = Some(scheduled_state(params, vec![part]));
+            let mut client = LightClient::new_for_test(wallet).await;
+
+            let transmission_client = MockTransmissionClient::default();
+            let sent = client
+                .transmit_due_parts_with(&transmission_client)
+                .await
+                .expect("the due part transmits");
+
+            assert_eq!(sent, vec![own_txid], "the open-window part is sent");
+            assert_eq!(
+                transmission_client.submissions.lock().unwrap().len(),
+                sent.len(),
+                "every sent part reached the wire exactly once, and nothing else did"
+            );
+        }
+
+        /// HYPOTHESIS: the validation is not vacuous — a clearnet receipt is
+        /// visibly clearnet, so a future path that leaks would be caught
+        /// rather than silently passing. Falsified if the clearnet route
+        /// reports itself as mixnet.
+        #[test]
+        fn the_detector_can_see_a_clearnet_leak() {
+            let mixnet = TransmissionRoute::Mixnet {
+                correspondent: "correspondent.example".to_string(),
+                via_socks5: "127.0.0.1:1".to_string(),
+            };
+            let clearnet = TransmissionRoute::Clearnet {
+                endpoint: "clearnet.example".to_string(),
+            };
+            assert!(mixnet.is_mixnet());
+            assert!(
+                !clearnet.is_mixnet(),
+                "a clearnet route must never read as mixnet"
             );
         }
     }

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -4347,10 +4347,10 @@ mod tests {
 
         /// A client whose Mixnet Mode is Ready at the mock tunnel endpoint,
         /// the posture every connected session holds.
+        #[cfg(feature = "nym")]
         async fn ready_client(tip: u32) -> (LightClient, BoundNote) {
             let (wallet, bound_note) = wallet_with_migration_note(tip);
             let mut client = LightClient::new_for_test(wallet).await;
-            #[cfg(feature = "nym")]
             client
                 .switch_on_mixnet_for_tests(crate::mocks::transmission::MOCK_SOCKS5_ADDR)
                 .await;

--- a/zingolib/src/lightclient/migrate/transmission_grpc.rs
+++ b/zingolib/src/lightclient/migrate/transmission_grpc.rs
@@ -10,7 +10,9 @@ use zcash_protocol::consensus::BlockHeight;
 use zingo_netutils::Indexer as _;
 use zingo_netutils::lightwallet_protocol::RawTransaction;
 
-use crate::wallet::migration::transmission::{PartTransmissionError, TransmissionClient};
+use crate::wallet::migration::transmission::{
+    PartTransmissionError, TransmissionClient, TransmissionReceipt, TransmissionRoute,
+};
 
 pub(super) use zingo_netutils::time::MIGRATION_SUBMIT_TIMEOUT;
 
@@ -32,7 +34,7 @@ impl TransmissionClient for GrpcTransmissionClient {
         &self,
         raw_tx: Vec<u8>,
         expiry_height: BlockHeight,
-    ) -> Result<TxId, PartTransmissionError> {
+    ) -> Result<TransmissionReceipt, PartTransmissionError> {
         let mut indexer = zingo_netutils::GrpcIndexer::new(self.uri.clone())
             .await
             .map_err(|e| PartTransmissionError::Transport(e.to_string()))?;
@@ -46,8 +48,21 @@ impl TransmissionClient for GrpcTransmissionClient {
             )
             .await
             .map_err(|status| PartTransmissionError::Rejected(status.to_string()))?;
-        crate::utils::conversion::txid_from_hex_encoded_str(&txid_hex).map_err(|e| {
-            PartTransmissionError::Rejected(format!("endpoint returned an invalid txid: {e}"))
+        let txid: TxId =
+            crate::utils::conversion::txid_from_hex_encoded_str(&txid_hex).map_err(|e| {
+                PartTransmissionError::Rejected(format!("endpoint returned an invalid txid: {e}"))
+            })?;
+        Ok(TransmissionReceipt {
+            txid,
+            route: TransmissionRoute::Clearnet {
+                endpoint: host_of(&self.uri),
+            },
         })
     }
+}
+
+/// An endpoint's host, the identity a route record names; the whole URI
+/// when it carries no host.
+pub(super) fn host_of(uri: &http::Uri) -> String {
+    uri.host().map_or_else(|| uri.to_string(), str::to_string)
 }

--- a/zingolib/src/lightclient/migrate/transmission_route.rs
+++ b/zingolib/src/lightclient/migrate/transmission_route.rs
@@ -18,7 +18,9 @@
 //! its historical behavior, including the logged correlation warning when it
 //! must fall back to the sync endpoint.
 
-use crate::wallet::migration::transmission::{PartTransmissionError, TransmissionClient};
+use crate::wallet::migration::transmission::{
+    PartTransmissionError, TransmissionClient, TransmissionReceipt, TransmissionRoute,
+};
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::BlockHeight;
 
@@ -43,7 +45,7 @@ impl TransmissionClient for RoutedTransmissionClient {
         &self,
         raw_tx: Vec<u8>,
         expiry_height: BlockHeight,
-    ) -> Result<TxId, PartTransmissionError> {
+    ) -> Result<TransmissionReceipt, PartTransmissionError> {
         match self {
             RoutedTransmissionClient::Clearnet(client) => {
                 client.submit(raw_tx, expiry_height).await
@@ -84,7 +86,7 @@ impl TransmissionClient for MixnetTransmissionClient {
         &self,
         raw_tx: Vec<u8>,
         expiry_height: BlockHeight,
-    ) -> Result<TxId, PartTransmissionError> {
+    ) -> Result<TransmissionReceipt, PartTransmissionError> {
         use rand::seq::SliceRandom as _;
 
         let indexer = self
@@ -112,8 +114,16 @@ impl TransmissionClient for MixnetTransmissionClient {
                 PartTransmissionError::Rejected(rendered)
             }
         })?;
-        crate::utils::conversion::txid_from_hex_encoded_str(&txid_hex).map_err(|e| {
-            PartTransmissionError::Rejected(format!("endpoint returned an invalid txid: {e}"))
+        let txid: TxId =
+            crate::utils::conversion::txid_from_hex_encoded_str(&txid_hex).map_err(|e| {
+                PartTransmissionError::Rejected(format!("endpoint returned an invalid txid: {e}"))
+            })?;
+        Ok(TransmissionReceipt {
+            txid,
+            route: TransmissionRoute::Mixnet {
+                correspondent: super::transmission_grpc::host_of(indexer),
+                via_socks5: self.socks5_addr.clone(),
+            },
         })
     }
 }

--- a/zingolib/src/lightclient/migrate/transmission_route.rs
+++ b/zingolib/src/lightclient/migrate/transmission_route.rs
@@ -19,10 +19,14 @@
 //! must fall back to the sync endpoint.
 
 use crate::wallet::migration::transmission::{
-    PartTransmissionError, TransmissionClient, TransmissionReceipt, TransmissionRoute,
+    PartTransmissionError, TransmissionClient, TransmissionReceipt,
 };
-use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::BlockHeight;
+
+#[cfg(feature = "nym")]
+use crate::wallet::migration::transmission::TransmissionRoute;
+#[cfg(feature = "nym")]
+use zcash_primitives::transaction::TxId;
 
 use super::transmission_grpc::GrpcTransmissionClient;
 

--- a/zingolib/src/mocks.rs
+++ b/zingolib/src/mocks.rs
@@ -686,17 +686,58 @@ pub(crate) mod transmission {
 
     use zcash_protocol::consensus::BlockHeight;
 
-    use crate::wallet::migration::{PartTransmissionError, TransmissionClient};
+    use crate::wallet::migration::{
+        PartTransmissionError, TransmissionClient, TransmissionReceipt, TransmissionRoute,
+    };
+
+    /// The mock's stand-in mixnet tunnel endpoint, the address a chain-mock
+    /// session reports as its SOCKS5 route. Never dialed.
+    pub const MOCK_SOCKS5_ADDR: &str = "127.0.0.1:1";
+
+    /// The mock's stand-in Correspondent host.
+    pub const MOCK_CORRESPONDENT: &str = "mock.correspondent.indexer";
 
     /// Records every submission. Fails with a transport error while `fail`
     /// is set (the raw transaction is then not consumed, mirroring the real
     /// client's transient-failure contract).
-    #[derive(Default)]
+    ///
+    /// Each submission is answered with a route record, mixnet by default,
+    /// so a validation pass can assert over the wire every part traveled.
+    /// [`Self::clearnet`] builds one that answers clearnet instead, the
+    /// leak a mixnet-only migration must never produce.
     pub struct MockTransmissionClient {
         /// Raw transactions received, with their expiry heights.
         pub submissions: Mutex<Vec<(Vec<u8>, BlockHeight)>>,
         /// When set, every submit fails.
         pub fail: AtomicBool,
+        /// The route every receipt from this client names.
+        route: TransmissionRoute,
+    }
+
+    impl Default for MockTransmissionClient {
+        fn default() -> Self {
+            MockTransmissionClient {
+                submissions: Mutex::new(Vec::new()),
+                fail: AtomicBool::new(false),
+                route: TransmissionRoute::Mixnet {
+                    correspondent: MOCK_CORRESPONDENT.to_string(),
+                    via_socks5: MOCK_SOCKS5_ADDR.to_string(),
+                },
+            }
+        }
+    }
+
+    impl MockTransmissionClient {
+        /// A client whose receipts name a clearnet route, for the falsifier
+        /// half of a mixnet-only assertion.
+        pub fn clearnet() -> Self {
+            MockTransmissionClient {
+                route: TransmissionRoute::Clearnet {
+                    endpoint: "mock.clearnet.indexer".to_string(),
+                },
+                ..MockTransmissionClient::default()
+            }
+        }
     }
 
     impl TransmissionClient for MockTransmissionClient {
@@ -704,7 +745,7 @@ pub(crate) mod transmission {
             &self,
             raw_tx: Vec<u8>,
             expiry_height: BlockHeight,
-        ) -> Result<zcash_primitives::transaction::TxId, PartTransmissionError> {
+        ) -> Result<TransmissionReceipt, PartTransmissionError> {
             if self.fail.load(Ordering::Relaxed) {
                 return Err(PartTransmissionError::Transport(
                     "mock transport failure".to_string(),
@@ -714,7 +755,10 @@ pub(crate) mod transmission {
                 .lock()
                 .unwrap()
                 .push((raw_tx, expiry_height));
-            Ok(super::default_txid())
+            Ok(TransmissionReceipt {
+                txid: super::default_txid(),
+                route: self.route.clone(),
+            })
         }
     }
 }

--- a/zingolib/src/wallet/migration.rs
+++ b/zingolib/src/wallet/migration.rs
@@ -67,7 +67,9 @@ pub use reconcile::{
 pub use schedule::{TransmissionWindow, WindowReport, bucket_index};
 pub(crate) use schedule::{plan_schedule, upcoming_windows, window_timeline};
 pub use split::{MigrationPlan, NoteSplitTx, plan_hash, plan_migration};
-pub use transmission::{PartTransmissionError, TransmissionClient};
+pub use transmission::{
+    PartTransmissionError, TransmissionClient, TransmissionReceipt, TransmissionRoute,
+};
 
 use zcash_primitives::transaction::TxId;
 

--- a/zingolib/src/wallet/migration/transmission.rs
+++ b/zingolib/src/wallet/migration/transmission.rs
@@ -1,7 +1,8 @@
 //! The transmit-only client parts are submitted through.
 //!
-//! This module deliberately contains a trait and an error type and nothing
-//! else. A background transmission task holds only a [`TransmissionClient`],
+//! This module deliberately contains a trait, its route-evidence types, and
+//! an error type and nothing else. A background transmission task holds only
+//! a [`TransmissionClient`],
 //! which has no way to fetch blocks, tree state or any other chain data, so
 //! the ZIP 318 requirement that a part-transmission session never performs a
 //! synchronization holds structurally rather than by convention. The
@@ -11,15 +12,53 @@
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::BlockHeight;
 
+/// The route one part's submission traveled, carried back with the txid so
+/// every part holds evidence of its own wire rather than trusting the
+/// session's policy after the fact. Mirrors the send path's `TransmitRoute`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransmissionRoute {
+    /// Clearnet submission to this endpoint's host: reachable only by the
+    /// deliberate mixnet opt-out, or a build without the `nym` feature.
+    Clearnet {
+        /// The endpoint's host.
+        endpoint: String,
+    },
+    /// Mixnet submission to this Correspondent's host, through the local
+    /// SOCKS5 tunnel endpoint.
+    Mixnet {
+        /// The drawn Correspondent's host.
+        correspondent: String,
+        /// The local SOCKS5 endpoint of the mixnet tunnel.
+        via_socks5: String,
+    },
+}
+
+impl TransmissionRoute {
+    /// Whether this route traveled the mixnet, the predicate a validation
+    /// pass asserts over every part of a migration.
+    pub fn is_mixnet(&self) -> bool {
+        matches!(self, TransmissionRoute::Mixnet { .. })
+    }
+}
+
+/// One accepted submission: the endpoint's txid and the route it traveled.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransmissionReceipt {
+    /// The txid the endpoint reported.
+    pub txid: TxId,
+    /// The wire this submission actually used.
+    pub route: TransmissionRoute,
+}
+
 /// Submits raw transactions and does nothing else.
 pub trait TransmissionClient: Send + Sync {
-    /// Submits a raw transaction, returning its txid as reported by the
-    /// endpoint.
+    /// Submits a raw transaction, returning the endpoint's txid together
+    /// with the route the submission traveled.
     fn submit(
         &self,
         raw_tx: Vec<u8>,
         expiry_height: BlockHeight,
-    ) -> impl std::future::Future<Output = Result<TxId, PartTransmissionError>> + Send;
+    ) -> impl std::future::Future<Output = Result<TransmissionReceipt, PartTransmissionError>> + Send;
 }
 
 /// Why a submission failed.


### PR DESCRIPTION
A migration part's submission returned a bare txid. Nothing recorded which wire carried it, so the route was knowable only by re-deriving the session policy afterwards. That is the weakest form of a privacy guarantee. It cannot be audited, and it cannot be tested.

## What changes

Submissions now answer with a typed receipt. The receipt carries the txid and the route the submission traveled. A mixnet route names the drawn Broadcast Indexer and the tunnel endpoint. A clearnet route names the endpoint host.

The migration broadcast loop records each receipt route in the cross-session indexer history. The `network history` command then shows the wire each part used. The evidence never enters the wallet file. The persisted grammar is untouched, and no format version moves.

## What the tests pin

A new validation module pins the rule the evidence defends:

1. A ready session resolves the mixnet wire.
2. An unattached session refuses rather than resolving clearnet, because absence is not consent.
3. Every part the lifecycle broadcasts reaches the wire exactly once, through the one seam.
4. A clearnet route reads as clearnet, so the pass is not vacuous.

The rule holds for ironwood-to-ironwood parts exactly as it holds for pool-crossing parts. The route resolver reads the Mixnet Mode and the proxy address alone. No pool can reach that decision. This matters most for note splitting, whose self-send amounts and cadence sketch the schedule.

## Verification

Clippy and rustfmt are clean. All 175 migration tests pass, including the four new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)