### PR TITLE
fix: a stale initial sync state reports no false completion

### DIFF
--- a/pepper-sync/CHANGELOG.md
+++ b/pepper-sync/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `sync::sync_status`: a session with no scannable blocks or outputs no longer
+  reports a finished sync. A stale initial sync state, whose previously scanned
+  counts stand at or above the wallet's whole span, saturates the session
+  denominator to zero. The status now reports the wallet's total progress for
+  that session, where it previously divided zero by zero and coerced the
+  resulting `NaN` to one hundred percent. The pool totals and the block span are
+  saturated likewise, so a rewound tree bound can no longer underflow them.
 - BREAKING: a wrapper error variant renders only its own layer. The
   `Display` texts of the `error::SyncError`, `error::MempoolError`, and
   `error::ScanError` wrapper variants no longer embed the wrapped source's

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -793,6 +793,27 @@ where
         u64::from(sapling) + u64::from(orchard) + u64::from(ironwood)
     }
 
+    /// The scale every scan-progress ratio is reported on.
+    const PERCENTAGE_SCALE: f32 = 100.0;
+    /// The percentage a fully scanned span reports.
+    const COMPLETE_PERCENTAGE: f32 = PERCENTAGE_SCALE;
+    /// The percentage an entirely unscanned span reports.
+    const NO_PROGRESS_PERCENTAGE: f32 = 0.0;
+    /// The smallest whole step a reported percentage moves by.
+    const PERCENTAGE_STEP: f32 = 1.0;
+    /// The percentage reported while scanning has finished but nullifiers await refetching.
+    const NULLIFIER_RETRIEVAL_PERCENTAGE: f32 = COMPLETE_PERCENTAGE - PERCENTAGE_STEP;
+    /// The block a span's own first height contributes to the span's inclusive length.
+    const INCLUSIVE_SPAN_ADJUSTMENT: u32 = 1;
+
+    /// Reports `scanned` as a percentage of `total`, and reports `None` where a zero denominator leaves that ratio undefined.
+    fn percentage_scanned(scanned: u64, total: u64) -> Option<f32> {
+        (total != 0).then(|| {
+            ((scanned as f32 / total as f32) * PERCENTAGE_SCALE)
+                .clamp(NO_PROGRESS_PERCENTAGE, COMPLETE_PERCENTAGE)
+        })
+    }
+
     let (
         total_sapling_outputs_scanned,
         total_orchard_outputs_scanned,
@@ -813,16 +834,16 @@ where
             sync_start_height: 0.into(),
             session_blocks_scanned: 0,
             total_blocks_scanned: 0,
-            percentage_session_blocks_scanned: 0.0,
-            percentage_total_blocks_scanned: 0.0,
+            percentage_session_blocks_scanned: NO_PROGRESS_PERCENTAGE,
+            percentage_total_blocks_scanned: NO_PROGRESS_PERCENTAGE,
             session_sapling_outputs_scanned: 0,
             session_orchard_outputs_scanned: 0,
             session_ironwood_outputs_scanned: 0,
             total_sapling_outputs_scanned: 0,
             total_orchard_outputs_scanned: 0,
             total_ironwood_outputs_scanned: 0,
-            percentage_session_outputs_scanned: 0.0,
-            percentage_total_outputs_scanned: 0.0,
+            percentage_session_outputs_scanned: NO_PROGRESS_PERCENTAGE,
+            percentage_total_outputs_scanned: NO_PROGRESS_PERCENTAGE,
             total_outputs_scanned: 0,
             total_outputs: 0,
         });
@@ -835,31 +856,39 @@ where
     let last_known_chain_height = sync_state
         .last_known_chain_height()
         .ok_or(SyncStatusError::NoSyncData)?;
-    let total_blocks = last_known_chain_height - birthday + 1;
+    let total_blocks = u32::from(last_known_chain_height)
+        .saturating_sub(u32::from(birthday))
+        .saturating_add(INCLUSIVE_SPAN_ADJUSTMENT);
     let total_sapling_outputs = sync_state
         .initial_sync_state
         .wallet_tree_bounds
         .sapling_final_tree_size
-        - sync_state
-            .initial_sync_state
-            .wallet_tree_bounds
-            .sapling_initial_tree_size;
+        .saturating_sub(
+            sync_state
+                .initial_sync_state
+                .wallet_tree_bounds
+                .sapling_initial_tree_size,
+        );
     let total_orchard_outputs = sync_state
         .initial_sync_state
         .wallet_tree_bounds
         .orchard_final_tree_size
-        - sync_state
-            .initial_sync_state
-            .wallet_tree_bounds
-            .orchard_initial_tree_size;
+        .saturating_sub(
+            sync_state
+                .initial_sync_state
+                .wallet_tree_bounds
+                .orchard_initial_tree_size,
+        );
     let total_ironwood_outputs = sync_state
         .initial_sync_state
         .wallet_tree_bounds
         .ironwood_final_tree_size
-        - sync_state
-            .initial_sync_state
-            .wallet_tree_bounds
-            .ironwood_initial_tree_size;
+        .saturating_sub(
+            sync_state
+                .initial_sync_state
+                .wallet_tree_bounds
+                .ironwood_initial_tree_size,
+        );
     let total_outputs = output_pool_total(
         total_sapling_outputs,
         total_orchard_outputs,
@@ -868,19 +897,14 @@ where
 
     let session_blocks_scanned = total_blocks_scanned
         .saturating_sub(sync_state.initial_sync_state.previously_scanned_blocks);
-    let mut percentage_session_blocks_scanned = ((session_blocks_scanned as f32
-        / total_blocks.saturating_sub(sync_state.initial_sync_state.previously_scanned_blocks)
-            as f32)
-        * 100.0)
-        .clamp(0.0, 100.0);
-    if percentage_session_blocks_scanned.is_nan() {
-        percentage_session_blocks_scanned = 100.0;
-    }
+    let session_blocks =
+        total_blocks.saturating_sub(sync_state.initial_sync_state.previously_scanned_blocks);
     let mut percentage_total_blocks_scanned =
-        ((total_blocks_scanned as f32 / total_blocks as f32) * 100.0).clamp(0.0, 100.0);
-    if percentage_total_blocks_scanned.is_nan() {
-        percentage_total_blocks_scanned = 100.0;
-    }
+        percentage_scanned(u64::from(total_blocks_scanned), u64::from(total_blocks))
+            .unwrap_or(COMPLETE_PERCENTAGE);
+    let mut percentage_session_blocks_scanned =
+        percentage_scanned(u64::from(session_blocks_scanned), u64::from(session_blocks))
+            .unwrap_or(percentage_total_blocks_scanned);
 
     let session_sapling_outputs_scanned = total_sapling_outputs_scanned.saturating_sub(
         sync_state
@@ -913,35 +937,29 @@ where
             .initial_sync_state
             .previously_scanned_ironwood_outputs,
     );
-    let mut percentage_session_outputs_scanned = ((session_outputs_scanned as f32
-        / total_outputs.saturating_sub(previously_scanned_outputs) as f32)
-        * 100.0)
-        .clamp(0.0, 100.0);
-    if percentage_session_outputs_scanned.is_nan() {
-        percentage_session_outputs_scanned = 100.0;
-    }
+    let session_outputs = total_outputs.saturating_sub(previously_scanned_outputs);
     let mut percentage_total_outputs_scanned =
-        ((total_outputs_scanned as f32 / total_outputs as f32) * 100.0).clamp(0.0, 100.0);
-    if percentage_total_outputs_scanned.is_nan() {
-        percentage_total_outputs_scanned = 100.0;
-    }
+        percentage_scanned(total_outputs_scanned, total_outputs).unwrap_or(COMPLETE_PERCENTAGE);
+    let mut percentage_session_outputs_scanned =
+        percentage_scanned(session_outputs_scanned, session_outputs)
+            .unwrap_or(percentage_total_outputs_scanned);
 
     if sync_state
         .scan_ranges()
         .iter()
         .any(|scan_range| scan_range.priority().awaits_nullifier_retrieval())
     {
-        if percentage_session_blocks_scanned == 100.0 {
-            percentage_session_blocks_scanned = 99.0;
+        if percentage_session_blocks_scanned == COMPLETE_PERCENTAGE {
+            percentage_session_blocks_scanned = NULLIFIER_RETRIEVAL_PERCENTAGE;
         }
-        if percentage_total_blocks_scanned == 100.0 {
-            percentage_total_blocks_scanned = 99.0;
+        if percentage_total_blocks_scanned == COMPLETE_PERCENTAGE {
+            percentage_total_blocks_scanned = NULLIFIER_RETRIEVAL_PERCENTAGE;
         }
-        if percentage_session_outputs_scanned == 100.0 {
-            percentage_session_outputs_scanned = 99.0;
+        if percentage_session_outputs_scanned == COMPLETE_PERCENTAGE {
+            percentage_session_outputs_scanned = NULLIFIER_RETRIEVAL_PERCENTAGE;
         }
-        if percentage_total_outputs_scanned == 100.0 {
-            percentage_total_outputs_scanned = 99.0;
+        if percentage_total_outputs_scanned == COMPLETE_PERCENTAGE {
+            percentage_total_outputs_scanned = NULLIFIER_RETRIEVAL_PERCENTAGE;
         }
     }
 
@@ -2822,6 +2840,224 @@ mod test {
                 "percentage {} disagrees with the exact ratio {}",
                 status.percentage_total_outputs_scanned,
                 expected_percentage,
+            );
+        }
+    }
+
+    /// The session-progress contract of [`crate::sync::sync_status`]
+    /// under a stale initial sync state, where the recorded
+    /// previously-scanned counts stand at or above the whole span the
+    /// wallet can scan. The session denominator then saturates to
+    /// zero, no session ratio exists, and the status must fall back to
+    /// the wallet's total progress rather than claim completion.
+    mod sync_status_stale_initial_state {
+        use std::collections::BTreeMap;
+
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::consensus::BlockHeight;
+
+        use crate::mocks::MockWalletBuilder;
+        use crate::sync::{ScanPriority, ScanRange, sync_status};
+        use crate::wallet::{SyncState, TreeBounds, WalletBlock};
+
+        /// The scale a ratio is reported on.
+        const PERCENTAGE_SCALE: f32 = 100.0;
+        /// The percentage a finished sync reports.
+        const COMPLETE_PERCENTAGE: f32 = PERCENTAGE_SCALE;
+
+        /// The wallet birthday, and so the first height of the span.
+        const BIRTHDAY_HEIGHT: u32 = 1_000;
+        /// The number of blocks between the birthday and the chain tip.
+        const TOTAL_BLOCKS: u32 = 10;
+        /// The number of those blocks this wallet has scanned.
+        const SCANNED_BLOCKS: u32 = 5;
+        /// The height of the chain tip the wallet last knew.
+        const CHAIN_TIP_HEIGHT: u32 = BIRTHDAY_HEIGHT + TOTAL_BLOCKS - 1;
+        /// The first height beyond the scanned range.
+        const SCANNED_RANGE_END: u32 = BIRTHDAY_HEIGHT + SCANNED_BLOCKS;
+        /// The factor by which a stale count exceeds the true span.
+        const STALENESS_FACTOR: u32 = 500;
+        /// A previously-scanned count left over from a wider span.
+        const STALE_PREVIOUSLY_SCANNED_BLOCKS: u32 = TOTAL_BLOCKS * STALENESS_FACTOR;
+
+        /// The sapling tree size at the start of the wallet's span.
+        const SAPLING_INITIAL_TREE_SIZE: u32 = 100;
+        /// The sapling outputs the whole span holds.
+        const SAPLING_TOTAL_OUTPUTS: u32 = 10;
+        /// The sapling outputs the wallet has scanned.
+        const SAPLING_SCANNED_OUTPUTS: u32 = 3;
+        /// The orchard tree size at the start of the wallet's span.
+        const ORCHARD_INITIAL_TREE_SIZE: u32 = 200;
+        /// The orchard outputs the whole span holds.
+        const ORCHARD_TOTAL_OUTPUTS: u32 = 20;
+        /// The orchard outputs the wallet has scanned.
+        const ORCHARD_SCANNED_OUTPUTS: u32 = 5;
+        /// The ironwood tree size at the start of the wallet's span.
+        const IRONWOOD_INITIAL_TREE_SIZE: u32 = 300;
+        /// The ironwood outputs the whole span holds.
+        const IRONWOOD_TOTAL_OUTPUTS: u32 = 40;
+        /// The ironwood outputs the wallet has scanned.
+        const IRONWOOD_SCANNED_OUTPUTS: u32 = 7;
+        /// The outputs the whole span holds, across every pool.
+        const TOTAL_OUTPUTS: u32 =
+            SAPLING_TOTAL_OUTPUTS + ORCHARD_TOTAL_OUTPUTS + IRONWOOD_TOTAL_OUTPUTS;
+        /// The outputs the wallet has scanned, across every pool.
+        const SCANNED_OUTPUTS: u32 =
+            SAPLING_SCANNED_OUTPUTS + ORCHARD_SCANNED_OUTPUTS + IRONWOOD_SCANNED_OUTPUTS;
+        /// A previously-scanned output count left over from a wider span.
+        const STALE_PREVIOUSLY_SCANNED_OUTPUTS: u32 = TOTAL_OUTPUTS * STALENESS_FACTOR;
+
+        /// A wallet block carrying only what tree-bounds accounting
+        /// reads: its height and tree sizes.
+        fn block(height: u32, tree_bounds: TreeBounds) -> WalletBlock {
+            WalletBlock {
+                block_height: BlockHeight::from_u32(height),
+                block_hash: BlockHash([0; 32]),
+                prev_hash: BlockHash([0; 32]),
+                time: 0,
+                txids: Vec::new(),
+                tree_bounds,
+            }
+        }
+
+        /// Tree bounds whose initial and final sizes coincide, for
+        /// blocks that only mark a boundary of a scanned range.
+        fn flat_bounds(sapling: u32, orchard: u32, ironwood: u32) -> TreeBounds {
+            TreeBounds {
+                sapling_initial_tree_size: sapling,
+                sapling_final_tree_size: sapling,
+                orchard_initial_tree_size: orchard,
+                orchard_final_tree_size: orchard,
+                ironwood_initial_tree_size: ironwood,
+                ironwood_final_tree_size: ironwood,
+            }
+        }
+
+        /// A wallet holding a half-scanned span whose initial sync
+        /// state records previously-scanned counts far above that
+        /// span, the shape a truncated or rewound wallet leaves
+        /// behind.
+        fn stale_state_wallet() -> crate::mocks::MockWallet {
+            let mut sync_state = SyncState::new_for_test(vec![
+                ScanRange::from_parts(
+                    BlockHeight::from_u32(BIRTHDAY_HEIGHT)
+                        ..BlockHeight::from_u32(SCANNED_RANGE_END),
+                    ScanPriority::Scanned,
+                ),
+                ScanRange::from_parts(
+                    BlockHeight::from_u32(SCANNED_RANGE_END)
+                        ..BlockHeight::from_u32(CHAIN_TIP_HEIGHT + 1),
+                    ScanPriority::Historic,
+                ),
+            ]);
+            sync_state.initial_sync_state.sync_start_height =
+                BlockHeight::from_u32(BIRTHDAY_HEIGHT);
+            sync_state.initial_sync_state.wallet_tree_bounds = TreeBounds {
+                sapling_initial_tree_size: SAPLING_INITIAL_TREE_SIZE,
+                sapling_final_tree_size: SAPLING_INITIAL_TREE_SIZE + SAPLING_TOTAL_OUTPUTS,
+                orchard_initial_tree_size: ORCHARD_INITIAL_TREE_SIZE,
+                orchard_final_tree_size: ORCHARD_INITIAL_TREE_SIZE + ORCHARD_TOTAL_OUTPUTS,
+                ironwood_initial_tree_size: IRONWOOD_INITIAL_TREE_SIZE,
+                ironwood_final_tree_size: IRONWOOD_INITIAL_TREE_SIZE + IRONWOOD_TOTAL_OUTPUTS,
+            };
+            sync_state.initial_sync_state.previously_scanned_blocks =
+                STALE_PREVIOUSLY_SCANNED_BLOCKS;
+            sync_state
+                .initial_sync_state
+                .previously_scanned_sapling_outputs = STALE_PREVIOUSLY_SCANNED_OUTPUTS;
+            sync_state
+                .initial_sync_state
+                .previously_scanned_orchard_outputs = STALE_PREVIOUSLY_SCANNED_OUTPUTS;
+            sync_state
+                .initial_sync_state
+                .previously_scanned_ironwood_outputs = STALE_PREVIOUSLY_SCANNED_OUTPUTS;
+
+            let wallet_blocks = BTreeMap::from([
+                (
+                    BlockHeight::from_u32(BIRTHDAY_HEIGHT),
+                    block(
+                        BIRTHDAY_HEIGHT,
+                        flat_bounds(
+                            SAPLING_INITIAL_TREE_SIZE,
+                            ORCHARD_INITIAL_TREE_SIZE,
+                            IRONWOOD_INITIAL_TREE_SIZE,
+                        ),
+                    ),
+                ),
+                (
+                    BlockHeight::from_u32(SCANNED_RANGE_END - 1),
+                    block(
+                        SCANNED_RANGE_END - 1,
+                        flat_bounds(
+                            SAPLING_INITIAL_TREE_SIZE + SAPLING_SCANNED_OUTPUTS,
+                            ORCHARD_INITIAL_TREE_SIZE + ORCHARD_SCANNED_OUTPUTS,
+                            IRONWOOD_INITIAL_TREE_SIZE + IRONWOOD_SCANNED_OUTPUTS,
+                        ),
+                    ),
+                ),
+            ]);
+
+            MockWalletBuilder::new()
+                .sync_state(sync_state)
+                .wallet_blocks(wallet_blocks)
+                .create_mock_wallet()
+        }
+
+        /// HYPOTHESIS: a session whose scannable span saturates to zero
+        /// never reports a finished sync, so the falsifier is a status
+        /// whose session block percentage reads complete while half the
+        /// span is unscanned.
+        #[tokio::test]
+        async fn stale_block_state_reports_total_progress_not_completion() {
+            let wallet = stale_state_wallet();
+
+            let status = sync_status(&wallet).await.unwrap();
+
+            let expected_total = (SCANNED_BLOCKS as f32 / TOTAL_BLOCKS as f32) * PERCENTAGE_SCALE;
+            assert!(
+                (status.percentage_total_blocks_scanned - expected_total).abs() < f32::EPSILON,
+                "total block percentage {} disagrees with the scanned ratio {}",
+                status.percentage_total_blocks_scanned,
+                expected_total,
+            );
+            assert_ne!(
+                status.percentage_session_blocks_scanned, COMPLETE_PERCENTAGE,
+                "a session that scanned nothing reported a finished sync",
+            );
+            assert!(
+                (status.percentage_session_blocks_scanned - expected_total).abs() < f32::EPSILON,
+                "session block percentage {} disagrees with the total progress {}",
+                status.percentage_session_blocks_scanned,
+                expected_total,
+            );
+        }
+
+        /// HYPOTHESIS: the output percentages obey the same rule as the
+        /// block percentages, so the falsifier is a status whose
+        /// session output percentage reads complete while most of the
+        /// span's outputs are unscanned.
+        #[tokio::test]
+        async fn stale_output_state_reports_total_progress_not_completion() {
+            let wallet = stale_state_wallet();
+
+            let status = sync_status(&wallet).await.unwrap();
+
+            let expected_total = (SCANNED_OUTPUTS as f32 / TOTAL_OUTPUTS as f32) * PERCENTAGE_SCALE;
+            assert!(
+                (status.percentage_total_outputs_scanned - expected_total).abs() < f32::EPSILON,
+                "total output percentage {} disagrees with the scanned ratio {}",
+                status.percentage_total_outputs_scanned,
+                expected_total,
+            );
+            assert_ne!(
+                status.percentage_session_outputs_scanned, COMPLETE_PERCENTAGE,
+                "a session that scanned no outputs reported a finished sync",
+            );
+            assert!(
+                (status.percentage_session_outputs_scanned - expected_total).abs() < f32::EPSILON,
+                "session output percentage {} disagrees with the total progress {}",
+                status.percentage_session_outputs_scanned,
+                expected_total,
             );
         }
     }

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -2845,11 +2845,11 @@ mod test {
     }
 
     /// The session-progress contract of [`crate::sync::sync_status`]
-    /// under a stale initial sync state, where the recorded
+    /// under a stale initial sync state, whose recorded
     /// previously-scanned counts stand at or above the whole span the
-    /// wallet can scan. The session denominator then saturates to
-    /// zero, no session ratio exists, and the status must fall back to
-    /// the wallet's total progress rather than claim completion.
+    /// wallet can scan, saturating the session denominator to zero and
+    /// obliging the status to report the wallet's total progress
+    /// rather than claim completion.
     mod sync_status_stale_initial_state {
         use std::collections::BTreeMap;
 


### PR DESCRIPTION
## The problem

`pepper-sync::sync::sync_status` reports two block percentages and two output
percentages. The session percentages divide the session's scanned count by the
blocks or outputs the session can still scan. That denominator subtracts the
previously scanned counts held in the initial sync state.

A stale initial sync state holds previously scanned counts at or above the
wallet's whole span. A truncated or rewound wallet leaves that shape behind.
Before #2674 the subtraction underflowed. #2674 saturated it, so the
denominator became zero.

The session ratio was then zero divided by zero, which is `NaN`. A pre-existing
guard coerced `NaN` to one hundred percent. A session that scanned nothing
therefore reported a finished sync. The command line interface and the mobile
progress bar both read that figure.

## The fix

The division now lives in one helper. The helper reports `None` for a zero
denominator, because no ratio exists there. Each caller states its own fallback.

The session percentages fall back to the total percentage. That figure is the
most honest statement available, because its denominator is the wallet's whole
span and does not depend on the stale counters. A half scanned wallet now reads
as half scanned. It no longer reads as complete.

The total percentages fall back to complete, which only happens for a span that
holds no outputs at all. Such a span is fully scanned by definition.

The neighboring arithmetic is saturated likewise. The three pool totals
subtracted one tree size from another without saturation. The block span
subtracted the birthday from the chain tip without saturation. A rewound tree
bound can no longer underflow either one. Every percentage constant is now
named.

## The tests

Two new tests pin the stale state shape. Each builds a wallet whose scan ranges
are half scanned, and whose initial sync state records previously scanned counts
five hundred times the true span.

The first test asserts the session block percentage. The second asserts the
session output percentage. Both fail on `dev` with a reported one hundred
percent. Both now report the wallet's true total progress.

The whole `pepper-sync` unit suite passes. The crate gains no dependency.

This pull request fixes finding 7 of issue #2688, which is Lane B. It follows
#2674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
