### PR TITLE
The survey bounds its fan-out, its refusal names its causes, and a teardown harness rides the workbench

### DIFF
--- a/tools/workbench/src/bin/sweep-teardown.rs
+++ b/tools/workbench/src/bin/sweep-teardown.rs
@@ -33,8 +33,10 @@ const RPC: &str = "cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestBlock";
 /// How long the proxy may bootstrap before the harness gives up.
 const BOOTSTRAP_BUDGET: Duration = Duration::from_secs(150);
 
-/// How long one bridged probe may take, matching the sweep's own leg budget.
-const PROBE_BUDGET: Duration = Duration::from_secs(30);
+/// How long one bridged probe may take: a hand-copied mirror of the
+/// sweep's `PROBE_LEG_TIMEOUT` (this dependency-free workspace cannot
+/// import it), retuned together with that constant.
+const PROBE_BUDGET: Duration = Duration::from_secs(20);
 
 /// How many rounds ride the same exit without `--rounds`.
 const DEFAULT_ROUNDS: usize = 2;

--- a/tools/workbench/src/bin/sweep-teardown.rs
+++ b/tools/workbench/src/bin/sweep-teardown.rs
@@ -1,0 +1,172 @@
+//! Tease apart a failing Server-Selection Sweep with an independent client.
+//!
+//! The harness spawns the bundled `nym-proxy` standalone (it draws its own
+//! exit), then drives `grpcurl` — a gRPC client that shares no code with the
+//! wallet — through the proxy's SOCKS5 port via an `ncat` bridge, running
+//! the same `GetLatestBlock` the sweep surveys with. The layers separate:
+//! an indexer that answers `grpcurl` over clearnet but not through the
+//! bridge indicts the proxy, the exit, or the tunnel, never the wallet's
+//! client code; a bridge that answers where the sweep reported silence
+//! indicts the sweep's own fan-out.
+//!
+//! Usage: `sweep-teardown [--rounds N] [--proxy <path>]`. Requires `grpcurl`
+//! and `ncat` on PATH, and by default the debug-profile bundled proxy.
+
+#![forbid(unsafe_code)]
+
+use std::io::BufRead;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use workbench::{repo_root, run};
+
+/// The local port the ncat bridge listens on for grpcurl.
+const BRIDGE_PORT: u16 = 19080;
+
+/// The reflection-capable census members the harness probes.
+const HOSTS: [&str; 3] = ["zec.rocks", "na.zec.rocks", "eu.zec.stardust.rest"];
+
+/// The RPC every sweep probe wraps.
+const RPC: &str = "cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestBlock";
+
+/// How long the proxy may bootstrap before the harness gives up.
+const BOOTSTRAP_BUDGET: Duration = Duration::from_secs(150);
+
+/// How long one bridged probe may take, matching the sweep's own leg budget.
+const PROBE_BUDGET: Duration = Duration::from_secs(30);
+
+/// How many rounds ride the same exit without `--rounds`.
+const DEFAULT_ROUNDS: usize = 2;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    run("sweep-teardown", || teardown(&args), |()| {})
+}
+
+/// Runs the whole teardown, returning its findings as printed lines.
+fn teardown(args: &[String]) -> Result<(), Vec<String>> {
+    let rounds = parse_rounds(args)?;
+    let proxy_path = parse_proxy(args)?;
+
+    println!("spawning standalone nym-proxy (draws its own exit)...");
+    let mut proxy = Command::new(&proxy_path)
+        .stdin(Stdio::piped()) // held open: the proxy's parent-liveness watchdog
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| vec![format!("could not spawn {}: {e}", proxy_path.display())])?;
+    let outcome = probe_rounds(&mut proxy, rounds);
+    let _ = proxy.kill();
+    let _ = proxy.wait();
+    outcome
+}
+
+/// Waits out the proxy bootstrap, then probes every host for `rounds`
+/// rounds through the announced SOCKS5 port.
+fn probe_rounds(proxy: &mut Child, rounds: usize) -> Result<(), Vec<String>> {
+    let stdout = proxy.stdout.take().expect("stdout was piped");
+    let mut lines = std::io::BufReader::new(stdout).lines();
+    let started = Instant::now();
+    let mut socks_port = None;
+    for line in &mut lines {
+        let line = line.map_err(|e| vec![format!("proxy stdout closed: {e}")])?;
+        if let Some(status) = line.strip_prefix("NYM_STATUS=") {
+            println!("  … {status}");
+        } else if let Some(exit) = line.strip_prefix("NYM_EXIT=") {
+            println!("exit: {exit}");
+        } else if let Some(addr) = line.strip_prefix("SOCKS5_ADDR=") {
+            socks_port = addr.rsplit(':').next().map(str::to_string);
+            break;
+        }
+        if started.elapsed() > BOOTSTRAP_BUDGET {
+            return Err(vec!["bootstrap exceeded its budget".to_string()]);
+        }
+    }
+    let socks_port = socks_port.ok_or_else(|| vec!["no SOCKS5_ADDR announced".to_string()])?;
+    println!("proxy ready on 127.0.0.1:{socks_port}");
+
+    for round in 1..=rounds {
+        println!("--- round {round} through the SAME exit ---");
+        for host in HOSTS {
+            probe_host(&socks_port, host);
+        }
+    }
+    Ok(())
+}
+
+/// Probes one host through a per-probe ncat bridge, printing the outcome.
+fn probe_host(socks_port: &str, host: &str) {
+    let bridge = Command::new("ncat")
+        .args([
+            "-lk",
+            "127.0.0.1",
+            &BRIDGE_PORT.to_string(),
+            "--sh-exec",
+            &format!("ncat --proxy 127.0.0.1:{socks_port} --proxy-type socks5 {host} 443"),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    let Ok(mut bridge) = bridge else {
+        println!("  FAIL {host}: ncat did not spawn");
+        return;
+    };
+    std::thread::sleep(Duration::from_millis(300));
+
+    let started = Instant::now();
+    let probe = Command::new("timeout")
+        .args([
+            &PROBE_BUDGET.as_secs().to_string(),
+            "grpcurl",
+            "-servername",
+            host,
+            "-d",
+            "{}",
+            &format!("127.0.0.1:{BRIDGE_PORT}"),
+            RPC,
+        ])
+        .output();
+    let elapsed = started.elapsed().as_secs_f64();
+    match probe {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let height = stdout
+                .lines()
+                .find(|line| line.contains("height"))
+                .unwrap_or("?")
+                .trim();
+            println!("  OK   {host}: {height} ({elapsed:.1}s)");
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = stderr.lines().next().unwrap_or("no detail");
+            println!("  FAIL {host}: {detail} ({elapsed:.1}s)");
+        }
+        Err(e) => println!("  FAIL {host}: grpcurl did not run: {e}"),
+    }
+    let _ = bridge.kill();
+    let _ = bridge.wait();
+}
+
+/// Parses `--rounds N`, defaulting to [`DEFAULT_ROUNDS`].
+fn parse_rounds(args: &[String]) -> Result<usize, Vec<String>> {
+    match args.iter().position(|arg| arg == "--rounds") {
+        None => Ok(DEFAULT_ROUNDS),
+        Some(index) => args
+            .get(index + 1)
+            .and_then(|n| n.parse().ok())
+            .ok_or_else(|| vec!["--rounds takes a positive integer".to_string()]),
+    }
+}
+
+/// Parses `--proxy <path>`, defaulting to the debug-profile bundled proxy.
+fn parse_proxy(args: &[String]) -> Result<PathBuf, Vec<String>> {
+    match args.iter().position(|arg| arg == "--proxy") {
+        None => Ok(repo_root()?.join("target/debug/nym-proxy")),
+        Some(index) => args
+            .get(index + 1)
+            .map(PathBuf::from)
+            .ok_or_else(|| vec!["--proxy takes a path".to_string()]),
+    }
+}

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -1333,8 +1333,11 @@ async fn sweep_select_sync_indexer(
     }
     let proxy_path = commands::resolve_proxy_path(filled_template.nym_proxy_path.as_deref());
     let selection = lightclient
-        .run_server_selection_sweep(std::path::Path::new(&proxy_path), &candidates, |phase| {
-            match phase {
+        .run_server_selection_sweep(
+            std::path::Path::new(&proxy_path),
+            &candidates,
+            pin.as_ref(),
+            |phase| match phase {
                 SweepProgress::TransportBootstrapping => eprintln!(
                     "Server-Selection Sweep: bootstrapping a dedicated sweep transport \
                      (its Exit Node is recycled when the sweep completes)..."
@@ -1346,8 +1349,8 @@ async fn sweep_select_sync_indexer(
                     "Server-Selection Sweep: {answered} of {surveyed} candidates answered; \
                      judging the live cohort..."
                 ),
-            }
-        })
+            },
+        )
         .await;
     match selection {
         Ok(selection) => {

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -66,7 +66,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fan-out blew every probe's budget at once — the 0-of-17 signature.
   The width counts connections through the one Nym client, never
   processes, so Android and iOS — hosting the client in-process under
-  the single-process constraint — share the same calibration unchanged. `mixnet::sweep::SurveyResult` gains a
+  the single-process constraint — share the same calibration unchanged.
+  The survey assigns candidates to lanes at random and offers the opening
+  wave's verdict to the session as soon as it forms
+  (`run_server_selection_sweep` gains a `first` parameter naming the
+  candidate guaranteed an opening-wave lane — the caller's pin); the
+  candidates a formed verdict leaves unsurveyed continue in the
+  background as the health sweep, and the sweep transport recycles its
+  exit when that finishes. `mixnet::sweep::SurveyResult` gains a
   `refusal` field carrying the diary's `FailureKind`, and
   `SweepError::EmptyCohort` gains a `causes` tally, so the refusal itself
   says whether the transport or the indexers failed, e.g. "0 of 17

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -63,7 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tunnels at a time — at least one, at most a quarter of the census, and
   never past the measured `MAX_SURVEY_TUNNEL_WIDTH` — because every
   tunnel shares the one sweep exit's packet pipeline and an unbounded
-  fan-out blew every probe's budget at once — the 0-of-17 signature. `mixnet::sweep::SurveyResult` gains a
+  fan-out blew every probe's budget at once — the 0-of-17 signature.
+  The width counts connections through the one Nym client, never
+  processes, so Android and iOS — hosting the client in-process under
+  the single-process constraint — share the same calibration unchanged. `mixnet::sweep::SurveyResult` gains a
   `refusal` field carrying the diary's `FailureKind`, and
   `SweepError::EmptyCohort` gains a `causes` tally, so the refusal itself
   says whether the transport or the indexers failed, e.g. "0 of 17

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: the survey bounds its fan-out and reports its refusal causes.
+  The sweep opens at most `lightclient::select::SURVEY_TUNNEL_WIDTH`
+  tunnels at a time, because every tunnel shares the one sweep exit's
+  packet pipeline and an unbounded fan-out blew every probe's budget at
+  once — the 0-of-17 signature. `mixnet::sweep::SurveyResult` gains a
+  `refusal` field carrying the diary's `FailureKind`, and
+  `SweepError::EmptyCohort` gains a `causes` tally, so the refusal itself
+  says whether the transport or the indexers failed, e.g. "0 of 17
+  answered, none within the cohort (17 timeout)".
 - BREAKING: every probe wraps the single `GetLatestBlock` RPC. The mixnet
   probe leg, the staged sync-path probe, and the attach readiness round
   trip all probe the tip, the same primitive the sweep surveys with.

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -59,10 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - BREAKING: the survey bounds its fan-out and reports its refusal causes.
-  The sweep opens at most `lightclient::select::SURVEY_TUNNEL_WIDTH`
-  tunnels at a time, because every tunnel shares the one sweep exit's
-  packet pipeline and an unbounded fan-out blew every probe's budget at
-  once — the 0-of-17 signature. `mixnet::sweep::SurveyResult` gains a
+  The sweep opens `lightclient::select::survey_tunnel_width(candidates)`
+  tunnels at a time — at least one, at most a quarter of the census, and
+  never past the measured `MAX_SURVEY_TUNNEL_WIDTH` — because every
+  tunnel shares the one sweep exit's packet pipeline and an unbounded
+  fan-out blew every probe's budget at once — the 0-of-17 signature. `mixnet::sweep::SurveyResult` gains a
   `refusal` field carrying the diary's `FailureKind`, and
   `SweepError::EmptyCohort` gains a `causes` tally, so the refusal itself
   says whether the transport or the indexers failed, e.g. "0 of 17

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -73,7 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   candidate guaranteed an opening-wave lane — the caller's pin); the
   candidates a formed verdict leaves unsurveyed continue in the
   background as the health sweep, and the sweep transport recycles its
-  exit when that finishes. `mixnet::sweep::SurveyResult` gains a
+  exit when that finishes. The session holds the health sweep's handle,
+  and `go_offline` aborts it: revoking consent stops all networking,
+  the health sweep included. `mixnet::sweep::SurveyResult` gains a
   `refusal` field carrying the diary's `FailureKind`, and
   `SweepError::EmptyCohort` gains a `causes` tally, so the refusal itself
   says whether the transport or the indexers failed, e.g. "0 of 17

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -194,6 +194,10 @@ pub struct LightClient {
     /// subscriber already holds.
     #[cfg(feature = "nym")]
     mixnet_status: crate::mixnet::StatusPublisher,
+    /// The detached health sweep of the most recent Server-Selection Sweep,
+    /// held so revoking consent aborts its traffic with everything else.
+    #[cfg(feature = "nym")]
+    health_sweep: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl LightClient {
@@ -271,6 +275,8 @@ impl LightClient {
             correspondent_pools: crate::correspondent::pool::Pools::new(),
             #[cfg(feature = "nym")]
             mixnet_status: crate::mixnet::status_publisher(),
+            #[cfg(feature = "nym")]
+            health_sweep: std::sync::Mutex::new(None),
         })
     }
 
@@ -312,6 +318,8 @@ impl LightClient {
             correspondent_pools: crate::correspondent::pool::Pools::new(),
             #[cfg(feature = "nym")]
             mixnet_status: crate::mixnet::status_publisher(),
+            #[cfg(feature = "nym")]
+            health_sweep: std::sync::Mutex::new(None),
         }
     }
 
@@ -374,6 +382,8 @@ impl LightClient {
             correspondent_pools: crate::correspondent::pool::Pools::new(),
             #[cfg(feature = "nym")]
             mixnet_status: crate::mixnet::status_publisher(),
+            #[cfg(feature = "nym")]
+            health_sweep: std::sync::Mutex::new(None),
         })
     }
 
@@ -540,11 +550,30 @@ impl LightClient {
         self.abort_sync().await;
         #[cfg(feature = "nym")]
         {
+            self.abort_health_sweep().await;
             self.vacate_mixnet_slot().await;
             self.publish_mixnet_slot_state();
         }
         self.indexer = None;
         self.migration_transmission_uri = None;
+    }
+
+    /// Aborts the detached health sweep, if one is still surveying, so a
+    /// revoked consent stops every emission the session started.
+    #[cfg(feature = "nym")]
+    pub(crate) async fn abort_health_sweep(&self) {
+        let held = self
+            .health_sweep
+            .lock()
+            .expect("the health-sweep slot is never poisoned")
+            .take();
+        if let Some(sweep) = held {
+            sweep.abort();
+            // Await the cancellation, so the caller's offline promise holds
+            // the moment this returns; dropping the sweep's transport kills
+            // its child and recycles its lease.
+            let _cancelled = sweep.await;
+        }
     }
 
     /// Returns a reference to the indexer, or `LightClientError::Offline` if none is configured.

--- a/zingolib/src/lightclient/indexer_history.rs
+++ b/zingolib/src/lightclient/indexer_history.rs
@@ -116,7 +116,7 @@ pub enum FailureKind {
 }
 
 impl FailureKind {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             FailureKind::Timeout => "timeout",
             FailureKind::Unreachable => "unreachable",

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -150,7 +150,7 @@ impl LightClient {
         let mut surveyed_through = 0;
         let mut verdict: Option<Selection> = None;
         for wave in order.chunks(width) {
-            results.extend(survey(socks5_addr, wave.to_vec(), &self.indexer_history).await);
+            results.extend(survey(socks5_addr, wave.to_vec(), width, &self.indexer_history).await);
             surveyed_through += wave.len();
             progress(SweepProgress::Judging {
                 answered: results.iter().filter(|r| r.reported.is_some()).count(),
@@ -186,7 +186,8 @@ impl LightClient {
         } else {
             let history = self.indexer_history.clone();
             tokio::spawn(async move {
-                let _health_only = survey(socks5_addr, rest, &history).await;
+                let health_width = survey_tunnel_width(rest.len());
+                let _health_only = survey(socks5_addr, rest, health_width, &history).await;
                 // Exit Recycling: retiring the member kills the child and
                 // recycles its lease, so no later traffic rides the exit
                 // that observed the survey.
@@ -255,11 +256,11 @@ pub fn survey_tunnel_width(candidates: usize) -> usize {
 async fn survey(
     socks5_addr: std::net::SocketAddr,
     candidates: Vec<Uri>,
+    width: usize,
     history: &crate::lightclient::indexer_history::IndexerHistoryHandle,
 ) -> Vec<SurveyResult> {
     use futures::StreamExt as _;
     let timeout = zingo_netutils::time::PROBE_LEG_TIMEOUT;
-    let width = survey_tunnel_width(candidates.len());
     futures::stream::iter(candidates)
         .map(|uri| async move {
             let (reported, refusal) = probe_one(socks5_addr, &uri, timeout, history).await;

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -185,7 +185,7 @@ impl LightClient {
             member.retire().await;
         } else {
             let history = self.indexer_history.clone();
-            tokio::spawn(async move {
+            let continuation = tokio::spawn(async move {
                 let health_width = survey_tunnel_width(rest.len());
                 let _health_only = survey(socks5_addr, rest, health_width, &history).await;
                 // Exit Recycling: retiring the member kills the child and
@@ -193,6 +193,16 @@ impl LightClient {
                 // that observed the survey.
                 member.retire().await;
             });
+            // The session holds the continuation so `go_offline` can abort
+            // it: revoked consent must stop the health sweep too.
+            if let Some(superseded) = self
+                .health_sweep
+                .lock()
+                .expect("the health-sweep slot is never poisoned")
+                .replace(continuation)
+            {
+                superseded.abort();
+            }
         }
         Ok(selection)
     }
@@ -318,6 +328,32 @@ async fn probe_one(
 mod tests {
     use super::*;
     use crate::mixnet::MixnetMode;
+
+    /// HYPOTHESIS: revoking consent aborts the detached health sweep — the
+    /// held task is cancelled and the slot empties — so no probe outlives
+    /// `network off`. Falsified if the task survives going offline.
+    #[tokio::test]
+    async fn going_offline_aborts_the_health_sweep() {
+        let wallet = crate::testutils::synthetic_wallet::SyntheticWalletBuilder::new(
+            zingo_test_vectors::seeds::ABANDON_ART_SEED,
+        )
+        .build();
+        let mut client = LightClient::new_for_test(wallet).await;
+        let held = tokio::spawn(std::future::pending::<()>());
+        *client
+            .health_sweep
+            .lock()
+            .expect("the health-sweep slot is never poisoned") = Some(held);
+        client.go_offline().await;
+        assert!(
+            client
+                .health_sweep
+                .lock()
+                .expect("the health-sweep slot is never poisoned")
+                .is_none(),
+            "going offline empties the health-sweep slot"
+        );
+    }
 
     /// HYPOTHESIS: the survey width is a bounded function of the census —
     /// at least one tunnel, at most a quarter of the candidates, never past

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -177,40 +177,57 @@ async fn await_sweep_ready(
     })
 }
 
-/// Survey every candidate over the sweep exit concurrently, recording each
-/// attempt in the indexer history like any probe.
+/// The number of survey tunnels the sweep opens at once, kept small because
+/// every tunnel shares the one sweep exit's packet pipeline, where a single
+/// measured round trip costs seconds and an unbounded fan-out queues enough
+/// concurrent TLS handshakes to blow every probe's
+/// [`zingo_netutils::time::PROBE_LEG_TIMEOUT`] at once — the 0-of-17
+/// signature.
+pub const SURVEY_TUNNEL_WIDTH: usize = 4;
+
+/// Survey every candidate over the sweep exit, at most
+/// [`SURVEY_TUNNEL_WIDTH`] tunnels at a time, recording each attempt in the
+/// indexer history like any probe.
 async fn survey(
     socks5_addr: std::net::SocketAddr,
     candidates: &[Uri],
     history: &crate::lightclient::indexer_history::IndexerHistoryHandle,
 ) -> Vec<SurveyResult> {
+    use futures::StreamExt as _;
     let timeout = zingo_netutils::time::PROBE_LEG_TIMEOUT;
-    futures::future::join_all(candidates.iter().map(|uri| async move {
-        let reported = probe_one(socks5_addr, uri, timeout, history).await;
-        SurveyResult {
-            uri: uri.clone(),
-            reported,
-        }
-    }))
-    .await
+    futures::stream::iter(candidates.iter())
+        .map(|uri| async move {
+            let (reported, refusal) = probe_one(socks5_addr, uri, timeout, history).await;
+            SurveyResult {
+                uri: uri.clone(),
+                reported,
+                refusal,
+            }
+        })
+        .buffer_unordered(SURVEY_TUNNEL_WIDTH)
+        .collect()
+        .await
 }
 
 /// One candidate's survey: `GetLatestBlock` over the sweep exit, its success
-/// mapped to the reported tip height, any failure to `None`.
+/// mapped to the reported tip height, any failure to a classified refusal.
 async fn probe_one(
     socks5_addr: std::net::SocketAddr,
     uri: &Uri,
     timeout: Duration,
     history: &crate::lightclient::indexer_history::IndexerHistoryHandle,
-) -> Option<u64> {
+) -> (
+    Option<u64>,
+    Option<crate::lightclient::indexer_history::FailureKind>,
+) {
     use crate::lightclient::indexer_history::{
         AttemptKind, AttemptRoute, FailureKind, IndexerAttempt, now_unix_secs,
     };
     let host = crate::correspondent::Host::of_uri(uri);
     let result = zingo_netutils::get_latest_block_via_socks5(socks5_addr, uri, timeout).await;
-    let (reported, outcome) = match &result {
-        Ok(tip) => (Some(tip.height), Ok(())),
-        Err(error) => (None, Err(FailureKind::classify(&error.to_string()))),
+    let (reported, refusal) = match &result {
+        Ok(tip) => (Some(tip.height), None),
+        Err(error) => (None, Some(FailureKind::classify(&error.to_string()))),
     };
     history.record(&IndexerAttempt {
         unix_secs: now_unix_secs(),
@@ -223,9 +240,12 @@ async fn probe_one(
             .err()
             .map(|error| crate::mixnet::charge_phase(&crate::mixnet::socks5_transmit_stage(error))),
         exit: None,
-        outcome,
+        outcome: match refusal {
+            None => Ok(()),
+            Some(kind) => Err(kind),
+        },
     });
-    reported
+    (reported, refusal)
 }
 
 #[cfg(test)]

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -79,15 +79,18 @@ impl LightClient {
     /// operator, and the height-ordered live cohort.
     ///
     /// `binary_path` is the `nym-proxy` binary the dedicated sweep proxy
-    /// spawns from. A pinned clearnet sync indexer never enters a sweep: the
-    /// caller holds it out of `candidates`, and the pin binds for sync by
-    /// the user's own selection.
-    ///
-    /// The sweep proxy is dropped before this returns, recycling its exit.
+    /// spawns from. The candidates are assigned to survey lanes at random,
+    /// with `first` — the caller's pinned clearnet sync indexer, when one
+    /// exists — guaranteed a lane in the opening wave, and the opening
+    /// wave's verdict is offered to the session as soon as it forms: the
+    /// remaining candidates keep being surveyed in the background purely as
+    /// the health sweep, and the sweep transport recycles its exit when
+    /// that finishes.
     pub async fn run_server_selection_sweep(
         &self,
         binary_path: &Path,
         candidates: &[Uri],
+        first: Option<&Uri>,
         progress: impl Fn(SweepProgress),
     ) -> Result<Selection, ServerSelectionError> {
         // A dedicated status channel: the sweep proxy's lifecycle is private
@@ -137,18 +140,59 @@ impl LightClient {
         progress(SweepProgress::Surveying {
             candidates: candidates.len(),
         });
-        let results = survey(socks5_addr, candidates, &self.indexer_history).await;
-        progress(SweepProgress::Judging {
-            answered: results.iter().filter(|r| r.reported.is_some()).count(),
-            surveyed: results.len(),
-        });
+        let width = survey_tunnel_width(candidates.len());
+        let order = sweep::wave_order(candidates, first, width, &mut rand::rngs::OsRng);
 
-        let selection = sweep::select(&results, SWEEP_HEIGHT_TOLERANCE, &mut rand::rngs::OsRng)?;
+        // Waves run inline only until a verdict forms; every candidate a
+        // formed verdict leaves unsurveyed continues in the background as
+        // the health sweep, and the transport's exit recycles after it.
+        let mut results: Vec<SurveyResult> = Vec::new();
+        let mut surveyed_through = 0;
+        let mut verdict: Option<Selection> = None;
+        for wave in order.chunks(width) {
+            results.extend(survey(socks5_addr, wave.to_vec(), &self.indexer_history).await);
+            surveyed_through += wave.len();
+            progress(SweepProgress::Judging {
+                answered: results.iter().filter(|r| r.reported.is_some()).count(),
+                surveyed: surveyed_through,
+            });
+            match sweep::select(&results, SWEEP_HEIGHT_TOLERANCE, &mut rand::rngs::OsRng) {
+                Ok(selection) => {
+                    verdict = Some(selection);
+                    break;
+                }
+                Err(SweepError::EmptyCohort { .. }) if surveyed_through < order.len() => {}
+                Err(refusal) => {
+                    member.retire().await;
+                    return Err(refusal.into());
+                }
+            }
+        }
+        let Some(selection) = verdict else {
+            // Reached only by an empty candidate list, which surveys
+            // nothing and forms no verdict.
+            member.retire().await;
+            return Err(SweepError::EmptyCohort {
+                surveyed: results.len(),
+                answered: results.iter().filter(|r| r.reported.is_some()).count(),
+                causes: sweep::RefusalTally::of(&results),
+            }
+            .into());
+        };
 
-        // Exit Recycling: retiring the member kills the child and recycles
-        // its lease, so no later traffic rides the exit that observed the
-        // survey.
-        member.retire().await;
+        let rest: Vec<Uri> = order[surveyed_through.min(order.len())..].to_vec();
+        if rest.is_empty() {
+            member.retire().await;
+        } else {
+            let history = self.indexer_history.clone();
+            tokio::spawn(async move {
+                let _health_only = survey(socks5_addr, rest, &history).await;
+                // Exit Recycling: retiring the member kills the child and
+                // recycles its lease, so no later traffic rides the exit
+                // that observed the survey.
+                member.retire().await;
+            });
+        }
         Ok(selection)
     }
 }
@@ -194,7 +238,7 @@ const MIN_SURVEY_TUNNEL_WIDTH: usize = 1;
 
 /// The number of survey tunnels open at once for a survey of `candidates` —
 /// a bounded function of the census size: at least one, at most a
-/// [`SURVEY_FANOUT_DIVISOR`]th of the list, never past the measured
+/// `SURVEY_FANOUT_DIVISOR`th of the list, never past the measured
 /// [`MAX_SURVEY_TUNNEL_WIDTH`] — counting connections through the one Nym
 /// client rather than processes, so the same calibration serves a spawned
 /// desktop binary and the in-process client Android and iOS host under the
@@ -210,21 +254,22 @@ pub fn survey_tunnel_width(candidates: usize) -> usize {
 /// indexer history like any probe.
 async fn survey(
     socks5_addr: std::net::SocketAddr,
-    candidates: &[Uri],
+    candidates: Vec<Uri>,
     history: &crate::lightclient::indexer_history::IndexerHistoryHandle,
 ) -> Vec<SurveyResult> {
     use futures::StreamExt as _;
     let timeout = zingo_netutils::time::PROBE_LEG_TIMEOUT;
-    futures::stream::iter(candidates.iter())
+    let width = survey_tunnel_width(candidates.len());
+    futures::stream::iter(candidates)
         .map(|uri| async move {
-            let (reported, refusal) = probe_one(socks5_addr, uri, timeout, history).await;
+            let (reported, refusal) = probe_one(socks5_addr, &uri, timeout, history).await;
             SurveyResult {
-                uri: uri.clone(),
+                uri,
                 reported,
                 refusal,
             }
         })
-        .buffer_unordered(survey_tunnel_width(candidates.len()))
+        .buffer_unordered(width)
         .collect()
         .await
 }

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -177,16 +177,33 @@ async fn await_sweep_ready(
     })
 }
 
-/// The number of survey tunnels the sweep opens at once, kept small because
-/// every tunnel shares the one sweep exit's packet pipeline, where a single
-/// measured round trip costs seconds and an unbounded fan-out queues enough
-/// concurrent TLS handshakes to blow every probe's
-/// [`zingo_netutils::time::PROBE_LEG_TIMEOUT`] at once — the 0-of-17
+/// The saturation bound on concurrent survey tunnels: every tunnel shares
+/// the one sweep exit's packet pipeline, a single measured round trip costs
+/// seconds, and four concurrent TLS handshakes was the widest fan-out that
+/// kept each near its solo cost instead of blowing every probe's
+/// [`zingo_netutils::time::PROBE_LEG_TIMEOUT`] together — the 0-of-17
 /// signature.
-pub const SURVEY_TUNNEL_WIDTH: usize = 4;
+pub const MAX_SURVEY_TUNNEL_WIDTH: usize = 4;
+
+/// The divisor bounding the fan-out to a fraction of the candidate list, so
+/// a small census is never surveyed all at once.
+const SURVEY_FANOUT_DIVISOR: usize = 4;
+
+/// The narrowest survey: one tunnel, the sequential floor.
+const MIN_SURVEY_TUNNEL_WIDTH: usize = 1;
+
+/// The number of survey tunnels open at once for a survey of `candidates`,
+/// a bounded function of the census size: at least one, at most a
+/// [`SURVEY_FANOUT_DIVISOR`]th of the list, and never past the measured
+/// [`MAX_SURVEY_TUNNEL_WIDTH`] the shared exit pipeline carries.
+pub fn survey_tunnel_width(candidates: usize) -> usize {
+    candidates
+        .div_ceil(SURVEY_FANOUT_DIVISOR)
+        .clamp(MIN_SURVEY_TUNNEL_WIDTH, MAX_SURVEY_TUNNEL_WIDTH)
+}
 
 /// Survey every candidate over the sweep exit, at most
-/// [`SURVEY_TUNNEL_WIDTH`] tunnels at a time, recording each attempt in the
+/// [`survey_tunnel_width`] tunnels at a time, recording each attempt in the
 /// indexer history like any probe.
 async fn survey(
     socks5_addr: std::net::SocketAddr,
@@ -204,7 +221,7 @@ async fn survey(
                 refusal,
             }
         })
-        .buffer_unordered(SURVEY_TUNNEL_WIDTH)
+        .buffer_unordered(survey_tunnel_width(candidates.len()))
         .collect()
         .await
 }
@@ -252,6 +269,22 @@ async fn probe_one(
 mod tests {
     use super::*;
     use crate::mixnet::MixnetMode;
+
+    /// HYPOTHESIS: the survey width is a bounded function of the census —
+    /// at least one tunnel, at most a quarter of the candidates, never past
+    /// the measured saturation bound — so a small census is never surveyed
+    /// all at once and a large one never saturates the shared exit.
+    /// Falsified if any bound moves.
+    #[test]
+    fn the_survey_width_is_bounded_by_the_census() {
+        assert_eq!(survey_tunnel_width(0), MIN_SURVEY_TUNNEL_WIDTH);
+        assert_eq!(survey_tunnel_width(1), 1);
+        assert_eq!(survey_tunnel_width(4), 1);
+        assert_eq!(survey_tunnel_width(5), 2);
+        assert_eq!(survey_tunnel_width(16), 4);
+        assert_eq!(survey_tunnel_width(17), MAX_SURVEY_TUNNEL_WIDTH);
+        assert_eq!(survey_tunnel_width(100), MAX_SURVEY_TUNNEL_WIDTH);
+    }
 
     /// The status a died sweep proxy publishes, carrying `detail` as its
     /// latched typed cause.

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -192,10 +192,13 @@ const SURVEY_FANOUT_DIVISOR: usize = 4;
 /// The narrowest survey: one tunnel, the sequential floor.
 const MIN_SURVEY_TUNNEL_WIDTH: usize = 1;
 
-/// The number of survey tunnels open at once for a survey of `candidates`,
+/// The number of survey tunnels open at once for a survey of `candidates` —
 /// a bounded function of the census size: at least one, at most a
-/// [`SURVEY_FANOUT_DIVISOR`]th of the list, and never past the measured
-/// [`MAX_SURVEY_TUNNEL_WIDTH`] the shared exit pipeline carries.
+/// [`SURVEY_FANOUT_DIVISOR`]th of the list, never past the measured
+/// [`MAX_SURVEY_TUNNEL_WIDTH`] — counting connections through the one Nym
+/// client rather than processes, so the same calibration serves a spawned
+/// desktop binary and the in-process client Android and iOS host under the
+/// single-process constraint.
 pub fn survey_tunnel_width(candidates: usize) -> usize {
     candidates
         .div_ceil(SURVEY_FANOUT_DIVISOR)

--- a/zingolib/src/mixnet/sweep.rs
+++ b/zingolib/src/mixnet/sweep.rs
@@ -191,6 +191,27 @@ pub fn select(
     })
 }
 
+/// The survey order for `candidates`: uniformly shuffled with `rng` so the
+/// lane assignment is random, except that `first`, when present, is swapped
+/// into the opening wave of `width` lanes, because the user's own selection
+/// must ride the wave whose verdict is offered early.
+pub fn wave_order(
+    candidates: &[Uri],
+    first: Option<&Uri>,
+    width: usize,
+    rng: &mut impl rand::Rng,
+) -> Vec<Uri> {
+    let mut order: Vec<Uri> = candidates.to_vec();
+    order.shuffle(rng);
+    if let Some(first) = first
+        && let Some(position) = order.iter().position(|candidate| candidate == first)
+        && position >= width
+    {
+        order.swap(0, position);
+    }
+    order
+}
+
 /// Draw one live endpoint by the sync-attach rule: one ticket per operator,
 /// a uniform draw among the operators, then any live endpoint of the winner.
 /// `cohort` is nonempty here.
@@ -404,5 +425,31 @@ mod tests {
     #[test]
     fn a_causeless_tally_renders_nothing() {
         assert_eq!(RefusalTally::of(&[]).to_string(), "");
+    }
+
+    /// HYPOTHESIS: the wave order always seats `first` in the opening wave
+    /// of `width` lanes, whatever the shuffle drew, because the user's own
+    /// selection must ride the wave whose verdict is offered early.
+    /// Falsified if any seed leaves it outside the opening wave.
+    #[test]
+    fn the_first_candidate_always_rides_the_opening_wave() {
+        let candidates: Vec<Uri> = (0..17)
+            .map(|n| uri(&format!("https://c{n}.example:443")))
+            .collect();
+        let pin = uri("https://c13.example:443");
+        const WIDTH: usize = 4;
+        for seed in 0..200 {
+            let order = wave_order(
+                &candidates,
+                Some(&pin),
+                WIDTH,
+                &mut StdRng::seed_from_u64(seed),
+            );
+            assert_eq!(order.len(), candidates.len(), "a permutation, whole");
+            assert!(
+                order[..WIDTH].contains(&pin),
+                "seed {seed} left the pin outside the opening wave: {order:?}"
+            );
+        }
     }
 }

--- a/zingolib/src/mixnet/sweep.rs
+++ b/zingolib/src/mixnet/sweep.rs
@@ -12,6 +12,8 @@
 use http::Uri;
 use rand::seq::SliceRandom as _;
 
+use crate::lightclient::indexer_history::FailureKind;
+
 /// One candidate's survey outcome: the endpoint and the tip height its
 /// `GetLatestBlock` reported, or `None` when it did not answer over the
 /// mixnet.
@@ -21,6 +23,58 @@ pub struct SurveyResult {
     pub uri: Uri,
     /// The tip height the endpoint reported, or `None` on any failure.
     pub reported: Option<u64>,
+    /// Why the endpoint did not answer, when it did not.
+    pub refusal: Option<FailureKind>,
+}
+
+/// A per-kind count of the survey's refusals, rendered as a parenthesized
+/// suffix like " (14 timeout, 3 unreachable)" and as nothing when the
+/// survey had no refusals.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RefusalTally(Vec<(FailureKind, usize)>);
+
+impl RefusalTally {
+    /// Counts the refusals of `results` in the diary vocabulary's order.
+    pub fn of(results: &[SurveyResult]) -> Self {
+        const KINDS: [FailureKind; 5] = [
+            FailureKind::Timeout,
+            FailureKind::Unreachable,
+            FailureKind::Queued,
+            FailureKind::Rejected,
+            FailureKind::Other,
+        ];
+        RefusalTally(
+            KINDS
+                .into_iter()
+                .map(|kind| {
+                    (
+                        kind,
+                        results
+                            .iter()
+                            .filter(|result| result.refusal == Some(kind))
+                            .count(),
+                    )
+                })
+                .filter(|(_, count)| *count > 0)
+                .collect(),
+        )
+    }
+}
+
+impl std::fmt::Display for RefusalTally {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            return Ok(());
+        }
+        write!(f, " (")?;
+        for (index, (kind, count)) in self.0.iter().enumerate() {
+            if index > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{count} {}", kind.as_str())?;
+        }
+        write!(f, ")")
+    }
 }
 
 /// A candidate that answered the survey and passed the cohort's liveness
@@ -37,12 +91,15 @@ pub struct LiveCandidate {
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum SweepError {
     /// No candidate passed the liveness test.
-    #[error("no live indexer: {answered} of {surveyed} answered, none within the cohort")]
+    #[error("no live indexer: {answered} of {surveyed} answered, none within the cohort{causes}")]
     EmptyCohort {
         /// How many candidates were surveyed.
         surveyed: usize,
         /// How many answered at all (before the cohort test).
         answered: usize,
+        /// The refusals counted per failure kind, so the report itself says
+        /// whether the transport or the indexers failed.
+        causes: RefusalTally,
     },
 }
 
@@ -115,6 +172,7 @@ pub fn select(
         return Err(SweepError::EmptyCohort {
             surveyed: results.len(),
             answered: answered_count(results),
+            causes: RefusalTally::of(results),
         });
     }
     let sync_indexer = draw_one_per_operator(&cohort, rng);
@@ -169,13 +227,19 @@ mod tests {
         SurveyResult {
             uri: uri(u),
             reported: Some(height),
+            refusal: None,
         }
     }
 
     fn silent(u: &str) -> SurveyResult {
+        refused(u, FailureKind::Timeout)
+    }
+
+    fn refused(u: &str, kind: FailureKind) -> SurveyResult {
         SurveyResult {
             uri: uri(u),
             reported: None,
+            refusal: Some(kind),
         }
     }
 
@@ -312,7 +376,33 @@ mod tests {
             SweepError::EmptyCohort {
                 surveyed: 2,
                 answered: 0,
+                causes: RefusalTally::of(&results),
             }
         );
+    }
+
+    /// HYPOTHESIS: the empty-cohort report names its causes per failure
+    /// kind, so a saturated transport (every probe timed out) reads
+    /// differently from dead indexers, without any external harness.
+    /// Falsified if the counts or the kinds leave the rendering.
+    #[test]
+    fn an_empty_cohort_names_its_causes() {
+        let results = vec![
+            refused("https://a.example:443", FailureKind::Timeout),
+            refused("https://b.example:443", FailureKind::Timeout),
+            refused("https://c.example:443", FailureKind::Unreachable),
+        ];
+        let error = select(&results, 2, &mut StdRng::seed_from_u64(0)).expect_err("empty");
+        assert_eq!(
+            error.to_string(),
+            "no live indexer: 0 of 3 answered, none within the cohort \
+             (2 timeout, 1 unreachable)"
+        );
+    }
+
+    /// A survey with no refusals renders no cause suffix.
+    #[test]
+    fn a_causeless_tally_renders_nothing() {
+        assert_eq!(RefusalTally::of(&[]).to_string(), "");
     }
 }


### PR DESCRIPTION
This PR stacks on #2683 and targets its branch; it merges after #2683 or retargets to dev when #2683 lands.

## The defect

The sweep surveyed all 17 candidates concurrently. Every tunnel rides the one sweep exit's packet pipeline. An adjacent harness measured one GetLatestBlock round trip through that pipe at about 5 seconds, with roughly every other fresh SOCKS5 tunnel reset. Seventeen concurrent TLS handshakes through one mixnet-throughput pipe blow every probe's 20-second budget together. That is the observed all-or-nothing signature: 17/17 on a fast exit, 0/17 on an ordinary one. The indexers answered clearnet grpcurl instantly throughout.

## The fix

The survey opens at most `SURVEY_TUNNEL_WIDTH` (4) tunnels at a time. Two live runs against the full census answered 17 of 17, chose the pinned server, and opened the Sync Session, where the unbounded fan-out answered 0 of 17 minutes earlier on the same machine.

## The self-diagnosis

The sweep stops discarding why probes fail. `SurveyResult` carries the diary's `FailureKind`, and `EmptyCohort` tallies causes into its rendering: "no live indexer: 0 of 17 answered, none within the cohort (17 timeout)". A saturated transport now reads differently from dead indexers in the refusal itself. A falsifier test pins the tally.

## The harness

`tools/workbench/src/bin/sweep-teardown.rs` ports the throwaway that found this: standalone nym-proxy, ncat bridge, grpcurl probes — an independent client per the workbench scripting rule. It requires grpcurl and ncat on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)