### PR TITLE
refactor!: the proxy hands out the socket address it listens on

### DIFF
--- a/zingo-netutils/CHANGELOG.md
+++ b/zingo-netutils/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- BREAKING: `NymProxy::socks5_addr` returns a `std::net::SocketAddr`
+  instead of a `String`. The proxy announces the loopback address it
+  bound, so a caller dials the typed address it is handed and never
+  parses one out of text.
+
 - BREAKING: `send_transaction_via_socks5`, `get_lightd_info_via_socks5`,
   and `transaction_known_via_socks5` take the SOCKS5 proxy address as a
   `std::net::SocketAddr` instead of a `&str`. The one dial-string

--- a/zingo-netutils/src/bin/live-indexer-discovery.rs
+++ b/zingo-netutils/src/bin/live-indexer-discovery.rs
@@ -95,13 +95,7 @@ async fn main() -> ExitCode {
             .uri
             .parse()
             .expect("the census tests pin every entry parseable");
-        let Ok(socks5_addr) = found.transport.socks5_addr().parse() else {
-            println!(
-                "  LOST {} (the proxy announced a non-socket address)",
-                found.indexer.uri
-            );
-            continue;
-        };
+        let socks5_addr = found.transport.socks5_addr();
         match get_lightd_info_via_socks5(socks5_addr, &uri, MIXNET_ROUND_TRIP_BOUND).await {
             Ok(info) => println!(
                 "  OK {} height={} (same transport, same exit)",

--- a/zingo-netutils/src/live_indexer_discovery.rs
+++ b/zingo-netutils/src/live_indexer_discovery.rs
@@ -216,16 +216,7 @@ async fn probe_once_listening(
     transport: &NymProxy,
     uri: &http::Uri,
 ) -> Result<LightdInfo, Socks5TransmitError> {
-    let announced = transport.socks5_addr();
-    let socks5_addr = announced.parse().map_err(|_| {
-        // The proxy's own announcement is in-process and practically always
-        // a socket address; a defect refuses typed rather than dialing text.
-        Socks5TransmitError::TunnelTransport {
-            destination: uri.to_string(),
-            detail: format!("the proxy announced a non-socket address: {announced}"),
-            source: None,
-        }
-    })?;
+    let socks5_addr = transport.socks5_addr();
     let deadline = Instant::now() + MIXNET_ROUND_TRIP_BOUND;
     loop {
         match get_lightd_info_via_socks5(socks5_addr, uri, MIXNET_ROUND_TRIP_BOUND).await {

--- a/zingo-netutils/src/mixnet_connect.rs
+++ b/zingo-netutils/src/mixnet_connect.rs
@@ -10,14 +10,6 @@
 //! [`crate::arm_race`].
 #![forbid(unsafe_code)]
 
-/// Strip the `socks5h://` scheme from a SOCKS5 URL, passing a bare
-/// `host:port` through unchanged. The pure core of
-/// [`NymProxy::socks5_addr`](crate::NymProxy::socks5_addr).
-#[cfg_attr(not(feature = "nym"), allow(dead_code))]
-pub(crate) fn strip_socks5_scheme(url: &str) -> &str {
-    url.strip_prefix("socks5h://").unwrap_or(url)
-}
-
 /// Fisher-Yates shuffle driven by a caller-supplied seed, so the permutation
 /// is a pure function of `(items, seed)`. The pure core of Exit Node
 /// shuffling: the caller supplies entropy (production hashes the clock,
@@ -39,19 +31,6 @@ pub(crate) fn seeded_shuffle<T>(items: &mut [T], mut seed: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn strips_the_socks5h_scheme() {
-        assert_eq!(
-            strip_socks5_scheme("socks5h://127.0.0.1:1080"),
-            "127.0.0.1:1080"
-        );
-    }
-
-    #[test]
-    fn passes_a_bare_address_through() {
-        assert_eq!(strip_socks5_scheme("127.0.0.1:1080"), "127.0.0.1:1080");
-    }
 
     #[test]
     fn a_seed_fixes_the_permutation() {

--- a/zingo-netutils/src/nym_proxy.rs
+++ b/zingo-netutils/src/nym_proxy.rs
@@ -45,7 +45,7 @@ use zingo_net_diag::{NetOpFailure, NetOpStage};
 
 use crate::arm_race::{LaunchPolicy, RaceAction, RaceEvent, RaceProgress, RaceState};
 use crate::error::NymProxyError;
-use crate::mixnet_connect::{seeded_shuffle, strip_socks5_scheme};
+use crate::mixnet_connect::seeded_shuffle;
 use crate::responsiveness::{Responsiveness, ResponsivenessClass};
 
 /// Default Nym API URL for mainnet.
@@ -67,7 +67,9 @@ use crate::time::{DISCOVERY_TIMEOUT, NYM_LIFECYCLE_TIMEOUT, PER_ATTEMPT_CONNECT_
 /// public exit gateway. The proxy listens on a localhost port.
 pub struct NymProxy {
     client: Socks5MixnetClient,
-    bind_port: u16,
+    /// The loopback address this proxy told the mixnet client to bind, which
+    /// is the address it announces to every caller.
+    socks5_addr: SocketAddr,
     exit_node: String,
     /// The clutch this acquisition raced, reused by a later redraw.
     clutch: Vec<String>,
@@ -193,9 +195,10 @@ impl NymProxy {
         bind_port: u16,
     ) -> Result<Self, NymProxyError> {
         let socks5_cfg = Socks5::new(exit_node_address);
+        let socks5_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), bind_port);
         let client = MixnetClientBuilder::new_ephemeral()
             .socks5_config(Socks5 {
-                bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), bind_port),
+                bind_address: socks5_addr,
                 ..socks5_cfg
             })
             .build()
@@ -205,7 +208,7 @@ impl NymProxy {
             .map_err(|e| NymProxyError::Connect(Box::new(e)))?;
         Ok(Self {
             client,
-            bind_port,
+            socks5_addr,
             exit_node: exit_node_address.to_string(),
             clutch: Vec::new(),
             // A pinned-Exit-Node start never races; the class only governs
@@ -220,14 +223,15 @@ impl NymProxy {
         &self.exit_node
     }
 
-    /// The local SOCKS5 proxy address (e.g., `"127.0.0.1:43210"`).
-    pub fn socks5_addr(&self) -> String {
-        strip_socks5_scheme(&self.client.socks5_url()).to_string()
+    /// The local SOCKS5 proxy address, the loopback socket address this proxy
+    /// listens on.
+    pub fn socks5_addr(&self) -> SocketAddr {
+        self.socks5_addr
     }
 
     /// The local bind port the SOCKS5 proxy listens on.
     pub fn bind_port(&self) -> u16 {
-        self.bind_port
+        self.socks5_addr.port()
     }
 
     /// Verify that a TCP connection can be established through this proxy to
@@ -241,10 +245,10 @@ impl NymProxy {
         target_host: &str,
         target_port: u16,
     ) -> Result<(), NymProxyError> {
-        let addr = self.socks5_addr();
-        let _stream = tokio_socks::tcp::Socks5Stream::connect(&*addr, (target_host, target_port))
-            .await
-            .map_err(|e| NymProxyError::ConnectivityCheck(e.to_string()))?;
+        let _stream =
+            tokio_socks::tcp::Socks5Stream::connect(self.socks5_addr(), (target_host, target_port))
+                .await
+                .map_err(|e| NymProxyError::ConnectivityCheck(e.to_string()))?;
         Ok(())
     }
 
@@ -286,7 +290,7 @@ impl NymProxy {
         // Swap only after the new client succeeded, so a failed reconnect
         // leaves the old client untouched.
         let old_client = std::mem::replace(&mut self.client, new_proxy.client);
-        self.bind_port = new_proxy.bind_port;
+        self.socks5_addr = new_proxy.socks5_addr;
         self.exit_node = new_proxy.exit_node;
         self.clutch = clutch;
         old_client.disconnect().await;
@@ -601,15 +605,25 @@ mod tests {
     use crate::responsiveness::{PrioritiseSpeed, RESERVATION_CLUTCH_SIZE};
     use crate::time::HEDGE_INTERVAL;
 
-    // The scheme-stripping and retry-engine logic is tested in
-    // `mixnet_connect`, where the tests call the REAL functions in the
-    // default build; the earlier copies of that logic here tested a
-    // transcription of the expression, not the code.
+    // The shuffling and retry-engine logic is tested in `mixnet_connect`,
+    // where the tests call the REAL functions in the default build; the
+    // earlier copies of that logic here tested a transcription of the
+    // expression, not the code.
 
     #[test]
     fn find_available_port_returns_nonzero() {
         let port = NymProxy::find_available_port().expect("find_available_port");
         assert!(port > 0);
+    }
+
+    /// HYPOTHESIS: the proxy announces the socket address it listens on, so
+    /// no caller ever parses an address out of text; falsified if
+    /// [`NymProxy::socks5_addr`] returns anything other than a
+    /// [`SocketAddr`].
+    #[test]
+    fn the_proxy_announces_a_typed_socket_address() {
+        let announce: fn(&NymProxy) -> SocketAddr = NymProxy::socks5_addr;
+        let _ = announce;
     }
 
     /// The arm count the paused-time races below run over; the clutch is
@@ -902,17 +916,13 @@ mod tests {
             .await
             .expect("NymProxy::start");
         let addr = proxy.socks5_addr();
-        assert!(
-            addr.starts_with("127.0.0.1:"),
-            "expected localhost address, got {addr}"
+        assert_eq!(
+            addr.ip(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            "expected a loopback address, got {addr}"
         );
-        let port: u16 = addr
-            .split(':')
-            .next_back()
-            .unwrap()
-            .parse()
-            .expect("port should be numeric");
-        assert!(port > 0, "port should be non-zero");
+        assert!(addr.port() > 0, "port should be non-zero");
+        assert_eq!(addr.port(), proxy.bind_port(), "one bound port, one report");
         proxy.disconnect().await;
     }
 
@@ -923,9 +933,7 @@ mod tests {
         let proxy = NymProxy::start::<PrioritiseSpeed>()
             .await
             .expect("NymProxy::start");
-        let addr = proxy.socks5_addr();
-
-        let stream = tokio_socks::tcp::Socks5Stream::connect(&*addr, "zec.rocks:443")
+        let stream = tokio_socks::tcp::Socks5Stream::connect(proxy.socks5_addr(), "zec.rocks:443")
             .await
             .expect("SOCKS5 connect");
 


### PR DESCRIPTION
## The problem

`NymProxy::socks5_addr` returned a `String`. The proxy rendered that
string from the nym-sdk client's `socks5_url`. Every caller then parsed
the string back into a `std::net::SocketAddr`.

That parse can never fail. The SDK formats the URL from the bind address
the proxy gave it. Each caller still had to write a refusal for the
impossible case. `probe_once_listening` charged its refusal to the
indexer as a tunnel transport failure. The discovery binary printed a
second refusal with different words.

## The fix

The proxy stores the loopback `SocketAddr` it hands the mixnet client.
`socks5_addr` returns that address. The `bind_port` accessor reads the
port off the address, so the duplicate port field is gone.

Both downstream parse arms are deleted. The `strip_socks5_scheme` helper
is deleted too. It existed only as the pure core of the old string
announcement.

This is a breaking change to a public accessor. The CHANGELOG of
`zingo-netutils` records it.

## The tests

The new test `the_proxy_announces_a_typed_socket_address` pins the
accessor's return type through a function pointer. It failed to compile
before the fix with `error[E0308]: mismatched types`. It passes now.

The live proxy test asserts on the address instead of on its text. It
checks the IPv4 loopback host and agreement between the address port and
`bind_port`.

Gates run: `cargo check --all-features --all-targets`, `cargo clippy
--all-features --all-targets`, `cargo fmt --check`, and `cargo nextest
run --features nym --lib` inside `zingo-netutils/`, which reports 57
tests passed. From the parent workspace: `cargo check -p zingolib
--features nym` and `cargo check -p zingo-cli --features nym,nym-diary`.

## References

This is Lane D of issue #2688, finding 11. It closes the address seam of
issue #2675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
