### PR TITLE
fix(pepper-sync): sync_status saturates its session arithmetic

### DIFF
--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -866,10 +866,11 @@ where
         total_ironwood_outputs,
     );
 
-    let session_blocks_scanned =
-        total_blocks_scanned - sync_state.initial_sync_state.previously_scanned_blocks;
+    let session_blocks_scanned = total_blocks_scanned
+        .saturating_sub(sync_state.initial_sync_state.previously_scanned_blocks);
     let mut percentage_session_blocks_scanned = ((session_blocks_scanned as f32
-        / (total_blocks - sync_state.initial_sync_state.previously_scanned_blocks) as f32)
+        / total_blocks.saturating_sub(sync_state.initial_sync_state.previously_scanned_blocks)
+            as f32)
         * 100.0)
         .clamp(0.0, 100.0);
     if percentage_session_blocks_scanned.is_nan() {
@@ -881,18 +882,21 @@ where
         percentage_total_blocks_scanned = 100.0;
     }
 
-    let session_sapling_outputs_scanned = total_sapling_outputs_scanned
-        - sync_state
+    let session_sapling_outputs_scanned = total_sapling_outputs_scanned.saturating_sub(
+        sync_state
             .initial_sync_state
-            .previously_scanned_sapling_outputs;
-    let session_orchard_outputs_scanned = total_orchard_outputs_scanned
-        - sync_state
+            .previously_scanned_sapling_outputs,
+    );
+    let session_orchard_outputs_scanned = total_orchard_outputs_scanned.saturating_sub(
+        sync_state
             .initial_sync_state
-            .previously_scanned_orchard_outputs;
-    let session_ironwood_outputs_scanned = total_ironwood_outputs_scanned
-        - sync_state
+            .previously_scanned_orchard_outputs,
+    );
+    let session_ironwood_outputs_scanned = total_ironwood_outputs_scanned.saturating_sub(
+        sync_state
             .initial_sync_state
-            .previously_scanned_ironwood_outputs;
+            .previously_scanned_ironwood_outputs,
+    );
     let session_outputs_scanned = output_pool_total(
         session_sapling_outputs_scanned,
         session_orchard_outputs_scanned,
@@ -910,7 +914,7 @@ where
             .previously_scanned_ironwood_outputs,
     );
     let mut percentage_session_outputs_scanned = ((session_outputs_scanned as f32
-        / (total_outputs - previously_scanned_outputs) as f32)
+        / total_outputs.saturating_sub(previously_scanned_outputs) as f32)
         * 100.0)
         .clamp(0.0, 100.0);
     if percentage_session_outputs_scanned.is_nan() {


### PR DESCRIPTION
## Problem

`sync_status` subtracts sync-start snapshots from live counters in six places. A reorg truncation can shrink a live counter below its snapshot. The subtraction then underflows. A debug build panics the sync task. The caller's `poll_sync` converts the panic into an abort.

The darkside reorg tests on #2671 trip the session outputs denominator at `pepper-sync/src/sync.rs:913`. The panic message is "attempt to subtract with overflow". The subtraction dates to the 2025-04-29 sync-status rewrite. It predates every open PR. The per-batch status publishing from #2670 adds more calls into this function, so the fix also protects that path.

## Change

All six snapshot subtractions now use `saturating_sub`. The sites are the session blocks numerator, the session blocks denominator, the three per-pool session output counts, and the session outputs denominator. A saturated denominator yields an infinite or NaN ratio. The existing clamp and NaN guard already normalise both to 100 percent.

The tree-bound subtractions are unchanged. Both of their operands come from the same sync-start snapshot, so they cannot disagree.

## Verification

`cargo check`, `cargo clippy --all-targets`, and `cargo fmt` pass for pepper-sync. The darkside reorg tests `reorg_removes_receipt` and `reorg_expires_outgoing_transaction` cover the panic path in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
