### PR TITLE
fix: the readiness gate wakes, bounds, and binds honestly

### DIFF
--- a/zingo-netutils/src/time.rs
+++ b/zingo-netutils/src/time.rs
@@ -68,6 +68,26 @@ pub const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(15);
 /// without yet giving up on it.
 pub const HEDGE_INTERVAL: Duration = Duration::from_secs(5);
 
+/// How long the readiness gate waits for the transport's first Exit Node
+/// announcement once the address has arrived: one Exit Node connect attempt
+/// plus the hedge interval that would have launched another, so a transport
+/// still finishing its exit connect is waited through while one that never
+/// binds an exit is refused long before the lifecycle budget.
+///
+/// ```
+/// use zingo_netutils::time::{
+///     EXIT_ANNOUNCEMENT_GRACE, HEDGE_INTERVAL, NYM_LIFECYCLE_TIMEOUT, PER_ATTEMPT_CONNECT_TIMEOUT,
+/// };
+///
+/// assert_eq!(
+///     EXIT_ANNOUNCEMENT_GRACE,
+///     PER_ATTEMPT_CONNECT_TIMEOUT + HEDGE_INTERVAL,
+/// );
+/// assert!(EXIT_ANNOUNCEMENT_GRACE < NYM_LIFECYCLE_TIMEOUT);
+/// ```
+pub const EXIT_ANNOUNCEMENT_GRACE: Duration =
+    Duration::from_secs(PER_ATTEMPT_CONNECT_TIMEOUT.as_secs() + HEDGE_INTERVAL.as_secs());
+
 /// The silence interval before a send's escalation launches a further
 /// Correspondent arm: the sum of a connect attempt's bound and one mixnet
 /// round trip, so a responsive Correspondent's confirmed delivery beats the

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: `lightclient::LightClient::attach_mixnet` now refuses an empty
+  exit report. `mixnet::MixnetProxyError` gains the `NoExits` variant, which
+  the attach returns when the host names no bound Exit Node, and an
+  exhaustive match over the enum needs the new arm. A host that attaches
+  must name the Exit Node its proxy bound, so Ready means the address and a
+  bound exit at every door.
 - The readiness gate now bounds its wait for the transport's first Exit Node
   announcement with the new `zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE`,
   which runs from the moment the address arrives. A proxy that latches ready

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- The readiness gate now bounds its wait for the transport's first Exit Node
+  announcement with the new `zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE`,
+  which runs from the moment the address arrives. A proxy that latches ready
+  and never announces a usable exit refuses within the grace instead of
+  holding the go-online moment for the whole `NYM_LIFECYCLE_TIMEOUT`. The
+  refusal is the existing `NotReady` variant, carrying the grace as the
+  budget it exceeded.
 - BREAKING: `mixnet::acquire::TransportError` gains the `ExitOutsideClutch`
   variant. A transport that reports ready without announcing an exit from
   the drawn Clutch now refuses with this variant instead of panicking, and

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -58,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_orchard_to_ironwood_migration`.
 
 ### Changed
+- BREAKING: `lightclient::select::ServerSelectionError` gains the
+  `ExitOutsideClutch` variant, which carries the exits the ready transport
+  reported. The bind refusal previously reached callers wrapped in
+  `TransportAcquisition`, whose message names a Clutch that could not be
+  drawn, and an exhaustive match over the enum needs the new arm.
 - BREAKING: `lightclient::LightClient::attach_mixnet` now refuses an empty
   exit report. `mixnet::MixnetProxyError` gains the `NoExits` variant, which
   the attach returns when the host names no bound Exit Node, and an

--- a/zingolib/src/correspondent/pool/exit_pool.rs
+++ b/zingolib/src/correspondent/pool/exit_pool.rs
@@ -92,19 +92,17 @@ pub(crate) fn clutch_nodes(clutch: &HashSet<Reservation>) -> Vec<crate::mixnet::
         .collect()
 }
 
-/// Takes the one reservation a ready transport reports as bound out of
+/// Takes the first reservation a ready transport reports as bound out of
 /// `clutch`, recycling the rest, or `None` when the report names no drawn
 /// node.
 pub(crate) fn take_bound_lease(
     clutch: &mut HashSet<Reservation>,
     reported: &[crate::mixnet::ExitNodeId],
 ) -> Option<Reservation> {
-    let bound = clutch
-        .iter()
-        .find(|reservation| reported.contains(reservation.node()))?
-        .node()
-        .clone();
-    clutch.take(&bound)
+    // The report is walked in announcement order, not the set's arbitrary
+    // one, so a transport that names several drawn exits binds the one it
+    // announced first and the same report always binds the same exit.
+    reported.iter().find_map(|node| clutch.take(node))
 }
 
 /// The session's Exit Pool: one reservation per discovered node, issued to
@@ -201,6 +199,40 @@ mod tests {
         .expect("the reported exit is drawn");
         assert_eq!(lease.node(), &crate::mixnet::ExitNodeId::from("exit-b"));
         assert_eq!(clutch.len(), 2, "the unbound reservations remain");
+    }
+
+    /// HYPOTHESIS: a report naming several drawn exits binds the
+    /// first-announced one, so the bind follows the transport's own order
+    /// rather than the set's arbitrary one. Falsified if any trial binds a
+    /// later announcement.
+    #[test]
+    fn the_bound_lease_follows_the_announcement_order() {
+        /// Independently ordered clutches, enough that an arbitrary pick
+        /// cannot agree with the announcement order by chance.
+        const ORDER_TRIALS: usize = 16;
+
+        let announced = [
+            crate::mixnet::ExitNodeId::from("exit-b"),
+            crate::mixnet::ExitNodeId::from("exit-c"),
+            crate::mixnet::ExitNodeId::from("exit-a"),
+        ];
+        let first = announced.first().expect("the announcement names exits");
+        for trial in 0..ORDER_TRIALS {
+            let mut clutch: HashSet<Reservation> = [
+                Reservation::dangling_for_test("exit-a"),
+                Reservation::dangling_for_test("exit-b"),
+                Reservation::dangling_for_test("exit-c"),
+            ]
+            .into_iter()
+            .collect();
+            let lease =
+                take_bound_lease(&mut clutch, &announced).expect("the report names drawn exits");
+            assert_eq!(
+                lease.node(),
+                first,
+                "trial {trial} bound a later announcement"
+            );
+        }
     }
 
     /// HYPOTHESIS: a report naming no drawn node (foreign or empty) takes

--- a/zingolib/src/lightclient/mixnet.rs
+++ b/zingolib/src/lightclient/mixnet.rs
@@ -626,7 +626,7 @@ mod tests {
                     // the driver lands Died.
                     crate::mixnet::ProvisionStrategy::Attach {
                         socks5_addr: "127.0.0.1:9",
-                        exits: &[],
+                        exits: &[crate::mixnet::ExitNodeId::from("host-bound-exit")],
                     },
                     crate::mixnet::MixnetStartPolicy::ForcedOn,
                 )

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -343,8 +343,9 @@ mod tests {
     }
 
     /// HYPOTHESIS: a transport that reaches Ready but never announces an
-    /// exit exceeds the bootstrap budget as a typed timeout, so an empty
-    /// announcement is a wait, never an ExitOutsideClutch refusal.
+    /// exit refuses as a typed timeout naming the exit-announcement grace,
+    /// so an empty announcement is a bounded wait, never an
+    /// ExitOutsideClutch refusal and never the whole lifecycle budget.
     /// Falsified if the waiter yields the empty announcement to the bind.
     #[tokio::test(start_paused = true)]
     async fn a_ready_that_never_announces_an_exit_times_out() {
@@ -355,8 +356,12 @@ mod tests {
             .await
             .expect_err("no exit ever arrives");
         assert!(
-            matches!(refusal, ServerSelectionError::TransportTimeout { .. }),
-            "an exitless Ready exhausts the budget as a timeout, got: {refusal}"
+            matches!(
+                refusal,
+                ServerSelectionError::TransportTimeout { budget }
+                    if budget == zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE
+            ),
+            "an exitless Ready refuses at the grace, got: {refusal}"
         );
     }
 

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -152,13 +152,16 @@ impl LightClient {
             SWEEP_HEIGHT_TOLERANCE,
             pin,
             &mut rand::rngs::OsRng,
-        )?;
+        );
 
         // Exit Recycling: retiring the member kills the child and recycles
         // its lease, so no later traffic rides the exit that observed the
-        // survey.
+        // survey. The judgment's verdict is held rather than propagated with
+        // the question mark, because a refusal that returned early would drop
+        // the member instead, recycling the reservation before the child's
+        // death is confirmed. Retiring here covers every post-bind exit.
         member.retire().await;
-        Ok(selection)
+        selection.map_err(ServerSelectionError::Selection)
     }
 }
 

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -48,6 +48,15 @@ pub enum ServerSelectionError {
     /// The sweep could not draw a ledgered Clutch for its transport.
     #[error("the sweep could not acquire a transport")]
     TransportAcquisition(#[source] crate::mixnet::acquire::TransportError),
+    /// The ready sweep transport bound an Exit Node outside the drawn Clutch.
+    #[error(
+        "the sweep transport bound an exit outside the drawn clutch ({} reported)",
+        reported.len()
+    )]
+    ExitOutsideClutch {
+        /// The exit identities the ready transport reported as bound.
+        reported: Vec<crate::mixnet::ExitNodeId>,
+    },
     /// The dedicated sweep proxy could not be spawned.
     #[error("the sweep proxy could not start")]
     ProxyStart(#[source] crate::mixnet::MixnetProxyError),
@@ -128,9 +137,7 @@ impl LightClient {
             crate::correspondent::pool::exit_pool::take_bound_lease(&mut clutch, &exits)
         else {
             proxy.stop().await;
-            return Err(ServerSelectionError::TransportAcquisition(
-                crate::mixnet::acquire::TransportError::ExitOutsideClutch { reported: exits },
-            ));
+            return Err(ServerSelectionError::ExitOutsideClutch { reported: exits });
         };
         drop(clutch);
         let member: crate::correspondent::pool::Member<
@@ -185,18 +192,33 @@ async fn await_sweep_ready(
         zingo_netutils::time::NYM_LIFECYCLE_TIMEOUT,
     )
     .await
-    .map_err(|refusal| match refusal {
-        crate::mixnet::acquire::TransportError::DiedDuringBootstrap { detail } => {
+    .map_err(sweep_refusal)
+}
+
+/// The sweep's own name for one transport refusal, mapping every variant by
+/// hand so a new one is a compile error rather than a silent acquisition
+/// story.
+fn sweep_refusal(refusal: crate::mixnet::acquire::TransportError) -> ServerSelectionError {
+    use crate::mixnet::acquire::TransportError;
+    match refusal {
+        TransportError::DiedDuringBootstrap { detail } => {
             ServerSelectionError::TransportDied { detail }
         }
-        crate::mixnet::acquire::TransportError::StatusChannelClosed => {
-            ServerSelectionError::TransportStatusClosed
+        TransportError::StatusChannelClosed => ServerSelectionError::TransportStatusClosed,
+        TransportError::NotReady { budget } => ServerSelectionError::TransportTimeout { budget },
+        TransportError::ExitOutsideClutch { reported } => {
+            ServerSelectionError::ExitOutsideClutch { reported }
         }
-        crate::mixnet::acquire::TransportError::NotReady { budget } => {
-            ServerSelectionError::TransportTimeout { budget }
-        }
-        other => ServerSelectionError::TransportAcquisition(other),
-    })
+        acquisition @ (TransportError::NoAcquirer
+        | TransportError::DiscoverySpawn(_)
+        | TransportError::DiscoveryFailed { .. }
+        | TransportError::ExitPoolNotSeeded
+        | TransportError::ExitPoolExhausted { .. }
+        | TransportError::Proxy(_)
+        | TransportError::HostUnavailable(_)
+        | TransportError::HostRefused(_)
+        | TransportError::DiedBeforeUse) => ServerSelectionError::TransportAcquisition(acquisition),
+    }
 }
 
 /// Survey every candidate over the sweep exit concurrently, recording each
@@ -323,12 +345,15 @@ mod tests {
     /// Falsified if the waiter returns the empty announcement.
     #[tokio::test(start_paused = true)]
     async fn a_ready_without_an_exit_is_awaited_through() {
+        /// Scheduler turns given to the waiter task, enough for it to
+        /// observe the exitless Ready and park on the channel.
+        const PARKING_YIELDS: usize = 8;
+
         let publisher = crate::mixnet::status_publisher();
         publisher.send_replace(ready_with(Vec::new()));
         let mut receiver = publisher.subscribe();
         let waiter = tokio::spawn(async move { await_sweep_ready(&mut receiver).await });
-        // Let the waiter observe the exitless Ready and park on the channel.
-        for _ in 0..8 {
+        for _ in 0..PARKING_YIELDS {
             tokio::task::yield_now().await;
         }
         publisher.send_replace(ready_with(vec![crate::mixnet::ExitNodeId::from(
@@ -365,6 +390,27 @@ mod tests {
                     if budget == zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE
             ),
             "an exitless Ready refuses at the grace, got: {refusal}"
+        );
+    }
+
+    /// HYPOTHESIS: the bind refusal tells its own story, naming the exit
+    /// the ready transport bound outside the drawn Clutch, and never the
+    /// acquisition's story of a Clutch that could not be drawn. Falsified
+    /// if the refusal a foreign exit report produces reads as an
+    /// acquisition failure.
+    #[test]
+    fn the_bind_refusal_never_tells_the_acquisition_story() {
+        let refusal = sweep_refusal(crate::mixnet::acquire::TransportError::ExitOutsideClutch {
+            reported: vec![crate::mixnet::ExitNodeId::from("exit-foreign")],
+        });
+        let told = refusal.to_string();
+        assert!(
+            !told.contains("could not acquire a transport"),
+            "the bind refusal must not borrow the acquisition's story, got: {told}"
+        );
+        assert!(
+            told.contains("outside the drawn clutch"),
+            "the bind refusal names the exit outside the clutch, got: {told}"
         );
     }
 

--- a/zingolib/src/mixnet/supervisor.rs
+++ b/zingolib/src/mixnet/supervisor.rs
@@ -688,14 +688,20 @@ fn parse_discovery_output(stdout: &str) -> HashSet<crate::mixnet::ExitNodeId> {
 
 /// Waits until the status channel reports Ready with an announced address
 /// and at least one bound exit, yielding both, or fails typed when the
-/// transport dies, the channel closes, or `budget` elapses.
+/// transport dies, the channel closes, `budget` elapses, or the first exit
+/// misses its grace after the address.
 pub(crate) async fn await_ready_endpoint(
     receiver: &mut tokio::sync::watch::Receiver<MixnetStatus>,
     budget: Duration,
 ) -> Result<(SocketAddr, Vec<crate::mixnet::ExitNodeId>), acquire::TransportError> {
+    // The grace runs from the first addressed Ready, so a transport that
+    // latches Ready and never binds an exit is refused well inside the
+    // lifecycle budget instead of holding the user's go-online moment for
+    // the whole of it.
+    let mut exit_deadline: Option<tokio::time::Instant> = None;
     let outcome = tokio::time::timeout(budget, async {
         loop {
-            {
+            let addressed = {
                 let status = receiver.borrow_and_update();
                 match status.mode {
                     MixnetMode::Ready => {
@@ -706,16 +712,35 @@ pub(crate) async fn await_ready_endpoint(
                         if let (Some(addr), Some(_)) = (status.socks5_addr, status.exits.first()) {
                             return Ok((addr, status.exits.clone()));
                         }
+                        status.socks5_addr.is_some()
                     }
                     MixnetMode::Died => {
                         return Err(acquire::TransportError::DiedDuringBootstrap {
                             detail: status.death.as_ref().and_then(|death| death.detail.clone()),
                         });
                     }
-                    _ => {}
+                    _ => false,
                 }
+            };
+            if addressed && exit_deadline.is_none() {
+                exit_deadline = Some(
+                    tokio::time::Instant::now() + zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE,
+                );
             }
-            if receiver.changed().await.is_err() {
+            let changed = match exit_deadline {
+                Some(deadline) => {
+                    match tokio::time::timeout_at(deadline, receiver.changed()).await {
+                        Ok(changed) => changed,
+                        Err(_elapsed) => {
+                            return Err(acquire::TransportError::NotReady {
+                                budget: zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE,
+                            });
+                        }
+                    }
+                }
+                None => receiver.changed().await,
+            };
+            if changed.is_err() {
                 return Err(acquire::TransportError::StatusChannelClosed);
             }
         }
@@ -1378,6 +1403,40 @@ mod tests {
             "the waiter yields the exit announced after the address"
         );
         handle.abort();
+    }
+
+    /// HYPOTHESIS: a Ready that announces its address but never an Exit
+    /// Node refuses once the exit-announcement grace elapses, so the
+    /// go-online moment is not held for the whole lifecycle budget.
+    #[tokio::test(start_paused = true)]
+    async fn an_exitless_ready_refuses_after_the_grace() {
+        let publisher = test_publisher();
+        let mut receiver = publisher.subscribe();
+        publisher.send_replace(MixnetStatus {
+            mode: MixnetMode::Ready,
+            socks5_addr: Some("127.0.0.1:1080".parse().expect("the test address parses")),
+            exits: Vec::new(),
+            bootstrap_detail: None,
+            death: None,
+        });
+        let started = tokio::time::Instant::now();
+        let refusal =
+            await_ready_endpoint(&mut receiver, zingo_netutils::time::NYM_LIFECYCLE_TIMEOUT)
+                .await
+                .expect_err("no exit ever arrives");
+        assert!(
+            matches!(
+                refusal,
+                acquire::TransportError::NotReady { budget }
+                    if budget == zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE
+            ),
+            "the refusal names the grace it exceeded, got: {refusal}"
+        );
+        assert_eq!(
+            started.elapsed(),
+            zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE,
+            "the wait ends at the grace, never at the lifecycle budget"
+        );
     }
 
     /// HYPOTHESIS: transport transitions are published into the session

--- a/zingolib/src/mixnet/supervisor.rs
+++ b/zingolib/src/mixnet/supervisor.rs
@@ -500,10 +500,14 @@ async fn drive_state<R: AsyncRead + Unpin>(
     while let Ok(Some(line)) = lines.next_line().await {
         if let Some(exit) = parse_exit_line(&line) {
             spoke_protocol = true;
-            // Recorded silently: the exit becomes visible evidence in the
-            // Ready snapshot the address announcement publishes.
             let mut guarded = state.lock().expect("proxy state mutex");
             guarded.exits.push(exit);
+            // An exit announced after the address changes the Ready
+            // snapshot, so it is published: a readiness waiter parked on an
+            // address-first Ready wakes on this publication alone.
+            if guarded.mode == MixnetMode::Ready {
+                publish_locked(&guarded, &publisher);
+            }
             continue;
         }
         if let Some(addr) = parse_socks5_addr_line(&line) {
@@ -1344,6 +1348,37 @@ mod tests {
     }
 
     // ----- session-channel publication falsifiers (the driver arc) -----
+
+    /// HYPOTHESIS: an exit announced after the address wakes a readiness
+    /// waiter that is already parked on the session channel, so a healthy
+    /// transport is never stopped as not ready for its announcement order.
+    #[tokio::test(start_paused = true)]
+    async fn an_exit_after_the_address_wakes_the_parked_waiter() {
+        let publisher = test_publisher();
+        let mut receiver = publisher.subscribe();
+        let state = bootstrapping();
+        let handle = tokio::spawn(drive_state(
+            OpenAfter::new(b"SOCKS5_ADDR=127.0.0.1:43210\nNYM_EXIT=exit-alpha\n"),
+            Arc::clone(&state),
+            Arc::clone(&publisher),
+            None,
+        ));
+        let (addr, exits) =
+            await_ready_endpoint(&mut receiver, zingo_netutils::time::NYM_LIFECYCLE_TIMEOUT)
+                .await
+                .expect("the announced exit reaches the parked waiter");
+        assert_eq!(
+            addr,
+            "127.0.0.1:43210".parse().expect("the test address parses"),
+            "the waiter yields the announced address"
+        );
+        assert_eq!(
+            exits,
+            vec![crate::mixnet::ExitNodeId::from("exit-alpha")],
+            "the waiter yields the exit announced after the address"
+        );
+        handle.abort();
+    }
 
     /// HYPOTHESIS: transport transitions are published into the session
     /// channel as they happen — a subscriber observes Ready with the

--- a/zingolib/src/mixnet/supervisor.rs
+++ b/zingolib/src/mixnet/supervisor.rs
@@ -95,6 +95,9 @@ pub enum MixnetProxyError {
         /// The address that failed to parse.
         addr: String,
     },
+    /// The exit report handed to `MixnetProxy::attach` names no Exit Node.
+    #[error("the attached endpoint reported no bound exit node")]
+    NoExits,
     /// The session could not draw a ledgered Clutch for the spawn.
     #[error(transparent)]
     Acquisition(Box<acquire::TransportError>),
@@ -284,6 +287,12 @@ impl MixnetProxy {
         exits: &[crate::mixnet::ExitNodeId],
         publisher: StatusPublisher,
     ) -> Result<Self, MixnetProxyError> {
+        // Ready means the address AND a bound exit, at every door: an
+        // attach that accepted an empty report would mint an exitless Ready
+        // that no later announcement can correct.
+        if exits.is_empty() {
+            return Err(MixnetProxyError::NoExits);
+        }
         let state = Arc::new(Mutex::new(ProxyState {
             mode: MixnetMode::Bootstrapping,
             socks5_addr: None,
@@ -1310,6 +1319,25 @@ mod tests {
         driver.abort();
     }
 
+    /// HYPOTHESIS: an attach whose report names no Exit Node refuses typed,
+    /// so the attach door and the acquisition gate share one definition of
+    /// Ready. Falsified if an exitless report mints a permanent Ready.
+    #[tokio::test]
+    async fn an_exitless_report_refuses_the_attach() {
+        match MixnetProxy::attach(
+            "127.0.0.1:1080".parse().expect("the test address parses"),
+            &[],
+            test_publisher(),
+        ) {
+            Err(MixnetProxyError::NoExits) => {}
+            Err(other) => panic!("the attach refused with '{other}' rather than the empty report"),
+            Ok(proxy) => {
+                proxy.stop().await;
+                panic!("an exitless report must never mint an attached transport")
+            }
+        }
+    }
+
     /// HYPOTHESIS: stop() on an attached transport is a deliberate teardown
     /// to Unattached — never Died, and never the wallet's SwitchedOff.
     /// Falsified if a live attachment reports anything but the transport
@@ -1321,10 +1349,10 @@ mod tests {
         // win regardless of where the driver is when it lands.
         let proxy = MixnetProxy::attach(
             "127.0.0.1:9".parse().expect("the test address parses"),
-            &[],
+            &[crate::mixnet::ExitNodeId::from("host-bound-exit")],
             test_publisher(),
         )
-        .expect("a valid address attaches");
+        .expect("a valid address and a named exit attach");
         // The readiness gate races this assert (a refused port can land Died
         // fast), so assert only what is invariant: a live attachment is in
         // the transport lifecycle, never in a wallet slot state.
@@ -1352,10 +1380,10 @@ mod tests {
         // fails fast and the driver lands Died.
         let proxy = MixnetProxy::attach(
             "127.0.0.1:9".parse().expect("the test address parses"),
-            &[],
+            &[crate::mixnet::ExitNodeId::from("host-bound-exit")],
             test_publisher(),
         )
-        .expect("a valid address attaches");
+        .expect("a valid address and a named exit attach");
         let deadline = std::time::Instant::now() + Duration::from_secs(60);
         while proxy.mode() != MixnetMode::Died {
             assert!(


### PR DESCRIPTION
This pull request fixes findings 1 through 6 of issue #2688, Lane A. Each
finding has its own commit. Each commit adds a falsifier that failed before
its fix.

## The problem

The readiness gate waits for a transport that announces an address and a
bound Exit Node. The child announces the two facts on separate lines, in
either order. The exit branch of the supervisor recorded the identity and
published nothing. A gate parked after an address-first Ready therefore never
woke. A healthy transport was stopped as not ready after the full lifecycle
budget of 120 seconds.

A proxy that latched Ready and never announced a usable exit burned that same
budget before it refused. The user waited two minutes at the go-online
moment.

Ready had two definitions, split by door. The acquisition gate demands the
address and an exit. The attach door accepted an empty exit list. It then
minted an exitless Ready that no later announcement could correct.

The bind-time take picked an arbitrary matching reservation out of a hash
set. Two identical reports bound different exits from run to run.

The sweep's judgment refusal dropped the surveying member instead of retiring
it. The exit's reservation recycled before the child's death was confirmed.

The bind refusal reached users wrapped in `TransportAcquisition`, which says
the sweep could not acquire a transport. The sweep had acquired one. The
mapping's catch-all arm would give any future variant that same wrong story.

## The fix

The exit branch now publishes whenever the mode is already Ready, so a parked
waiter wakes on the announcement itself.

A new constant, `zingo_netutils::time::EXIT_ANNOUNCEMENT_GRACE`, bounds the
wait for the first exit after the address. It is derived from one Exit Node
connect attempt plus the hedge interval. The refusal stays the typed
`NotReady`, carrying the grace as the budget it exceeded.

`MixnetProxy::attach` refuses an empty report with the new `NoExits` variant.
One definition of Ready now survives at both doors.

`take_bound_lease` walks the report in announcement order. One report always
binds one exit.

The sweep holds the judgment's verdict, retires the member, and maps the
verdict afterwards. No early return stands between the bind and the
retirement.

The bind refusal gains its own variant, `ServerSelectionError::ExitOutsideClutch`,
with a truthful message. The mapping moves into a named function that matches
every transport variant by hand.

## The tests

Six falsifiers cover the six findings. Five are new. The sixth finding also
keeps the existing distinct-variant falsifier green.

- `an_exit_after_the_address_wakes_the_parked_waiter` drives the real reader
  with an address line and then an exit line. It asserts a subscribed
  `await_ready_endpoint` yields. No status is published by hand.
- `an_exitless_ready_refuses_after_the_grace` runs on paused time. It asserts
  the refusal names the grace and lands at the grace.
- `an_exitless_report_refuses_the_attach` asserts the typed refusal at the
  attach seam.
- `the_bound_lease_follows_the_announcement_order` binds one report against
  sixteen independently ordered clutches.
- `the_bind_refusal_never_tells_the_acquisition_story` asserts the rendering
  of the bind refusal.

Finding 5 has no cheap test, because a red run would need a real proxy child
and a whole survey. Its commit body justifies the fix by control flow.

Two public behaviors change. `attach_mixnet` refuses an empty exit report,
and `ServerSelectionError` gains a variant. The zingolib CHANGELOG records
both as breaking, along with the new grace bound.

## Gates

`cargo check` passes for zingolib with `nym` and for zingo-cli with `nym` and
`nym-diary`. Clippy reports no warnings on the touched crates under those
features. `cargo fmt --check` is clean. The targeted `cargo nextest run` over
the touched modules passes, and the zingo-netutils doc-tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
