### PR TITLE
One probe primitive: every sweep and probe wraps GetLatestBlock, and a surveyed pin is chosen unless unresponsive

### DIFF
--- a/docs/adr/0034-server-selection-is-a-mixnet-liveness-sweep.md
+++ b/docs/adr/0034-server-selection-is-a-mixnet-liveness-sweep.md
@@ -93,3 +93,25 @@ transmissions-are-probes Health economy. The sweep itself gains a
 ratified second role: it is the session's baseline health probe, the
 last probe-only act a session performs. The judgment this record calls
 liveness is since named Health in the glossary.
+
+## Addendum (2026-08-12)
+
+Four rulings from the sweep-failure investigation amend the mechanism.
+First, the survey's probe is `GetLatestBlock`, the lightest tip call an
+indexer answers, replacing `GetLightdInfo`; the liveness judgment rests
+on the height tolerance alone, and the census's chain partition carries
+the chain distinction. Second, the user's pinned clearnet sync indexer
+(`--sync-server`, renamed from `--server`, which survives as an alias)
+rides the survey and is chosen when it answers; a pin the survey found
+unresponsive is reported with the sweep's verdict offered as the
+alternative, and a sweep whose own transport failed is never charged
+against the pin, so a dead exit draw cannot close a pinned session's
+Sync Session. The DeadPin outcome is gone. Third, the survey bounds its
+fan-out: all candidates once rode one exit's packet pipeline
+concurrently, which saturated it and produced the all-or-nothing
+0-of-17 signature, so the width is now a bounded function of the census
+size, calibrated identically for spawned desktop binaries and the
+in-process client the mobile platforms host. Fourth, the survey stops
+discarding why probes fail: refusals carry the diary's failure kinds,
+and an empty cohort tallies its causes in its own rendering, so a
+saturated transport reads differently from dead indexers.

--- a/tools/workbench/src/bin/run-cli.rs
+++ b/tools/workbench/src/bin/run-cli.rs
@@ -17,7 +17,7 @@
 //!
 //! The launched session decides its own connectivity: first boot is offline,
 //! and only a consent act — a stored standing Connectivity Consent from a
-//! previous run, an explicit `--online`/`--server` passed through in the
+//! previous run, an explicit `--online`/`--sync-server` passed through in the
 //! trailing arguments, or the in-session `network on` command (ADR 0026) —
 //! takes it online (ADR 0025). Neither this tool nor a bundled proxy binary
 //! implies consent.

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Breaking.** `network probe` wraps the single `GetLatestBlock` RPC, the
+  same tip call the Server-Selection Sweep surveys with, and reports the
+  tip height alone: there is no chain name in the reply to print.
 - A failed command renders its whole cause chain at the dispatch seam,
   one `caused by:` line per source link, over the sanctioned
   `zingo-net-diag` chain walk; the closing save's failure renders the

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Breaking.** The `--server` flag is renamed `--sync-server`, naming what
+  the pin is: a clearnet sync indexer, selected by the user. The old
+  spelling survives as a visible alias, so existing command lines keep
+  working. The pin rides the Server-Selection Sweep's survey and is chosen
+  when it answers; a pin the survey found unresponsive is reported with the
+  sweep's verdict offered as the alternative, and a sweep whose own
+  transport failed never counts against the pin. The messages say "pinned
+  clearnet sync indexer" where they said "pinned server".
 - **Breaking.** `network probe` wraps the single `GetLatestBlock` RPC, the
   same tip call the Server-Selection Sweep surveys with, and reports the
   tip height alone: there is no chain name in the reply to print.

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1209,10 +1209,7 @@ use zingolib::netutils::time::PROBE_LEG_TIMEOUT;
 #[cfg(feature = "nym")]
 fn render_mixnet_probe(probe: &zingolib::mixnet::probe::MixnetProbe) -> String {
     let leg = |leg: &zingolib::mixnet::probe::ProbeLeg| match &leg.outcome {
-        Ok(success) => format!(
-            "ok in {}ms: chain {}, height {}",
-            leg.millis, success.chain, success.height
-        ),
+        Ok(success) => format!("ok in {}ms: height {}", leg.millis, success.height),
         Err(failure) => format!("FAILED after {}ms: {failure}", leg.millis),
     };
     format!("{}\n  mixnet:   {}", probe.host, leg(&probe.leg))
@@ -2310,7 +2307,7 @@ pub(crate) enum CliCommand {
             $ZINGO_NYM_PROXY, else one bundled beside this binary, else PATH.
             `off` disconnects every network capability of the session, keeping
             any stored standing consent; `network on` re-consents (ADR 0032).
-            `probe` runs GetLightdInfo over the mixnet route to establish an
+            `probe` runs GetLatestBlock over the mixnet route to establish an
             indexer's liveness; it requires the mixnet and touches no
             clearnet endpoint. `history` shows per-indexer attempts across
             sessions, and needs the nym-diary feature plus --indexer-diary.

--- a/zingo-cli/src/commands/tests.rs
+++ b/zingo-cli/src/commands/tests.rs
@@ -664,16 +664,13 @@ mod network_command_parsing {
         let live = MixnetProbe {
             host: zingolib::correspondent::Host::of_host_str("zec.rocks"),
             leg: ProbeLeg {
-                outcome: Ok(ProbeSuccess {
-                    chain: "main".to_string(),
-                    height: 3_420_400,
-                }),
+                outcome: Ok(ProbeSuccess { height: 3_420_400 }),
                 millis: 180,
             },
         };
         assert_eq!(
             render_mixnet_probe(&live),
-            "zec.rocks\n  mixnet:   ok in 180ms: chain main, height 3420400"
+            "zec.rocks\n  mixnet:   ok in 180ms: height 3420400"
         );
 
         let dead = MixnetProbe {

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -1295,8 +1295,11 @@ fn census_chain(chain: &ChainType) -> Option<zingolib::indexers::IndexerChain> {
 }
 
 /// Runs the Server-Selection Sweep (ADR 0034), narrating each phase, and
-/// binds its verdict as the sync indexer; returns whether this Sync Session
-/// may open.
+/// binds a sync indexer; returns whether this Sync Session may open. A
+/// pinned server rides the survey and is chosen when it answers; a pin the
+/// survey found unresponsive is reported with the sweep's verdict offered
+/// as the alternative, and a sweep whose own transport failed never counts
+/// against the pin.
 #[cfg(feature = "nym")]
 async fn sweep_select_sync_indexer(
     lightclient: &mut LightClient,
@@ -1330,11 +1333,8 @@ async fn sweep_select_sync_indexer(
     }
     let proxy_path = commands::resolve_proxy_path(filled_template.nym_proxy_path.as_deref());
     let selection = lightclient
-        .run_server_selection_sweep(
-            std::path::Path::new(&proxy_path),
-            &candidates,
-            pin.as_ref(),
-            |phase| match phase {
+        .run_server_selection_sweep(std::path::Path::new(&proxy_path), &candidates, |phase| {
+            match phase {
                 SweepProgress::TransportBootstrapping => eprintln!(
                     "Server-Selection Sweep: bootstrapping a dedicated sweep transport \
                      (its Exit Node is recycled when the sweep completes)..."
@@ -1346,11 +1346,33 @@ async fn sweep_select_sync_indexer(
                     "Server-Selection Sweep: {answered} of {surveyed} candidates answered; \
                      judging the live cohort..."
                 ),
-            },
-        )
+            }
+        })
         .await;
     match selection {
         Ok(selection) => {
+            if let Some(pinned) = &pin {
+                if selection.cohort.iter().any(|live| &live.uri == pinned) {
+                    // The user's selection answered the survey: it is chosen,
+                    // and it is already bound from config.
+                    eprintln!(
+                        "Server-Selection Sweep: sync attaches to the pinned server {pinned} \
+                         (live cohort of {}).",
+                        selection.cohort.len(),
+                    );
+                    return true;
+                }
+                eprintln!(
+                    "Server-Selection Sweep: the pinned server {pinned} did not answer the \
+                     survey or lags the live cohort of {}. A live alternative: {}. This Sync \
+                     Session does not open; run `changeserver {}` at the prompt, or relaunch \
+                     pinning a live server.",
+                    selection.cohort.len(),
+                    selection.sync_indexer,
+                    selection.sync_indexer,
+                );
+                return false;
+            }
             let chosen = selection.sync_indexer.clone();
             match lightclient.set_indexer_uri(chosen.clone()).await {
                 Ok(()) => {
@@ -1373,6 +1395,14 @@ async fn sweep_select_sync_indexer(
             }
         }
         Err(e) => {
+            if let Some(pinned) = &pin {
+                eprintln!(
+                    "Server-Selection Sweep: no verdict: {}. The survey never judged the pinned \
+                     server {pinned}; it stands, and this Sync Session opens against it.",
+                    commands::render_error_chain(&e),
+                );
+                return true;
+            }
             eprintln!("{}", sweep_refusal_notice(&e));
             false
         }

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -85,10 +85,11 @@ pub fn build_clap_app() -> clap::Command {
                 .help("Specify wallet birthday when restoring from seed. This is the earliest block height where the wallet has a transaction. \
 For a NEW wallet created in Offline mode it is instead an optional override of the library's built-in birthday floor."))
             .arg(Arg::new("server")
-                .long("server")
+                .long("sync-server")
+                .visible_alias("server")
                 .value_name("server")
-                .help("Pin a specific Indexer server. Without it, an online session's \
-Server-Selection Sweep selects the sync indexer.")
+                .help("Pin a specific clearnet sync indexer. It rides the Server-Selection \
+Sweep's survey and is chosen when it answers; without it, the sweep selects the sync indexer.")
                 .value_parser(parse_uri))
             .arg(Arg::new("offline")
                 .long("offline")
@@ -99,7 +100,7 @@ Server-Selection Sweep selects the sync indexer.")
                 .long("online")
                 .action(clap::ArgAction::SetTrue)
                 .conflicts_with("offline")
-                .help("Consent to go online this session (Connectivity Consent). First boot is offline by design; this flag, --remember-online, an explicit --server, or a stored standing consent takes a session online. The choice is not persisted."))
+                .help("Consent to go online this session (Connectivity Consent). First boot is offline by design; this flag, --remember-online, an explicit --sync-server, or a stored standing consent takes a session online. The choice is not persisted."))
             .arg(Arg::new("remember-online")
                 .long("remember-online")
                 .action(clap::ArgAction::SetTrue)
@@ -717,7 +718,7 @@ enum ConnectivityDecision {
 
 /// Combines the launch acts with the stored choice (ADR 0025): the
 /// deliberate `--offline` wins over everything, a launch act (`--online`,
-/// `--remember-online`, an explicit `--server`) over the store, the store
+/// `--remember-online`, an explicit `--sync-server`) over the store, the store
 /// alone sustains the connection, and nothing else goes online.
 #[cfg(feature = "nym")]
 fn decide_connectivity(
@@ -800,7 +801,7 @@ fn get_communication_mode(matches: &clap::ArgMatches) -> std::io::Result<Communi
                 "No Connectivity Consent is recorded, so this session runs offline: local \
                  operations work and nothing touches the network. To go online, pass --online \
                  (this session only), --remember-online (store the choice for future \
-                 sessions), or --server <uri>; in the session, `network on` also grants \
+                 sessions), or --sync-server <uri>; in the session, `network on` also grants \
                  consent and switches to ONLINE MODE. Pass --offline to run offline \
                  deliberately and silence this notice."
             );
@@ -860,12 +861,12 @@ pub(crate) struct ConfigTemplate {
     /// The pinned Indexer: `None` when the session is Offline, and equally
     /// when it is Online unpinned, where the Server-Selection Sweep selects.
     server: Option<http::Uri>,
-    /// True when `--server` was typed on the command line: the pin the
+    /// True when `--sync-server` was typed on the command line: the pin the
     /// Server-Selection Sweep surveys and never substitutes.
     #[cfg_attr(not(feature = "nym"), allow(dead_code))]
     server_pinned: bool,
     /// All servers that responded to `get_info()` during dynamic selection,
-    /// sorted fastest to slowest. Empty if `--server` was specified explicitly.
+    /// sorted fastest to slowest. Empty if `--sync-server` was specified explicitly.
     /// Will be used for automatic failover when sync fails.
     #[cfg(feature = "clearnet-test-mode")]
     #[allow(dead_code)]
@@ -914,13 +915,13 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
     #[cfg(feature = "clearnet-test-mode")]
     #[error(transparent)]
     ResolveServer(#[from] server_select_clearnet::ResolveServerError),
-    /// The pinned `--server` is not a valid indexer URI.
+    /// The pinned `--sync-server` is not a valid indexer URI.
     #[cfg(not(feature = "clearnet-test-mode"))]
-    #[error("invalid --server URI.")]
+    #[error("invalid --sync-server URI.")]
     IndexerUri(#[from] http::uri::InvalidUri),
-    /// The pinned server misses its scheme, host, or port.
+    /// The pinned clearnet sync indexer misses its scheme, host, or port.
     #[error(
-        "Please provide the --server parameter as [scheme]://[host]:[port].\nYou provided: {server}"
+        "Please provide the --sync-server parameter as [scheme]://[host]:[port].\nYou provided: {server}"
     )]
     ServerShape {
         /// The under-specified server URI.
@@ -988,7 +989,7 @@ impl ConfigTemplate {
             }
         };
         // Without the quarantined sweep, resolution is pure: the typed
-        // `--server` pin or nothing, never a probe and never a default.
+        // `--sync-server` pin or nothing, never a probe and never a default.
         #[cfg(not(feature = "clearnet-test-mode"))]
         let server = match communication_mode {
             CommunicationMode::DeliberateOffline | CommunicationMode::UnconsentedOffline => None,
@@ -1296,7 +1297,7 @@ fn census_chain(chain: &ChainType) -> Option<zingolib::indexers::IndexerChain> {
 
 /// Runs the Server-Selection Sweep (ADR 0034), narrating each phase, and
 /// binds a sync indexer; returns whether this Sync Session may open. A
-/// pinned server rides the survey and is chosen when it answers; a pin the
+/// pinned clearnet sync indexer rides the survey and is chosen when it answers; a pin the
 /// survey found unresponsive is reported with the sweep's verdict offered
 /// as the alternative, and a sweep whose own transport failed never counts
 /// against the pin.
@@ -1318,7 +1319,7 @@ async fn sweep_select_sync_indexer(
         && !zingolib::mixnet::probe::probe_eligible(pinned)
     {
         eprintln!(
-            "Server-Selection Sweep: pinned server {pinned} is outside the mixnet exit policy \
+            "Server-Selection Sweep: the pinned clearnet sync indexer {pinned} is outside the mixnet exit policy \
              (https on port 443), so no sweep can survey it; binding it directly."
         );
         return true;
@@ -1356,14 +1357,14 @@ async fn sweep_select_sync_indexer(
                     // The user's selection answered the survey: it is chosen,
                     // and it is already bound from config.
                     eprintln!(
-                        "Server-Selection Sweep: sync attaches to the pinned server {pinned} \
+                        "Server-Selection Sweep: sync attaches to the pinned clearnet sync indexer {pinned} \
                          (live cohort of {}).",
                         selection.cohort.len(),
                     );
                     return true;
                 }
                 eprintln!(
-                    "Server-Selection Sweep: the pinned server {pinned} did not answer the \
+                    "Server-Selection Sweep: the pinned clearnet sync indexer {pinned} did not answer the \
                      survey or lags the live cohort of {}. A live alternative: {}. This Sync \
                      Session does not open; run `changeserver {}` at the prompt, or relaunch \
                      pinning a live server.",
@@ -1397,8 +1398,8 @@ async fn sweep_select_sync_indexer(
         Err(e) => {
             if let Some(pinned) = &pin {
                 eprintln!(
-                    "Server-Selection Sweep: no verdict: {}. The survey never judged the pinned \
-                     server {pinned}; it stands, and this Sync Session opens against it.",
+                    "Server-Selection Sweep: no verdict: {}. The survey never judged the \
+                     pinned clearnet sync indexer {pinned}; it stands, and this Sync Session opens against it.",
                     commands::render_error_chain(&e),
                 );
                 return true;

--- a/zingo-cli/src/server_select_clearnet.rs
+++ b/zingo-cli/src/server_select_clearnet.rs
@@ -1,6 +1,6 @@
 //! Dynamic server selection via `get_info()` against a curated list of indexers.
 //!
-//! When no `--server` is specified, we call `get_info()` on each URI in
+//! When no `--sync-server` is specified, we call `get_info()` on each URI in
 //! `zingolib::netutils::indexers::MOST_UP_INDEXER_URIS` (the census) concurrently,
 //! measure response time, and return the responsive servers sorted
 //! from fastest to slowest.
@@ -120,7 +120,10 @@ pub(crate) async fn select_servers() -> Vec<RankedServer> {
         .filter_map(|s| s.parse::<http::Uri>().ok())
         .collect();
 
-    eprintln!("No --server specified. Probing {} indexers...", uris.len());
+    eprintln!(
+        "No --sync-server specified. Probing {} indexers...",
+        uris.len()
+    );
 
     let (ranked, failures) = probe_servers(uris, SERVER_RANKING_TIMEOUT).await;
 
@@ -149,17 +152,17 @@ pub(crate) async fn select_servers() -> Vec<RankedServer> {
 /// Why the clearnet resolution produced no server.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ResolveServerError {
-    /// The explicit `--server` value failed to parse as a URI.
+    /// The explicit `--sync-server` value failed to parse as a URI.
     #[error(transparent)]
     InvalidUri(#[from] http::uri::InvalidUri),
     /// No probed indexer answered, and no default server exists.
-    #[error("no probed server responded and there is no default server; pass --server")]
+    #[error("no probed server responded and there is no default server; pass --sync-server")]
     NoResponder,
 }
 
 /// Resolves the indexer server from CLI arguments.
 ///
-/// If `--server` was provided explicitly, uses that URI and returns an
+/// If `--sync-server` was provided explicitly, uses that URI and returns an
 /// empty ranked list. Otherwise, probes curated indexers with `get_info()`
 /// and returns the fastest responder along with the full ranked list.
 ///
@@ -180,7 +183,7 @@ pub(crate) fn resolve_server(
 }
 
 /// Resolves the indexer for a session going online without an explicit
-/// `--server`: the fastest probed responder, refused typed when nothing
+/// `--sync-server`: the fastest probed responder, refused typed when nothing
 /// answered, since no default server exists.
 pub(crate) async fn resolve_ranked_server()
 -> Result<(http::Uri, Vec<RankedServer>), ResolveServerError> {

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -516,10 +516,22 @@ mod communication_mode {
     }
 
     /// Naming an endpoint is consenting to connect to it: an explicit
-    /// --server is a consent act (ADR 0025).
+    /// --sync-server is a consent act (ADR 0025).
     #[cfg(feature = "nym")]
     #[test]
     fn an_explicit_server_is_a_consent_act() {
+        let dir = scratch_dir();
+        assert_eq!(
+            mode_with_dir(&dir, &["--sync-server", examples::SERVER_URI]),
+            CommunicationMode::Online
+        );
+    }
+
+    /// The retired spelling survives as a visible alias: `--server` parses
+    /// as the `--sync-server` pin, so existing command lines keep working.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn the_old_server_spelling_is_an_alias() {
         let dir = scratch_dir();
         assert_eq!(
             mode_with_dir(&dir, &["--server", examples::SERVER_URI]),
@@ -603,7 +615,7 @@ mod communication_mode {
             for act in [
                 vec!["--online"],
                 vec!["--remember-online"],
-                vec!["--server", examples::SERVER_URI],
+                vec!["--sync-server", examples::SERVER_URI],
             ] {
                 let mut args = vec![
                     examples::BIN_NAME,
@@ -677,7 +689,7 @@ mod communication_mode {
                 .try_get_matches_from([
                     examples::BIN_NAME,
                     "--offline",
-                    "--server",
+                    "--sync-server",
                     examples::SERVER_URI
                 ])
                 .is_err()
@@ -916,12 +928,13 @@ mod config_template {
         #[cfg(feature = "nym")]
         use crate::CommunicationMode;
 
-        /// An explicit `--server` is an online act, which only nym builds
+        /// An explicit `--sync-server` is an online act, which only nym builds
         /// accept (ADR 0026).
         #[cfg(feature = "nym")]
         #[test]
         fn defaults() {
-            let config = fill(&[examples::BIN_NAME, "--server", examples::SERVER_URI]).unwrap();
+            let config =
+                fill(&[examples::BIN_NAME, "--sync-server", examples::SERVER_URI]).unwrap();
             assert_eq!(config.data_dir, PathBuf::from("wallets"));
             assert_eq!(config.chaintype, ChainType::Mainnet);
             assert_eq!(config.communication_mode, CommunicationMode::Online);
@@ -1035,11 +1048,12 @@ mod config_template {
 
         /// The URI shape check sits on the online resolution path, which
         /// only nym builds reach: the offline-only build refuses the
-        /// `--server` act before any URI is inspected (ADR 0026).
+        /// `--sync-server` act before any URI is inspected (ADR 0026).
         #[cfg(feature = "nym")]
         #[test]
         fn server_missing_port() {
-            let err = fill(&[examples::BIN_NAME, "--server", "https://example.com"]).unwrap_err();
+            let err =
+                fill(&[examples::BIN_NAME, "--sync-server", "https://example.com"]).unwrap_err();
             assert!(err.contains("scheme"));
         }
     }
@@ -1062,7 +1076,7 @@ mod config_template {
         #[cfg(feature = "nym")]
         #[test]
         fn unpinned_online_configures_no_indexer() {
-            // --online is the consent act; with no --server there is no
+            // --online is the consent act; with no --sync-server there is no
             // default to fill in, and the sweep selects the sync indexer.
             let zc = fill_and_build(&[
                 examples::BIN_NAME,
@@ -1086,7 +1100,7 @@ mod config_template {
         fn custom_server_is_propagated() {
             let zc = fill_and_build(&[
                 examples::BIN_NAME,
-                "--server",
+                "--sync-server",
                 examples::SERVER_URI,
                 "--seed",
                 HOSPITAL_MUSEUM_SEED,
@@ -1110,7 +1124,7 @@ mod config_template {
             for act in [
                 vec!["--online"],
                 vec!["--remember-online"],
-                vec!["--server", examples::SERVER_URI],
+                vec!["--sync-server", examples::SERVER_URI],
             ] {
                 let mut args = vec![examples::BIN_NAME];
                 args.extend(act.iter());

--- a/zingo-cli/tests/log_file.rs
+++ b/zingo-cli/tests/log_file.rs
@@ -152,7 +152,7 @@ async fn tracing_error_from_pepper_sync_goes_to_log_file() {
 
     let mut child = Command::new(zingo_cli_binary())
         .env("RUST_LOG", "info")
-        .arg("--sync-server")
+        .arg("--server")
         .arg(&server_uri)
         // The mixnet is unconditional for a connected session, so hand the
         // spawner a stub that answers the directory query and then exits at

--- a/zingo-cli/tests/log_file.rs
+++ b/zingo-cli/tests/log_file.rs
@@ -152,7 +152,7 @@ async fn tracing_error_from_pepper_sync_goes_to_log_file() {
 
     let mut child = Command::new(zingo_cli_binary())
         .env("RUST_LOG", "info")
-        .arg("--server")
+        .arg("--sync-server")
         .arg(&server_uri)
         // The mixnet is unconditional for a connected session, so hand the
         // spawner a stub that answers the directory query and then exits at

--- a/zingo-netutils/CHANGELOG.md
+++ b/zingo-netutils/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- BREAKING: `get_lightd_info_via_socks5` is removed. Every probe wraps
+  the single `GetLatestBlock` RPC through `get_latest_block_via_socks5`,
+  and `live_indexer_discovery::DiscoveredIndexer` carries `tip: BlockId`
+  where it carried `info: LightdInfo`.
 - BREAKING: the `zingo-nym-proxy-ffi` crate and the `uniffi-bindgen`
   helper leave this workspace; zingo-mobile now hosts the mobile UniFFI
   proxy shim in its own `nym-host` workspace (zingo-mobile PR #1251).

--- a/zingo-netutils/CHANGELOG.md
+++ b/zingo-netutils/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `get_latest_block_via_socks5`: the `GetLatestBlock` tip fetch through
+  the local SOCKS5 proxy, the lightest liveness probe an indexer answers,
+  now the Server-Selection Sweep's survey primitive.
 - The `responsiveness` module partitions network operations at compile
   time: the sealed `Responsiveness` trait with the `Critical` and
   `NonCritical` marker types, the `ResponsivenessClass` enum with

--- a/zingo-netutils/src/bin/live-indexer-discovery.rs
+++ b/zingo-netutils/src/bin/live-indexer-discovery.rs
@@ -1,7 +1,7 @@
 //! Demonstrates ADR 0029's boot phase: probe every mixnet-eligible census
 //! endpoint through its own uniformly-sampled exit, then hold the
 //! successes as maintained connections and prove they still answer with a
-//! second `GetLightdInfo` round over the same transports.
+//! second `GetLatestBlock` round over the same transports.
 //!
 //! ```text
 //! pool-discovery [--budget N]
@@ -15,7 +15,7 @@ use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use zingo_netutils::ensure_default_crypto_provider;
-use zingo_netutils::get_lightd_info_via_socks5;
+use zingo_netutils::get_latest_block_via_socks5;
 use zingo_netutils::indexers::IndexerChain;
 use zingo_netutils::live_indexer_discovery::{DiscoveryFailureKind, discover_live_indexers};
 use zingo_netutils::time::MIXNET_ROUND_TRIP_BOUND;
@@ -67,11 +67,10 @@ async fn main() -> ExitCode {
     );
     for found in &report.live {
         println!(
-            "  LIVE {} operator={} height={} vendor={} ({:.1?})",
+            "  LIVE {} operator={} height={} ({:.1?})",
             found.indexer.uri,
             found.indexer.operator(),
-            found.info.block_height,
-            found.info.vendor,
+            found.tip.height,
             found.elapsed
         );
     }
@@ -102,10 +101,10 @@ async fn main() -> ExitCode {
             );
             continue;
         };
-        match get_lightd_info_via_socks5(socks5_addr, &uri, MIXNET_ROUND_TRIP_BOUND).await {
-            Ok(info) => println!(
+        match get_latest_block_via_socks5(socks5_addr, &uri, MIXNET_ROUND_TRIP_BOUND).await {
+            Ok(tip) => println!(
                 "  OK {} height={} (same transport, same exit)",
-                found.indexer.uri, info.block_height
+                found.indexer.uri, tip.height
             ),
             Err(source) => println!("  LOST {} ({source})", found.indexer.uri),
         }

--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -99,7 +99,7 @@ mod socks5_transmit;
 #[cfg(feature = "socks5-transmit")]
 pub use socks5_transmit::{
     ProxyDialFailure, Socks5TransmitError, TunnelFailure, get_latest_block_via_socks5,
-    get_lightd_info_via_socks5, send_transaction_via_socks5, transaction_known_via_socks5,
+    send_transaction_via_socks5, transaction_known_via_socks5,
 };
 
 fn client_tls_config() -> ClientTlsConfig {

--- a/zingo-netutils/src/lib.rs
+++ b/zingo-netutils/src/lib.rs
@@ -98,8 +98,8 @@ pub mod live_indexer_discovery;
 mod socks5_transmit;
 #[cfg(feature = "socks5-transmit")]
 pub use socks5_transmit::{
-    ProxyDialFailure, Socks5TransmitError, TunnelFailure, get_lightd_info_via_socks5,
-    send_transaction_via_socks5, transaction_known_via_socks5,
+    ProxyDialFailure, Socks5TransmitError, TunnelFailure, get_latest_block_via_socks5,
+    get_lightd_info_via_socks5, send_transaction_via_socks5, transaction_known_via_socks5,
 };
 
 fn client_tls_config() -> ClientTlsConfig {

--- a/zingo-netutils/src/live_indexer_discovery.rs
+++ b/zingo-netutils/src/live_indexer_discovery.rs
@@ -13,18 +13,18 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use lightwallet_protocol::LightdInfo;
+use lightwallet_protocol::BlockId;
 
 use crate::NymProxy;
 use crate::error::NymProxyError;
 use crate::indexers::{Indexer, IndexerChain, mixnet_eligible};
 use crate::mixnet_connect::seeded_shuffle;
-use crate::socks5_transmit::{Socks5TransmitError, get_lightd_info_via_socks5};
+use crate::socks5_transmit::{Socks5TransmitError, get_latest_block_via_socks5};
 use crate::time::{
     ATTACH_LISTENER_RETRY_PAUSE, MIXNET_ROUND_TRIP_BOUND, PER_ATTEMPT_CONNECT_TIMEOUT,
 };
 
-/// A census endpoint that answered `GetLightdInfo` through its own exit.
+/// A census endpoint that answered `GetLatestBlock` through its own exit.
 /// Holding the value holds the transport: dropping a `DiscoveredIndexer`
 /// tears the maintained connection down.
 pub struct DiscoveredIndexer {
@@ -34,8 +34,8 @@ pub struct DiscoveredIndexer {
     pub exit_node: String,
     /// The transport the probe rode, kept alive as the pool connection.
     pub transport: NymProxy,
-    /// The endpoint's `GetLightdInfo` answer.
-    pub info: LightdInfo,
+    /// The endpoint's `GetLatestBlock` answer.
+    pub tip: BlockId,
     /// Bootstrap plus probe, wall clock.
     pub elapsed: Duration,
 }
@@ -56,7 +56,7 @@ pub struct DiscoveryFailure {
 pub enum DiscoveryFailureKind {
     /// The assigned exit never became a working transport.
     Bootstrap(NymProxyError),
-    /// The transport came up but the endpoint's `GetLightdInfo` did not.
+    /// The transport came up but the endpoint's `GetLatestBlock` did not.
     Probe(Socks5TransmitError),
 }
 
@@ -180,11 +180,11 @@ async fn probe_via_unique_exit(
         .parse()
         .expect("the census tests pin every entry parseable");
     match probe_once_listening(&transport, &uri).await {
-        Ok(info) => {
+        Ok(tip) => {
             on_progress(format!(
                 "{}: live at height {} via exit {} ({:.1?})",
                 indexer.uri,
-                info.block_height,
+                tip.height,
                 short_exit(&exit_node),
                 started.elapsed()
             ));
@@ -192,7 +192,7 @@ async fn probe_via_unique_exit(
                 indexer,
                 exit_node,
                 transport,
-                info,
+                tip,
                 elapsed: started.elapsed(),
             })
         }
@@ -215,7 +215,7 @@ async fn probe_via_unique_exit(
 async fn probe_once_listening(
     transport: &NymProxy,
     uri: &http::Uri,
-) -> Result<LightdInfo, Socks5TransmitError> {
+) -> Result<BlockId, Socks5TransmitError> {
     let announced = transport.socks5_addr();
     let socks5_addr = announced.parse().map_err(|_| {
         // The proxy's own announcement is in-process and practically always
@@ -228,7 +228,7 @@ async fn probe_once_listening(
     })?;
     let deadline = Instant::now() + MIXNET_ROUND_TRIP_BOUND;
     loop {
-        match get_lightd_info_via_socks5(socks5_addr, uri, MIXNET_ROUND_TRIP_BOUND).await {
+        match get_latest_block_via_socks5(socks5_addr, uri, MIXNET_ROUND_TRIP_BOUND).await {
             Err(Socks5TransmitError::ProxyUnreachable { .. }) if Instant::now() < deadline => {
                 tokio::time::sleep(ATTACH_LISTENER_RETRY_PAUSE).await;
             }

--- a/zingo-netutils/src/socks5_transmit.rs
+++ b/zingo-netutils/src/socks5_transmit.rs
@@ -15,7 +15,7 @@
 //! child is dead" from "the mixnet exit refused this destination" from "the
 //! indexer itself said no". The caller decides what to do with a failure.
 //! [`Socks5TransmitError::is_failover_candidate`] offers the escalation's
-//! reading without discarding anything. [`get_lightd_info_via_socks5`]
+//! reading without discarding anything. [`get_latest_block_via_socks5`]
 //! mirrors the clearnet probe through the same tunnel, pairing the two
 //! routes for diagnosis.
 #![forbid(unsafe_code)]
@@ -31,9 +31,7 @@ use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 use crate::SendRejection;
 use crate::crypto::ensure_default_crypto_provider;
-use lightwallet_protocol::{
-    BlockId, ChainSpec, CompactTxStreamerClient, Empty, LightdInfo, RawTransaction, TxFilter,
-};
+use lightwallet_protocol::{BlockId, ChainSpec, CompactTxStreamerClient, RawTransaction, TxFilter};
 
 /// Why a SOCKS5-tunneled operation did not complete, typed by the connection
 /// phase that failed and carrying that phase's complete underlying data
@@ -286,26 +284,6 @@ pub async fn send_transaction_via_socks5(
         response.error_code,
         response.error_message,
     )?)
-}
-
-/// Fetches the indexer's `GetLightdInfo` through the local SOCKS5 proxy,
-/// the mixnet leg of a paired clearnet/mixnet probe. The same phase-typed
-/// failures as the send path, so a probe diagnoses exactly what a send
-/// would hit.
-pub async fn get_lightd_info_via_socks5(
-    socks5_addr: SocketAddr,
-    indexer: &Uri,
-    timeout: Duration,
-) -> Result<LightdInfo, Socks5TransmitError> {
-    let mut client = connect_via_socks5(socks5_addr, indexer, timeout).await?;
-    let mut request = tonic::Request::new(Empty {});
-    request.set_timeout(timeout);
-    bounded_rpc(
-        destination_of(indexer),
-        timeout,
-        client.get_lightd_info(request),
-    )
-    .await
 }
 
 /// Fetches the indexer's `GetLatestBlock` tip through the local SOCKS5

--- a/zingo-netutils/src/socks5_transmit.rs
+++ b/zingo-netutils/src/socks5_transmit.rs
@@ -31,7 +31,9 @@ use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 
 use crate::SendRejection;
 use crate::crypto::ensure_default_crypto_provider;
-use lightwallet_protocol::{CompactTxStreamerClient, Empty, LightdInfo, RawTransaction, TxFilter};
+use lightwallet_protocol::{
+    BlockId, ChainSpec, CompactTxStreamerClient, Empty, LightdInfo, RawTransaction, TxFilter,
+};
 
 /// Why a SOCKS5-tunneled operation did not complete, typed by the connection
 /// phase that failed and carrying that phase's complete underlying data
@@ -302,6 +304,25 @@ pub async fn get_lightd_info_via_socks5(
         destination_of(indexer),
         timeout,
         client.get_lightd_info(request),
+    )
+    .await
+}
+
+/// Fetches the indexer's `GetLatestBlock` tip through the local SOCKS5
+/// proxy, the lightest liveness probe an indexer answers, with the same
+/// phase-typed failures as the send path.
+pub async fn get_latest_block_via_socks5(
+    socks5_addr: SocketAddr,
+    indexer: &Uri,
+    timeout: Duration,
+) -> Result<BlockId, Socks5TransmitError> {
+    let mut client = connect_via_socks5(socks5_addr, indexer, timeout).await?;
+    let mut request = tonic::Request::new(ChainSpec {});
+    request.set_timeout(timeout);
+    bounded_rpc(
+        destination_of(indexer),
+        timeout,
+        client.get_latest_block(request),
     )
     .await
 }

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -70,9 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameter; `mixnet::sweep::select` and `live_cohort` lose their `pin`
   and `chain` parameters; `SweepError::DeadPin` is removed; and
   `mixnet::sweep::SurveyResult::reported` carries the bare tip height.
-  The judgment rests on the height tolerance alone, and a caller holds
-  any pinned clearnet sync indexer out of the candidates, binding it for
-  sync by the user's own selection.
+  The judgment rests on the height tolerance alone. A pinned server rides
+  the candidate list like any other, and the caller judges the pin against
+  the returned cohort: it is chosen when it answered, and an unanswered pin
+  is reported with the sweep's verdict offered as the alternative.
 - BREAKING: `mixnet::acquire::TransportError` gains the `ExitOutsideClutch`
   variant. A transport that reports ready without announcing an exit from
   the drawn Clutch now refuses with this variant instead of panicking, and

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: the Server-Selection Sweep no longer knows a pin, and its
+  survey probes with `GetLatestBlock` instead of `GetLightdInfo`.
+  `lightclient::select::run_server_selection_sweep` loses its `pin`
+  parameter; `mixnet::sweep::select` and `live_cohort` lose their `pin`
+  and `chain` parameters; `SweepError::DeadPin` is removed; and
+  `mixnet::sweep::SurveyResult::reported` carries the bare tip height.
+  The judgment rests on the height tolerance alone, and a caller holds
+  any pinned clearnet sync indexer out of the candidates, binding it for
+  sync by the user's own selection.
 - BREAKING: `mixnet::acquire::TransportError` gains the `ExitOutsideClutch`
   variant. A transport that reports ready without announcing an exit from
   the drawn Clutch now refuses with this variant instead of panicking, and

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: every probe wraps the single `GetLatestBlock` RPC. The mixnet
+  probe leg, the staged sync-path probe, and the attach readiness round
+  trip all probe the tip, the same primitive the sweep surveys with.
+  `mixnet::probe::ProbeSuccess` loses its `chain` field and carries the
+  tip height alone, and `SyncProbeStep::GrpcInfo` is renamed `GrpcTip`,
+  rendering `grpc-tip`.
 - BREAKING: the Server-Selection Sweep no longer knows a pin, and its
   survey probes with `GetLatestBlock` instead of `GetLightdInfo`.
   `lightclient::select::run_server_selection_sweep` loses its `pin`

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 use http::Uri;
 
 use super::LightClient;
-use crate::mixnet::probe::ProbeSuccess;
 use crate::mixnet::sweep::{self, Selection, SurveyResult, SweepError};
 
 /// Two blocks: the height tolerance around the observed median that counts
@@ -80,19 +79,17 @@ impl LightClient {
     /// operator, and the height-ordered live cohort.
     ///
     /// `binary_path` is the `nym-proxy` binary the dedicated sweep proxy
-    /// spawns from. `pin` is an explicit user server: it is surveyed like any
-    /// candidate and selected when live, and its absence from the live cohort
-    /// fails [`SweepError::DeadPin`] rather than falling back to the draw.
+    /// spawns from. A pinned clearnet sync indexer never enters a sweep: the
+    /// caller holds it out of `candidates`, and the pin binds for sync by
+    /// the user's own selection.
     ///
     /// The sweep proxy is dropped before this returns, recycling its exit.
     pub async fn run_server_selection_sweep(
         &self,
         binary_path: &Path,
         candidates: &[Uri],
-        pin: Option<&Uri>,
         progress: impl Fn(SweepProgress),
     ) -> Result<Selection, ServerSelectionError> {
-        let chain = lightd_chain_name(&self.chain_type());
         // A dedicated status channel: the sweep proxy's lifecycle is private
         // to this call and must not touch the session's mixnet status.
         let publisher = crate::mixnet::status_publisher();
@@ -146,29 +143,13 @@ impl LightClient {
             surveyed: results.len(),
         });
 
-        let selection = sweep::select(
-            &results,
-            chain,
-            SWEEP_HEIGHT_TOLERANCE,
-            pin,
-            &mut rand::rngs::OsRng,
-        )?;
+        let selection = sweep::select(&results, SWEEP_HEIGHT_TOLERANCE, &mut rand::rngs::OsRng)?;
 
         // Exit Recycling: retiring the member kills the child and recycles
         // its lease, so no later traffic rides the exit that observed the
         // survey.
         member.retire().await;
         Ok(selection)
-    }
-}
-
-/// The chain name a `GetLightdInfo` reply carries for `chain`, the
-/// vocabulary the survey's liveness judgment must compare against.
-fn lightd_chain_name(chain: &crate::config::ChainType) -> &'static str {
-    match chain {
-        crate::config::ChainType::Mainnet => "main",
-        crate::config::ChainType::Testnet => "test",
-        crate::config::ChainType::Regtest(_) => "regtest",
     }
 }
 
@@ -214,27 +195,21 @@ async fn survey(
     .await
 }
 
-/// One candidate's survey: `GetLightdInfo` over the sweep exit, its success
-/// mapped to the reported chain and height, any failure to `None`.
+/// One candidate's survey: `GetLatestBlock` over the sweep exit, its success
+/// mapped to the reported tip height, any failure to `None`.
 async fn probe_one(
     socks5_addr: std::net::SocketAddr,
     uri: &Uri,
     timeout: Duration,
     history: &crate::lightclient::indexer_history::IndexerHistoryHandle,
-) -> Option<ProbeSuccess> {
+) -> Option<u64> {
     use crate::lightclient::indexer_history::{
         AttemptKind, AttemptRoute, FailureKind, IndexerAttempt, now_unix_secs,
     };
     let host = crate::correspondent::Host::of_uri(uri);
-    let result = zingo_netutils::get_lightd_info_via_socks5(socks5_addr, uri, timeout).await;
+    let result = zingo_netutils::get_latest_block_via_socks5(socks5_addr, uri, timeout).await;
     let (reported, outcome) = match &result {
-        Ok(info) => (
-            Some(ProbeSuccess {
-                chain: info.chain_name.clone(),
-                height: info.block_height,
-            }),
-            Ok(()),
-        ),
+        Ok(tip) => (Some(tip.height), Ok(())),
         Err(error) => (None, Err(FailureKind::classify(&error.to_string()))),
     };
     history.record(&IndexerAttempt {
@@ -257,35 +232,6 @@ async fn probe_one(
 mod tests {
     use super::*;
     use crate::mixnet::MixnetMode;
-
-    /// HYPOTHESIS: the judgment compares against the wire's chain
-    /// vocabulary (`main`, `test`, `regtest`), never `ChainType`'s own
-    /// rendering (`mainnet`). Falsified if the mapping drifts back to the
-    /// Display form, which emptied a 17-of-17 mainnet cohort on 2026-08-06.
-    #[test]
-    fn the_judgment_speaks_the_wire_chain_vocabulary() {
-        use zingo_common_components::protocol::ActivationHeights;
-
-        assert_eq!(
-            lightd_chain_name(&crate::config::ChainType::Mainnet),
-            "main"
-        );
-        assert_eq!(
-            lightd_chain_name(&crate::config::ChainType::Testnet),
-            "test"
-        );
-        assert_eq!(
-            lightd_chain_name(&crate::config::ChainType::Regtest(
-                ActivationHeights::default()
-            )),
-            "regtest"
-        );
-        assert_ne!(
-            lightd_chain_name(&crate::config::ChainType::Mainnet),
-            crate::config::ChainType::Mainnet.to_string(),
-            "the Display form is not the wire form"
-        );
-    }
 
     /// The status a died sweep proxy publishes, carrying `detail` as its
     /// latched typed cause.

--- a/zingolib/src/mixnet/probe.rs
+++ b/zingolib/src/mixnet/probe.rs
@@ -1,27 +1,30 @@
 //! Connectivity probes: the mixnet indexer probe and the staged sync-path
 //! probe.
 //!
-//! The mixnet probe runs `GetLightdInfo` against an indexer through the
-//! session's SOCKS5 proxy: it establishes an indexer's liveness over the
-//! mixnet, the precondition every sync attach requires (the 2026-08-06
-//! ruling), and its outcomes are appended to the cross-session indexer
-//! history like send attempts, so reliability accumulates. The probe has
-//! no clearnet leg: a session's only clearnet communication is sync
-//! itself.
+//! Every probe in this module wraps the single `GetLatestBlock` RPC, the
+//! lightest call an indexer answers, the same primitive the
+//! Server-Selection Sweep surveys with.
+//!
+//! The mixnet probe runs it against an indexer through the session's
+//! SOCKS5 proxy: it establishes an indexer's liveness over the mixnet,
+//! the precondition every sync attach requires (the 2026-08-06 ruling),
+//! and its outcomes are appended to the cross-session indexer history
+//! like send attempts, so reliability accumulates. The probe has no
+//! clearnet leg: a session's only clearnet communication is sync itself.
 //!
 //! The staged sync-path probe ([`probe_sync_server`]) serves connectivity
 //! triage for the ordinary synchronization path — the sole clearnet
 //! exception (the Connection Doctor, zingo-mobile's diagnostics plan): it
 //! walks one server through TCP connect, secure-channel establishment,
-//! and a `GetLightdInfo` round trip, timing each stage and reporting each
-//! failure as a typed [`NetOpFailure`], so a non-developer's report says
-//! which layer broke without anyone parsing prose. It contacts the server
-//! from the client's real IP, so it is a user-invoked diagnostic, never
-//! an automatic path.
+//! and a `GetLatestBlock` round trip, timing each stage and reporting
+//! each failure as a typed [`NetOpFailure`], so a non-developer's report
+//! says which layer broke without anyone parsing prose. It contacts the
+//! server from the client's real IP, so it is a user-invoked diagnostic,
+//! never an automatic path.
 //!
-//! Every outcome in this module is data: success carries the server's chain
-//! name and height as fields ([`ProbeSuccess`]), failure carries the
-//! taxonomy record with its cause chain as a vector. Rendering belongs to
+//! Every outcome in this module is data: success carries the server's tip
+//! height as a field ([`ProbeSuccess`]), failure carries the taxonomy
+//! record with its cause chain as a vector. Rendering belongs to
 //! consumers.
 #![forbid(unsafe_code)]
 
@@ -35,23 +38,12 @@ use crate::lightclient::indexer_history::{
     AttemptKind, AttemptRoute, FailureKind, IndexerAttempt, IndexerHistoryHandle, now_unix_secs,
 };
 
-/// What a successful `GetLightdInfo` proves, as fields rather than a
+/// What a successful `GetLatestBlock` proves, as a field rather than a
 /// formatted sentence, so the mobile FFI crosses it as data.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProbeSuccess {
-    /// The chain name the server reports (`main`, `test`, `regtest`).
-    pub chain: String,
-    /// The block height the server reports.
+    /// The tip height the server reports.
     pub height: u64,
-}
-
-impl ProbeSuccess {
-    fn of(info: &zingo_netutils::lightwallet_protocol::LightdInfo) -> Self {
-        ProbeSuccess {
-            chain: info.chain_name.clone(),
-            height: info.block_height,
-        }
-    }
 }
 
 /// One probe attempt's outcome and timing.
@@ -94,9 +86,9 @@ async fn mixnet_leg(
     host: &crate::correspondent::Host,
 ) -> ProbeLeg {
     let started = Instant::now();
-    let outcome = zingo_netutils::get_lightd_info_via_socks5(socks5_addr, indexer, timeout)
+    let outcome = zingo_netutils::get_latest_block_via_socks5(socks5_addr, indexer, timeout)
         .await
-        .map(|info| ProbeSuccess::of(&info))
+        .map(|tip| ProbeSuccess { height: tip.height })
         .map_err(|e| super::socks5_transmit_failure(&e, host));
     let leg = ProbeLeg {
         millis: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
@@ -162,8 +154,8 @@ pub enum SyncProbeStep {
     /// as one connect phase. With [`Self::TcpConnect`] already green, a
     /// failure here is the secure channel, not reachability.
     TlsChannel,
-    /// A `GetLightdInfo` round trip over the established channel.
-    GrpcInfo,
+    /// A `GetLatestBlock` round trip over the established channel.
+    GrpcTip,
 }
 
 impl std::fmt::Display for SyncProbeStep {
@@ -171,7 +163,7 @@ impl std::fmt::Display for SyncProbeStep {
         match self {
             SyncProbeStep::TcpConnect => write!(f, "tcp-connect"),
             SyncProbeStep::TlsChannel => write!(f, "tls-channel"),
-            SyncProbeStep::GrpcInfo => write!(f, "grpc-info"),
+            SyncProbeStep::GrpcTip => write!(f, "grpc-tip"),
         }
     }
 }
@@ -211,7 +203,7 @@ fn probe_port(server: &Uri) -> u16 {
 }
 
 /// Walks `server` through the staged sync-path probe: TCP connect, the
-/// secure channel, and a `GetLightdInfo` round trip, each stage bounded by
+/// secure channel, and a `GetLatestBlock` round trip, each stage bounded by
 /// `stage_timeout` and timed, each failure a typed [`NetOpFailure`]. Runs
 /// against the ordinary synchronization path (no tunnel, no wallet, no
 /// lock), so the Connection Doctor can call it per configured server.
@@ -291,9 +283,9 @@ pub async fn probe_sync_server(server: &Uri, stage_timeout: Duration) -> SyncSer
 
     // Stage 3: the RPC itself.
     let started = Instant::now();
-    let rpc = tokio::time::timeout(stage_timeout, grpc.get_lightd_info(stage_timeout)).await;
+    let rpc = tokio::time::timeout(stage_timeout, grpc.get_latest_block(stage_timeout)).await;
     let (failure, info) = match rpc {
-        Ok(Ok(info)) => (None, Some(ProbeSuccess::of(&info))),
+        Ok(Ok(tip)) => (None, Some(ProbeSuccess { height: tip.height })),
         Ok(Err(status)) => (
             Some(NetOpFailure::from_error(
                 NetOpStage::RemoteHttp,
@@ -305,7 +297,7 @@ pub async fn probe_sync_server(server: &Uri, stage_timeout: Duration) -> SyncSer
         Err(_) => (Some(timed_out()), None),
     };
     stages.push(SyncProbeStage {
-        step: SyncProbeStep::GrpcInfo,
+        step: SyncProbeStep::GrpcTip,
         millis: started.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
         failure,
     });

--- a/zingolib/src/mixnet/supervisor.rs
+++ b/zingolib/src/mixnet/supervisor.rs
@@ -397,7 +397,7 @@ async fn attach_readiness(socks5_addr: SocketAddr) -> Result<(), zingo_net_diag:
         if attempt > 0 {
             tokio::time::sleep(ATTACH_LISTENER_RETRY_PAUSE).await;
         }
-        match zingo_netutils::get_lightd_info_via_socks5(
+        match zingo_netutils::get_latest_block_via_socks5(
             socks5_addr,
             &indexer,
             MIXNET_ROUND_TRIP_BOUND,

--- a/zingolib/src/mixnet/sweep.rs
+++ b/zingolib/src/mixnet/sweep.rs
@@ -4,27 +4,27 @@
 //! judgment that turns its results into a sync indexer. This module is the
 //! judgment, kept pure so every rule the sweep rests on is pinned without a
 //! transport. It takes the survey's per-candidate outcomes and yields the
-//! live cohort, the drawn or pinned sync indexer, and the transmit
-//! candidates the selection excludes.
+//! live cohort, the drawn sync indexer, and the transmit candidates the
+//! selection excludes. A user's pinned clearnet sync indexer never enters:
+//! the caller holds it out of the sweep.
 #![forbid(unsafe_code)]
 
 use http::Uri;
 use rand::seq::SliceRandom as _;
 
-use super::probe::ProbeSuccess;
-
-/// One candidate's survey outcome: the endpoint and what its `GetLightdInfo`
-/// reported, or `None` when it did not answer over the mixnet.
+/// One candidate's survey outcome: the endpoint and the tip height its
+/// `GetLatestBlock` reported, or `None` when it did not answer over the
+/// mixnet.
 #[derive(Clone, Debug)]
 pub struct SurveyResult {
     /// The surveyed endpoint.
     pub uri: Uri,
-    /// The endpoint's reported chain and height, or `None` on any failure.
-    pub reported: Option<ProbeSuccess>,
+    /// The tip height the endpoint reported, or `None` on any failure.
+    pub reported: Option<u64>,
 }
 
 /// A candidate that answered the survey and passed the cohort's liveness
-/// test: its chain matched and its height sat within the median tolerance.
+/// test: its tip height sat within the median tolerance.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LiveCandidate {
     /// The live endpoint.
@@ -36,7 +36,7 @@ pub struct LiveCandidate {
 /// Why a sweep selected no sync indexer.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum SweepError {
-    /// No candidate passed the liveness test, and no server was pinned.
+    /// No candidate passed the liveness test.
     #[error("no live indexer: {answered} of {surveyed} answered, none within the cohort")]
     EmptyCohort {
         /// How many candidates were surveyed.
@@ -44,9 +44,6 @@ pub enum SweepError {
         /// How many answered at all (before the cohort test).
         answered: usize,
     },
-    /// A server was pinned, but it did not pass the liveness test.
-    #[error("pinned server '{0}' is not live over the mixnet")]
-    DeadPin(Uri),
 }
 
 /// A sweep's verdict: the chosen sync indexer, the transmit candidates that
@@ -75,24 +72,22 @@ fn median(sorted_desc: &[u64]) -> u64 {
     sorted_desc[sorted_desc.len() / 2]
 }
 
-/// The live cohort of a survey: every result whose chain matches `chain` and
-/// whose height sits within `tolerance` of the answered set's median height.
-/// Height-descending. The median, never the maximum, so one inflated report
-/// cannot lift the bar (ADR 0034).
-pub fn live_cohort(results: &[SurveyResult], chain: &str, tolerance: u64) -> Vec<LiveCandidate> {
-    let mut on_chain: Vec<(&Uri, u64)> = results
+/// The live cohort of a survey: every result whose tip height sits within
+/// `tolerance` of the answered set's median height. Height-descending. The
+/// median, never the maximum, so one inflated report cannot lift the bar
+/// (ADR 0034).
+pub fn live_cohort(results: &[SurveyResult], tolerance: u64) -> Vec<LiveCandidate> {
+    let mut answered: Vec<(&Uri, u64)> = results
         .iter()
-        .filter_map(|r| r.reported.as_ref().map(|info| (&r.uri, info)))
-        .filter(|(_, info)| info.chain == chain)
-        .map(|(uri, info)| (uri, info.height))
+        .filter_map(|r| r.reported.map(|height| (&r.uri, height)))
         .collect();
-    if on_chain.is_empty() {
+    if answered.is_empty() {
         return Vec::new();
     }
-    on_chain.sort_by_key(|(_, height)| std::cmp::Reverse(*height));
-    let heights: Vec<u64> = on_chain.iter().map(|(_, h)| *h).collect();
+    answered.sort_by_key(|(_, height)| std::cmp::Reverse(*height));
+    let heights: Vec<u64> = answered.iter().map(|(_, h)| *h).collect();
     let mid = median(&heights);
-    on_chain
+    answered
         .into_iter()
         .filter(|(_, h)| h.abs_diff(mid) <= tolerance)
         .map(|(uri, height)| LiveCandidate {
@@ -109,36 +104,20 @@ fn answered_count(results: &[SurveyResult]) -> usize {
 }
 
 /// Judge a survey into a [`Selection`], drawing one ticket per operator over
-/// the live cohort with `rng`. `pin` is an explicit user server: when set,
-/// it is selected if it is in the cohort and the sweep fails [`SweepError::DeadPin`]
-/// otherwise, never falling back to the draw (ADR 0034).
+/// the live cohort with `rng`.
 pub fn select(
     results: &[SurveyResult],
-    chain: &str,
     tolerance: u64,
-    pin: Option<&Uri>,
     rng: &mut impl rand::Rng,
 ) -> Result<Selection, SweepError> {
-    let cohort = live_cohort(results, chain, tolerance);
-
-    let sync_indexer = match pin {
-        Some(pinned) => {
-            if cohort.iter().any(|c| &c.uri == pinned) {
-                pinned.clone()
-            } else {
-                return Err(SweepError::DeadPin(pinned.clone()));
-            }
-        }
-        None => {
-            if cohort.is_empty() {
-                return Err(SweepError::EmptyCohort {
-                    surveyed: results.len(),
-                    answered: answered_count(results),
-                });
-            }
-            draw_one_per_operator(&cohort, rng)
-        }
-    };
+    let cohort = live_cohort(results, tolerance);
+    if cohort.is_empty() {
+        return Err(SweepError::EmptyCohort {
+            surveyed: results.len(),
+            answered: answered_count(results),
+        });
+    }
+    let sync_indexer = draw_one_per_operator(&cohort, rng);
 
     let sync_operator = Operator::of_uri(&sync_indexer);
     let transmit_candidates = cohort
@@ -186,13 +165,10 @@ mod tests {
         text.parse().expect("static uri")
     }
 
-    fn answered(u: &str, chain: &str, height: u64) -> SurveyResult {
+    fn answered(u: &str, height: u64) -> SurveyResult {
         SurveyResult {
             uri: uri(u),
-            reported: Some(ProbeSuccess {
-                chain: chain.to_string(),
-                height,
-            }),
+            reported: Some(height),
         }
     }
 
@@ -208,12 +184,12 @@ mod tests {
     #[test]
     fn the_median_defends_against_an_inflated_height() {
         let results = vec![
-            answered("https://a.example:443", "main", 100),
-            answered("https://b.example:443", "main", 101),
-            answered("https://c.example:443", "main", 100),
-            answered("https://liar.example:443", "main", 100_000),
+            answered("https://a.example:443", 100),
+            answered("https://b.example:443", 101),
+            answered("https://c.example:443", 100),
+            answered("https://liar.example:443", 100_000),
         ];
-        let cohort = live_cohort(&results, "main", 2);
+        let cohort = live_cohort(&results, 2);
         let hosts: Vec<&str> = cohort.iter().filter_map(|c| c.uri.host()).collect();
         assert_eq!(hosts, vec!["b.example", "a.example", "c.example"]);
         assert!(
@@ -226,26 +202,25 @@ mod tests {
     #[test]
     fn the_cohort_is_height_descending() {
         let results = vec![
-            answered("https://a.example:443", "main", 100),
-            answered("https://b.example:443", "main", 102),
-            answered("https://c.example:443", "main", 101),
+            answered("https://a.example:443", 100),
+            answered("https://b.example:443", 102),
+            answered("https://c.example:443", 101),
         ];
-        let cohort = live_cohort(&results, "main", 2);
+        let cohort = live_cohort(&results, 2);
         assert_eq!(
             cohort.iter().map(|c| c.height).collect::<Vec<_>>(),
             vec![102, 101, 100]
         );
     }
 
-    /// A wrong-chain responder and a silent candidate are both excluded.
+    /// A silent candidate is excluded from the cohort.
     #[test]
-    fn wrong_chain_and_silent_candidates_are_excluded() {
+    fn silent_candidates_are_excluded() {
         let results = vec![
-            answered("https://main.example:443", "main", 100),
-            answered("https://test.example:443", "test", 100),
+            answered("https://main.example:443", 100),
             silent("https://dead.example:443"),
         ];
-        let cohort = live_cohort(&results, "main", 2);
+        let cohort = live_cohort(&results, 2);
         assert_eq!(cohort.len(), 1);
         assert_eq!(cohort[0].uri.host(), Some("main.example"));
     }
@@ -254,13 +229,13 @@ mod tests {
     #[test]
     fn the_tolerance_is_within_two_blocks_of_the_median() {
         let results = vec![
-            answered("https://a.example:443", "main", 100),
-            answered("https://b.example:443", "main", 100),
-            answered("https://c.example:443", "main", 100),
-            answered("https://lag.example:443", "main", 98),
-            answered("https://old.example:443", "main", 97),
+            answered("https://a.example:443", 100),
+            answered("https://b.example:443", 100),
+            answered("https://c.example:443", 100),
+            answered("https://lag.example:443", 98),
+            answered("https://old.example:443", 97),
         ];
-        let cohort = live_cohort(&results, "main", 2);
+        let cohort = live_cohort(&results, 2);
         let hosts: Vec<&str> = cohort.iter().filter_map(|c| c.uri.host()).collect();
         assert!(hosts.contains(&"lag.example"), "two blocks off is live");
         assert!(!hosts.contains(&"old.example"), "three blocks off is not");
@@ -271,15 +246,15 @@ mod tests {
     #[test]
     fn the_sync_operator_is_excluded_from_transmit_candidates() {
         let results = vec![
-            answered("https://na.zec.rocks:443", "main", 100),
-            answered("https://eu.zec.rocks:443", "main", 100),
-            answered("https://other.example:443", "main", 100),
+            answered("https://na.zec.rocks:443", 100),
+            answered("https://eu.zec.rocks:443", 100),
+            answered("https://other.example:443", 100),
         ];
         // Seed chosen so the draw lands on the zec.rocks operator; the test
         // asserts the exclusion regardless by checking the operator of the
         // winner against the transmit set.
-        let selection = select(&results, "main", 2, None, &mut StdRng::seed_from_u64(1))
-            .expect("a live cohort selects");
+        let selection =
+            select(&results, 2, &mut StdRng::seed_from_u64(1)).expect("a live cohort selects");
         let sync_op = Operator::of_uri(&selection.sync_indexer);
         for candidate in &selection.transmit_candidates {
             assert_ne!(
@@ -297,16 +272,15 @@ mod tests {
     #[test]
     fn the_draw_is_one_ticket_per_operator() {
         let results = vec![
-            answered("https://na.zec.rocks:443", "main", 100),
-            answered("https://eu.zec.rocks:443", "main", 100),
-            answered("https://sa.zec.rocks:443", "main", 100),
-            answered("https://solo.example:443", "main", 100),
+            answered("https://na.zec.rocks:443", 100),
+            answered("https://eu.zec.rocks:443", 100),
+            answered("https://sa.zec.rocks:443", 100),
+            answered("https://solo.example:443", 100),
         ];
         let mut solo_wins = 0;
         let mut rocks_wins = 0;
         for seed in 0..2_000 {
-            let selection = select(&results, "main", 2, None, &mut StdRng::seed_from_u64(seed))
-                .expect("selects");
+            let selection = select(&results, 2, &mut StdRng::seed_from_u64(seed)).expect("selects");
             let winner = Operator::of_uri(&selection.sync_indexer)
                 .expect("every selected sync indexer has a host");
             match winner.to_string().as_str() {
@@ -325,56 +299,14 @@ mod tests {
         assert!((800..1200).contains(&rocks_wins), "rocks won {rocks_wins}");
     }
 
-    /// A pinned server that is live is selected, bypassing the draw.
-    #[test]
-    fn a_live_pin_is_selected() {
-        let results = vec![
-            answered("https://pinned.example:443", "main", 100),
-            answered("https://other.example:443", "main", 100),
-        ];
-        let pin = uri("https://pinned.example:443");
-        let selection = select(
-            &results,
-            "main",
-            2,
-            Some(&pin),
-            &mut StdRng::seed_from_u64(0),
-        )
-        .expect("a live pin selects");
-        assert_eq!(selection.sync_indexer, pin);
-    }
-
-    /// A pinned server that is not live fails DeadPin, never falling back to
-    /// the draw over the rest of the cohort.
-    #[test]
-    fn a_dead_pin_fails_without_fallback() {
-        let results = vec![
-            answered("https://pinned.example:443", "main", 90),
-            answered("https://a.example:443", "main", 100),
-            answered("https://b.example:443", "main", 100),
-        ];
-        let pin = uri("https://pinned.example:443");
-        let error = select(
-            &results,
-            "main",
-            2,
-            Some(&pin),
-            &mut StdRng::seed_from_u64(0),
-        )
-        .expect_err("a lagging pin is dead");
-        assert_eq!(error, SweepError::DeadPin(pin));
-    }
-
-    /// An empty cohort without a pin reports how many were surveyed and how
-    /// many answered.
+    /// An empty cohort reports how many were surveyed and how many answered.
     #[test]
     fn an_empty_cohort_reports_its_counts() {
         let results = vec![
             silent("https://a.example:443"),
             silent("https://b.example:443"),
         ];
-        let error =
-            select(&results, "main", 2, None, &mut StdRng::seed_from_u64(0)).expect_err("empty");
+        let error = select(&results, 2, &mut StdRng::seed_from_u64(0)).expect_err("empty");
         assert_eq!(
             error,
             SweepError::EmptyCohort {


### PR DESCRIPTION
Every probe wraps the single `GetLatestBlock` RPC: the sweep's survey, the mixnet probe leg, the staged sync-path probe, the attach readiness round trip, and live indexer discovery. `get_lightd_info_via_socks5` loses its last caller and is removed. `ProbeSuccess` carries the tip height alone; the judgment rests on the height tolerance; the census's chain partition carries the chain distinction.

The pin rides the survey and the caller judges it against the cohort. It is chosen when it answers. An unanswered pin is reported with the sweep's verdict offered as the alternative, and the Sync Session does not open on a server the user did not select. A sweep whose own transport failed never counts against the pin: the pin stands and sync opens, which ends the availability failure where one dead mixnet exit closed a pinned session's sync.

zingolib's sweep runner and judgment no longer know a pin (`run_server_selection_sweep` loses the parameter; `SweepError::DeadPin` is removed). Each crate's CHANGELOG records its break. Verified: 345 zingolib, 234 zingo-cli, and netutils tests pass; a live run against a pinned server during a 0-of-17 sweep opened sync against the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)