### PR TITLE
docs: apply the PR 2623 review to the perspective docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,9 @@ trim_trailing_whitespace = false
 [*.json]
 indent_size = 4
 indent_style = space
+
+# The editorial goldens are byte-exact pins, captured once and never
+# regenerated; some pinned lines end in spaces and none end in a newline.
+[zingolib/tests/golden/*]
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,6 +4843,7 @@ dependencies = [
  "zingo-status",
  "zingo_common_components",
  "zingo_test_vectors",
+ "zingolib",
  "zip32",
 ]
 

--- a/libtonode-tests/Cargo.toml
+++ b/libtonode-tests/Cargo.toml
@@ -26,7 +26,7 @@ extra-credit-tests = ["sentinels", "unit_test_twins", "slow"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-zingolib = { workspace = true, features = ["testutils"] }
+zingolib = { workspace = true, features = ["perspective", "testutils"] }
 zingolib_testutils = { path = "../zingolib_testutils" }
 zcash_local_net = { workspace = true }
 http = { workspace = true }

--- a/zingo-cli/Cargo.toml
+++ b/zingo-cli/Cargo.toml
@@ -29,7 +29,7 @@ zingo_common_components = { workspace = true }
 # zingolib's re-exports (`zingolib::netutils`, ADR 0024 decision 7). The
 # dev-dependency below reaches netutils' test scaffolding directly, which
 # ships nothing and creates no duplicate copy.
-zingolib = { workspace = true }
+zingolib = { workspace = true, features = ["perspective"] }
 
 zcash_address = { workspace = true }
 zcash_client_backend = { workspace = true }

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: the editorial layer moved from `wallet::summary::data` to
+  `zingolib::perspective` (`ValueTransfer` and its kinds, the finsight
+  rollups, and the `value_transfers` / `messages_containing` / `finsight` /
+  `do_total_*` methods), behind the new `perspective` feature, which is off
+  by default. A consumer that renders value transfers enables the feature
+  and imports the types from `zingolib::perspective`.
 - `config::ClientConfigBuilder`: `build` method now returns result for improved error handling.
 - `config::construct_lightwalletd_uri`: `server` parameter changed from `Option<String>` to `String`. documentation
   updated to include options for defaults.

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -59,6 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `do_total_*` methods), behind the new `perspective` feature, which is off
   by default. A consumer that renders value transfers enables the feature
   and imports the types from `zingolib::perspective`.
+- The `testutils` feature enables `perspective`, so the chain-generics
+  value-transfer fixture is present whenever the test scaffolding is
+  compiled.
 - `config::ClientConfigBuilder`: `build` method now returns result for improved error handling.
 - `config::construct_lightwalletd_uri`: `server` parameter changed from `Option<String>` to `String`. documentation
   updated to include options for defaults.

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -21,6 +21,7 @@ nym = ["zingo-netutils/socks5-transmit", "zingo-price/socks5-fetch"]
 # file is capped. Without this feature the handle is inert.
 nym-diary = []
 testutils = [
+    "perspective",
     "portpicker",
     "zingo_test_vectors",
     "tempfile",
@@ -98,6 +99,10 @@ zingo-net-diag = { workspace = true, features = ["serde"] }
 zcash_proofs = { workspace = true, features = ["download-params"] }
 
 [dev-dependencies]
+# Self dev-dependency: activates these features for every test target, so
+# the feature-gated integration tests always compile and run in
+# package-scoped invocations instead of silently building empty binaries.
+zingolib = { path = ".", features = ["perspective", "testutils"] }
 pepper-sync = { workspace = true, features = ["test-features"] }
 # The nym tests read their temporal parameters from `time::test`.
 zingo-netutils = { workspace = true, features = ["testutils"] }

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -9,12 +9,10 @@ homepage = "https://github.com/zingolabs/zingolib"
 license = "MIT"
 
 [features]
-default = ["perspective"]
-# The editorial layer (`zingolib::perspective`). Default-on and consumed by
-# every governed consumer; the feature exists as a boundary marker, not a
-# capability toggle — CI's feature-powerset job compiles the perspective-off
-# subset, proving core builds without its editorial layer (ADR 0024,
-# amendment 2026-08-04).
+default = []
+# The editorial layer (`zingolib::perspective`). Off by default: a consumer
+# that wants the editorial layer opts in, and the default build proves core
+# stands without it.
 perspective = []
 nym = ["zingo-netutils/socks5-transmit", "zingo-price/socks5-fetch"]
 # Let the wallet open the on-disk indexer diary (indexer-history.tsv beside

--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -77,63 +77,6 @@ async fn funded_send_confirms_on_the_mock_chain() {
     check_client_balances!(recipient, i: 70_000 o: 0 s: 0 t: 0);
 }
 
-/// Mock-chain twin of libtonode `slow::zero_value_receipts` (live
-/// original kept as the control): a zero-value receipt must surface as
-/// exactly one Received{0, Orchard} value transfer and must not perturb
-/// spendable arithmetic across a subsequent send.
-#[cfg(feature = "perspective")]
-#[tokio::test]
-async fn zero_value_receipts() {
-    use crate::perspective::value_transfer::{SentValueTransfer, ValueTransferKind};
-
-    let mut net = MockNet::launch().await;
-    let mut recipient = net
-        .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
-        .await;
-    let recipient_ua = get_base_address(&recipient, PoolType::IRONWOOD).await;
-
-    net.chain.write().await.mine_empty_blocks(1);
-    fund(&net, vec![(&recipient_ua, 100_000, None)], 1).await;
-    // The zero-value receipt, in its own block as on the live chain.
-    fund(&net, vec![(&recipient_ua, 0, None)], 1).await;
-
-    recipient.sync_and_await().await.unwrap();
-    from_inputs::quick_send(
-        &mut recipient,
-        vec![(&external_address(PoolType::IRONWOOD), 1_000, None)],
-    )
-    .await
-    .unwrap();
-    net.chain.write().await.mine_mempool();
-    net.chain.write().await.mine_empty_blocks(1);
-    recipient.sync_and_await().await.unwrap();
-
-    // Identical to the live pin: the recipient holds the 100_000 funding
-    // note less the 1_000 payment and its 10_000 ZIP-317 fee.
-    check_client_balances!(recipient, i: 89_000 o: 0 s: 0 t: 0);
-
-    let value_transfers = recipient.value_transfers(true).await.unwrap();
-    assert!(
-        value_transfers
-            .iter()
-            .any(|vt| vt.kind == ValueTransferKind::Received && vt.value == 100_000)
-    );
-    assert_eq!(
-        value_transfers
-            .iter()
-            .filter(|vt| vt.kind == ValueTransferKind::Received
-                && vt.value == 0
-                && vt.pools_received == [PoolType::IRONWOOD])
-            .count(),
-        1
-    );
-    assert!(value_transfers.iter().any(|vt| {
-        vt.kind == ValueTransferKind::Sent(SentValueTransfer::Send)
-            && vt.value == 1_000
-            && vt.transaction_fee == Some(10_000)
-    }));
-}
-
 /// Mock-chain twin of libtonode `slow::list_value_transfers_check_fees`
 /// (live original kept as the control): a two-output cross-pool send to
 /// the wallet's own transparent and sapling addresses costs the exact
@@ -963,135 +906,6 @@ async fn send_survives_lost_response_and_queued_duplicate_rejection() {
     check_client_balances!(recipient, i: 70_000 o: 0 s: 0 t: 0);
 }
 
-/// A confirmed Orchard→Ironwood immediate migration transaction must surface in the
-/// history as a `migration` value transfer, not `memo-to-self` and not
-/// `basic`. Its self-received Ironwood output carries the canonical empty
-/// memo (`MemoBytes::empty()`), so this pins the self-send classification
-/// order in `value_transfers()`: the migration predicate must win over the
-/// received-memo check regardless of how that memo decodes.
-#[cfg(feature = "perspective")]
-#[tokio::test]
-async fn immediate_migration_is_a_migration_value_transfer() {
-    use zip32::AccountId;
-
-    use crate::perspective::value_transfer::{
-        SelfSendValueTransfer, SentValueTransfer, ValueTransferKind,
-    };
-    use crate::testutils::synthetic_wallet::inject_confirmed_orchard_notes;
-
-    const NOTE_VALUE: u64 = 1_000_000;
-    const TIP: u32 = 41;
-
-    // A real mock-net client, synced over an empty chain, handed one
-    // spendable legacy-Orchard note whose nullifier is really derived, so
-    // pepper-sync's spend detection marks it when the immediate migration spends it and
-    // the summary sees the transaction as Orchard-funded.
-    let mut net = MockNet::launch().await;
-    net.chain.write().await.mine_empty_blocks(TIP);
-    let mut client = net
-        .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
-        .await;
-    client
-        .sync_and_await()
-        .await
-        .expect("initial sync succeeds");
-    {
-        let wallet_lock = client.wallet().clone();
-        let mut wallet = wallet_lock.write().await;
-        inject_confirmed_orchard_notes(&mut wallet, 1, NOTE_VALUE, TIP);
-    }
-
-    let summary = client
-        .migrate_immediately(AccountId::ZERO)
-        .await
-        .expect("the immediate migration builds and transmits");
-    assert_eq!(
-        summary.txids.len(),
-        1,
-        "one note migrates in one transaction"
-    );
-
-    net.chain.write().await.mine_mempool();
-    client.sync_and_await().await.unwrap();
-
-    let value_transfers = client.value_transfers(false).await.unwrap();
-    let kinds: Vec<_> = value_transfers.iter().map(|vt| vt.kind).collect();
-    assert!(
-        kinds.contains(&ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
-            SelfSendValueTransfer::Migration,
-        ))),
-        "the immediate migration transaction must classify as a migration value transfer; got {kinds:?}",
-    );
-}
-
-/// An Orchard-funded self-send that lands in the Ironwood pool AND carries a
-/// received memo must still classify as `migration`, not `memo-to-self`: the
-/// migration predicate wins the self-send classification regardless of
-/// memos, and the memo itself stays on the value transfer. This is the
-/// ordering pin for `value_transfers()`: before the reorder the memo check
-/// fired first and relabeled the migration `memo-to-self`.
-#[cfg(feature = "perspective")]
-#[tokio::test]
-async fn migration_with_memo_is_still_a_migration_value_transfer() {
-    use crate::perspective::value_transfer::{
-        SelfSendValueTransfer, SentValueTransfer, ValueTransferKind,
-    };
-    use crate::testutils::synthetic_wallet::inject_confirmed_orchard_notes;
-
-    const NOTE_VALUE: u64 = 1_000_000;
-    const TIP: u32 = 41;
-    const MEMO: &str = "moving my own funds";
-
-    let mut net = MockNet::launch().await;
-    net.chain.write().await.mine_empty_blocks(TIP);
-    let mut client = net
-        .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
-        .await;
-    client
-        .sync_and_await()
-        .await
-        .expect("initial sync succeeds");
-    {
-        let wallet_lock = client.wallet().clone();
-        let mut wallet = wallet_lock.write().await;
-        inject_confirmed_orchard_notes(&mut wallet, 1, NOTE_VALUE, TIP);
-    }
-
-    // A send to the wallet's own orchard receiver lands in the Ironwood pool
-    // post-NU6.3, funded from the legacy Orchard note: an Orchard→Ironwood
-    // self-send carrying a real memo. Asserted on the pending (transmitted)
-    // record, the state the history shows right after transmission, and the
-    // same classification path as a confirmed transaction. (Mining it would
-    // conflict the injected note's fabricated orchard tree leaf with the
-    // send's real orchard commitments at the same positions.)
-    let own_ua = get_base_address(&client, PoolType::Shielded(ShieldedPool::Orchard)).await;
-    from_inputs::quick_send(&mut client, vec![(&own_ua, 50_000, Some(MEMO))])
-        .await
-        .unwrap();
-
-    let value_transfers = client.value_transfers(false).await.unwrap();
-    let migration = value_transfers
-        .iter()
-        .find(|vt| {
-            vt.kind
-                == ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
-                    SelfSendValueTransfer::Migration,
-                ))
-        })
-        .unwrap_or_else(|| {
-            panic!(
-                "the memo-carrying Orchard→Ironwood self-send must classify as a \
-                 migration value transfer; got {:?}",
-                value_transfers.iter().map(|vt| vt.kind).collect::<Vec<_>>(),
-            )
-        });
-    assert!(
-        migration.memos.iter().any(|memo| memo == MEMO),
-        "the migration value transfer must keep its memo; got {:?}",
-        migration.memos,
-    );
-}
-
 /// A failed transmit inside a note-splitting round must not leave any
 /// transaction stranded in `Calculated`. The immediate migration sibling
 /// (`migrate_immediately`) fails every unsent transaction so the
@@ -1204,4 +1018,177 @@ async fn failed_split_round_transmit_strands_calculated_transactions() {
          with their input notes marked spent: {calculated:?}",
         calculated.len()
     );
+}
+
+/// The offline twins whose assertions read the editorial surface.
+#[cfg(feature = "perspective")]
+mod editorial {
+    use crate::lightclient::LightClient;
+    use crate::perspective::value_transfer::{
+        SelfSendValueTransfer, SentValueTransfer, ValueTransfer, ValueTransferKind, ValueTransfers,
+    };
+    use crate::testutils::synthetic_wallet::inject_confirmed_orchard_notes;
+
+    use super::*;
+
+    const NOTE_VALUE: u64 = 1_000_000;
+    const TIP: u32 = 41;
+
+    /// A real mock-net client, synced over an empty chain, handed one
+    /// spendable legacy-Orchard note whose nullifier is really derived, so
+    /// pepper-sync's spend detection marks it when a migration spends it
+    /// and the summary sees the transaction as Orchard-funded.
+    async fn orchard_funded_client() -> (MockNet, LightClient) {
+        let mut net = MockNet::launch().await;
+        net.chain.write().await.mine_empty_blocks(TIP);
+        let mut client = net
+            .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .await;
+        client
+            .sync_and_await()
+            .await
+            .expect("initial sync succeeds");
+        {
+            let wallet_lock = client.wallet().clone();
+            let mut wallet = wallet_lock.write().await;
+            inject_confirmed_orchard_notes(&mut wallet, 1, NOTE_VALUE, TIP);
+        }
+        (net, client)
+    }
+
+    /// The first value transfer classified as an Orchard→Ironwood migration.
+    fn migration_transfer(value_transfers: &ValueTransfers) -> Option<&ValueTransfer> {
+        value_transfers.iter().find(|vt| {
+            vt.kind
+                == ValueTransferKind::Sent(SentValueTransfer::SendToSelf(
+                    SelfSendValueTransfer::Migration,
+                ))
+        })
+    }
+
+    /// Mock-chain twin of libtonode `slow::zero_value_receipts` (live
+    /// original kept as the control): a zero-value receipt must surface as
+    /// exactly one Received{0, Orchard} value transfer and must not perturb
+    /// spendable arithmetic across a subsequent send.
+    #[tokio::test]
+    async fn zero_value_receipts() {
+        let mut net = MockNet::launch().await;
+        let mut recipient = net
+            .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
+            .await;
+        let recipient_ua = get_base_address(&recipient, PoolType::IRONWOOD).await;
+
+        net.chain.write().await.mine_empty_blocks(1);
+        fund(&net, vec![(&recipient_ua, 100_000, None)], 1).await;
+        // The zero-value receipt, in its own block as on the live chain.
+        fund(&net, vec![(&recipient_ua, 0, None)], 1).await;
+
+        recipient.sync_and_await().await.unwrap();
+        from_inputs::quick_send(
+            &mut recipient,
+            vec![(&external_address(PoolType::IRONWOOD), 1_000, None)],
+        )
+        .await
+        .unwrap();
+        net.chain.write().await.mine_mempool();
+        net.chain.write().await.mine_empty_blocks(1);
+        recipient.sync_and_await().await.unwrap();
+
+        // Identical to the live pin: the recipient holds the 100_000 funding
+        // note less the 1_000 payment and its 10_000 ZIP-317 fee.
+        check_client_balances!(recipient, i: 89_000 o: 0 s: 0 t: 0);
+
+        let value_transfers = recipient.value_transfers(true).await.unwrap();
+        assert!(
+            value_transfers
+                .iter()
+                .any(|vt| vt.kind == ValueTransferKind::Received && vt.value == 100_000)
+        );
+        assert_eq!(
+            value_transfers
+                .iter()
+                .filter(|vt| vt.kind == ValueTransferKind::Received
+                    && vt.value == 0
+                    && vt.pools_received == [PoolType::IRONWOOD])
+                .count(),
+            1
+        );
+        assert!(value_transfers.iter().any(|vt| {
+            vt.kind == ValueTransferKind::Sent(SentValueTransfer::Send)
+                && vt.value == 1_000
+                && vt.transaction_fee == Some(10_000)
+        }));
+    }
+
+    /// A confirmed Orchard→Ironwood immediate migration transaction must surface in the
+    /// history as a `migration` value transfer, not `memo-to-self` and not
+    /// `basic`. Its self-received Ironwood output carries the canonical empty
+    /// memo (`MemoBytes::empty()`), so this pins the self-send classification
+    /// order in `value_transfers()`: the migration predicate must win over the
+    /// received-memo check regardless of how that memo decodes.
+    #[tokio::test]
+    async fn immediate_migration_is_a_migration_value_transfer() {
+        use zip32::AccountId;
+
+        let (net, mut client) = orchard_funded_client().await;
+
+        let summary = client
+            .migrate_immediately(AccountId::ZERO)
+            .await
+            .expect("the immediate migration builds and transmits");
+        assert_eq!(
+            summary.txids.len(),
+            1,
+            "one note migrates in one transaction"
+        );
+
+        net.chain.write().await.mine_mempool();
+        client.sync_and_await().await.unwrap();
+
+        let value_transfers = client.value_transfers(false).await.unwrap();
+        assert!(
+            migration_transfer(&value_transfers).is_some(),
+            "the immediate migration transaction must classify as a migration value transfer; got {:?}",
+            value_transfers.iter().map(|vt| vt.kind).collect::<Vec<_>>(),
+        );
+    }
+
+    /// An Orchard-funded self-send that lands in the Ironwood pool AND carries a
+    /// received memo must still classify as `migration`, not `memo-to-self`: the
+    /// migration predicate wins the self-send classification regardless of
+    /// memos, and the memo itself stays on the value transfer. This is the
+    /// ordering pin for `value_transfers()`: before the reorder the memo check
+    /// fired first and relabeled the migration `memo-to-self`.
+    #[tokio::test]
+    async fn migration_with_memo_is_still_a_migration_value_transfer() {
+        const MEMO: &str = "moving my own funds";
+
+        let (_net, mut client) = orchard_funded_client().await;
+
+        // A send to the wallet's own orchard receiver lands in the Ironwood pool
+        // post-NU6.3, funded from the legacy Orchard note: an Orchard→Ironwood
+        // self-send carrying a real memo. Asserted on the pending (transmitted)
+        // record, the state the history shows right after transmission, and the
+        // same classification path as a confirmed transaction. (Mining it would
+        // conflict the injected note's fabricated orchard tree leaf with the
+        // send's real orchard commitments at the same positions.)
+        let own_ua = get_base_address(&client, PoolType::Shielded(ShieldedPool::Orchard)).await;
+        from_inputs::quick_send(&mut client, vec![(&own_ua, 50_000, Some(MEMO))])
+            .await
+            .unwrap();
+
+        let value_transfers = client.value_transfers(false).await.unwrap();
+        let migration = migration_transfer(&value_transfers).unwrap_or_else(|| {
+            panic!(
+                "the memo-carrying Orchard→Ironwood self-send must classify as a \
+                 migration value transfer; got {:?}",
+                value_transfers.iter().map(|vt| vt.kind).collect::<Vec<_>>(),
+            )
+        });
+        assert!(
+            migration.memos.iter().any(|memo| memo == MEMO),
+            "the migration value transfer must keep its memo; got {:?}",
+            migration.memos,
+        );
+    }
 }

--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -1022,7 +1022,7 @@ async fn failed_split_round_transmit_strands_calculated_transactions() {
 
 /// The offline twins whose assertions read the editorial surface.
 #[cfg(feature = "perspective")]
-mod editorial {
+mod perspective {
     use crate::lightclient::LightClient;
     use crate::perspective::value_transfer::{
         SelfSendValueTransfer, SentValueTransfer, ValueTransfer, ValueTransferKind, ValueTransfers,

--- a/zingolib/src/perspective.rs
+++ b/zingolib/src/perspective.rs
@@ -1,8 +1,6 @@
 //! The editorial layer: the house perspective over the canonical wallet
 //! record, deriving presentation-facing statements that never feed wallet
-//! logic. Compiled behind the default-on `perspective` feature, whose off
-//! build proves core stands without this layer (ADR 0024, amendment
-//! 2026-08-04).
+//! logic.
 
 pub mod finsight;
 pub mod value_transfer;
@@ -189,8 +187,7 @@ fn finsight_from(value_transfers: &ValueTransfers) -> Finsight {
     }
 }
 
-/// The editorial reductions over the wallet, carrying the method names,
-/// signatures, and output shapes `wallet::summary` exposed before the move.
+/// The editorial reductions over the wallet.
 impl LightWallet {
     /// Provides a list of value transfers related to this capability.
     /// A value transfer is a group of all notes to a specific receiver in a transaction.

--- a/zingolib/src/perspective.rs
+++ b/zingolib/src/perspective.rs
@@ -13,8 +13,8 @@ use crate::lightclient::LightClient;
 use crate::wallet::LightWallet;
 use crate::wallet::error::{KeyError, SummaryError};
 use crate::wallet::summary::data::{
-    OutgoingCoinSummary, OutgoingNoteSummary, Scope, SendType, TransactionKind, TransactionSummary,
-    pools_present,
+    BasicNoteSummary, OutgoingCoinSummary, OutgoingNoteSummary, Scope, SendType, TransactionKind,
+    TransactionSummary, pools_present,
 };
 
 use finsight::{
@@ -24,6 +24,49 @@ use finsight::{
 use value_transfer::{
     SelfSendValueTransfer, SentValueTransfer, ValueTransfer, ValueTransferKind, ValueTransfers,
 };
+
+/// The summary accessors that serve only the editorial derivation.
+impl TransactionSummary {
+    /// The shielded note summaries paired with their pool, newest pool first
+    /// (ironwood, orchard, sapling), the order value transfers are listed in.
+    pub(crate) fn shielded_notes_by_pool(&self) -> [(&[BasicNoteSummary], PoolType); 3] {
+        [
+            (self.ironwood_notes.as_slice(), PoolType::IRONWOOD),
+            (self.orchard_notes.as_slice(), PoolType::ORCHARD),
+            (self.sapling_notes.as_slice(), PoolType::SAPLING),
+        ]
+    }
+
+    /// All memos on this transaction's wallet-received shielded notes, in pool
+    /// order ironwood, orchard, sapling.
+    pub(crate) fn received_memos(&self) -> Vec<String> {
+        self.shielded_notes_by_pool()
+            .into_iter()
+            .flat_map(|(notes, _)| notes.iter().filter_map(|note| note.memo.clone()))
+            .collect()
+    }
+
+    /// The sum of every output this transaction delivered to the wallet's own
+    /// addresses: all wallet-received shielded notes plus transparent coins.
+    pub(crate) fn self_received_value(&self) -> u64 {
+        self.shielded_notes_by_pool()
+            .into_iter()
+            .flat_map(|(notes, _)| notes.iter().map(|note| note.value))
+            .chain(self.transparent_coins.iter().map(|coin| coin.value))
+            .sum()
+    }
+
+    /// The sum of the wallet-received shielded notes that carry a memo,
+    /// excluding memo-less change.
+    pub(crate) fn received_memo_value(&self) -> u64 {
+        self.shielded_notes_by_pool()
+            .into_iter()
+            .flat_map(|(notes, _)| notes.iter())
+            .filter(|note| note.memo.is_some())
+            .map(|note| note.value)
+            .sum()
+    }
+}
 
 /// Creates one value transfer of `kind` for each shielded pool the transaction
 /// received notes into, newest pool first (ironwood, orchard, sapling).

--- a/zingolib/src/perspective.rs
+++ b/zingolib/src/perspective.rs
@@ -314,9 +314,7 @@ impl LightWallet {
         Ok(value_transfers)
     }
 
-    /// Every finsight rollup from one derivation of the value transfers;
-    /// the per-rollup methods below re-derive them on each call, so a
-    /// consumer wanting several rollups should take them from here.
+    /// Every finsight rollup from one derivation of the value transfers.
     pub async fn finsight(&self) -> Result<Finsight, SummaryError> {
         let value_transfers = self.value_transfers(false).await?;
         Ok(finsight_from(&value_transfers))

--- a/zingolib/src/perspective/finsight.rs
+++ b/zingolib/src/perspective/finsight.rs
@@ -1,5 +1,5 @@
-//! The financial-insight rollup types, relocated from zingolib's summary
-//! data module when their derivation moved to this crate.
+//! The financial-insight rollup types: per-address reductions over the
+//! wallet's external sends.
 
 /// Every external send's value, grouped by recipient address: one entry
 /// per address, holding the value of each Send value transfer made to it.

--- a/zingolib/src/perspective/value_transfer.rs
+++ b/zingolib/src/perspective/value_transfer.rs
@@ -1,5 +1,5 @@
-//! The value-transfer editorial types, relocated from zingolib's summary
-//! data module when the derivation moved to this crate.
+//! The value-transfer editorial types: per-recipient statements of value
+//! movement derived from transaction summaries.
 
 use chrono::DateTime;
 use json::JsonValue;

--- a/zingolib/src/perspective/value_transfer.rs
+++ b/zingolib/src/perspective/value_transfer.rs
@@ -6,7 +6,7 @@ use json::JsonValue;
 
 use zcash_protocol::{PoolType, TxId, consensus::BlockHeight};
 
-use crate::wallet::summary::data::TransactionSummary;
+use crate::wallet::summary::data::{TransactionSummary, display_pools, pools_to_json};
 use zingo_status::confirmation_status::ConfirmationStatus;
 
 /// Value transfer kind.
@@ -62,21 +62,6 @@ impl std::fmt::Display for ValueTransferKind {
             },
         }
     }
-}
-
-/// Names of the given pools, e.g. `["Orchard", "Ironwood"]`.
-fn pool_names(pools: &[PoolType]) -> Vec<String> {
-    pools.iter().map(ToString::to_string).collect()
-}
-
-/// Formats a list of pools for display, e.g. "Orchard, Ironwood".
-fn display_pools(pools: &[PoolType]) -> String {
-    pool_names(pools).join(", ")
-}
-
-/// Converts a list of pools to a JSON array of pool names.
-fn pools_to_json(pools: &[PoolType]) -> JsonValue {
-    JsonValue::from(pool_names(pools))
 }
 
 /// A value transfer is a note group abstraction.

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -5,7 +5,6 @@ use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::{PoolType, ShieldedPool};
 
-#[cfg(feature = "perspective")]
 use crate::perspective::value_transfer::{
     SelfSendValueTransfer, SentValueTransfer, ValueTransferKind,
 };
@@ -16,7 +15,6 @@ use crate::testutils::lightclient::get_base_address;
 use crate::testutils::timestamped_test_log;
 
 /// Fixture for testing various vt transactions
-#[cfg(feature = "perspective")]
 pub async fn create_various_value_transfers<CC>()
 where
     CC: ConductChain,

--- a/zingolib/src/wallet/keys.rs
+++ b/zingolib/src/wallet/keys.rs
@@ -527,31 +527,18 @@ mod tests {
     use zingo_common_components::protocol::ActivationHeights;
     use zingo_test_vectors::seeds;
 
-    use crate::config::{ChainType, WalletConfig};
-    use crate::testutils::default_test_wallet_settings;
+    use crate::config::ChainType;
     use crate::wallet::LightWallet;
     use crate::wallet::keys::unified::{ReceiverSelection, UnifiedAddressId};
 
-    /// Key derivation needs no network: these were libtonode integration
-    /// tests whose only assertions are derivations against fixed vectors, and
-    /// each spent ~12s launching zebrad+zainod for scaffolding it never used.
-    fn regtest_wallet(mnemonic_phrase: String) -> LightWallet {
-        LightWallet::new(
-            ChainType::Regtest(ActivationHeights::default()),
-            WalletConfig::MnemonicPhrase {
-                mnemonic_phrase,
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1,
-                wallet_settings: default_test_wallet_settings(),
-            },
-        )
-        .unwrap()
+    fn regtest_wallet(mnemonic_phrase: &str) -> LightWallet {
+        crate::testutils::synthetic_wallet::SyntheticWalletBuilder::new(mnemonic_phrase).build()
     }
 
     /// Migrated from libtonode `fast::ensure_taddrs_from_old_seeds_work`.
     #[test]
     fn taddrs_from_old_seeds_stay_stable() {
-        let wallet = regtest_wallet(seeds::HOSPITAL_MUSEUM_SEED.to_string());
+        let wallet = regtest_wallet(seeds::HOSPITAL_MUSEUM_SEED);
         // The first taddr generated on commit 9e71a14eb424631372fd08503b1bd83ea763c7fb
         assert_eq!(
             wallet.transparent_addresses().values().next().unwrap(),
@@ -565,7 +552,7 @@ mod tests {
         let seed_phrase = Mnemonic::<bip0039::English>::from_entropy([1; 32])
             .unwrap()
             .to_string();
-        let mut wallet = regtest_wallet(seed_phrase);
+        let mut wallet = regtest_wallet(&seed_phrase);
         let network = ChainType::Regtest(ActivationHeights::default());
 
         // The scenario ClientBuilder::build_client generates an extra

--- a/zingolib/src/wallet/summary.rs
+++ b/zingolib/src/wallet/summary.rs
@@ -364,30 +364,14 @@ mod tests {
     use pepper_sync::wallet::{IronwoodNote, OrchardNote, OutputId, WalletTransaction};
     use zcash_primitives::transaction::TxId;
     use zcash_protocol::memo::Memo;
-    use zingo_common_components::protocol::ActivationHeights;
     use zingo_status::confirmation_status::ConfirmationStatus;
     use zingo_test_vectors::seeds;
 
-    use crate::config::{ChainType, WalletConfig};
     use crate::mocks::orchard_note::OrchardCryptoNoteBuilder;
-    use crate::testutils::default_test_wallet_settings;
     use crate::wallet::LightWallet;
 
-    /// Message semantics need no network: the ported tests in this module
-    /// were libtonode integration tests (the first two ports alone cost
-    /// 49s and 132s of LocalNet mining/syncing) whose assertions are pure
-    /// summary/value-transfer derivation over wallet transaction records.
     fn regtest_wallet(mnemonic_phrase: &str) -> LightWallet {
-        LightWallet::new(
-            ChainType::Regtest(ActivationHeights::default()),
-            WalletConfig::MnemonicPhrase {
-                mnemonic_phrase: mnemonic_phrase.to_string(),
-                no_of_accounts: 1.try_into().unwrap(),
-                birthday: 1,
-                wallet_settings: default_test_wallet_settings(),
-            },
-        )
-        .unwrap()
+        crate::testutils::synthetic_wallet::SyntheticWalletBuilder::new(mnemonic_phrase).build()
     }
 
     /// Migrated from libtonode

--- a/zingolib/src/wallet/summary/data.rs
+++ b/zingolib/src/wallet/summary/data.rs
@@ -210,50 +210,6 @@ impl TransactionSummary {
     }
 }
 
-/// The editorial accessors, compiled only for the perspective layer.
-#[cfg(feature = "perspective")]
-impl TransactionSummary {
-    /// The shielded note summaries paired with their pool, newest pool first
-    /// (ironwood, orchard, sapling), the order value transfers are listed in.
-    pub(crate) fn shielded_notes_by_pool(&self) -> [(&[BasicNoteSummary], PoolType); 3] {
-        [
-            (self.ironwood_notes.as_slice(), PoolType::IRONWOOD),
-            (self.orchard_notes.as_slice(), PoolType::ORCHARD),
-            (self.sapling_notes.as_slice(), PoolType::SAPLING),
-        ]
-    }
-
-    /// All memos on this transaction's wallet-received shielded notes, in pool
-    /// order ironwood, orchard, sapling.
-    pub(crate) fn received_memos(&self) -> Vec<String> {
-        self.shielded_notes_by_pool()
-            .into_iter()
-            .flat_map(|(notes, _)| notes.iter().filter_map(|note| note.memo.clone()))
-            .collect()
-    }
-
-    /// The sum of every output this transaction delivered to the wallet's own
-    /// addresses: all wallet-received shielded notes plus transparent coins.
-    pub(crate) fn self_received_value(&self) -> u64 {
-        self.shielded_notes_by_pool()
-            .into_iter()
-            .flat_map(|(notes, _)| notes.iter().map(|note| note.value))
-            .chain(self.transparent_coins.iter().map(|coin| coin.value))
-            .sum()
-    }
-
-    /// The sum of the wallet-received shielded notes that carry a memo,
-    /// excluding memo-less change.
-    pub(crate) fn received_memo_value(&self) -> u64 {
-        self.shielded_notes_by_pool()
-            .into_iter()
-            .flat_map(|(notes, _)| notes.iter())
-            .filter(|note| note.memo.is_some())
-            .map(|note| note.value)
-            .sum()
-    }
-}
-
 impl std::fmt::Display for TransactionSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (

--- a/zingolib/src/wallet/summary/data.rs
+++ b/zingolib/src/wallet/summary/data.rs
@@ -76,12 +76,12 @@ fn pool_names(pools: &[PoolType]) -> Vec<String> {
 }
 
 /// Formats a list of pools for display, e.g. "Orchard, Ironwood".
-fn display_pools(pools: &[PoolType]) -> String {
+pub(crate) fn display_pools(pools: &[PoolType]) -> String {
     pool_names(pools).join(", ")
 }
 
 /// Converts a list of pools to a JSON array of pool names.
-fn pools_to_json(pools: &[PoolType]) -> JsonValue {
+pub(crate) fn pools_to_json(pools: &[PoolType]) -> JsonValue {
     JsonValue::from(pool_names(pools))
 }
 
@@ -152,50 +152,6 @@ impl TransactionSummary {
             && self.pools_received().contains(&PoolType::IRONWOOD)
     }
 
-    /// The shielded note summaries paired with their pool, newest pool first
-    /// (ironwood, orchard, sapling), the order value transfers are listed in.
-    #[cfg(feature = "perspective")]
-    pub(crate) fn shielded_notes_by_pool(&self) -> [(&[BasicNoteSummary], PoolType); 3] {
-        [
-            (self.ironwood_notes.as_slice(), PoolType::IRONWOOD),
-            (self.orchard_notes.as_slice(), PoolType::ORCHARD),
-            (self.sapling_notes.as_slice(), PoolType::SAPLING),
-        ]
-    }
-
-    /// All memos on this transaction's wallet-received shielded notes, in pool
-    /// order ironwood, orchard, sapling.
-    #[cfg(feature = "perspective")]
-    pub(crate) fn received_memos(&self) -> Vec<String> {
-        self.shielded_notes_by_pool()
-            .into_iter()
-            .flat_map(|(notes, _)| notes.iter().filter_map(|note| note.memo.clone()))
-            .collect()
-    }
-
-    /// The sum of every output this transaction delivered to the wallet's own
-    /// addresses: all wallet-received shielded notes plus transparent coins.
-    #[cfg(feature = "perspective")]
-    pub(crate) fn self_received_value(&self) -> u64 {
-        self.shielded_notes_by_pool()
-            .into_iter()
-            .flat_map(|(notes, _)| notes.iter().map(|note| note.value))
-            .chain(self.transparent_coins.iter().map(|coin| coin.value))
-            .sum()
-    }
-
-    /// The sum of the wallet-received shielded notes that carry a memo,
-    /// excluding memo-less change.
-    #[cfg(feature = "perspective")]
-    pub(crate) fn received_memo_value(&self) -> u64 {
-        self.shielded_notes_by_pool()
-            .into_iter()
-            .flat_map(|(notes, _)| notes.iter())
-            .filter(|note| note.memo.is_some())
-            .map(|note| note.value)
-            .sum()
-    }
-
     /// Prepares the fields in the summary for display
     #[must_use]
     pub fn prepare_for_display(
@@ -251,6 +207,50 @@ impl TransactionSummary {
             outgoing_sapling_notes,
             outgoing_transparent_coins,
         )
+    }
+}
+
+/// The editorial accessors, compiled only for the perspective layer.
+#[cfg(feature = "perspective")]
+impl TransactionSummary {
+    /// The shielded note summaries paired with their pool, newest pool first
+    /// (ironwood, orchard, sapling), the order value transfers are listed in.
+    pub(crate) fn shielded_notes_by_pool(&self) -> [(&[BasicNoteSummary], PoolType); 3] {
+        [
+            (self.ironwood_notes.as_slice(), PoolType::IRONWOOD),
+            (self.orchard_notes.as_slice(), PoolType::ORCHARD),
+            (self.sapling_notes.as_slice(), PoolType::SAPLING),
+        ]
+    }
+
+    /// All memos on this transaction's wallet-received shielded notes, in pool
+    /// order ironwood, orchard, sapling.
+    pub(crate) fn received_memos(&self) -> Vec<String> {
+        self.shielded_notes_by_pool()
+            .into_iter()
+            .flat_map(|(notes, _)| notes.iter().filter_map(|note| note.memo.clone()))
+            .collect()
+    }
+
+    /// The sum of every output this transaction delivered to the wallet's own
+    /// addresses: all wallet-received shielded notes plus transparent coins.
+    pub(crate) fn self_received_value(&self) -> u64 {
+        self.shielded_notes_by_pool()
+            .into_iter()
+            .flat_map(|(notes, _)| notes.iter().map(|note| note.value))
+            .chain(self.transparent_coins.iter().map(|coin| coin.value))
+            .sum()
+    }
+
+    /// The sum of the wallet-received shielded notes that carry a memo,
+    /// excluding memo-less change.
+    pub(crate) fn received_memo_value(&self) -> u64 {
+        self.shielded_notes_by_pool()
+            .into_iter()
+            .flat_map(|(notes, _)| notes.iter())
+            .filter(|note| note.memo.is_some())
+            .map(|note| note.value)
+            .sum()
     }
 }
 

--- a/zingolib/tests/derivation.rs
+++ b/zingolib/tests/derivation.rs
@@ -1,17 +1,12 @@
 #![forbid(unsafe_code)]
 #![cfg(all(feature = "perspective", feature = "testutils"))]
-//! Unit tests of the value-transfer derivation, relocated from
-//! zingolib's summary test module when the derivation moved to the
-//! perspective module. Message semantics need no network: the ported tests in this
-//! module were libtonode integration tests (the first two ports alone
-//! cost 49s and 132s of LocalNet mining/syncing) whose assertions are
-//! pure summary/value-transfer derivation over wallet transaction
-//! records.
+//! Unit tests of the value-transfer derivation over fabricated wallet
+//! transaction records.
 
 #[path = "support/common.rs"]
 mod common;
 
-use pepper_sync::wallet::{IronwoodNote, OutgoingIronwoodNote, OutputId, WalletTransaction};
+use pepper_sync::wallet::{IronwoodNote, OutputId, WalletTransaction};
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::memo::Memo;
 use zingo_common_components::protocol::ActivationHeights;
@@ -21,11 +16,13 @@ use zingolib::ZENNIES_FOR_ZINGO_REGTEST_ADDRESS;
 use zingolib::config::ChainType;
 use zingolib::mocks::orchard_note::OrchardCryptoNoteBuilder;
 use zingolib::perspective::value_transfer::{
-    SelfSendValueTransfer, SentValueTransfer, ValueTransferKind,
+    SelfSendValueTransfer, SentValueTransfer, ValueTransferKind, ValueTransfers,
 };
 use zingolib::wallet::keys::unified::ReceiverSelection;
 
-use common::{received_texts, regtest_wallet, sent};
+use common::{
+    own_orchard_receiver, received_texts, regtest_wallet, self_send, sent, zfz_self_send,
+};
 
 /// Migrated from libtonode `fast::filter_empty_messages`.
 #[tokio::test]
@@ -121,60 +118,16 @@ async fn message_thread() {
 }
 
 /// Migrated from libtonode `fast::create_send_to_self_with_zfz_active`:
-/// the assertions are value-transfer KIND classification (a self-send
-/// yields SendToSelf(Basic). The Zennies-for-Zingo output yields a
-/// Sent(Send) addressed to the ZFZ address), which is pure summary
-/// derivation. The proposal/transmission pipeline the integration test
-/// drove incidentally remains covered by the chain-bound send tests.
+/// a self-send yields SendToSelf(Basic) and the Zennies-for-Zingo output
+/// yields a Sent(Send) addressed to the ZFZ address.
 #[tokio::test]
 async fn create_send_to_self_with_zfz_active() {
     let mut wallet = regtest_wallet(seeds::HOSPITAL_MUSEUM_SEED);
-    let network = ChainType::Regtest(ActivationHeights::default());
 
-    let own_orchard_receiver = *wallet
-        .unified_addresses()
-        .values()
-        .next()
-        .unwrap()
-        .orchard()
-        .unwrap();
-    let zcash_client_backend::address::Address::Unified(zfz_unified_address) =
-        zcash_client_backend::address::Address::decode(&network, ZENNIES_FOR_ZINGO_REGTEST_ADDRESS)
-            .unwrap()
-    else {
-        panic!("ZFZ address must be unified");
-    };
-
-    let txid = TxId::from_bytes([1; 32]);
-    let transaction = WalletTransaction::new_for_test_with_ironwood_notes(
-        txid,
-        ConfirmationStatus::Confirmed(10.into()),
-        vec![],
-        vec![
-            // The send-to-self output: recipient is one of the wallet's
-            // own orchard receivers.
-            OutgoingIronwoodNote::new_for_test(
-                OutputId::new(txid, 0),
-                zip32::AccountId::ZERO,
-                zip32::Scope::External,
-                OrchardCryptoNoteBuilder::default()
-                    .recipient(own_orchard_receiver)
-                    .build(),
-                Memo::Empty,
-                None,
-            ),
-            // The Zennies-for-Zingo output.
-            OutgoingIronwoodNote::new_for_test(
-                OutputId::new(txid, 1),
-                zip32::AccountId::ZERO,
-                zip32::Scope::External,
-                OrchardCryptoNoteBuilder::default().build(),
-                Memo::Empty,
-                Some(zfz_unified_address),
-            ),
-        ],
-    );
-    wallet.wallet_transactions.insert(txid, transaction);
+    let transaction = zfz_self_send(1, 10, own_orchard_receiver(&wallet));
+    wallet
+        .wallet_transactions
+        .insert(transaction.txid(), transaction);
 
     let value_transfers = wallet.value_transfers(true).await.unwrap();
 
@@ -215,50 +168,17 @@ async fn send_exposes_recipient_pools_received() {
 
 /// A send-to-self value transfer exposes the pools its value arrived
 /// into (here: ironwood), letting consumers label pool movements such
-/// as an orchard -> ironwood migration outside zingolib. The funding
-/// side (`pools_sent_from`) needs real spend links, so it is pinned by
-/// the chain-bound shield tests in libtonode instead.
+/// as an orchard -> ironwood migration outside zingolib.
 #[tokio::test]
 async fn send_to_self_exposes_pools_received() {
     use zcash_protocol::PoolType;
 
     let mut wallet = regtest_wallet(seeds::HOSPITAL_MUSEUM_SEED);
-    let own_orchard_receiver = *wallet
-        .unified_addresses()
-        .values()
-        .next()
-        .unwrap()
-        .orchard()
-        .unwrap();
 
-    let txid = TxId::from_bytes([1; 32]);
-    let transaction = WalletTransaction::new_for_test_with_ironwood_notes(
-        txid,
-        ConfirmationStatus::Confirmed(10.into()),
-        // The self-received output, landing in the ironwood pool.
-        vec![IronwoodNote::new_for_test(
-            OutputId::new(txid, 0),
-            zip32::AccountId::ZERO,
-            zip32::Scope::Internal,
-            OrchardCryptoNoteBuilder::default().build(),
-            Memo::Empty,
-            None,
-        )],
-        // The outgoing view of the same output: recipient is one of
-        // the wallet's own receivers, making the transaction a
-        // send-to-self.
-        vec![OutgoingIronwoodNote::new_for_test(
-            OutputId::new(txid, 0),
-            zip32::AccountId::ZERO,
-            zip32::Scope::External,
-            OrchardCryptoNoteBuilder::default()
-                .recipient(own_orchard_receiver)
-                .build(),
-            Memo::Empty,
-            None,
-        )],
-    );
-    wallet.wallet_transactions.insert(txid, transaction);
+    let transaction = self_send(1, 10, own_orchard_receiver(&wallet));
+    wallet
+        .wallet_transactions
+        .insert(transaction.txid(), transaction);
 
     let value_transfers = wallet.value_transfers(true).await.unwrap();
 
@@ -311,10 +231,11 @@ async fn by_address_finsight() {
     );
 }
 
-/// Migrated from libtonode `fast::value_transfers`: a four-output
-/// memo'd receive aggregates into one value transfer carrying all
-/// four memos, and the derivation is idempotent and sort-stable
-/// (the descending ordering is exactly the reverse of ascending).
+/// Migrated from libtonode `fast::value_transfers`: a four-output memo'd
+/// receive aggregates into one value transfer, the derivation is
+/// idempotent, and the descending sort reverses the ascending one at
+/// transaction granularity while preserving intra-transaction creation
+/// order.
 #[tokio::test]
 async fn value_transfers_aggregation_and_ordering() {
     use std::str::FromStr as _;
@@ -373,24 +294,52 @@ async fn value_transfers_aggregation_and_ordering() {
             ),
         );
     }
+    // ...plus one transaction yielding TWO value transfers (a self-send
+    // and a ZFZ send), so the intra-transaction assertions bite.
+    let zfz_txid = TxId::from_bytes([4; 32]);
+    let transaction = zfz_self_send(4, 7, own_orchard_receiver(&wallet));
+    wallet
+        .wallet_transactions
+        .insert(transaction.txid(), transaction);
 
-    let value_transfers = wallet.value_transfers(true).await.unwrap();
-    let value_transfers1 = wallet.value_transfers(true).await.unwrap();
-    let value_transfers2 = wallet.value_transfers(true).await.unwrap();
-    let mut value_transfers3 = wallet.value_transfers(false).await.unwrap();
-    let mut value_transfers4 = wallet.value_transfers(false).await.unwrap();
+    let descending = wallet.value_transfers(true).await.unwrap();
+    let ascending = wallet.value_transfers(false).await.unwrap();
 
-    let four_memo_transfer = value_transfers
+    let four_memo_transfer = descending
         .iter()
         .find(|transfer| transfer.txid == TxId::from_bytes([1; 32]))
         .unwrap();
     assert_eq!(four_memo_transfer.memos.len(), 4);
 
-    value_transfers3.reverse();
-    value_transfers4.reverse();
+    // Idempotence.
+    assert_eq!(descending, wallet.value_transfers(true).await.unwrap());
+    assert_eq!(ascending, wallet.value_transfers(false).await.unwrap());
 
-    assert_eq!(value_transfers, value_transfers1);
-    assert_eq!(value_transfers, value_transfers2);
-    assert_eq!(value_transfers, value_transfers3);
-    assert_eq!(value_transfers, value_transfers4);
+    // Descending reverses ascending at transaction granularity only: the
+    // per-transaction blocks reverse, while each transaction's transfers
+    // keep their creation order in both directions.
+    let transaction_blocks = |value_transfers: &ValueTransfers| {
+        let mut blocks: Vec<TxId> = Vec::new();
+        for value_transfer in value_transfers.iter() {
+            if blocks.last() != Some(&value_transfer.txid) {
+                blocks.push(value_transfer.txid);
+            }
+        }
+        blocks
+    };
+    let mut reversed_ascending_blocks = transaction_blocks(&ascending);
+    reversed_ascending_blocks.reverse();
+    assert_eq!(transaction_blocks(&descending), reversed_ascending_blocks);
+
+    let kinds_of = |value_transfers: &ValueTransfers, txid: TxId| {
+        value_transfers
+            .iter()
+            .filter(|value_transfer| value_transfer.txid == txid)
+            .map(|value_transfer| value_transfer.kind)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(kinds_of(&descending, zfz_txid).len(), 2);
+    for txid in transaction_blocks(&descending) {
+        assert_eq!(kinds_of(&descending, txid), kinds_of(&ascending, txid));
+    }
 }

--- a/zingolib/tests/golden.rs
+++ b/zingolib/tests/golden.rs
@@ -1,20 +1,9 @@
 #![forbid(unsafe_code)]
 #![cfg(all(feature = "perspective", feature = "testutils"))]
-//! Golden-JSON regression harness for the editorial surface.
-//!
-//! These goldens were captured from zingolib's PRE-extraction editorial
-//! implementation and pin the consumer contract bit-for-bit: the JSON and
-//! Display renderings of `value_transfers`, `messages_containing`, and the
-//! three `do_total_*` rollups. The extraction increments must reproduce
-//! them exactly; a diff here is a compatibility break, never a fixture to
-//! update. The capture mechanism was removed after the original capture,
-//! so these files are never regenerated: a contract change that is truly
-//! intended must re-mint its golden rows by hand, in review.
-//!
-//! One deliberate softening: the `do_total_*` structs are HashMap-backed,
-//! so their JSON key order is random per process — for those the harness
-//! canonicalizes object key order before comparison. Value equality is the
-//! real contract there; consumers see random key order today too.
+//! Golden regression harness pinning the editorial surface's JSON and
+//! Display renderings byte-for-byte against pre-extraction captures,
+//! canonicalizing key order only for the HashMap-backed `do_total_*`
+//! rollups.
 
 #[path = "support/common.rs"]
 mod common;
@@ -27,19 +16,19 @@ use zcash_protocol::memo::Memo;
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_status::confirmation_status::ConfirmationStatus;
 use zingo_test_vectors::seeds;
-use zingolib::ZENNIES_FOR_ZINGO_REGTEST_ADDRESS;
 use zingolib::config::ChainType;
 use zingolib::mocks::orchard_note::OrchardCryptoNoteBuilder;
 use zingolib::wallet::LightWallet;
 use zingolib::wallet::keys::unified::ReceiverSelection;
 
-use common::{received, regtest_wallet, sent};
+use common::{own_orchard_receiver, received, regtest_wallet, self_send, sent, zfz_self_send};
 
-/// A wallet exercising every editorial classification the goldens pin:
-/// received text/empty/arbitrary memos, a plain send with a memo, a
+/// A wallet exercising every editorial classification the goldens pin
+/// (received text/empty/arbitrary memos, a plain send with a memo, a
 /// memo-to-self on a sending transaction, a basic send-to-self, and the
-/// Zennies-for-Zingo dual-output self-send.
-fn editorial_wallet() -> LightWallet {
+/// Zennies-for-Zingo dual-output self-send), returned with Bob's encoded
+/// address.
+fn editorial_wallet() -> (LightWallet, String) {
     let mut alice_wallet = regtest_wallet(seeds::HOSPITAL_MUSEUM_SEED);
     let network = ChainType::Regtest(ActivationHeights::default());
 
@@ -47,20 +36,6 @@ fn editorial_wallet() -> LightWallet {
     let (_, bob) = other_wallet
         .generate_unified_address(ReceiverSelection::all_shielded(), zip32::AccountId::ZERO)
         .unwrap();
-
-    let own_orchard_receiver = *alice_wallet
-        .unified_addresses()
-        .values()
-        .next()
-        .unwrap()
-        .orchard()
-        .unwrap();
-    let zcash_client_backend::address::Address::Unified(zfz_unified_address) =
-        zcash_client_backend::address::Address::decode(&network, ZENNIES_FOR_ZINGO_REGTEST_ADDRESS)
-            .unwrap()
-    else {
-        panic!("ZFZ address must be unified");
-    };
 
     // tx1: received, one text memo alongside an empty one.
     let tx1 = received(
@@ -98,73 +73,17 @@ fn editorial_wallet() -> LightWallet {
     );
     // tx5: a basic send-to-self (outgoing to one of the wallet's own
     // receivers, self-received internally).
-    let txid5 = TxId::from_bytes([5; 32]);
-    let tx5 = WalletTransaction::new_for_test_with_ironwood_notes(
-        txid5,
-        ConfirmationStatus::Confirmed(14.into()),
-        vec![IronwoodNote::new_for_test(
-            OutputId::new(txid5, 0),
-            zip32::AccountId::ZERO,
-            zip32::Scope::Internal,
-            OrchardCryptoNoteBuilder::default().build(),
-            Memo::Empty,
-            None,
-        )],
-        vec![OutgoingIronwoodNote::new_for_test(
-            OutputId::new(txid5, 0),
-            zip32::AccountId::ZERO,
-            zip32::Scope::External,
-            OrchardCryptoNoteBuilder::default()
-                .recipient(own_orchard_receiver)
-                .build(),
-            Memo::Empty,
-            None,
-        )],
-    );
+    let tx5 = self_send(5, 14, own_orchard_receiver(&alice_wallet));
     // tx6: the Zennies-for-Zingo pattern — a self-send output plus a send
     // to the ZFZ address in one transaction.
-    let txid6 = TxId::from_bytes([6; 32]);
-    let tx6 = WalletTransaction::new_for_test_with_ironwood_notes(
-        txid6,
-        ConfirmationStatus::Confirmed(15.into()),
-        vec![],
-        vec![
-            OutgoingIronwoodNote::new_for_test(
-                OutputId::new(txid6, 0),
-                zip32::AccountId::ZERO,
-                zip32::Scope::External,
-                OrchardCryptoNoteBuilder::default()
-                    .recipient(own_orchard_receiver)
-                    .build(),
-                Memo::Empty,
-                None,
-            ),
-            OutgoingIronwoodNote::new_for_test(
-                OutputId::new(txid6, 1),
-                zip32::AccountId::ZERO,
-                zip32::Scope::External,
-                OrchardCryptoNoteBuilder::default().build(),
-                Memo::Empty,
-                Some(zfz_unified_address),
-            ),
-        ],
-    );
+    let tx6 = zfz_self_send(6, 15, own_orchard_receiver(&alice_wallet));
 
     for transaction in [tx1, tx2, tx3, tx4, tx5, tx6] {
         alice_wallet
             .wallet_transactions
             .insert(transaction.txid(), transaction);
     }
-    alice_wallet
-}
-
-fn bob_encoded() -> String {
-    let network = ChainType::Regtest(ActivationHeights::default());
-    let mut other_wallet = regtest_wallet(seeds::ABANDON_ART_SEED);
-    let (_, bob) = other_wallet
-        .generate_unified_address(ReceiverSelection::all_shielded(), zip32::AccountId::ZERO)
-        .unwrap();
-    bob.encode(&network)
+    (alice_wallet, bob.encode(&network))
 }
 
 /// Recursively sorts JSON object keys so HashMap-backed outputs compare
@@ -209,8 +128,7 @@ fn check_golden(name: &str, actual: &str) {
 
 #[tokio::test]
 async fn editorial_surface_matches_goldens() {
-    let wallet = editorial_wallet();
-    let bob = bob_encoded();
+    let (wallet, bob) = editorial_wallet();
 
     let value_transfers = wallet.value_transfers(true).await.unwrap();
     check_golden("value_transfers.txt", &value_transfers.to_string());

--- a/zingolib/tests/support/common.rs
+++ b/zingolib/tests/support/common.rs
@@ -1,9 +1,4 @@
-//! Record-fabrication rig shared by this crate's integration tests:
-//! deterministic offline wallets built through the pepper-sync
-//! `new_for_test` constructors (datetime pinned to 0).
-//!
-//! Each test binary compiles this module separately and uses a subset
-//! of the rig, so unused-in-this-binary items are expected.
+//! Record-fabrication rig shared by this crate's integration tests.
 #![allow(dead_code)]
 
 use std::str::FromStr as _;
@@ -13,22 +8,39 @@ use zcash_primitives::transaction::TxId;
 use zcash_protocol::memo::Memo;
 use zingo_common_components::protocol::ActivationHeights;
 use zingo_status::confirmation_status::ConfirmationStatus;
-use zingolib::config::{ChainType, WalletConfig};
+use zingolib::config::ChainType;
 use zingolib::mocks::orchard_note::OrchardCryptoNoteBuilder;
-use zingolib::testutils::default_test_wallet_settings;
+use zingolib::testutils::synthetic_wallet::SyntheticWalletBuilder;
 use zingolib::wallet::LightWallet;
 
 pub fn regtest_wallet(mnemonic_phrase: &str) -> LightWallet {
-    LightWallet::new(
-        ChainType::Regtest(ActivationHeights::default()),
-        WalletConfig::MnemonicPhrase {
-            mnemonic_phrase: mnemonic_phrase.to_string(),
-            no_of_accounts: 1.try_into().unwrap(),
-            birthday: 1,
-            wallet_settings: default_test_wallet_settings(),
-        },
-    )
-    .unwrap()
+    SyntheticWalletBuilder::new(mnemonic_phrase).build()
+}
+
+/// The wallet's first orchard receiver.
+pub fn own_orchard_receiver(wallet: &LightWallet) -> orchard::Address {
+    *wallet
+        .unified_addresses()
+        .values()
+        .next()
+        .unwrap()
+        .orchard()
+        .unwrap()
+}
+
+/// The Zennies-for-Zingo unified address for the regtest chain.
+pub fn zfz_unified_address() -> zcash_client_backend::address::UnifiedAddress {
+    let network = ChainType::Regtest(ActivationHeights::default());
+    let zcash_client_backend::address::Address::Unified(address) =
+        zcash_client_backend::address::Address::decode(
+            &network,
+            zingolib::get_zennies_for_zingo_address(network),
+        )
+        .unwrap()
+    else {
+        panic!("ZFZ address must be unified");
+    };
+    address
 }
 
 pub fn received(txid_byte: u8, height: u32, memos: &[Memo]) -> WalletTransaction {
@@ -83,5 +95,68 @@ pub fn sent(
             Memo::from_str(memo).unwrap(),
             Some(recipient.clone()),
         )],
+    )
+}
+
+/// A basic send-to-self: one internally self-received note whose outgoing
+/// view is addressed to `own_receiver`.
+pub fn self_send(txid_byte: u8, height: u32, own_receiver: orchard::Address) -> WalletTransaction {
+    let txid = TxId::from_bytes([txid_byte; 32]);
+    WalletTransaction::new_for_test_with_ironwood_notes(
+        txid,
+        ConfirmationStatus::Confirmed(height.into()),
+        vec![IronwoodNote::new_for_test(
+            OutputId::new(txid, 0),
+            zip32::AccountId::ZERO,
+            zip32::Scope::Internal,
+            OrchardCryptoNoteBuilder::default().build(),
+            Memo::Empty,
+            None,
+        )],
+        vec![OutgoingIronwoodNote::new_for_test(
+            OutputId::new(txid, 0),
+            zip32::AccountId::ZERO,
+            zip32::Scope::External,
+            OrchardCryptoNoteBuilder::default()
+                .recipient(own_receiver)
+                .build(),
+            Memo::Empty,
+            None,
+        )],
+    )
+}
+
+/// The Zennies-for-Zingo dual-output pattern: a send-to-self output to
+/// `own_receiver` plus a send to the ZFZ address in one transaction.
+pub fn zfz_self_send(
+    txid_byte: u8,
+    height: u32,
+    own_receiver: orchard::Address,
+) -> WalletTransaction {
+    let txid = TxId::from_bytes([txid_byte; 32]);
+    WalletTransaction::new_for_test_with_ironwood_notes(
+        txid,
+        ConfirmationStatus::Confirmed(height.into()),
+        vec![],
+        vec![
+            OutgoingIronwoodNote::new_for_test(
+                OutputId::new(txid, 0),
+                zip32::AccountId::ZERO,
+                zip32::Scope::External,
+                OrchardCryptoNoteBuilder::default()
+                    .recipient(own_receiver)
+                    .build(),
+                Memo::Empty,
+                None,
+            ),
+            OutgoingIronwoodNote::new_for_test(
+                OutputId::new(txid, 1),
+                zip32::AccountId::ZERO,
+                zip32::Scope::External,
+                OrchardCryptoNoteBuilder::default().build(),
+                Memo::Empty,
+                Some(zfz_unified_address()),
+            ),
+        ],
     )
 }

--- a/zingolib_testutils/Cargo.toml
+++ b/zingolib_testutils/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# zingolib
-zingolib = { workspace = true, features = ["testutils"] }
+zingolib = { workspace = true, features = ["perspective", "testutils"] }
 zingo_common_components.workspace = true
 
 # zingo infrastructure


### PR DESCRIPTION
This follow-up applies the review comments from #2623 and the post-merge review findings.

## Dorian's review comments

The review asked for doc comments that serve the docs.rs first-time reader. Three module docs narrated a past relocation. One referenced an ADR and its amendment. Each doc now states what the module holds in one present-tense sentence.

The `default?` thread is applied as asked: the `perspective` feature leaves the default set. The default build proves core stands without the editorial layer. `zingo-cli`, `zingolib_testutils`, and `libtonode-tests` opt in explicitly. The CHANGELOG records the editorial-layer break under Unreleased.

## Post-merge review findings

The ported golden and derivation binaries compiled to zero tests in package-scoped runs. A self dev-dependency now activates their features, and the eight tests run everywhere. The `testutils` feature enables `perspective`, which closes the one-sided gate on the chain-generics fixture. The golden directory is exempt from `.editorconfig` whitespace normalization, so a save can no longer corrupt the byte-exact pins.

The pool renderers, the `regtest_wallet` helpers, and the golden fixtures each had live duplicates; one copy now serves every consumer. The four editorial accessors sit in one perspective-gated impl block. The ordering test now holds a two-transfer transaction and pins the true property: transaction blocks reverse between the sorts, and intra-transaction creation order is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)