### PR TITLE
chore(netutils): commit the crate-level rust-analyzer config enabling nym

### DIFF
--- a/zingo-netutils/rust-analyzer.toml
+++ b/zingo-netutils/rust-analyzer.toml
@@ -1,0 +1,1 @@
+cargo.features = ["nym"]


### PR DESCRIPTION
## Why

`zingo-netutils` is excluded from the parent cargo workspace. No member build
enables its `nym` feature. rust-analyzer therefore compiles out `mod nym_proxy`.
No symbol in that module can be resolved, in any editor.

## What

This PR commits a one-line `rust-analyzer.toml` at the crate root. The file
enables the `nym` feature for any language server rooted at the crate. The
format is editor-independent, and rust-analyzer reads it directly from disk.

## Cost and scope

The file is inert for editors rooted at the repository root. Those sessions
load only the parent workspace, and nothing changes for them. A developer opts
in by rooting a language server at the crate. Helix users set
`workspace-lsp-roots = ["zingo-netutils"]`. Opted-in sessions resolve the
crate's standalone nym-sdk graph. That graph includes the ratified `ring`
exception (ADR 0011).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
