### PR TITLE
fix: the diary tolerates a bad exit column and the sweep probes for real

### DIFF
--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: `lightclient::LightClient::switch_on_mixnet_for_tests` takes a
+  `std::net::SocketAddr` instead of a `&str`. The helper used to parse the
+  text and abort the process on a placeholder, which killed an external
+  harness. The contract is now checked at compile time. A caller passes a
+  parsed address, so `"127.0.0.1:1"` becomes `"127.0.0.1:1".parse().unwrap()`
+  or an address constant of its own.
 - The indexer diary tolerates a corrupt exit column per column. A stored row
   whose exit column no longer names an Exit Node now loads with every other
   field intact and no exit, where it was previously dropped whole.

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- The indexer diary tolerates a corrupt exit column per column. A stored row
+  whose exit column no longer names an Exit Node now loads with every other
+  field intact and no exit, where it was previously dropped whole.
 - BREAKING: `mixnet::acquire::TransportError` gains the `ExitOutsideClutch`
   variant. A transport that reports ready without announcing an exit from
   the drawn Clutch now refuses with this variant instead of panicking, and

--- a/zingolib/src/lightclient/indexer_history.rs
+++ b/zingolib/src/lightclient/indexer_history.rs
@@ -222,7 +222,9 @@ impl IndexerAttempt {
     fn parse(line: &str) -> Option<Self> {
         let fields: Vec<&str> = line.split('\t').collect();
         // A six-field line predates the phase and exit columns; it loads
-        // with neither rather than being skipped.
+        // with neither rather than being skipped. Tolerance is per column,
+        // so an exit column that no longer names an Exit Node costs the
+        // exit alone and the rest of the row still loads.
         let (phase, exit, outcome_token) = match fields.len() {
             6 => (None, None, fields[5]),
             8 => (
@@ -230,7 +232,7 @@ impl IndexerAttempt {
                     .then(|| crate::correspondent::health::FailurePhase::parse(fields[5])),
                 match fields[6] {
                     "-" => None,
-                    token => Some(crate::mixnet::ExitNodeId::parse(token).ok()?),
+                    token => crate::mixnet::ExitNodeId::parse(token).ok(),
                 },
                 fields[7],
             ),
@@ -553,6 +555,34 @@ mod tests {
         assert_eq!(
             loaded[0].host,
             crate::correspondent::Host::of_host_str("tab here and newline")
+        );
+    }
+
+    /// An exit column that no longer names an Exit Node, because a hostile
+    /// identity flattened to blanks or a torn write emptied the field.
+    const BLANK_EXIT_COLUMN: &str = " ";
+
+    /// HYPOTHESIS: the loader's tolerance is per column, so a row whose exit
+    /// column no longer parses loads with every other field intact.
+    /// Falsified if the unparseable exit column discards the whole row.
+    #[test]
+    fn a_corrupt_exit_column_costs_only_the_exit() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let handle = recording_handle(dir.path());
+        let mut recorded = an_attempt("zec.rocks", Err(FailureKind::Timeout));
+        let exit = recorded.exit.as_ref().expect("the fixture rode an exit");
+        let corrupt = recorded
+            .to_line()
+            .replace(exit.as_str(), BLANK_EXIT_COLUMN)
+            .into_bytes();
+        std::fs::write(dir.path().join("indexer-history.tsv"), corrupt)
+            .expect("write a row whose exit column is corrupt");
+
+        recorded.exit = None;
+        assert_eq!(
+            handle.load(),
+            vec![recorded],
+            "every column but the exit survives a corrupt exit"
         );
     }
 

--- a/zingolib/src/lightclient/mixnet.rs
+++ b/zingolib/src/lightclient/mixnet.rs
@@ -241,13 +241,9 @@ impl LightClient {
     /// Ready session does and the transmit path submits over the mock
     /// indexer's channel without ever dialing the address.
     #[cfg(any(test, feature = "testutils"))]
-    pub async fn switch_on_mixnet_for_tests(&mut self, socks5_addr: &str) {
+    pub async fn switch_on_mixnet_for_tests(&mut self, socks5_addr: std::net::SocketAddr) {
         self.vacate_mixnet_slot().await;
-        self.mixnet_slot = crate::mixnet::MixnetSlot::AttachedForTests {
-            socks5_addr: socks5_addr
-                .parse()
-                .expect("the test stand-in socks5 address parses"),
-        };
+        self.mixnet_slot = crate::mixnet::MixnetSlot::AttachedForTests { socks5_addr };
         // Every slot transition publishes (the one-shared-watch invariant),
         // the stand-in included.
         self.publish_mixnet_slot_state();
@@ -652,6 +648,24 @@ mod tests {
             assert!(
                 !subscriber.has_changed().expect("the publisher is alive"),
                 "no stale transport publication may follow the deliberate disable"
+            );
+        }
+
+        /// HYPOTHESIS: the test-only mixnet switch takes an already parsed
+        /// socket address, so the contract is checked by the compiler and no
+        /// external harness can abort inside it on a placeholder string.
+        /// Falsified if the helper still takes text and parses within.
+        #[tokio::test]
+        async fn the_test_switch_takes_a_typed_socket_address() {
+            let mut client = LightClient::new_for_test(wallet()).await;
+            let socks5_addr = crate::mocks::transmission::MOCK_SOCKS5_ADDR;
+
+            client.switch_on_mixnet_for_tests(socks5_addr).await;
+
+            assert_eq!(
+                client.mixnet_socks5_addr(),
+                Some(socks5_addr),
+                "the slot reports the very address the caller handed it"
             );
         }
 

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -214,43 +214,20 @@ async fn survey(
     .await
 }
 
-/// One candidate's survey: `GetLightdInfo` over the sweep exit, its success
-/// mapped to the reported chain and height, any failure to `None`.
+/// One candidate's survey: the shared mixnet probe over the sweep exit,
+/// which times and records the attempt, its success mapped to the reported
+/// chain and height and any failure to `None`.
 async fn probe_one(
     socks5_addr: std::net::SocketAddr,
     uri: &Uri,
     timeout: Duration,
     history: &crate::lightclient::indexer_history::IndexerHistoryHandle,
 ) -> Option<ProbeSuccess> {
-    use crate::lightclient::indexer_history::{
-        AttemptKind, AttemptRoute, FailureKind, IndexerAttempt, now_unix_secs,
-    };
-    let host = crate::correspondent::Host::of_uri(uri);
-    let result = zingo_netutils::get_lightd_info_via_socks5(socks5_addr, uri, timeout).await;
-    let (reported, outcome) = match &result {
-        Ok(info) => (
-            Some(ProbeSuccess {
-                chain: info.chain_name.clone(),
-                height: info.block_height,
-            }),
-            Ok(()),
-        ),
-        Err(error) => (None, Err(FailureKind::classify(&error.to_string()))),
-    };
-    history.record(&IndexerAttempt {
-        unix_secs: now_unix_secs(),
-        host,
-        route: AttemptRoute::Mixnet,
-        kind: AttemptKind::Probe,
-        millis: 0,
-        phase: result
-            .as_ref()
-            .err()
-            .map(|error| crate::mixnet::charge_phase(&crate::mixnet::socks5_transmit_stage(error))),
-        exit: None,
-        outcome,
-    });
-    reported
+    crate::mixnet::probe::probe_indexer(uri, socks5_addr, timeout, history)
+        .await
+        .leg
+        .outcome
+        .ok()
 }
 
 #[cfg(test)]
@@ -285,6 +262,75 @@ mod tests {
             crate::config::ChainType::Mainnet.to_string(),
             "the Display form is not the wire form"
         );
+    }
+
+    /// The port value that asks the operating system to assign a free one.
+    const ANY_PORT: u16 = 0;
+
+    /// The fraction of its bound a probe against a proxy that never answers
+    /// must be seen to spend, loose enough that a coarse clock cannot make a
+    /// measured wait look unmeasured.
+    const MEASURED_WAIT_DIVISOR: u32 = 2;
+
+    /// The candidate the survey asks about, which the silent proxy never
+    /// reaches.
+    const UNANSWERED_CANDIDATE: &str = "https://sweep-candidate.example";
+
+    /// HYPOTHESIS: the sweep's per-candidate probe rides the shared probe
+    /// machinery, so the attempt it writes to the indexer diary carries the
+    /// latency it measured. Falsified if a sweep attempt lands with an
+    /// unmeasured duration while a liveness probe records a real one.
+    #[tokio::test]
+    async fn a_surveyed_candidate_records_the_latency_it_measured() {
+        use zingo_netutils::time::test::FAST_STAGE_BOUND;
+
+        // A stand-in proxy that accepts the dial and never speaks SOCKS5,
+        // so the probe spends its whole bound waiting for an answer.
+        let proxy = tokio::net::TcpListener::bind(std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            ANY_PORT,
+        ))
+        .await
+        .expect("a loopback listener binds");
+        let socks5_addr = proxy
+            .local_addr()
+            .expect("the listener reports its address");
+        let silence = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((socket, _)) = proxy.accept().await {
+                held.push(socket);
+            }
+        });
+        let dir = tempfile::tempdir().expect("temp dir");
+        let history = crate::lightclient::indexer_history::IndexerHistoryHandle::beside_wallet(
+            &dir.path().join("zingo-wallet.dat"),
+        );
+        history.set_recording(true);
+
+        let reported = probe_one(
+            socks5_addr,
+            &UNANSWERED_CANDIDATE.parse().expect("the static uri parses"),
+            FAST_STAGE_BOUND,
+            &history,
+        )
+        .await;
+
+        assert!(
+            reported.is_none(),
+            "a proxy that never answers reports no candidate"
+        );
+        let attempt = history
+            .load()
+            .pop()
+            .expect("the survey records its attempt");
+        let floor = FAST_STAGE_BOUND / MEASURED_WAIT_DIVISOR;
+        assert!(
+            u128::from(attempt.millis) >= floor.as_millis(),
+            "the recorded latency must be the measured wait, got {}ms against a {}ms floor",
+            attempt.millis,
+            floor.as_millis()
+        );
+        silence.abort();
     }
 
     /// The status a died sweep proxy publishes, carrying `detail` as its

--- a/zingolib/src/mocks.rs
+++ b/zingolib/src/mocks.rs
@@ -690,9 +690,16 @@ pub(crate) mod transmission {
         PartTransmissionError, TransmissionClient, TransmissionReceipt, TransmissionRoute,
     };
 
+    /// The port of the mock's stand-in tunnel endpoint, reserved by no
+    /// service the tests run.
+    pub const MOCK_SOCKS5_PORT: u16 = 1;
+
     /// The mock's stand-in mixnet tunnel endpoint, the address a chain-mock
-    /// session reports as its SOCKS5 route. Never dialed.
-    pub const MOCK_SOCKS5_ADDR: &str = "127.0.0.1:1";
+    /// session reports as its SOCKS5 route and never dials.
+    pub const MOCK_SOCKS5_ADDR: std::net::SocketAddr = std::net::SocketAddr::new(
+        std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+        MOCK_SOCKS5_PORT,
+    );
 
     /// The mock's stand-in Correspondent host.
     pub const MOCK_CORRESPONDENT: &str = "mock.correspondent.indexer";

--- a/zingolib/src/testutils/mock_indexer.rs
+++ b/zingolib/src/testutils/mock_indexer.rs
@@ -913,7 +913,9 @@ impl MockNet {
         // clearnet, so the same tests cover both routes across the
         // feature matrix.
         #[cfg(feature = "nym")]
-        lightclient.switch_on_mixnet_for_tests("127.0.0.1:1").await;
+        lightclient
+            .switch_on_mixnet_for_tests(crate::mocks::transmission::MOCK_SOCKS5_ADDR)
+            .await;
         lightclient
     }
 }


### PR DESCRIPTION
This branch closes Lane C of issue #2688. It fixes findings 6, 7, and 10 of
issue #2672. Each finding has its own commit, red test first.

## The diary tolerates a bad exit column

The indexer diary promises that a corrupt file never poisons a load. The
loader skipped what it could not read and kept the rest. The exit column
broke that promise. An unparseable exit identity discarded the whole row.
The row's timestamp, host, route, latency, and outcome went with it. The
writer flattens tabs into spaces, so a hostile exit name can produce such a
row without any torn write.

The exit column now falls back to no exit. The phase column already worked
that way. Every other field of the row survives.

## The test-only mixnet switch takes a typed address

`LightClient::switch_on_mixnet_for_tests` took the stand-in SOCKS5 endpoint
as text. It parsed the text inside and aborted on a placeholder. An external
testutils consumer, such as a zingo-mobile or zingo-pc harness, therefore
lost its process far from the mistake.

The parameter is now a `std::net::SocketAddr`. The compiler holds the
contract, and the helper cannot panic. The transmission mock's
`MOCK_SOCKS5_ADDR` is now that typed address, built from the loopback host
and the named `MOCK_SOCKS5_PORT`. The in-tree callers pass the constant. The
zingolib CHANGELOG records the breaking signature under Changed and names
the migration a caller performs.

## One probe pipeline

The Server-Selection Sweep probed each candidate with its own copy of the
probe-and-record pair. The copy wrote a hard-coded zero into the diary's
latency column. A persisted sweep row therefore claimed a duration nobody
measured. A liveness probe on the same route recorded the real figure. The
copy also classified the transport error's own text, where the pipeline
classifies the typed failure record, so one judgment had two rules.

The sweep's per-candidate probe now calls `probe_indexer`, the machinery the
liveness probe already uses. That machinery times the leg and records the
attempt. A sweep row now carries a measured latency, and the classification
rule lives in one place.

## Tests

Three tests were written red and are now green.

1. `lightclient::indexer_history::tests::a_corrupt_exit_column_costs_only_the_exit`
   writes a row whose exit column is blank after flattening. It failed
   before the fix because the load returned no rows at all.
2. `lightclient::mixnet::tests::session_driver_contract::the_test_switch_takes_a_typed_socket_address`
   hands the helper a parsed address and asserts the slot reports it. It
   failed to compile before the fix with `E0308`, which is the falsifier a
   compile-time contract deserves.
3. `lightclient::select::tests::a_surveyed_candidate_records_the_latency_it_measured`
   surveys one candidate through a stand-in proxy that accepts the dial and
   never answers. It asserts the recorded latency clears half the probe
   bound. It failed before the fix with a recorded latency of zero
   milliseconds.

The gates are green: `cargo check -p zingolib --features nym`, `cargo check
-p zingo-cli --features nym,nym-diary`, `cargo clippy` on both crates with
those features and no new warnings, `cargo fmt --check`, and the targeted
`cargo nextest run` over the diary, probe, sweep, and select modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
