### PR TITLE
docs: ADR 0021's webpki bundle outlives the shim's departure

### DIFF
--- a/docs/adr/0021-shim-tls-verifies-against-the-webpki-bundle.md
+++ b/docs/adr/0021-shim-tls-verifies-against-the-webpki-bundle.md
@@ -1,6 +1,7 @@
 # The mixnet shim's TLS verifies against the compiled-in webpki bundle
 
-Status: accepted (zingolib#2531). Scoped to the mobile mixnet shim's own
+Status: accepted (zingolib#2531); amended 2026-08-10 after zingolib#2666.
+Scoped to the mobile mixnet shim's own
 TLS — the `zingo-netutils` standalone workspace, where the nym SDK's HTTP
 clients reach the Nym directory, API, and gateways. Wallet↔indexer TLS and
 every other TLS surface in the parent workspace are unaffected.
@@ -85,3 +86,22 @@ per-app ceremony; if the shim ever needs enterprise or user-installed CA
 trust; or if the Nym infrastructure's certificate chains stop resolving
 against the Mozilla bundle. The nightly upstream watch in the update
 policy is also the tripwire for the first of these.
+
+## Amendment (2026-08-10): the decision outlives the shim's departure
+
+zingolib#2666 moved the mobile UniFFI proxy shim to zingo-mobile's
+`nym-host` workspace, so this workspace no longer builds a mobile
+artifact. The scope named above therefore reads today as the
+`zingo-netutils` standalone workspace itself: the nym SDK's HTTP clients
+behind the desktop `nym-proxy` binary and the crate's library consumers.
+
+The decision stands on its surviving rationale, ratified 2026-08-10. The
+compiled-in bundle keeps certificate verification byte-identical on every
+host that builds this workspace, keeps the workspace free of hand-written
+unsafe, and stays testable in plain CI. The Android initialization story
+in "Why" is the decision's origin, not its continuing justification here.
+The relocated shim consumes this crate as a git dependency from its own
+standalone workspace, and a `[patch.crates-io]` substitution never
+crosses a workspace root, so the verifier the shim's TLS resolves is
+zingo-mobile's to declare and to record. The update policy and the
+reconsideration tripwires above are unchanged.

--- a/zingo-netutils/Cargo.toml
+++ b/zingo-netutils/Cargo.toml
@@ -144,11 +144,12 @@ x509-parser = "0.18"
 # (paired with the `rebuild-proto` feature above) and the time v0.3.47 pin.
 [patch.crates-io]
 time = { git = "https://github.com/time-rs/time", tag = "v0.3.47" }
-# ADR 0021 (zingolib#2531): the mixnet shim's TLS verifies against the
-# compiled-in Mozilla bundle instead of rustls-platform-verifier's
-# OS-trust-store integration, which on Android demands JNI initialization
-# the shim's zero-unsafe invariant rules out. The stand-in lives in this
-# workspace under the upstream crate's name; see the ADR for the update
-# policy that keeps it tracking upstream.
+# ADR 0021 (zingolib#2531, amended 2026-08-10): this workspace's nym-stack
+# TLS verifies against the compiled-in Mozilla bundle instead of
+# rustls-platform-verifier's OS-trust-store integration, keeping
+# verification byte-identical on every platform and the workspace free of
+# hand-written unsafe. The stand-in lives in this workspace under the
+# upstream crate's name; see the ADR for the update policy that keeps it
+# tracking upstream.
 rustls-platform-verifier = { path = "webpki-verifier-shim" }
 lightwallet-protocol = { git = "https://github.com/zingolabs/lightwallet-protocol-rust", rev = "9bdfdc77eb283f2a3d26c27100cc2ac90148cd93" }

--- a/zingo-netutils/webpki-verifier-shim/src/lib.rs
+++ b/zingo-netutils/webpki-verifier-shim/src/lib.rs
@@ -1,14 +1,14 @@
 //! The webpki-roots stand-in for `rustls-platform-verifier` (ADR 0021,
 //! zingolib#2531).
 //!
-//! The mobile mixnet shim cannot use the real crate: on Android it demands
-//! JVM-side initialization with an app `Context` before any TLS handshake,
-//! which requires hand-written JNI — `unsafe` the shim's ratified invariant
-//! forbids — plus a Kotlin component in every consuming app. This crate is
-//! substituted through the workspace `[patch.crates-io]` and verifies
-//! against the compiled-in Mozilla root bundle (`webpki-root-certs`)
-//! instead of the operating system's trust store, identically on every
-//! platform.
+//! This workspace does not use the real crate: ADR 0021 chose the
+//! compiled-in Mozilla root bundle (`webpki-root-certs`) over the
+//! operating system's trust store, so verification is byte-identical on
+//! every platform and the workspace stays free of hand-written `unsafe`.
+//! The choice originated in the Android JNI initialization that the
+//! since-relocated mobile shim could not perform (zingolib#2531; the shim
+//! now lives in zingo-mobile). This crate is substituted through the
+//! workspace `[patch.crates-io]`.
 //!
 //! API parity is deliberately minimal: the only consumer in this workspace's
 //! dependency tree is reqwest (`>=0.6, <0.8` requirement), which constructs


### PR DESCRIPTION
PR #2666 moved the mobile UniFFI proxy shim to zingo-mobile, so ADR 0021's scope prose, the netutils patch comment, and the webpki-verifier-shim module header all cited a departed crate. A dated amendment restates the scope as the netutils standalone workspace and the surviving desktop rationale, and it delegates the relocated shim's verifier to zingo-mobile, whose ADR 0004 declares Android platform verification. Per the 2026-08-10 ruling the certificate roots stay bundled here. Resolves finding 2 of the PR #2666 review.

Fixes: 
