### PR TITLE
The exit-use categories of ADR 0039 are sealed lease types

### DIFF
--- a/docs/adr/0039-an-exit-node-is-exclusive-or-shared-across-correspondents.md
+++ b/docs/adr/0039-an-exit-node-is-exclusive-or-shared-across-correspondents.md
@@ -1,6 +1,11 @@
 # An Exit Node is Exclusive to one Correspondent or Shared across many
 
-Status: draft — ratified in session 2026-08-07, pending review
+Status: draft — ratified in session 2026-08-07, pending review.
+Amended 2026-08-10: the sealed categories are implemented as lease
+types — `Member<T, Exclusive>`'s one dial consumes the member, and
+`Member<T, Shared>` dials repeatedly for its one holder — declared at
+the Indexer Pool, Price Source Pool, and Server-Selection Sweep
+acquisition sites.
 
 ## Context
 

--- a/zingolib/src/correspondent/pool.rs
+++ b/zingolib/src/correspondent/pool.rs
@@ -16,37 +16,127 @@ pub(crate) const PRICE_POOL_COMPLEMENT: usize = 1;
 pub(crate) trait PoolTransport: Send + 'static {
     /// Whether the transport still reports itself ready.
     fn is_ready(&self) -> bool;
+    /// The transport's local SOCKS5 address, while it lives.
+    fn socks5_addr(&self) -> Option<String>;
+    /// Tears the transport down.
+    fn stop(self) -> impl std::future::Future<Output = ()> + Send;
 }
 
-/// One ready member: an Exit-Bound transport and the Exclusive Lease of
-/// the Exit Node it bound.
-pub(crate) struct Member<T> {
-    /// The ready transport a run consumes.
-    pub(crate) transport: T,
-    /// The bound Exit Node's owning lease, recycled when the member drops.
-    pub(crate) lease: exit_pool::Reservation,
+/// The sealed category of a bound exit's Correspondent exposure.
+pub(crate) trait ExitUse: sealed::Sealed + Send + 'static {}
+
+/// The category serving exactly one Correspondent, whose dial consumes the
+/// member.
+pub(crate) enum Exclusive {}
+
+/// The category fanning out to many Correspondents for its one holder.
+pub(crate) enum Shared {}
+
+mod sealed {
+    pub(crate) trait Sealed {}
+    impl Sealed for super::Exclusive {}
+    impl Sealed for super::Shared {}
+}
+
+impl ExitUse for Exclusive {}
+impl ExitUse for Shared {}
+
+/// One ready member: an Exit-Bound transport and the owning lease of the
+/// Exit Node it bound, in the exit-use category `U`.
+pub(crate) struct Member<T, U: ExitUse> {
+    transport: T,
+    lease: exit_pool::Reservation,
+    category: std::marker::PhantomData<U>,
+}
+
+impl<T: PoolTransport, U: ExitUse> Member<T, U> {
+    /// A member in the exit-use category its acquisition site declares.
+    pub(crate) fn new(transport: T, lease: exit_pool::Reservation) -> Self {
+        Member {
+            transport,
+            lease,
+            category: std::marker::PhantomData,
+        }
+    }
+
+    /// Whether the member's transport still reports itself ready.
+    pub(crate) fn is_ready(&self) -> bool {
+        self.transport.is_ready()
+    }
+
+    /// The bound Exit Node's identity.
+    #[cfg(test)]
+    pub(crate) fn node(&self) -> &str {
+        self.lease.node()
+    }
+
+    /// Stops the transport and recycles the lease.
+    pub(crate) async fn retire(self) {
+        self.transport.stop().await;
+    }
+}
+
+impl<T: PoolTransport> Member<T, Exclusive> {
+    /// The one dial: consumes the member, yielding the tunnel address for a
+    /// single Correspondent contact and the spent holder to retire.
+    pub(crate) fn dial(self) -> (Option<String>, SpentExit<T>) {
+        let addr = self.transport.socks5_addr();
+        (
+            addr,
+            SpentExit {
+                transport: self.transport,
+                lease: self.lease,
+            },
+        )
+    }
+}
+
+impl<T: PoolTransport> Member<T, Shared> {
+    /// The tunnel address for one more Correspondent contact, while the
+    /// transport lives.
+    pub(crate) fn addr(&self) -> Option<String> {
+        self.transport.socks5_addr()
+    }
+}
+
+/// A dialled Exclusive member, capable only of teardown.
+pub(crate) struct SpentExit<T> {
+    transport: T,
+    lease: exit_pool::Reservation,
+}
+
+impl<T: PoolTransport> SpentExit<T> {
+    /// The spent exit's identity, for the attempt record.
+    pub(crate) fn node(&self) -> &str {
+        self.lease.node()
+    }
+
+    /// Stops the transport and recycles the lease.
+    pub(crate) async fn retire(self) {
+        self.transport.stop().await;
+    }
 }
 
 /// What a take found: the member to consume, and any dead members evicted
 /// on the way, which the caller tears down.
-pub(crate) struct Take<T> {
+pub(crate) struct Take<T, U: ExitUse> {
     /// The ready member, when one exists.
-    pub(crate) member: Option<Member<T>>,
-    /// Members found dead during the scan, to be stopped by the caller.
-    pub(crate) evicted: Vec<Member<T>>,
+    pub(crate) member: Option<Member<T, U>>,
+    /// Members found dead during the scan, to be retired by the caller.
+    pub(crate) evicted: Vec<Member<T, U>>,
 }
 
 /// One Correspondent Pool's synchronous state; async refill orchestration
 /// lives with the caller that owns the transport factory.
-pub(crate) struct CorrespondentPool<T> {
-    members: Vec<Member<T>>,
+pub(crate) struct CorrespondentPool<T, U: ExitUse> {
+    members: Vec<Member<T, U>>,
     complement: usize,
     /// Refills already launched but not yet admitted, so deficit never
     /// over-spawns.
     inflight: usize,
 }
 
-impl<T: PoolTransport> CorrespondentPool<T> {
+impl<T: PoolTransport, U: ExitUse> CorrespondentPool<T, U> {
     /// An empty pool aiming at `complement` ready members.
     pub(crate) fn new(complement: usize) -> Self {
         CorrespondentPool {
@@ -73,17 +163,17 @@ impl<T: PoolTransport> CorrespondentPool<T> {
     }
 
     /// Admits a ready member.
-    pub(crate) fn admit(&mut self, member: Member<T>) {
+    pub(crate) fn admit(&mut self, member: Member<T, U>) {
         self.members.push(member);
     }
 
     /// Takes the oldest still-ready member, evicting dead ones on the way.
-    pub(crate) fn take(&mut self) -> Take<T> {
+    pub(crate) fn take(&mut self) -> Take<T, U> {
         let mut evicted = Vec::new();
         let mut member = None;
         while member.is_none() && !self.members.is_empty() {
             let candidate = self.members.remove(0);
-            if candidate.transport.is_ready() {
+            if candidate.is_ready() {
                 member = Some(candidate);
             } else {
                 evicted.push(candidate);
@@ -92,18 +182,19 @@ impl<T: PoolTransport> CorrespondentPool<T> {
         Take { member, evicted }
     }
 
-    /// Empties the pool for teardown, returning every member to stop.
-    pub(crate) fn drain(&mut self) -> Vec<Member<T>> {
+    /// Empties the pool for teardown, returning every member to retire.
+    pub(crate) fn drain(&mut self) -> Vec<Member<T, U>> {
         std::mem::take(&mut self.members)
     }
 }
 
 /// The two Correspondent Pools with the spawn context their refills need.
 pub(crate) struct Pools {
-    /// The Indexer Pool of Exit-Bound members.
-    pub(crate) indexer: std::sync::Mutex<CorrespondentPool<crate::nym::MixnetProxy>>,
+    /// The Indexer Pool of Exclusive-exit members a Transmission's pulls
+    /// consume.
+    pub(crate) indexer: std::sync::Mutex<CorrespondentPool<crate::nym::MixnetProxy, Exclusive>>,
     /// The Price Source Pool's one Shared-exit member.
-    pub(crate) price: std::sync::Mutex<CorrespondentPool<crate::nym::MixnetProxy>>,
+    pub(crate) price: std::sync::Mutex<CorrespondentPool<crate::nym::MixnetProxy, Shared>>,
     /// The session's sole issuer of Exit Node Reservations; reservations
     /// hold a weak ledger handle and recycle themselves on drop.
     pub(crate) exits: std::sync::Arc<std::sync::Mutex<exit_pool::ExitPool>>,
@@ -162,6 +253,50 @@ impl Pools {
         self.acquirer.lock().expect("pool acquirer mutex").clone()
     }
 
+    /// Takes `pool`'s next live member, or acquires a fresh one in the
+    /// category the call site declares, retiring the dead on the way.
+    pub(crate) async fn take_or_acquire<U: ExitUse>(
+        &self,
+        pool: for<'a> fn(
+            &'a Pools,
+        )
+            -> &'a std::sync::Mutex<CorrespondentPool<crate::nym::MixnetProxy, U>>,
+    ) -> Result<Member<crate::nym::MixnetProxy, U>, acquire::TransportError> {
+        let take = {
+            let mut pool = pool(self).lock().expect("pool mutex");
+            pool.take()
+        };
+        for dead in take.evicted {
+            dead.retire().await;
+        }
+        if let Some(member) = take.member {
+            return Ok(member);
+        }
+        let acquirer = self.acquirer().ok_or(acquire::TransportError::NoAcquirer)?;
+        let (transport, lease) = self.acquire_bound(acquirer.as_ref()).await?;
+        Ok(Member::new(transport, lease))
+    }
+
+    /// Acquires one ready transport over a fresh Clutch, keeping only the
+    /// bound exit's lease.
+    async fn acquire_bound(
+        &self,
+        acquirer: &dyn crate::nym::acquire::TransportAcquirable,
+    ) -> Result<(crate::nym::MixnetProxy, exit_pool::Reservation), acquire::TransportError> {
+        let mut clutch = self.draw_clutch(acquirer).await?;
+        let nodes = exit_pool::clutch_nodes(&clutch);
+        let (transport, exit) =
+            crate::nym::supervisor::acquire_ready_transport(acquirer, &nodes).await?;
+        // Bind-time recycle: keeping only the bound lease drops the rest.
+        let bound = clutch
+            .iter()
+            .position(|reservation| reservation.node() == exit)
+            .expect("the bound exit is one of the clutch's nodes");
+        let lease = clutch.swap_remove(bound);
+        drop(clutch);
+        Ok((transport, lease))
+    }
+
     /// Stops every member of both pools and forbids the session's in-flight
     /// refills from admitting, for session teardown.
     pub(crate) async fn drain_all(&self) {
@@ -171,14 +306,13 @@ impl Pools {
         self.generation
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         *self.acquirer.lock().expect("pool acquirer mutex") = None;
-        let drained: Vec<Member<crate::nym::MixnetProxy>> = {
-            let mut members = self.indexer.lock().expect("indexer pool mutex").drain();
-            members.extend(self.price.lock().expect("price pool mutex").drain());
-            members
-        };
-        for member in drained {
-            // Dropping the member recycles its lease after the stop.
-            member.transport.stop().await;
+        let indexer_drained = self.indexer.lock().expect("indexer pool mutex").drain();
+        let price_drained = self.price.lock().expect("price pool mutex").drain();
+        for member in indexer_drained {
+            member.retire().await;
+        }
+        for member in price_drained {
+            member.retire().await;
         }
     }
 
@@ -199,7 +333,7 @@ impl Pools {
         for _ in 0..indexer_deficit {
             let pools = std::sync::Arc::clone(self);
             tokio::spawn(async move {
-                refill_one(&pools, PoolKind::Indexer).await;
+                refill_one(&pools, |pools: &Pools| &pools.indexer).await;
             });
         }
         let price_deficit = {
@@ -213,77 +347,56 @@ impl Pools {
         for _ in 0..price_deficit {
             let pools = std::sync::Arc::clone(self);
             tokio::spawn(async move {
-                refill_one(&pools, PoolKind::Price).await;
+                refill_one(&pools, |pools: &Pools| &pools.price).await;
             });
         }
     }
 }
 
-/// Which Correspondent Pool a refill serves.
-#[derive(Clone, Copy)]
-pub(crate) enum PoolKind {
-    /// The Indexer Pool a Transmission's pulls consume.
-    Indexer,
-    /// The Shared-exit Price Source Pool.
-    Price,
-}
-
-/// One refill: acquire a ready transport excluding every in-use and spent
-/// exit, then admit it.
-async fn refill_one(pools: &std::sync::Arc<Pools>, kind: PoolKind) {
+/// One refill of `pool`: acquire a ready transport over a fresh Clutch,
+/// then admit it in the pool's own exit-use category.
+async fn refill_one<U: ExitUse>(
+    pools: &std::sync::Arc<Pools>,
+    pool: for<'a> fn(
+        &'a Pools,
+    ) -> &'a std::sync::Mutex<CorrespondentPool<crate::nym::MixnetProxy, U>>,
+) {
     // The generation this refill was launched under; a drain that lands
     // before we admit bumps it, and we then refuse rather than admit a live
     // child into the drained pool.
     let launched_at = pools.generation();
-    let pool = match kind {
-        PoolKind::Indexer => &pools.indexer,
-        PoolKind::Price => &pools.price,
-    };
     let Some(acquirer) = pools.acquirer() else {
-        pool.lock().expect("pool mutex").note_refill_finished();
+        pool(pools)
+            .lock()
+            .expect("pool mutex")
+            .note_refill_finished();
         return;
     };
-    let mut clutch = match pools.draw_clutch(acquirer.as_ref()).await {
-        Ok(clutch) => clutch,
-        Err(cause) => {
-            pool.lock().expect("pool mutex").note_refill_finished();
-            log::warn!("pool refill drew no clutch: {cause}");
-            return;
-        }
-    };
-    let nodes = exit_pool::clutch_nodes(&clutch);
-    match crate::nym::supervisor::acquire_ready_transport(acquirer.as_ref(), &nodes).await {
-        Ok((transport, exit)) => {
-            // Bind-time recycle: keeping only the bound lease drops the
-            // rest, so the pool drains only by what is leased.
-            let bound = clutch
-                .iter()
-                .position(|reservation| reservation.node() == exit)
-                .expect("the bound exit is one of the clutch's nodes");
-            let lease = clutch.swap_remove(bound);
-            drop(clutch);
+    match pools.acquire_bound(acquirer.as_ref()).await {
+        Ok((transport, lease)) => {
             // The generation check and the admit share one lock hold, so a
             // drain cannot slip between them and orphan the child.
-            let stale = {
-                let mut pool = pool.lock().expect("pool mutex");
+            let stale: Option<Member<crate::nym::MixnetProxy, U>> = {
+                let mut pool = pool(pools).lock().expect("pool mutex");
                 pool.note_refill_finished();
                 if pools.generation() == launched_at {
-                    pool.admit(Member { transport, lease });
+                    pool.admit(Member::new(transport, lease));
                     None
                 } else {
-                    Some(Member { transport, lease })
+                    Some(Member::new(transport, lease))
                 }
             };
             if let Some(member) = stale {
-                // A drain landed while we acquired: stop the child and drop
-                // the lease rather than admit into a torn-down session.
-                member.transport.stop().await;
+                // A drain landed while we acquired: retire rather than admit
+                // into a torn-down session.
+                member.retire().await;
             }
         }
         Err(cause) => {
-            // Dropping the clutch recycles every reservation.
-            drop(clutch);
-            pool.lock().expect("pool mutex").note_refill_finished();
+            pool(pools)
+                .lock()
+                .expect("pool mutex")
+                .note_refill_finished();
             log::warn!("pool refill failed: {cause}");
         }
     }
@@ -301,20 +414,28 @@ mod tests {
         fn is_ready(&self) -> bool {
             self.ready
         }
+
+        fn socks5_addr(&self) -> Option<String> {
+            self.ready.then(|| "127.0.0.1:7".to_string())
+        }
+
+        fn stop(self) -> impl std::future::Future<Output = ()> + Send {
+            std::future::ready(())
+        }
     }
 
-    fn member(exit: &str, ready: bool) -> Member<FakeTransport> {
-        Member {
-            transport: FakeTransport { ready },
-            lease: exit_pool::Reservation::dangling_for_test(exit),
-        }
+    fn member(exit: &str, ready: bool) -> Member<FakeTransport, Exclusive> {
+        Member::new(
+            FakeTransport { ready },
+            exit_pool::Reservation::dangling_for_test(exit),
+        )
     }
 
     /// HYPOTHESIS: the deficit counts in-flight refills, so two scans never
     /// launch more acquisitions than the complement.
     #[test]
     fn the_deficit_never_overspawns() {
-        let mut pool: CorrespondentPool<FakeTransport> =
+        let mut pool: CorrespondentPool<FakeTransport, Exclusive> =
             CorrespondentPool::new(INDEXER_POOL_COMPLEMENT);
         assert_eq!(pool.deficit(), 2);
         pool.note_refill_launched();
@@ -331,14 +452,14 @@ mod tests {
     /// exclusion.
     #[test]
     fn a_take_evicts_the_dead_and_records_the_spent() {
-        let mut pool: CorrespondentPool<FakeTransport> =
+        let mut pool: CorrespondentPool<FakeTransport, Exclusive> =
             CorrespondentPool::new(INDEXER_POOL_COMPLEMENT);
         pool.admit(member("exit-dead", false));
         pool.admit(member("exit-live", true));
         let take = pool.take();
         assert_eq!(take.evicted.len(), 1, "the dead member is evicted");
         let taken = take.member.expect("the live member is taken");
-        assert_eq!(taken.lease.node(), "exit-live");
+        assert_eq!(taken.node(), "exit-live");
         assert!(pool.take().member.is_none(), "both members left the pool");
     }
 
@@ -347,7 +468,7 @@ mod tests {
     /// tunnel.
     #[test]
     fn an_empty_pool_is_a_miss_not_a_reuse() {
-        let mut pool: CorrespondentPool<FakeTransport> = CorrespondentPool::new(1);
+        let mut pool: CorrespondentPool<FakeTransport, Exclusive> = CorrespondentPool::new(1);
         pool.admit(member("exit-a", true));
         let first = pool.take();
         assert!(first.member.is_some());
@@ -360,15 +481,15 @@ mod tests {
     /// is consumed rather than lent.
     #[test]
     fn consecutive_takes_never_repeat_an_exit() {
-        let mut pool: CorrespondentPool<FakeTransport> =
+        let mut pool: CorrespondentPool<FakeTransport, Exclusive> =
             CorrespondentPool::new(INDEXER_POOL_COMPLEMENT);
         pool.admit(member("exit-a", true));
         pool.admit(member("exit-b", true));
         let first = pool.take().member.expect("first take");
         let second = pool.take().member.expect("second take");
         assert_ne!(
-            first.lease.node(),
-            second.lease.node(),
+            first.node(),
+            second.node(),
             "a member is consumed, never reused"
         );
         assert!(pool.take().member.is_none(), "the pool is spent");
@@ -392,5 +513,30 @@ mod tests {
             pools.acquirer().is_none(),
             "a drain must clear the acquirer so ensure_filled cannot relaunch"
         );
+    }
+
+    /// HYPOTHESIS: a Shared member serves repeated dials for its one
+    /// holder, then retires once.
+    #[tokio::test]
+    async fn a_shared_member_serves_repeated_dials() {
+        let member: Member<FakeTransport, Shared> = Member::new(
+            FakeTransport { ready: true },
+            exit_pool::Reservation::dangling_for_test("exit-shared"),
+        );
+        let first = member.addr().expect("a live shared member has an address");
+        let second = member.addr().expect("a second dial is permitted");
+        assert_eq!(first, second, "one tunnel serves the whole fan-out");
+        member.retire().await;
+    }
+
+    /// HYPOTHESIS: an Exclusive dial consumes the member, leaving only a
+    /// spent holder that still names its exit for the attempt record.
+    #[tokio::test]
+    async fn an_exclusive_dial_is_terminal() {
+        let member = member("exit-exclusive", true);
+        let (addr, spent) = member.dial();
+        assert!(addr.is_some(), "a live exclusive member dials once");
+        assert_eq!(spent.node(), "exit-exclusive");
+        spent.retire().await;
     }
 }

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -657,46 +657,12 @@ impl LightClient {
             .is_some_and(crate::nym::MixnetProxy::is_spawned)
             && self.correspondent_pools.acquirer().is_some()
         {
-            let take = {
-                let mut pool = self
-                    .correspondent_pools
-                    .price
-                    .lock()
-                    .expect("price pool mutex");
-                pool.take()
-            };
-            for dead in take.evicted {
-                // Dropping the dead member recycles its lease after the stop.
-                dead.transport.stop().await;
-            }
-            match take.member {
-                Some(member) => Some(member),
-                None => {
-                    let acquirer = self
-                        .correspondent_pools
-                        .acquirer()
-                        .expect("checked above; the acquirer is set");
-                    let mut clutch = self
-                        .correspondent_pools
-                        .draw_clutch(acquirer.as_ref())
-                        .await
-                        .map_err(crate::wallet::error::PriceError::TransportAcquisition)?;
-                    let nodes = crate::correspondent::pool::exit_pool::clutch_nodes(&clutch);
-                    let (transport, exit) =
-                        crate::nym::supervisor::acquire_ready_transport(acquirer.as_ref(), &nodes)
-                            .await
-                            .map_err(crate::wallet::error::PriceError::TransportAcquisition)?;
-                    // Bind-time recycle: keeping only the bound lease drops
-                    // the rest.
-                    let bound = clutch
-                        .iter()
-                        .position(|reservation| reservation.node() == exit)
-                        .expect("the bound exit is one of the clutch's nodes");
-                    let lease = clutch.swap_remove(bound);
-                    drop(clutch);
-                    Some(crate::correspondent::pool::Member { transport, lease })
-                }
-            }
+            Some(
+                self.correspondent_pools
+                    .take_or_acquire(|pools| &pools.price)
+                    .await
+                    .map_err(crate::wallet::error::PriceError::TransportAcquisition)?,
+            )
         } else {
             None
         };
@@ -705,13 +671,11 @@ impl LightClient {
         // reports no address died between take and use, so the run refuses
         // rather than silently degrading to the slot tunnel.
         let via_socks5 = match pooled.as_ref() {
-            Some(member) => match member.transport.socks5_addr() {
+            Some(member) => match member.addr() {
                 Some(addr) => addr,
                 None => {
                     if let Some(member) = pooled {
-                        let crate::correspondent::pool::Member { transport, lease } = member;
-                        transport.stop().await;
-                        drop(lease);
+                        member.retire().await;
                         self.correspondent_pools.ensure_filled();
                     }
                     return Err(LightClientError::from(
@@ -732,10 +696,7 @@ impl LightClient {
         let dispatched = std::time::Instant::now();
         let raced = zingo_price::race_current_price(Some(&via_socks5)).await;
         if let Some(member) = pooled {
-            // The lease recycles by drop after the transport's stop.
-            let crate::correspondent::pool::Member { transport, lease } = member;
-            transport.stop().await;
-            drop(lease);
+            member.retire().await;
             self.correspondent_pools.ensure_filled();
         }
         let raced = raced.map_err(crate::wallet::error::PriceError::from)?;

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -89,7 +89,7 @@ impl LightClient {
         let acquirer = crate::nym::acquire::SpawnedBinary::at(binary_path.to_path_buf());
         // The sweep refuses without a ledgered Clutch; its reservations are
         // held for the sweep's life and recycled by drop on every return.
-        let clutch = self
+        let mut clutch = self
             .correspondent_pools
             .draw_clutch(&acquirer)
             .await
@@ -105,7 +105,19 @@ impl LightClient {
         .map_err(ServerSelectionError::TransportAcquisition)?;
 
         progress(SweepProgress::TransportBootstrapping);
-        let socks5_addr = await_sweep_ready(&mut receiver).await?;
+        let (socks5_addr, exits) = await_sweep_ready(&mut receiver).await?;
+        // Bind-time recycle: the survey's fan-out is a declared Shared use
+        // of the one bound exit, and the unbound reservations return now.
+        let bound = clutch
+            .iter()
+            .position(|reservation| exits.iter().any(|exit| exit == reservation.node()))
+            .expect("the bound exit is one of the clutch's nodes");
+        let lease = clutch.swap_remove(bound);
+        drop(clutch);
+        let member: crate::correspondent::pool::Member<
+            crate::nym::MixnetProxy,
+            crate::correspondent::pool::Shared,
+        > = crate::correspondent::pool::Member::new(proxy, lease);
         progress(SweepProgress::Surveying {
             candidates: candidates.len(),
         });
@@ -123,11 +135,10 @@ impl LightClient {
             &mut rand::rngs::OsRng,
         )?;
 
-        // Exit Recycling: dropping the dedicated proxy kills the child, and
-        // the Clutch's leases recycle when this function returns, so no
-        // later traffic rides the exit that observed the survey.
-        drop(proxy);
-        drop(clutch);
+        // Exit Recycling: retiring the member kills the child and recycles
+        // its lease, so no later traffic rides the exit that observed the
+        // survey.
+        member.retire().await;
         Ok(selection)
     }
 }
@@ -143,10 +154,11 @@ fn lightd_chain_name(chain: &crate::config::ChainType) -> &'static str {
 }
 
 /// Wait for the dedicated sweep proxy to reach `Ready` and yield its SOCKS5
-/// address, or fail typed when it dies or its bootstrap budget elapses.
+/// address with its bound Exit Nodes, or fail typed when it dies or its
+/// bootstrap budget elapses.
 async fn await_sweep_ready(
     receiver: &mut tokio::sync::watch::Receiver<crate::nym::MixnetStatus>,
-) -> Result<String, ServerSelectionError> {
+) -> Result<(String, Vec<String>), ServerSelectionError> {
     let budget = zingo_netutils::time::NYM_LIFECYCLE_TIMEOUT;
     let outcome = tokio::time::timeout(budget, async {
         loop {
@@ -155,7 +167,7 @@ async fn await_sweep_ready(
                 match status.mode {
                     MixnetMode::Ready => {
                         if let Some(addr) = status.socks5_addr.clone() {
-                            return Ok(addr);
+                            return Ok((addr, status.exits.clone()));
                         }
                     }
                     MixnetMode::Died => {
@@ -179,7 +191,7 @@ async fn await_sweep_ready(
     })
     .await;
     match outcome {
-        Ok(Ok(addr)) => Ok(addr),
+        Ok(Ok(ready)) => Ok(ready),
         Ok(Err(reason)) => Err(ServerSelectionError::TransportUnready(reason)),
         Err(_elapsed) => Err(ServerSelectionError::TransportUnready(format!(
             "no readiness within {}s",

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -292,39 +292,18 @@ pub(crate) struct PullTransports;
 
 #[cfg(feature = "nym")]
 impl PullTransports {
-    /// One pull's own Exit-Bound transport: the Indexer Pool's next member,
-    /// or a fresh acquisition when the pool is empty.
+    /// One pull's own Exclusive-exit transport: the Indexer Pool's next
+    /// member, or a fresh acquisition when the pool is empty.
     async fn acquire(
         &self,
-    ) -> Result<crate::correspondent::pool::Member<crate::nym::MixnetProxy>, acquire::TransportError>
-    {
-        let take = {
-            let mut pool = self.pools.indexer.lock().expect("indexer pool mutex");
-            pool.take()
-        };
-        for dead in take.evicted {
-            // Dropping the dead member recycles its lease after the stop.
-            dead.transport.stop().await;
-        }
-        if let Some(member) = take.member {
-            return Ok(member);
-        }
-        let acquirer = self
-            .pools
-            .acquirer()
-            .ok_or(acquire::TransportError::NoAcquirer)?;
-        let mut clutch = self.pools.draw_clutch(acquirer.as_ref()).await?;
-        let nodes = crate::correspondent::pool::exit_pool::clutch_nodes(&clutch);
-        let (transport, exit) =
-            crate::nym::supervisor::acquire_ready_transport(acquirer.as_ref(), &nodes).await?;
-        // Bind-time recycle: keeping only the bound lease drops the rest.
-        let bound = clutch
-            .iter()
-            .position(|reservation| reservation.node() == exit)
-            .expect("the bound exit is one of the clutch's nodes");
-        let lease = clutch.swap_remove(bound);
-        drop(clutch);
-        Ok(crate::correspondent::pool::Member { transport, lease })
+    ) -> Result<
+        crate::correspondent::pool::Member<
+            crate::nym::MixnetProxy,
+            crate::correspondent::pool::Exclusive,
+        >,
+        acquire::TransportError,
+    > {
+        self.pools.take_or_acquire(|pools| &pools.indexer).await
     }
 
     /// Tops the pools back up after a pull consumed a member.
@@ -469,20 +448,22 @@ async fn mixnet_escalating_transmit(
                 })?),
                 None => None,
             };
-            // A pooled member carries its own Exclusive exit; only an
+            // A pooled member carries its own Exclusive exit, and the one
+            // consuming dial is the only way to read its tunnel; only an
             // attached session (no member) rides the shared slot tunnel. A
             // member whose transport reports no address died between take
             // and use, so the pull refuses rather than silently degrading
             // to the shared tunnel and mislabeling the diary.
-            let socks5_addr = match member.as_ref() {
-                Some(member) => member.transport.socks5_addr().ok_or_else(|| {
-                    zingo_net_diag::NetOpFailure::message(
+            let (socks5_addr, spent) = match member.map(crate::correspondent::pool::Member::dial) {
+                Some((Some(addr), spent)) => (addr, Some(spent)),
+                Some((None, _spent)) => {
+                    return Err(zingo_net_diag::NetOpFailure::message(
                         zingo_net_diag::NetOpStage::LocalProxyConnect,
                         host.clone(),
                         "the pooled transport died before its pull could use it",
-                    )
-                })?,
-                None => shared_addr,
+                    ));
+                }
+                None => (shared_addr, None),
             };
             let target = SocksTarget {
                 socks5_addr,
@@ -505,15 +486,11 @@ async fn mixnet_escalating_transmit(
             .map_err(|TransmitFailed(error)| crate::nym::socks5_transmit_failure(&error, &host));
             // The consumed transport dies with its pull, whatever the
             // outcome, so its exit carries exactly this one Transmission;
-            // dropping the member recycles its lease even when the pull is
-            // cancelled mid-await.
-            let bound_exit = member
-                .as_ref()
-                .map(|member| member.lease.node().to_string());
-            if let Some(member) = member {
-                let crate::correspondent::pool::Member { transport, lease } = member;
-                transport.stop().await;
-                drop(lease);
+            // dropping the spent holder recycles its lease even when the
+            // pull is cancelled mid-await.
+            let bound_exit = spent.as_ref().map(|spent| spent.node().to_string());
+            if let Some(spent) = spent {
+                spent.retire().await;
                 if let Some(context) = pulls {
                     context.refill();
                 }

--- a/zingolib/src/nym/supervisor.rs
+++ b/zingolib/src/nym/supervisor.rs
@@ -624,6 +624,14 @@ impl crate::correspondent::pool::PoolTransport for MixnetProxy {
     fn is_ready(&self) -> bool {
         self.mode() == MixnetMode::Ready
     }
+
+    fn socks5_addr(&self) -> Option<String> {
+        MixnetProxy::socks5_addr(self)
+    }
+
+    fn stop(self) -> impl std::future::Future<Output = ()> + Send {
+        MixnetProxy::stop(self)
+    }
 }
 
 /// Runs the proxy binary's discover mode and returns the Exit Nodes it


### PR DESCRIPTION
## What this does

ADR 0039 partitions exit use into Exclusive and Shared. Until now the partition lived only in doc-comments. This change makes it structural.

A pool member is now `Member<T, Exclusive>` or `Member<T, Shared>`. The category is declared at the acquisition site. An Exclusive member offers one `dial`, and that call consumes the member. The caller is left with a `SpentExit`, which can only name its exit and retire. A second Correspondent contact through the same member does not compile. A Shared member offers a borrowing `addr`, so one holder can fan out to many Correspondents.

The three acquisition sites declare their categories. The Indexer Pool holds Exclusive members, and a send pull dials through the consuming seam. The Price Source Pool holds the one Shared member. The Server-Selection Sweep wraps its dedicated transport in a Shared member. The sweep also gains bind-time recycling of its unbound reservations.

## Also in this change

The take-or-acquire sequence and the clutch-bind sequence were duplicated between the send path and the price path. They collapse into `Pools::take_or_acquire` and `Pools::acquire_bound`.

## What this does not change

No public API changes. The attached session's slot tunnel is not a pool member, so it carries no category yet; that seam is follow-up work.

## Verification

The zingolib suite passes with the nym feature (467 tests). The zingo-cli suite passes (230 tests). `cargo hack check --each-feature` passes on both crates. Two new tests pin the category behavior: a Shared member serves repeated dials, and an Exclusive dial is terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)