### PR TITLE
A new online wallet refuses an explicit --birthday

### DIFF
--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Breaking.** An online session that would create a NEW wallet refuses an
+  explicit `--birthday` instead of silently ignoring it. A new wallet is
+  born at the chain tip, so the flag names a restore height that cannot
+  apply; the refusal says so and points at `--seed` and `--viewkey`. Seed
+  and viewkey restores keep the flag as the restore height, and an offline
+  new wallet keeps it as the birthday-floor override.
 - **Breaking.** The `--server` flag is renamed `--sync-server`, naming what
   the pin is: a clearnet sync indexer, selected by the user. The old
   spelling survives as a visible alias, so existing command lines keep

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -902,6 +902,14 @@ If you don't remember the block height, you can pass '--birthday 0' to scan from
     /// The birthday token is not a block number.
     #[error("Couldn't parse birthday. This should be a block number. Error={0}")]
     BirthdayUnparseable(std::num::ParseIntError),
+    /// `--birthday` names a restore height, and a new online wallet is born
+    /// at the chain tip.
+    #[error(
+        "`--birthday` names a restore height, but this session creates a NEW \
+         wallet born at the chain tip. Drop --birthday, or pass --seed or \
+         --viewkey to restore."
+    )]
+    BirthdayWithoutRestore,
     /// `--online` grants a connection the named command never uses.
     #[error(
         "`{command}` needs no network, so `--online` grants a connection it never \
@@ -954,6 +962,7 @@ impl ConfigTemplate {
             );
             return Err(ConfigTemplateError::BirthdayRequired);
         }
+        let birthday_explicit = maybe_birthday.is_some();
         let birthday = match maybe_birthday.unwrap_or("0".to_string()).parse::<u64>() {
             Ok(b) => b,
             Err(e) => {
@@ -976,6 +985,18 @@ impl ConfigTemplate {
 
         let data_dir = data_dir_from(&matches);
         log::info!("data_dir: {}", data_dir.to_str().unwrap());
+        // An online session with no key source and no wallet file creates a
+        // NEW wallet born at the chain tip, where an explicit --birthday
+        // would be silently ignored; the launch refuses instead (ruling
+        // 2026-08-12). The offline arm keeps honoring the flag as its
+        // birthday-floor override.
+        if birthday_explicit
+            && !from_provided
+            && communication_mode == CommunicationMode::Online
+            && !data_dir.join(DEFAULT_WALLET_NAME).exists()
+        {
+            return Err(ConfigTemplateError::BirthdayWithoutRestore);
+        }
         // Offline mode never resolves a server: the session's contract is
         // that no Indexer is ever configured.
         #[cfg(feature = "clearnet-test-mode")]

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -25,6 +25,12 @@ mod config_template_refusals {
             "`balance` needs no network, so `--online` grants a connection it never \
              uses. Drop `--online`, or run it at the interactive prompt."
         );
+        assert_eq!(
+            crate::ConfigTemplateError::BirthdayWithoutRestore.to_string(),
+            "`--birthday` names a restore height, but this session creates a NEW \
+             wallet born at the chain tip. Drop --birthday, or pass --seed or \
+             --viewkey to restore."
+        );
     }
 }
 
@@ -840,6 +846,64 @@ mod config_template {
     /// Helper: parse args, fill config, and build ZingoConfig in one step.
     fn fill_and_build(args: &[&str]) -> zingolib::config::ClientConfig {
         build(&fill(args).unwrap())
+    }
+
+    /// HYPOTHESIS: an online session with no key source and no wallet file
+    /// creates a NEW wallet born at the chain tip, so an explicit
+    /// --birthday would be silently ignored, and the launch refuses
+    /// instead. Falsified if the fill accepts the flag.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn a_new_online_wallet_refuses_an_explicit_birthday() {
+        let dir = tempfile::tempdir().expect("a scratch dir opens");
+        let err = fill(&[
+            examples::BIN_NAME,
+            "--sync-server",
+            examples::SERVER_URI,
+            "--birthday",
+            "400000",
+            "--data-dir",
+            dir.path().to_str().expect("the scratch path renders"),
+        ])
+        .expect_err("a new online wallet refuses --birthday");
+        assert!(err.contains("NEW wallet born at the chain tip"), "{err}");
+    }
+
+    /// A seed restore keeps its explicit birthday: the flag names the
+    /// restore height there, never a dead letter.
+    #[cfg(feature = "nym")]
+    #[test]
+    fn a_seed_restore_keeps_its_birthday() {
+        let dir = tempfile::tempdir().expect("a scratch dir opens");
+        let config = fill(&[
+            examples::BIN_NAME,
+            "--sync-server",
+            examples::SERVER_URI,
+            "--seed",
+            examples::SEED_PHRASE,
+            "--birthday",
+            "400000",
+            "--data-dir",
+            dir.path().to_str().expect("the scratch path renders"),
+        ])
+        .expect("a seed restore accepts --birthday");
+        assert_eq!(config.birthday, 400_000);
+    }
+
+    /// An offline new wallet keeps honoring --birthday as its
+    /// birthday-floor override, exactly as before the online refusal.
+    #[test]
+    fn an_offline_new_wallet_keeps_its_birthday_override() {
+        let dir = tempfile::tempdir().expect("a scratch dir opens");
+        let config = fill(&[
+            examples::BIN_NAME,
+            "--birthday",
+            "400000",
+            "--data-dir",
+            dir.path().to_str().expect("the scratch path renders"),
+        ])
+        .expect("an offline new wallet accepts --birthday");
+        assert_eq!(config.birthday, 400_000);
     }
 
     mod offline {


### PR DESCRIPTION
This PR stacks on #2686; it retargets when the stack beneath it lands.

An online session with no `--seed`, no `--viewkey`, and no wallet file creates a NEW wallet born at the chain tip. `--birthday` names a restore height there, and the launch silently discarded it: a `--birthday 400000` session synced from the tip with no notice. The launch now refuses in the `OnlineGrantUnused` style:

```
`--birthday` names a restore height, but this session creates a NEW wallet born at the chain tip. Drop --birthday, or pass --seed or --viewkey to restore.
```

Seed and viewkey restores keep the flag as the restore height. An offline new wallet keeps it as the birthday-floor override. Three tests pin the refusal prose and both surviving acceptances; all 238 zingo-cli tests pass on every feature plane.

Out of scope, flagged for its own ruling: an EXISTING wallet file also quietly ignores `--birthday` in favor of its stored birthday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)