### PR TITLE
--sync-server names the pinned clearnet sync indexer, with --server kept as an alias

### DIFF
--- a/docs/adr/0034-server-selection-is-a-mixnet-liveness-sweep.md
+++ b/docs/adr/0034-server-selection-is-a-mixnet-liveness-sweep.md
@@ -93,3 +93,25 @@ transmissions-are-probes Health economy. The sweep itself gains a
 ratified second role: it is the session's baseline health probe, the
 last probe-only act a session performs. The judgment this record calls
 liveness is since named Health in the glossary.
+
+## Addendum (2026-08-12)
+
+Four rulings from the sweep-failure investigation amend the mechanism.
+First, the survey's probe is `GetLatestBlock`, the lightest tip call an
+indexer answers, replacing `GetLightdInfo`; the liveness judgment rests
+on the height tolerance alone, and the census's chain partition carries
+the chain distinction. Second, the user's pinned clearnet sync indexer
+(`--sync-server`, renamed from `--server`, which survives as an alias)
+rides the survey and is chosen when it answers; a pin the survey found
+unresponsive is reported with the sweep's verdict offered as the
+alternative, and a sweep whose own transport failed is never charged
+against the pin, so a dead exit draw cannot close a pinned session's
+Sync Session. The DeadPin outcome is gone. Third, the survey bounds its
+fan-out: all candidates once rode one exit's packet pipeline
+concurrently, which saturated it and produced the all-or-nothing
+0-of-17 signature, so the width is now a bounded function of the census
+size, calibrated identically for spawned desktop binaries and the
+in-process client the mobile platforms host. Fourth, the survey stops
+discarding why probes fail: refusals carry the diary's failure kinds,
+and an empty cohort tallies its causes in its own rendering, so a
+saturated transport reads differently from dead indexers.

--- a/tools/workbench/src/bin/run-cli.rs
+++ b/tools/workbench/src/bin/run-cli.rs
@@ -17,7 +17,7 @@
 //!
 //! The launched session decides its own connectivity: first boot is offline,
 //! and only a consent act — a stored standing Connectivity Consent from a
-//! previous run, an explicit `--online`/`--server` passed through in the
+//! previous run, an explicit `--online`/`--sync-server` passed through in the
 //! trailing arguments, or the in-session `network on` command (ADR 0026) —
 //! takes it online (ADR 0025). Neither this tool nor a bundled proxy binary
 //! implies consent.

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Breaking.** The `--server` flag is renamed `--sync-server`, naming what
+  the pin is: a clearnet sync indexer, selected by the user. The old
+  spelling survives as a visible alias, so existing command lines keep
+  working. The pin rides the Server-Selection Sweep's survey and is chosen
+  when it answers; a pin the survey found unresponsive is reported with the
+  sweep's verdict offered as the alternative, and a sweep whose own
+  transport failed never counts against the pin. The messages say "pinned
+  clearnet sync indexer" where they said "pinned server".
 - **Breaking.** `network probe` wraps the single `GetLatestBlock` RPC, the
   same tip call the Server-Selection Sweep surveys with, and reports the
   tip height alone: there is no chain name in the reply to print.

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -85,10 +85,11 @@ pub fn build_clap_app() -> clap::Command {
                 .help("Specify wallet birthday when restoring from seed. This is the earliest block height where the wallet has a transaction. \
 For a NEW wallet created in Offline mode it is instead an optional override of the library's built-in birthday floor."))
             .arg(Arg::new("server")
-                .long("server")
+                .long("sync-server")
+                .visible_alias("server")
                 .value_name("server")
-                .help("Pin a specific Indexer server. Without it, an online session's \
-Server-Selection Sweep selects the sync indexer.")
+                .help("Pin a specific clearnet sync indexer. It rides the Server-Selection \
+Sweep's survey and is chosen when it answers; without it, the sweep selects the sync indexer.")
                 .value_parser(parse_uri))
             .arg(Arg::new("offline")
                 .long("offline")
@@ -99,7 +100,7 @@ Server-Selection Sweep selects the sync indexer.")
                 .long("online")
                 .action(clap::ArgAction::SetTrue)
                 .conflicts_with("offline")
-                .help("Consent to go online this session (Connectivity Consent). First boot is offline by design; this flag, --remember-online, an explicit --server, or a stored standing consent takes a session online. The choice is not persisted."))
+                .help("Consent to go online this session (Connectivity Consent). First boot is offline by design; this flag, --remember-online, an explicit --sync-server, or a stored standing consent takes a session online. The choice is not persisted."))
             .arg(Arg::new("remember-online")
                 .long("remember-online")
                 .action(clap::ArgAction::SetTrue)
@@ -717,7 +718,7 @@ enum ConnectivityDecision {
 
 /// Combines the launch acts with the stored choice (ADR 0025): the
 /// deliberate `--offline` wins over everything, a launch act (`--online`,
-/// `--remember-online`, an explicit `--server`) over the store, the store
+/// `--remember-online`, an explicit `--sync-server`) over the store, the store
 /// alone sustains the connection, and nothing else goes online.
 #[cfg(feature = "nym")]
 fn decide_connectivity(
@@ -800,7 +801,7 @@ fn get_communication_mode(matches: &clap::ArgMatches) -> std::io::Result<Communi
                 "No Connectivity Consent is recorded, so this session runs offline: local \
                  operations work and nothing touches the network. To go online, pass --online \
                  (this session only), --remember-online (store the choice for future \
-                 sessions), or --server <uri>; in the session, `network on` also grants \
+                 sessions), or --sync-server <uri>; in the session, `network on` also grants \
                  consent and switches to ONLINE MODE. Pass --offline to run offline \
                  deliberately and silence this notice."
             );
@@ -860,12 +861,12 @@ pub(crate) struct ConfigTemplate {
     /// The pinned Indexer: `None` when the session is Offline, and equally
     /// when it is Online unpinned, where the Server-Selection Sweep selects.
     server: Option<http::Uri>,
-    /// True when `--server` was typed on the command line: the pin the
+    /// True when `--sync-server` was typed on the command line: the pin the
     /// Server-Selection Sweep surveys and never substitutes.
     #[cfg_attr(not(feature = "nym"), allow(dead_code))]
     server_pinned: bool,
     /// All servers that responded to `get_info()` during dynamic selection,
-    /// sorted fastest to slowest. Empty if `--server` was specified explicitly.
+    /// sorted fastest to slowest. Empty if `--sync-server` was specified explicitly.
     /// Will be used for automatic failover when sync fails.
     #[cfg(feature = "clearnet-test-mode")]
     #[allow(dead_code)]
@@ -914,13 +915,13 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
     #[cfg(feature = "clearnet-test-mode")]
     #[error(transparent)]
     ResolveServer(#[from] server_select_clearnet::ResolveServerError),
-    /// The pinned `--server` is not a valid indexer URI.
+    /// The pinned `--sync-server` is not a valid indexer URI.
     #[cfg(not(feature = "clearnet-test-mode"))]
-    #[error("invalid --server URI.")]
+    #[error("invalid --sync-server URI.")]
     IndexerUri(#[from] http::uri::InvalidUri),
-    /// The pinned server misses its scheme, host, or port.
+    /// The pinned clearnet sync indexer misses its scheme, host, or port.
     #[error(
-        "Please provide the --server parameter as [scheme]://[host]:[port].\nYou provided: {server}"
+        "Please provide the --sync-server parameter as [scheme]://[host]:[port].\nYou provided: {server}"
     )]
     ServerShape {
         /// The under-specified server URI.
@@ -988,7 +989,7 @@ impl ConfigTemplate {
             }
         };
         // Without the quarantined sweep, resolution is pure: the typed
-        // `--server` pin or nothing, never a probe and never a default.
+        // `--sync-server` pin or nothing, never a probe and never a default.
         #[cfg(not(feature = "clearnet-test-mode"))]
         let server = match communication_mode {
             CommunicationMode::DeliberateOffline | CommunicationMode::UnconsentedOffline => None,
@@ -1296,7 +1297,7 @@ fn census_chain(chain: &ChainType) -> Option<zingolib::indexers::IndexerChain> {
 
 /// Runs the Server-Selection Sweep (ADR 0034), narrating each phase, and
 /// binds a sync indexer; returns whether this Sync Session may open. A
-/// pinned server rides the survey and is chosen when it answers; a pin the
+/// pinned clearnet sync indexer rides the survey and is chosen when it answers; a pin the
 /// survey found unresponsive is reported with the sweep's verdict offered
 /// as the alternative, and a sweep whose own transport failed never counts
 /// against the pin.
@@ -1318,7 +1319,7 @@ async fn sweep_select_sync_indexer(
         && !zingolib::mixnet::probe::probe_eligible(pinned)
     {
         eprintln!(
-            "Server-Selection Sweep: pinned server {pinned} is outside the mixnet exit policy \
+            "Server-Selection Sweep: the pinned clearnet sync indexer {pinned} is outside the mixnet exit policy \
              (https on port 443), so no sweep can survey it; binding it directly."
         );
         return true;
@@ -1356,14 +1357,14 @@ async fn sweep_select_sync_indexer(
                     // The user's selection answered the survey: it is chosen,
                     // and it is already bound from config.
                     eprintln!(
-                        "Server-Selection Sweep: sync attaches to the pinned server {pinned} \
+                        "Server-Selection Sweep: sync attaches to the pinned clearnet sync indexer {pinned} \
                          (live cohort of {}).",
                         selection.cohort.len(),
                     );
                     return true;
                 }
                 eprintln!(
-                    "Server-Selection Sweep: the pinned server {pinned} did not answer the \
+                    "Server-Selection Sweep: the pinned clearnet sync indexer {pinned} did not answer the \
                      survey or lags the live cohort of {}. A live alternative: {}. This Sync \
                      Session does not open; run `changeserver {}` at the prompt, or relaunch \
                      pinning a live server.",
@@ -1397,8 +1398,8 @@ async fn sweep_select_sync_indexer(
         Err(e) => {
             if let Some(pinned) = &pin {
                 eprintln!(
-                    "Server-Selection Sweep: no verdict: {}. The survey never judged the pinned \
-                     server {pinned}; it stands, and this Sync Session opens against it.",
+                    "Server-Selection Sweep: no verdict: {}. The survey never judged the \
+                     pinned clearnet sync indexer {pinned}; it stands, and this Sync Session opens against it.",
                     commands::render_error_chain(&e),
                 );
                 return true;

--- a/zingo-cli/src/server_select_clearnet.rs
+++ b/zingo-cli/src/server_select_clearnet.rs
@@ -1,6 +1,6 @@
 //! Dynamic server selection via `get_info()` against a curated list of indexers.
 //!
-//! When no `--server` is specified, we call `get_info()` on each URI in
+//! When no `--sync-server` is specified, we call `get_info()` on each URI in
 //! `zingolib::netutils::indexers::MOST_UP_INDEXER_URIS` (the census) concurrently,
 //! measure response time, and return the responsive servers sorted
 //! from fastest to slowest.
@@ -120,7 +120,10 @@ pub(crate) async fn select_servers() -> Vec<RankedServer> {
         .filter_map(|s| s.parse::<http::Uri>().ok())
         .collect();
 
-    eprintln!("No --server specified. Probing {} indexers...", uris.len());
+    eprintln!(
+        "No --sync-server specified. Probing {} indexers...",
+        uris.len()
+    );
 
     let (ranked, failures) = probe_servers(uris, SERVER_RANKING_TIMEOUT).await;
 
@@ -149,17 +152,17 @@ pub(crate) async fn select_servers() -> Vec<RankedServer> {
 /// Why the clearnet resolution produced no server.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ResolveServerError {
-    /// The explicit `--server` value failed to parse as a URI.
+    /// The explicit `--sync-server` value failed to parse as a URI.
     #[error(transparent)]
     InvalidUri(#[from] http::uri::InvalidUri),
     /// No probed indexer answered, and no default server exists.
-    #[error("no probed server responded and there is no default server; pass --server")]
+    #[error("no probed server responded and there is no default server; pass --sync-server")]
     NoResponder,
 }
 
 /// Resolves the indexer server from CLI arguments.
 ///
-/// If `--server` was provided explicitly, uses that URI and returns an
+/// If `--sync-server` was provided explicitly, uses that URI and returns an
 /// empty ranked list. Otherwise, probes curated indexers with `get_info()`
 /// and returns the fastest responder along with the full ranked list.
 ///
@@ -180,7 +183,7 @@ pub(crate) fn resolve_server(
 }
 
 /// Resolves the indexer for a session going online without an explicit
-/// `--server`: the fastest probed responder, refused typed when nothing
+/// `--sync-server`: the fastest probed responder, refused typed when nothing
 /// answered, since no default server exists.
 pub(crate) async fn resolve_ranked_server()
 -> Result<(http::Uri, Vec<RankedServer>), ResolveServerError> {

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -516,10 +516,22 @@ mod communication_mode {
     }
 
     /// Naming an endpoint is consenting to connect to it: an explicit
-    /// --server is a consent act (ADR 0025).
+    /// --sync-server is a consent act (ADR 0025).
     #[cfg(feature = "nym")]
     #[test]
     fn an_explicit_server_is_a_consent_act() {
+        let dir = scratch_dir();
+        assert_eq!(
+            mode_with_dir(&dir, &["--sync-server", examples::SERVER_URI]),
+            CommunicationMode::Online
+        );
+    }
+
+    /// The retired spelling survives as a visible alias: `--server` parses
+    /// as the `--sync-server` pin, so existing command lines keep working.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn the_old_server_spelling_is_an_alias() {
         let dir = scratch_dir();
         assert_eq!(
             mode_with_dir(&dir, &["--server", examples::SERVER_URI]),
@@ -603,7 +615,7 @@ mod communication_mode {
             for act in [
                 vec!["--online"],
                 vec!["--remember-online"],
-                vec!["--server", examples::SERVER_URI],
+                vec!["--sync-server", examples::SERVER_URI],
             ] {
                 let mut args = vec![
                     examples::BIN_NAME,
@@ -677,7 +689,7 @@ mod communication_mode {
                 .try_get_matches_from([
                     examples::BIN_NAME,
                     "--offline",
-                    "--server",
+                    "--sync-server",
                     examples::SERVER_URI
                 ])
                 .is_err()
@@ -916,12 +928,13 @@ mod config_template {
         #[cfg(feature = "nym")]
         use crate::CommunicationMode;
 
-        /// An explicit `--server` is an online act, which only nym builds
+        /// An explicit `--sync-server` is an online act, which only nym builds
         /// accept (ADR 0026).
         #[cfg(feature = "nym")]
         #[test]
         fn defaults() {
-            let config = fill(&[examples::BIN_NAME, "--server", examples::SERVER_URI]).unwrap();
+            let config =
+                fill(&[examples::BIN_NAME, "--sync-server", examples::SERVER_URI]).unwrap();
             assert_eq!(config.data_dir, PathBuf::from("wallets"));
             assert_eq!(config.chaintype, ChainType::Mainnet);
             assert_eq!(config.communication_mode, CommunicationMode::Online);
@@ -1035,11 +1048,12 @@ mod config_template {
 
         /// The URI shape check sits on the online resolution path, which
         /// only nym builds reach: the offline-only build refuses the
-        /// `--server` act before any URI is inspected (ADR 0026).
+        /// `--sync-server` act before any URI is inspected (ADR 0026).
         #[cfg(feature = "nym")]
         #[test]
         fn server_missing_port() {
-            let err = fill(&[examples::BIN_NAME, "--server", "https://example.com"]).unwrap_err();
+            let err =
+                fill(&[examples::BIN_NAME, "--sync-server", "https://example.com"]).unwrap_err();
             assert!(err.contains("scheme"));
         }
     }
@@ -1062,7 +1076,7 @@ mod config_template {
         #[cfg(feature = "nym")]
         #[test]
         fn unpinned_online_configures_no_indexer() {
-            // --online is the consent act; with no --server there is no
+            // --online is the consent act; with no --sync-server there is no
             // default to fill in, and the sweep selects the sync indexer.
             let zc = fill_and_build(&[
                 examples::BIN_NAME,
@@ -1086,7 +1100,7 @@ mod config_template {
         fn custom_server_is_propagated() {
             let zc = fill_and_build(&[
                 examples::BIN_NAME,
-                "--server",
+                "--sync-server",
                 examples::SERVER_URI,
                 "--seed",
                 HOSPITAL_MUSEUM_SEED,
@@ -1110,7 +1124,7 @@ mod config_template {
             for act in [
                 vec!["--online"],
                 vec!["--remember-online"],
-                vec!["--server", examples::SERVER_URI],
+                vec!["--sync-server", examples::SERVER_URI],
             ] {
                 let mut args = vec![examples::BIN_NAME];
                 args.extend(act.iter());

--- a/zingo-cli/tests/log_file.rs
+++ b/zingo-cli/tests/log_file.rs
@@ -152,7 +152,7 @@ async fn tracing_error_from_pepper_sync_goes_to_log_file() {
 
     let mut child = Command::new(zingo_cli_binary())
         .env("RUST_LOG", "info")
-        .arg("--server")
+        .arg("--sync-server")
         .arg(&server_uri)
         // The mixnet is unconditional for a connected session, so hand the
         // spawner a stub that answers the directory query and then exits at


### PR DESCRIPTION
This PR stacks on #2683 and targets its branch, beside #2684; it retargets to dev when #2683 lands.

The `--server` flag is renamed `--sync-server`, naming what the pin is: a clearnet sync indexer, selected by the user. The old spelling survives as a **visible alias**, so existing command lines keep working; a grammar test pins the alias. Every message and doc-comment says "pinned clearnet sync indexer" where it said "pinned server". The clearnet-test-mode prose and the workbench `run-cli` doc follow the rename.

A docs commit appends ADR 0034's 2026-08-12 addendum recording the day's four sweep rulings: the `GetLatestBlock` probe, the surveyed pin chosen unless unresponsive (with the verdict offered as the alternative, and a failed survey never charged against the pin), the bounded survey width calibrated for the single-process mobile platforms, and the cause-tallying refusal.

All 235 zingo-cli tests pass, including the new alias pin; both feature planes compile; clippy is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)