### PR TITLE
The prompt never waits on the wallet lock, and a dead sync recovers by redraw

### DIFF
--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- A dead sync recovers without the user when the error's typed
+  recommendation allows it. A transient error relaunches sync against the
+  bound indexer. An error that condemns the server redraws the sync
+  indexer with a Server-Selection Sweep, in which the failed indexer is
+  surveyed again only when it is the sole candidate; the redraw serves
+  only an online session with no pinned server. Three automatic
+  recoveries may run back to back before the session parks on the
+  reported error, and a completed sync restores the budget.
 - A seed phrase may arrive in the `ZINGO_SEED` environment variable when
   `--seed` is absent. A seed on the command line is visible in the host's
   process list for as long as the session runs, and in the shell history
@@ -23,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transparent_gap_limit` to `settings` command.
 
 ### Changed
+- The interactive prompt never contends with a running sync for the
+  wallet lock. Its chain height now rides the same lock-free progress
+  channel the sync indicator reads, and the prompt's dedicated height
+  query is gone, so Enter returns a prompt immediately while sync scans.
+- Every dispatched CLI command narrates its progress every ten seconds
+  while it runs, where the diagnostic interval was two.
 - **Breaking.** `network probe` wraps the single `GetLatestBlock` RPC, the
   same tip call the Server-Selection Sweep surveys with, and reports the
   tip height alone: there is no chain name in the reply to print.

--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -34,6 +34,8 @@ use log::{error, info};
 use log::{debug, warn};
 
 use pepper_sync::config::{PerformanceLevel, SyncConfig, TransparentAddressDiscovery};
+#[cfg(feature = "nym")]
+use pepper_sync::error::{SyncError, SyncRecoveryObservables};
 use zingolib::config::{ChainType, ClientConfig, DEFAULT_WALLET_NAME, WalletConfig};
 use zingolib::data::PollReport;
 use zingolib::lightclient::{DEFAULT_REQUEST_TIMEOUT, LightClient};
@@ -252,8 +254,9 @@ fn parse_ufvk(s: &str) -> Result<String, String> {
 
 /// Performs the per-prompt housekeeping, awaited on the command-loop
 /// thread where the [`LightClient`] lives: polls the sync task, reports
-/// any save-task failure, and returns the sync indicator to embed in the
-/// interactive prompt: `" [Syncing X / Y outputs]"` while sync is in
+/// any save-task failure, and returns the prompt's status segment,
+/// `Block:{height}` followed by the sync indicator:
+/// `" [Syncing X / Y outputs]"` while sync is in
 /// progress, `" [Synced X / X outputs]"` when fully synced,
 /// `" [Sync error]"` on failure, or `" [Sync stopped at X / Y outputs]"`
 /// when no sync task is running and the wallet is not fully synced.
@@ -262,20 +265,37 @@ fn parse_ufvk(s: &str) -> Result<String, String> {
 /// [`pepper_sync::sync_status`], `check_save_error`), never by inspecting
 /// a command's output string. Every line this function prints is
 /// narration, so all of it goes to stderr (ADR 0031).
-async fn prompt_indicator(lightclient: &mut LightClient) -> String {
+async fn prompt_indicator(
+    lightclient: &mut LightClient,
+    sync_recovery: &mut SyncRecovery,
+) -> String {
+    let height = prompt_height(lightclient).await;
     let indicator = match lightclient.poll_sync() {
         PollReport::Ready(Err(e)) => {
             // The doubled "Sync error: Error:" is deliberate: it reproduces
             // the historical output byte for byte, where the polled command
             // string (itself prefixed "Error:") was interpolated after
             // "Sync error: ".
-            eprintln!(
-                "Sync error: Error: {}\nPlease restart sync with `sync run`.",
-                commands::render_error_chain(&e)
-            );
-            " [Sync error]".to_string()
+            eprintln!("Sync error: Error: {}", commands::render_error_chain(&e));
+            #[cfg(feature = "nym")]
+            let recovered = attempt_sync_recovery(lightclient, sync_recovery, &e).await;
+            #[cfg(not(feature = "nym"))]
+            let recovered = {
+                let _ = &sync_recovery;
+                false
+            };
+            if recovered {
+                syncing_indicator(scan_progress(lightclient).await)
+            } else {
+                eprintln!("Please restart sync with `sync run`.");
+                " [Sync error]".to_string()
+            }
         }
         PollReport::Ready(Ok(sync_result)) => {
+            #[cfg(feature = "nym")]
+            {
+                sync_recovery.attempts_left = SYNC_RECOVERY_ATTEMPT_BUDGET;
+            }
             eprintln!("{sync_result}");
             synced_indicator(scan_progress(lightclient).await)
         }
@@ -285,7 +305,7 @@ async fn prompt_indicator(lightclient: &mut LightClient) -> String {
     if let Err(e) = lightclient.check_save_error().await {
         eprintln!("Error: save failed. {e}\nRestarting save task...");
     }
-    indicator
+    format!("Block:{height}{indicator}")
 }
 
 /// Waits on the loop thread for the launched sync task to finish, narrating
@@ -322,6 +342,25 @@ struct ScanProgress {
     outputs_scanned: u64,
     total_outputs: u64,
     complete: bool,
+}
+
+/// Reads the prompt's chain height from the sync engine's progress channel while sync runs, from the wallet otherwise, or zero when neither knows a height yet.
+async fn prompt_height(lightclient: &LightClient) -> u32 {
+    if lightclient.sync_mode() == pepper_sync::wallet::SyncMode::NotRunning {
+        lightclient
+            .wallet()
+            .read()
+            .await
+            .sync_state
+            .last_known_chain_height()
+            .map_or(0, u32::from)
+    } else {
+        lightclient
+            .latest_sync_status()
+            .as_ref()
+            .and_then(|status| status.scan_ranges.last())
+            .map_or(0, |range| u32::from(range.block_range().end - 1))
+    }
 }
 
 /// Reads the scan progress from the sync engine's progress channel while sync runs, from the wallet otherwise, or `None` if sync status is unavailable.
@@ -443,18 +482,9 @@ fn start_interactive(cli_config: &ConfigTemplate, ch: CommandChannel) {
     };
 
     loop {
-        // Read the height first
-        let height = send_request(Request::Command(commands::CliCommand::Height))
-            .ok()
-            .and_then(|s| json::parse(&s).ok())
-            .and_then(|v| v["height"].as_i64())
-            .unwrap_or(0);
+        let prompt_status = send_request(Request::PromptIndicator).unwrap_or_default();
 
-        let sync_indicator = send_request(Request::PromptIndicator).unwrap_or_default();
-
-        let readline = rl.readline(&format!(
-            "({chain_name}) Block:{height}{sync_indicator} >> "
-        ));
+        let readline = rl.readline(&format!("({chain_name}) {prompt_status} >> "));
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str())
@@ -524,8 +554,9 @@ enum Request {
     /// with the command's output or `Err` with the rendered error line.
     Command(commands::CliCommand),
     /// Perform the per-prompt housekeeping (sync poll, save check) via
-    /// typed calls on the loop thread. The reply is the sync indicator
-    /// to embed in the interactive prompt.
+    /// typed calls on the loop thread. The reply is the prompt's status
+    /// segment: the chain height and the sync indicator, read without
+    /// contending with a running sync for the wallet lock.
     PromptIndicator,
     /// Block on the loop thread until the launched sync task finishes,
     /// narrating scan progress on stderr, and reply with the sync result.
@@ -545,6 +576,60 @@ struct CommandChannel {
     receiver: Receiver<Result<String, String>>,
 }
 
+/// How many automatic sync recoveries may run back-to-back before the
+/// session parks on the reported error and waits for `sync run`.
+#[cfg(feature = "nym")]
+const SYNC_RECOVERY_ATTEMPT_BUDGET: usize = 3;
+
+/// What the command loop needs to recover a dead sync without the user.
+#[cfg(feature = "nym")]
+pub(crate) struct SyncRecovery {
+    /// The census chain a redraw surveys; `None` withholds the redraw
+    /// (a pinned, offline, or regtest session), leaving only same-server
+    /// relaunches.
+    redraw_chain: Option<zingolib::indexers::IndexerChain>,
+    /// The `nym-proxy` binary a redraw's sweep spawns.
+    proxy_path: String,
+    /// The automatic recoveries left before the session parks.
+    attempts_left: usize,
+}
+
+/// What the command loop needs to recover a dead sync without the user.
+#[cfg(not(feature = "nym"))]
+pub(crate) struct SyncRecovery;
+
+/// The move one automatic sync-recovery attempt makes.
+#[cfg(feature = "nym")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryAction {
+    /// Report the error and wait for the user's `sync run`.
+    Park,
+    /// Launch a fresh sync task against the still-bound indexer.
+    Relaunch,
+    /// Redraw the sync indexer with a Server-Selection Sweep, then launch
+    /// a fresh sync task against the winner.
+    Redraw,
+}
+
+/// Plans one automatic recovery from the error's typed recommendation, the
+/// attempts left, and whether this session may redraw its indexer.
+#[cfg(feature = "nym")]
+fn plan_recovery(
+    observable: SyncRecoveryObservables,
+    attempts_left: usize,
+    redraw_available: bool,
+) -> RecoveryAction {
+    if attempts_left == 0 {
+        return RecoveryAction::Park;
+    }
+    match observable {
+        SyncRecoveryObservables::Abort => RecoveryAction::Park,
+        SyncRecoveryObservables::MaybeRecoverableServer => RecoveryAction::Relaunch,
+        SyncRecoveryObservables::ServerUnavailable if redraw_available => RecoveryAction::Redraw,
+        SyncRecoveryObservables::ServerUnavailable => RecoveryAction::Park,
+    }
+}
+
 /// Spawns a background thread that executes each parsed-command message
 /// against the [`LightClient`] and replies through the returned
 /// [`CommandChannel`], exiting on [`commands::CliCommand::Quit`].
@@ -552,6 +637,7 @@ struct CommandChannel {
 pub(crate) fn command_loop(
     mut lightclient: LightClient,
     communication_mode: CommunicationMode,
+    mut sync_recovery: SyncRecovery,
 ) -> CommandChannel {
     let (command_transmitter, command_receiver) = channel::<Request>();
     let (resp_transmitter, resp_receiver) = channel::<Result<String, String>>();
@@ -562,7 +648,10 @@ pub(crate) fn command_loop(
                 Request::Command(command) => command,
                 Request::PromptIndicator => {
                     resp_transmitter
-                        .send(Ok(RT.block_on(prompt_indicator(&mut lightclient))))
+                        .send(Ok(RT.block_on(prompt_indicator(
+                            &mut lightclient,
+                            &mut sync_recovery,
+                        ))))
                         .unwrap();
                     continue;
                 }
@@ -1140,9 +1229,23 @@ async fn build_zingo_config(filled_template: &ConfigTemplate) -> std::io::Result
 #[allow(clippy::disallowed_methods)]
 pub(crate) fn startup(filled_template: &ConfigTemplate) -> std::io::Result<CommandChannel> {
     let lightclient = RT.block_on(startup_async(filled_template))?;
+    #[cfg(feature = "nym")]
+    let sync_recovery = SyncRecovery {
+        redraw_chain: (matches!(
+            filled_template.communication_mode,
+            CommunicationMode::Online
+        ) && !filled_template.server_pinned)
+            .then(|| census_chain(&filled_template.chaintype))
+            .flatten(),
+        proxy_path: commands::resolve_proxy_path(filled_template.nym_proxy_path.as_deref()),
+        attempts_left: SYNC_RECOVERY_ATTEMPT_BUDGET,
+    };
+    #[cfg(not(feature = "nym"))]
+    let sync_recovery = SyncRecovery;
     Ok(command_loop(
         lightclient,
         filled_template.communication_mode,
+        sync_recovery,
     ))
 }
 
@@ -1330,8 +1433,6 @@ async fn sweep_select_sync_indexer(
     lightclient: &mut LightClient,
     filled_template: &ConfigTemplate,
 ) -> bool {
-    use zingolib::lightclient::select::SweepProgress;
-
     let Some(chain) = census_chain(&filled_template.chaintype) else {
         return true;
     };
@@ -1362,24 +1463,7 @@ async fn sweep_select_sync_indexer(
             std::path::Path::new(&proxy_path),
             &candidates,
             pin.as_ref(),
-            |phase| match phase {
-                SweepProgress::TransportBootstrapping => eprintln!(
-                    "Server-Selection Sweep: bootstrapping a dedicated sweep transport \
-                     (its Exit Node is recycled when the sweep completes)..."
-                ),
-                SweepProgress::Surveying { candidates } => eprintln!(
-                    "Server-Selection Sweep: surveying {candidates} candidates over the mixnet..."
-                ),
-                SweepProgress::ExitAbandoned { draw } => eprintln!(
-                    "Server-Selection Sweep: the Exit Node of draw {draw} carries nothing — \
-                     a reliable address stayed silent through it; abandoning that exit and \
-                     surveying again from the start..."
-                ),
-                SweepProgress::Judging { answered, surveyed } => eprintln!(
-                    "Server-Selection Sweep: {answered} of {surveyed} candidates answered; \
-                     judging the live cohort..."
-                ),
-            },
+            narrate_sweep_progress,
         )
         .await;
     match judge_sweep_outcome(&selection, pin.as_ref()) {
@@ -1437,6 +1521,142 @@ async fn sweep_select_sync_indexer(
                     false
                 }
             }
+        }
+    }
+}
+
+/// Narrates one Server-Selection Sweep phase transition on stderr.
+#[cfg(feature = "nym")]
+fn narrate_sweep_progress(phase: zingolib::lightclient::select::SweepProgress) {
+    use zingolib::lightclient::select::SweepProgress;
+    match phase {
+        SweepProgress::TransportBootstrapping => eprintln!(
+            "Server-Selection Sweep: bootstrapping a dedicated sweep transport \
+             (its Exit Node is recycled when the sweep completes)..."
+        ),
+        SweepProgress::Surveying { candidates } => eprintln!(
+            "Server-Selection Sweep: surveying {candidates} candidates over the mixnet..."
+        ),
+        SweepProgress::ExitAbandoned { draw } => eprintln!(
+            "Server-Selection Sweep: the Exit Node of draw {draw} carries nothing — \
+             a reliable address stayed silent through it; abandoning that exit and \
+             surveying again from the start..."
+        ),
+        SweepProgress::Judging { answered, surveyed } => eprintln!(
+            "Server-Selection Sweep: {answered} of {surveyed} candidates answered; \
+             judging the live cohort..."
+        ),
+    }
+}
+
+/// Reports whether two URIs name the same indexer endpoint by scheme, host,
+/// and port, so a bound URI's path rendering never defeats the comparison.
+#[cfg(feature = "nym")]
+fn same_endpoint(a: &http::Uri, b: &http::Uri) -> bool {
+    a.scheme_str() == b.scheme_str() && a.host() == b.host() && a.port_u16() == b.port_u16()
+}
+
+/// Attempts one automatic recovery of a dead sync, returning whether a new
+/// sync task is running.
+#[cfg(feature = "nym")]
+async fn attempt_sync_recovery<E: std::fmt::Debug + std::fmt::Display>(
+    lightclient: &mut LightClient,
+    recovery: &mut SyncRecovery,
+    error: &SyncError<E>,
+) -> bool {
+    let Some(bound) = lightclient.indexer_uri() else {
+        return false;
+    };
+    let action = plan_recovery(
+        error.recovery_recommendation(),
+        recovery.attempts_left,
+        recovery.redraw_chain.is_some(),
+    );
+    let attempt = SYNC_RECOVERY_ATTEMPT_BUDGET - recovery.attempts_left + 1;
+    match action {
+        RecoveryAction::Park => return false,
+        RecoveryAction::Relaunch => {
+            recovery.attempts_left -= 1;
+            eprintln!(
+                "Sync relaunches against {bound}: the error class says the same server may \
+                 recover (automatic recovery {attempt} of {SYNC_RECOVERY_ATTEMPT_BUDGET})."
+            );
+        }
+        RecoveryAction::Redraw => {
+            recovery.attempts_left -= 1;
+            eprintln!(
+                "Sync's indexer {bound} failed and the error class condemns the server; \
+                 abandoning it and redrawing \
+                 (automatic recovery {attempt} of {SYNC_RECOVERY_ATTEMPT_BUDGET})..."
+            );
+            let chain = recovery
+                .redraw_chain
+                .expect("plan_recovery only redraws when a census chain is present");
+            if !redraw_sync_indexer(lightclient, chain, &recovery.proxy_path, &bound).await {
+                return false;
+            }
+        }
+    }
+    let sync_run = commands::CliCommand::Sync {
+        sub: commands::SyncSubCommand::Run,
+    };
+    match commands::dispatch_parsed(sync_run, lightclient).await {
+        Ok(update) => {
+            eprintln!("{update}");
+            true
+        }
+        Err(e) => {
+            eprintln!("Error: {}", commands::render_error_chain(&e));
+            false
+        }
+    }
+}
+
+/// Runs a redraw Server-Selection Sweep that demotes the failed indexer,
+/// surveying it again only when it is the sole candidate, and returns
+/// whether a fresh winner is bound.
+#[cfg(feature = "nym")]
+async fn redraw_sync_indexer(
+    lightclient: &mut LightClient,
+    chain: zingolib::indexers::IndexerChain,
+    proxy_path: &str,
+    failed: &http::Uri,
+) -> bool {
+    let mut candidates: Vec<http::Uri> = zingolib::indexers::mixnet_eligible(chain)
+        .map(|indexer| indexer.uri.parse().expect("census URIs parse"))
+        .collect();
+    if candidates.len() > 1 {
+        candidates.retain(|candidate| !same_endpoint(candidate, failed));
+    }
+    let selection = lightclient
+        .run_server_selection_sweep(
+            std::path::Path::new(proxy_path),
+            &candidates,
+            None,
+            narrate_sweep_progress,
+        )
+        .await;
+    match judge_sweep_outcome(&selection, None) {
+        SweepVerdict::BindWinner { chosen, notice } => {
+            match lightclient.set_indexer_uri(chosen.clone()).await {
+                Ok(()) => {
+                    eprintln!("{notice}");
+                    true
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Server-Selection Sweep: selected {chosen}, but binding it failed: {}.",
+                        commands::render_error_chain(&e),
+                    );
+                    false
+                }
+            }
+        }
+        SweepVerdict::Refuse { notice }
+        | SweepVerdict::PinStands { notice }
+        | SweepVerdict::RecommendFallback { notice, .. } => {
+            eprintln!("{notice}");
+            false
         }
     }
 }

--- a/zingo-cli/src/tests.rs
+++ b/zingo-cli/src/tests.rs
@@ -799,6 +799,72 @@ mod sync {
     }
 }
 
+#[cfg(feature = "nym")]
+mod sync_recovery {
+    use pepper_sync::error::SyncRecoveryObservables;
+
+    use crate::{RecoveryAction, SYNC_RECOVERY_ATTEMPT_BUDGET, plan_recovery};
+
+    #[test]
+    fn a_condemned_server_redraws_when_the_session_may() {
+        assert_eq!(
+            plan_recovery(
+                SyncRecoveryObservables::ServerUnavailable,
+                SYNC_RECOVERY_ATTEMPT_BUDGET,
+                true,
+            ),
+            RecoveryAction::Redraw
+        );
+    }
+
+    #[test]
+    fn a_condemned_server_parks_a_session_that_may_not_redraw() {
+        assert_eq!(
+            plan_recovery(
+                SyncRecoveryObservables::ServerUnavailable,
+                SYNC_RECOVERY_ATTEMPT_BUDGET,
+                false,
+            ),
+            RecoveryAction::Park
+        );
+    }
+
+    #[test]
+    fn a_recoverable_error_relaunches_against_the_same_server() {
+        assert_eq!(
+            plan_recovery(
+                SyncRecoveryObservables::MaybeRecoverableServer,
+                SYNC_RECOVERY_ATTEMPT_BUDGET,
+                false,
+            ),
+            RecoveryAction::Relaunch
+        );
+    }
+
+    #[test]
+    fn an_abort_parks_regardless_of_budget_and_redraw() {
+        assert_eq!(
+            plan_recovery(
+                SyncRecoveryObservables::Abort,
+                SYNC_RECOVERY_ATTEMPT_BUDGET,
+                true,
+            ),
+            RecoveryAction::Park
+        );
+    }
+
+    #[test]
+    fn an_exhausted_budget_parks_every_class() {
+        for observable in [
+            SyncRecoveryObservables::MaybeRecoverableServer,
+            SyncRecoveryObservables::ServerUnavailable,
+            SyncRecoveryObservables::Abort,
+        ] {
+            assert_eq!(plan_recovery(observable, 0, true), RecoveryAction::Park);
+        }
+    }
+}
+
 mod config_template {
     use super::*;
     use crate::{

--- a/zingo-netutils/CHANGELOG.md
+++ b/zingo-netutils/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only mint left with the child-side Sentinel gate, is removed.
 
 ### Changed
+- `time::PROGRESS_HEARTBEAT_INTERVAL` settles on a ten-second cadence. The
+  two-second value was a temporary diagnostic aid for the silent-phase
+  reports, and its narration crowded the interactive session it served.
 - BREAKING: an acquisition's clutch grows from three Exit Node reservations
   to four, and a racing arm now wins by carrying a round trip rather than by
   binding a socket. Building a mixnet client never contacts the exit, so a

--- a/zingo-netutils/src/time.rs
+++ b/zingo-netutils/src/time.rs
@@ -203,11 +203,9 @@ pub const MIGRATION_SUBMIT_TIMEOUT: Duration = Duration::from_secs(30);
 pub const CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Every dispatched CLI command narrates its latest progress line at this
-/// interval while it runs, so no command is silent past one interval; a
-/// command that completes before the first tick stays silent. Temporarily
-/// two seconds to strengthen the diagnostic signal while the silent-phase
-/// reports are investigated; the ratified cadence is eight.
-pub const PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+/// interval while it runs, so no command is silent past one interval and a
+/// command that completes before the first tick stays silent.
+pub const PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 
 // ---------------------------------------------------------------------------
 // Diagnostics and server selection


### PR DESCRIPTION
Builds on the merged #2695 sweep machinery. Three changes serve one
interactive session.

## The prompt returns immediately

The prompt blocked on Enter. Its height query took the wallet read lock.
A running sync holds that lock for long stretches. The prompt's height
now rides the lock-free sync progress channel. This mirrors the
`scan_progress` pattern. The watch channel's last scan range ends at the
height the lock would report. The prompt loop's `Height` round trip is
gone. A wallet-lock audit found no other automatic lock toucher. Every
remaining lock site is a user-invoked command.

## A dead sync recovers without the user

A remote stream reset parked the session on `[Sync error]`. The prompt
housekeeping now classifies the failure with pepper-sync's typed
`recovery_recommendation`. A transient error relaunches sync against the
bound indexer. An error that condemns the server redraws with a
Server-Selection Sweep. The redraw surveys the failed indexer again only
when it is the sole candidate. The redraw serves only an online session
with no pinned server. Three automatic recoveries may run back to back
before the session parks. A completed sync restores the budget. The
narration names the failed indexer, the attempt count, and the winner.

## The heartbeat settles on ten seconds

The two-second `PROGRESS_HEARTBEAT_INTERVAL` was a diagnostic aid. Its
narration crowded the session. The 2026-08-14 session ruled a ten-second
cadence.

## Verification

`cargo hack check --each-feature` passes on zingolib and zingo-cli.
Clippy is clean under `nym,nym-diary` and under no default features.
The zingo-cli lib suites pass in both shapes: 245 and 203 tests.
Five new unit tests pin the recovery planner's decision table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)