### PR TITLE
docs: forbid magic numbers in the agent code-style rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Goal: produce prose and code that reads as if written by a specific, competent h
 - No docstrings that just restate the signature.
 - Names: concise and domain-specific. Avoid generic placeholders (`data`, `result`, `output`, `item`, `value`, `temp`, `handleData`, a helper named `helper`) and avoid over-long descriptive names where a short one is idiomatic.
 - No completeness theater: no unrequested demo/usage blocks, no logs narrating execution ("Starting...", "Done!"), no emoji in output, no unprompted complexity analysis in comments.
+- Never use magic numbers, anywhere. Every bare literal gets a name: prefer the most private binding the context allows, and a named constant where privacy can't confine it. Derive new constants from existing named constants rather than repeating a number.
 - Don't add guards for conditions that can't occur. Don't wrap non-throwing code in try/catch. Don't swallow-and-log errors; let them propagate.
 - Match the surrounding codebase's idioms and conventions over textbook-uniform formatting.
 


### PR DESCRIPTION
AGENTS.md gains one rule under "Code (all languages)". No bare numeric
literal may appear anywhere. Every literal gets a name. The most private
binding the context allows is preferred. A named constant covers what
privacy cannot confine. New constants derive from existing named
constants rather than repeating a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)