### PR TITLE
fix(zingo-cli)!: quit reports a save-task shutdown only when one ran

### DIFF
--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -30,7 +30,7 @@ use zingolib::lightclient::migrate::{
     ImmediateMigrationPhase, ImmediateMigrationStatus, PartSendResult, SplitOutcome, SplitPhase,
     SplitStatus, SplitStep,
 };
-use zingolib::lightclient::{LightClient, TransmitProgressHandle};
+use zingolib::lightclient::{LightClient, SaveShutdown, TransmitProgressHandle};
 use zingolib::utils::conversion::txid_from_hex_encoded_str;
 use zingolib::wallet::keys::WalletAddressRef;
 use zingolib::wallet::keys::unified::{ReceiverSelection, UnifiedKeyStore};
@@ -547,7 +547,8 @@ async fn quickshield(lightclient: &mut LightClient) -> Result<String, CommandErr
 
 async fn quit(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.shutdown_save_task().await {
-        Ok(()) => eprintln!("Save task shutdown successfully."),
+        Ok(SaveShutdown::ShutDown) => eprintln!("Save task shutdown successfully."),
+        Ok(SaveShutdown::NotRunning) => eprintln!("No save task was running."),
         Err(e) => eprintln!("Error: save failed. {}", render_error_chain(&e)),
     }
     Ok("Zingo CLI quit successfully.".to_string())
@@ -619,7 +620,8 @@ async fn save(sub: SaveSubCommand, lightclient: &mut LightClient) -> Result<Stri
             )),
         },
         SaveSubCommand::Shutdown => match lightclient.shutdown_save_task().await {
-            Ok(()) => Ok("Save task shutdown successfully.".to_string()),
+            Ok(SaveShutdown::ShutDown) => Ok("Save task shutdown successfully.".to_string()),
+            Ok(SaveShutdown::NotRunning) => Ok("No save task was running.".to_string()),
             Err(e) => Err(CommandError::NotYetTyped(
                 format!("save failed. {}", render_error_chain(&e)).into(),
             )),

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: `lightclient::LightClient::shutdown_save_task` returns
+  `std::io::Result<SaveShutdown>` instead of `std::io::Result<()>`, where the
+  new `lightclient::SaveShutdown` enum distinguishes a stopped task
+  (`ShutDown`) from an absent one (`NotRunning`), so callers can report a
+  shutdown request against a never-launched saver accurately.
 - BREAKING: `mixnet::acquire::TransportError` gains the `ExitOutsideClutch`
   variant. A transport that reports ready without announcing an exit from
   the drawn Clutch now refuses with this variant instead of panicking, and

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -54,6 +54,7 @@ pub mod send;
 pub mod sync;
 pub(crate) mod transmit;
 
+pub use save::SaveShutdown;
 pub use transmit::TransmitProgressHandle;
 
 #[cfg(test)]

--- a/zingolib/src/lightclient/save.rs
+++ b/zingolib/src/lightclient/save.rs
@@ -8,6 +8,15 @@ use std::{borrow::BorrowMut as _, fs::remove_file, sync::atomic};
 use super::LightClient;
 use crate::data::PollReport;
 
+/// The outcome of a save-task shutdown request, distinguishing a stopped task from an absent one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveShutdown {
+    /// A running save task was stopped after its final save completed.
+    ShutDown,
+    /// No save task was running.
+    NotRunning,
+}
+
 /// Writes `bytes` to file at `wallet_path` using a blocking thread.
 ///
 /// The write is atomic: bytes go to a `.tmp` sibling file first, then renamed into place.
@@ -116,12 +125,14 @@ impl LightClient {
         }
     }
 
-    pub async fn shutdown_save_task(&mut self) -> std::io::Result<()> {
+    /// Stops the save task after its in-flight save completes, reporting whether a task was running at all.
+    pub async fn shutdown_save_task(&mut self) -> std::io::Result<SaveShutdown> {
         self.save_active.store(false, atomic::Ordering::Release);
         if let Some(save_handle) = self.save_handle.take() {
-            save_handle.await.expect("task panicked")
+            save_handle.await.expect("task panicked")?;
+            Ok(SaveShutdown::ShutDown)
         } else {
-            Ok(())
+            Ok(SaveShutdown::NotRunning)
         }
     }
 


### PR DESCRIPTION
## Problem

The quit path printed "Save task shutdown successfully." even when no save task had been launched. `shutdown_save_task` returned `Ok(())` for a stopped task and an absent one alike, so the caller could not tell the outcomes apart. The false report matters for the saver-disable experiment on issue #2680, where a session deliberately runs with no saver.

## Change

`shutdown_save_task` now returns `std::io::Result<SaveShutdown>`. The new `lightclient::SaveShutdown` enum distinguishes a stopped task (`ShutDown`) from an absent one (`NotRunning`). Both CLI reporting sites narrate the absent case as "No save task was running.": the quit path and the `save shutdown` sub-command. The return-type change is the breaking part. The zingolib CHANGELOG records it.

## Verification

`cargo clippy --all-targets` and `cargo fmt` pass for both crates. All 232 zingo-cli unit tests pass under `cargo nextest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
