### PR TITLE
The nine triaged fixes from the second review of PR #2671

### DIFF
--- a/pepper-sync/CHANGELOG.md
+++ b/pepper-sync/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- BREAKING: a wrapper error variant renders only its own layer. The
+  `Display` texts of the `error::SyncError`, `error::MempoolError`, and
+  `error::ScanError` wrapper variants no longer embed the wrapped source's
+  text, and `ScanError::EncodingError` renders transparently. A consumer
+  recovers the full failure story by walking the `source()` chain.
 - `wallet::WalletTransaction::update_status`: added `fail_confirmed` bool for protecting against confirmed txs being
     set to failed in cases other than re-org truncation.
 

--- a/pepper-sync/src/error.rs
+++ b/pepper-sync/src/error.rs
@@ -9,6 +9,21 @@ use zcash_protocol::{PoolType, ShieldedPool};
 
 use crate::wallet::OutputId;
 
+/// The separator between two layers of a rendered cause chain.
+pub(crate) const CAUSE_CHAIN_SEPARATOR: &str = ": ";
+
+/// Renders `error` and every `source()` link as one separated line, so a log
+/// message keeps the whole cause chain.
+pub(crate) fn cause_chain_text(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut texts = vec![error.to_string()];
+    let mut link = error.source();
+    while let Some(cause) = link {
+        texts.push(cause.to_string());
+        link = cause.source();
+    }
+    texts.join(CAUSE_CHAIN_SEPARATOR)
+}
+
 /// Top level error enumerating any error that may occur during sync
 #[derive(Debug, thiserror::Error)]
 pub enum SyncError<E>

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -2406,7 +2406,10 @@ where
             }
             Err(e @ MempoolError::ShutdownWithoutStream) => return Err(e),
             Err(MempoolError::ServerError(e)) => {
-                tracing::warn!("Mempool stream request failed! Status: {e}.\nRetrying...");
+                tracing::warn!(
+                    "Mempool stream request failed! Status: {}.\nRetrying...",
+                    crate::error::cause_chain_text(&e)
+                );
                 tokio::time::sleep(Duration::from_secs(3)).await;
             }
         }

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -212,9 +212,7 @@ async fn change_server(
 ) -> Result<String, CommandError> {
     match lightclient.set_indexer_uri(uri.unwrap_or_default()).await {
         Ok(()) => Ok("server set".to_string()),
-        Err(e) => Err(CommandError::NotYetTyped(
-            format!("failed to set server: {e}").into(),
-        )),
+        Err(e) => Err(not_yet_typed(e)),
     }
 }
 
@@ -550,7 +548,7 @@ async fn quickshield(lightclient: &mut LightClient) -> Result<String, CommandErr
 async fn quit(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.shutdown_save_task().await {
         Ok(()) => eprintln!("Save task shutdown successfully."),
-        Err(e) => eprintln!("Error: save failed. {e}"),
+        Err(e) => eprintln!("Error: save failed. {}", render_error_chain(&e)),
     }
     Ok("Zingo CLI quit successfully.".to_string())
 }
@@ -613,13 +611,17 @@ async fn save(sub: SaveSubCommand, lightclient: &mut LightClient) -> Result<Stri
         SaveSubCommand::Check => match lightclient.check_save_error().await {
             Ok(()) => Ok(String::new()),
             Err(e) => Err(CommandError::NotYetTyped(
-                format!("save failed. {e}\nRestarting save task...").into(),
+                format!(
+                    "save failed. {}\nRestarting save task...",
+                    render_error_chain(&e)
+                )
+                .into(),
             )),
         },
         SaveSubCommand::Shutdown => match lightclient.shutdown_save_task().await {
             Ok(()) => Ok("Save task shutdown successfully.".to_string()),
             Err(e) => Err(CommandError::NotYetTyped(
-                format!("save failed. {e}").into(),
+                format!("save failed. {}", render_error_chain(&e)).into(),
             )),
         },
     }
@@ -1140,7 +1142,7 @@ pub enum NetworkCommandError {
     /// switching the session to Online Mode; the session stays offline.
     /// Reachable only from the quarantined clearnet resolution.
     #[cfg(feature = "clearnet-test-mode")]
-    #[error("no indexer could be resolved for going online: {0}")]
+    #[error("no indexer could be resolved for going online")]
     ServerResolution(#[from] crate::server_select_clearnet::ResolveServerError),
     /// The `network on` consent act selected an indexer, but the connection
     /// failed; the session stays offline. Reachable only from the

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -916,7 +916,7 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
     ResolveServer(#[from] server_select_clearnet::ResolveServerError),
     /// The pinned `--server` is not a valid indexer URI.
     #[cfg(not(feature = "clearnet-test-mode"))]
-    #[error("invalid --server URI. {0}")]
+    #[error("invalid --server URI.")]
     IndexerUri(#[from] http::uri::InvalidUri),
     /// The pinned server misses its scheme, host, or port.
     #[error(
@@ -1189,9 +1189,10 @@ async fn startup_async(filled_template: &ConfigTemplate) -> std::io::Result<Ligh
             .await
             .map_err(|e| {
                 std::io::Error::other(format!(
-                    "Failed to start the Nym mixnet proxy: {e}. Mixnet Mode is required for a \
+                    "Failed to start the Nym mixnet proxy: {}. Mixnet Mode is required for a \
                      connected session; install the nym-proxy binary, pass --nym-proxy <path>, \
                      or set $ZINGO_NYM_PROXY.",
+                    commands::render_error_chain(&e),
                 ))
             })?;
         info!(
@@ -1276,7 +1277,7 @@ async fn startup_async(filled_template: &ConfigTemplate) -> std::io::Result<Ligh
         && filled_template.waitsync
         && let Err(e) = lightclient.await_sync().await
     {
-        eprintln!("error: {e}");
+        eprintln!("error: {}", commands::render_error_chain(&e));
     }
 
     Ok(lightclient)
@@ -1363,8 +1364,9 @@ async fn sweep_select_sync_indexer(
                 }
                 Err(e) => {
                     eprintln!(
-                        "Server-Selection Sweep: selected {chosen}, but binding it failed: {e}. \
-                         This Sync Session does not open."
+                        "Server-Selection Sweep: selected {chosen}, but binding it failed: {}. \
+                         This Sync Session does not open.",
+                        commands::render_error_chain(&e),
                     );
                     false
                 }

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -71,7 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PriceError::TransportAcquisition` stop embedding their sources' text
   and carry them as `source()` links (the pure `{0}` wrappers become
   transparent), because every consumer walks the chain;
-  `TransportError::HostRefused` follows the same rule.
+  `TransportError::HostRefused` and the wrapper variants of
+  `lightclient::error::SendError` and `wallet::error::PriceError` follow
+  the same rule.
   `LightClientError::NoEligibleCorrespondent` now carries the typed
   `correspondent::NoEligibleCorrespondents` union — that union and
   `correspondent::Operator` are public — so the empty-pool and

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: `mixnet::acquire::TransportError` gains the `ExitOutsideClutch`
+  variant. A transport that reports ready without announcing an exit from
+  the drawn Clutch now refuses with this variant instead of panicking, and
+  an exhaustive match over the enum needs the new arm.
 - BREAKING: a refused Server-Selection Sweep names its transport failure by
   type. `lightclient::select::ServerSelectionError::TransportUnready(String)`
   is replaced by three variants: `TransportDied`, which carries the death

--- a/zingolib/src/correspondent.rs
+++ b/zingolib/src/correspondent.rs
@@ -179,9 +179,13 @@ pub(crate) fn eligible_correspondents(
     sync_indexer: Option<&Uri>,
     health: &health::Health,
 ) -> Result<Vec<Uri>, NoEligibleCorrespondents> {
+    let candidates = correspondent_indexers();
+    if candidates.is_empty() {
+        return Err(NoEligibleCorrespondents::EmptyPool);
+    }
     let pool = match sync_indexer {
-        Some(sync_indexer) => eligible_from(correspondent_indexers(), sync_indexer)?,
-        None => correspondent_indexers(),
+        Some(sync_indexer) => eligible_from(candidates, sync_indexer)?,
+        None => candidates,
     };
     Ok(health.filter_with_floor(pool))
 }

--- a/zingolib/src/lightclient/error.rs
+++ b/zingolib/src/lightclient/error.rs
@@ -172,10 +172,10 @@ pub enum MigrationError {
 #[derive(Debug, thiserror::Error)]
 pub enum SendError {
     /// Propose send error.
-    #[error("Propose send error. {0}")]
+    #[error("Propose send error.")]
     ProposeSendError(#[from] ProposeSendError),
     /// Propose shield error.
-    #[error("Propose shield error. {0}")]
+    #[error("Propose shield error.")]
     ProposeShieldError(#[from] ProposeShieldError),
     /// Failed to construct sending transaction.
     #[error("Failed to construct sending transaction. {0}")]
@@ -190,7 +190,7 @@ pub enum SendError {
     #[error("No proposal found in the wallet.")]
     NoStoredProposal,
     /// Transmission error.
-    #[error("Transmission error. {0}")]
+    #[error("Transmission error.")]
     TransmissionError(#[from] TransmissionError),
 }
 

--- a/zingolib/src/lightclient/migrate.rs
+++ b/zingolib/src/lightclient/migrate.rs
@@ -2282,7 +2282,7 @@ fn immediate_migration_entry_gate(
 
 /// The separator between two layers of a rendered cause chain, matching the
 /// rendering `zingo_net_diag` gives its own failure records.
-const CAUSE_CHAIN_SEPARATOR: &str = ": ";
+pub(crate) const CAUSE_CHAIN_SEPARATOR: &str = ": ";
 
 /// Renders every layer of a failure's cause chain into the one text a batch
 /// report carries across serde.

--- a/zingolib/src/lightclient/mixnet.rs
+++ b/zingolib/src/lightclient/mixnet.rs
@@ -4,6 +4,8 @@
 //! deliberate disable, never as a silent fallback: a session that never
 //! enabled the mixnet, or whose enable failed, is `Unattached` and refuses.
 
+#![forbid(unsafe_code)]
+
 use super::error::LightClientError;
 use super::{LightClient, MixnetPriceFetch};
 

--- a/zingolib/src/lightclient/sync.rs
+++ b/zingolib/src/lightclient/sync.rs
@@ -317,7 +317,8 @@ impl LightClient {
         match self.poll_sync() {
             PollReport::Ready(Err(e)) => {
                 let action = e.recovery_recommendation();
-                let description = e.to_string();
+                let description =
+                    zingo_net_diag::chain_texts(&e).join(super::migrate::CAUSE_CHAIN_SEPARATOR);
                 Some((action, description))
             }
             _ => None,

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -151,11 +151,11 @@ pub enum WalletError {
 #[derive(Debug, thiserror::Error)]
 pub enum PriceError {
     /// Price error
-    #[error("price error. {0}")]
+    #[error("price error.")]
     PriceError(#[from] zingo_price::PriceError),
     /// Every source in the three-source race failed; the report names each
     /// source's typed failure with its cause chain.
-    #[error("price race failed. {0}")]
+    #[error("price race failed.")]
     RaceFailed(#[from] zingo_price::PriceRaceFailure),
     /// Price list not initialised
     #[error("price list not initialised. please wait for sync to obtain time of wallet birthday")]

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -277,6 +277,22 @@ pub async fn sync_client_to_validator_tip<V, I>(
     sync_to_target_height(client, tip).await.unwrap();
 }
 
+/// Zebra's mempool rejection text for a spend of, or anchored at, the tip
+/// block; the leaf link of the send failure's cause chain carries it.
+const TIP_BLOCK_REJECTION: &str = "until the next chain tip block";
+
+/// Reports whether any link of `error`'s cause chain carries zebra's tip-block rejection text.
+fn rejects_tip_block_spend(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut link: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(current) = link {
+        if current.to_string().contains(TIP_BLOCK_REJECTION) {
+            return true;
+        }
+        link = current.source();
+    }
+    false
+}
+
 /// The single lag-safe send primitive: sends `receivers` from `sender` in
 /// one transaction, then mines one block at a time (waiting for `sender`'s
 /// wallet to reach each new height) until the transaction is confirmed.
@@ -313,7 +329,7 @@ where
 {
     let txids = match from_inputs::quick_send(sender, receivers.clone()).await {
         Ok(txids) => txids,
-        Err(e) if e.to_string().contains("until the next chain tip block") => {
+        Err(e) if rejects_tip_block_spend(&e) => {
             // Tip-block spend rejected: separate from the tip and retry once.
             increase_height_and_wait_for_client(local_net, sender, 1)
                 .await


### PR DESCRIPTION
PR #2671 merged before its second review's findings landed. This PR carries the nine triaged fixes as follow-ups on `dev`. Issue #2675 tracks the one deferred finding.

## Chain-rendering repairs

The one-link rule truncated `Display` to a single layer, and six surfaces still rendered with `to_string()` or `{e}`. Each is repaired.

- `send_and_bump`'s tip-rejection retry guard matched the truncated text and went dead. It now walks the `source()` chain (1fb59acdb).
- The `SendError` and `PriceError` wrappers kept `{0}` beside `#[from]`, so a chain walk rendered their payload twice. They now state one layer (2bc8c53ab).
- `poll_sync_recovery` returned a bare "sync error." description. It now renders the whole chain (3c1042ab1).
- Seven CLI sites printed detail-free or opaque lines: three startup prints, and four untyped seams that flattened failures into leaf strings. All render over the chain walk now (e2cdc80d0).
- The mempool retry warning lost its tonic detail. It renders through a local walk, because pepper-sync's dependency set must not grow (5f342281c).

## Consistency and conventions

- An Indexerless `eligible_correspondents` draw returned an empty pool as `Ok`; it now refuses `EmptyPool` like the indexer-bound arm (d911c8ebd).
- `lightclient/mixnet.rs` gains the file-level `#![forbid(unsafe_code)]` its siblings carry (60df4a6e8).
- The CHANGELOGs record the two breaking surfaces #2671 shipped unannounced: zingolib's `TransportError::ExitOutsideClutch` variant, and pepper-sync's truncated error `Display` (bb8873a10).

## Verification

All 814 unit tests pass across pepper-sync, zingolib, and zingo-cli. `cargo hack check --each-feature` is green on all 18 feature planes of the three crates. Clippy and rustfmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
