### PR TITLE
docs: ADR 0021 scopes the webpki bundle to this workspace

### DIFF
--- a/.agents/claude.md
+++ b/.agents/claude.md
@@ -1,0 +1,10 @@
+# Agent instructions: documentation
+
+## The one-sentence documentation rule (ratified 2026-08-10)
+
+Every item doc-comment — Rust `///`, and the doc-comment on any item in
+another language — is exactly one sentence. That sentence must not
+reference ADRs, issues, or any other document. Module headers (`//!`)
+are exempt, and test doc-comments that follow a ratified convention
+(for example HYPOTHESIS falsifiers) keep that convention's shape. Apply
+the rule to every unmerged doc-comment before merge.

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ libtonode-tests/tests/chain_generics.proptest-regressions
 libtonode-tests/store_all_checkpoints_test
 .zingo-cli/
 .DS_Store
-# Generated uniffi bindings are build products (bundle-android-shim regenerates
-# them from the cdylib); the wire contract is pinned by test-data/golden instead.
-zingo-netutils/nym-proxy-ffi/bindings/
 .agent-plans/
 
 # Local corpus of real wallet files (live seed material — never commit)

--- a/docs/agents/net-diag-design.md
+++ b/docs/agents/net-diag-design.md
@@ -81,7 +81,7 @@ beyond the stability contract below.
 New crate `zingo-net-diag` at the repository root, std-only, zero
 dependencies. Both cargo workspaces path-depend on it (the parent
 workspace from `zingo-price` and `zingolib`, the `zingo-netutils`
-standalone workspace optionally, for the shim follow-up). Zero
+standalone workspace optionally, from its nym stack). Zero
 dependencies is a hard requirement: it is what lets one crate serve two
 lockfile-isolated workspaces without resolver coupling.
 


### PR DESCRIPTION
## What this changes

- ADR 0021 gains a dated amendment. The bundled certificate roots stay
  for this workspace's TLS. The amendment restates the rationale in
  desktop terms.
- The netutils patch comment and the webpki-verifier-shim module header
  stop citing the departed shim crate.
- The net-diag design document names the nym stack as the netutils
  consumer of `zingo-net-diag`, not the deleted shim follow-up.
- The `.gitignore` drops the rule for the deleted shim bindings
  directory.
- `.agents/claude.md` records the one-sentence documentation rule.

## Why

PR #2666 moved the mobile UniFFI proxy shim to zingo-mobile. Its review
found six documentation leftovers. This branch fixes four of them. The
other two dissolved when zingo-mobile PR #1276 made the shim a live
git-dependency consumer of this workspace. The shim's TLS verifier is
now zingo-mobile's decision. Its ADR 0004 declares Android platform
verification, and the amendment here records that delegation.

## Verification

The changes are documentation and comments only. The netutils standalone
manifest still parses, and the amendment's claims were checked against
zingo-mobile PR #1276 at head 30e1d8d0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
