### PR TITLE
feat!: the sweep assigns every indexer, and the sync indexer is drawn

### DIFF
--- a/zingo-cli/src/lib.rs
+++ b/zingo-cli/src/lib.rs
@@ -1466,7 +1466,7 @@ enum SweepVerdict {
     /// The survey refused the pin but holds a healthy alternative, which
     /// binds only by the user's explicit consent, refusing by default.
     RecommendFallback {
-        /// The healthy indexer the sweep selected.
+        /// The healthy indexer the sweep drew.
         alternative: http::Uri,
         /// The narration recommending the fallback before the consent ask.
         notice: String,
@@ -1520,7 +1520,7 @@ fn judge_sweep_outcome(
                     alternative: selection.sync_indexer.clone(),
                     notice: format!(
                         "Server-Selection Sweep: the pinned server {pinned} did not answer the \
-                         survey or lags the live cohort of {}. The sweep selected a healthy \
+                         survey or lags the live cohort of {}. The sweep drew a healthy \
                          alternative: {}.",
                         selection.cohort.len(),
                         selection.sync_indexer,

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The Server-Selection Sweep probes and assigns every indexer before its
+  verdict (ruled 2026-08-14): no healthy answer ends the survey early, a
+  healthy pinned server still wins outright, and otherwise the sync
+  indexer is drawn among every healthy answer, all of which are
+  draw-eligible, with the transmit candidates excluding the sync
+  operator so different operations select different indexers.
+
 ### Deprecated
 
 ### Added

--- a/zingolib/src/lightclient/select.rs
+++ b/zingolib/src/lightclient/select.rs
@@ -73,13 +73,12 @@ impl LightClient {
     /// operator, and the height-ordered live cohort.
     ///
     /// `binary_path` is the `nym-proxy` binary the dedicated sweep proxy
-    /// spawns from. The candidates are assigned to survey lanes at random,
-    /// `pin` guaranteed an opening lane, and the first healthy answer is
-    /// the verdict — the pin preempts while its own probe is pending and is
-    /// chosen the moment it answers — offered to the session immediately:
-    /// every unresolved candidate continues in the background as the health
-    /// sweep, whose handle the session holds so revoking consent aborts it,
-    /// and the sweep transport recycles its exit when that finishes.
+    /// spawns from. The candidates are assigned to survey lanes at random
+    /// and every one is probed and assigned a verdict (ruled 2026-08-14):
+    /// a healthy `pin` wins outright, and otherwise the sync indexer is
+    /// drawn among every healthy answer, all of which are draw-eligible for
+    /// the session's operations, with the transmit candidates excluding the
+    /// sync operator so different operations select different indexers.
     pub async fn run_server_selection_sweep(
         &self,
         binary_path: &Path,
@@ -92,9 +91,8 @@ impl LightClient {
             std::sync::Arc::new(crate::mixnet::acquire::SpawnedBinary::at(
                 binary_path.to_path_buf(),
             ));
-        // Random lane assignment, the pin guaranteed an opening lane: the
-        // first healthy answer is the verdict, the pin preempting while its
-        // own probe is pending. Acquisition, the Sentinel-ridden wave, and
+        // Random lane assignment; the whole census is probed and assigned
+        // before the drawn verdict. Acquisition, the Sentinel-ridden wave, and
         // the redraw of an exit that carries nothing are the shared
         // speed-priority loop's; this runner owns only the judgment.
         let order = sweep::wave_order(candidates, pin, SURVEY_WAVE_WIDTH, &mut rand::rngs::OsRng);
@@ -102,8 +100,6 @@ impl LightClient {
             pools: self.correspondent_pools.clone(),
             acquirer,
             order: order.clone(),
-            chain: chain.to_string(),
-            pin: pin.cloned(),
             timeout: zingo_netutils::time::PROBE_LEG_TIMEOUT,
             history: self.indexer_history.clone(),
         };
@@ -121,7 +117,9 @@ impl LightClient {
             surveyed: results.len(),
         });
 
-        let Some(chosen) = sweep::first_healthy_verdict(&results, chain, pin) else {
+        let Some(chosen) =
+            sweep::healthy_draw_verdict(&results, chain, pin, &mut rand::rngs::OsRng)
+        else {
             // Every candidate was surveyed through a proven exit and none
             // was healthy, so the refusal is about the candidates.
             member.retire().await;
@@ -132,7 +130,7 @@ impl LightClient {
             }
             .into());
         };
-        let selection = sweep::first_healthy_selection(&results, chain, chosen);
+        let selection = sweep::assigned_selection(&results, chain, chosen);
 
         // Every candidate the verdict left unresolved continues in the
         // background purely as the health sweep; the session holds its
@@ -166,13 +164,11 @@ impl LightClient {
 }
 
 /// The Server-Selection Sweep as a speed-priority operation: it races the
-/// census through one Exit Node and settles on the first healthy answer.
+/// census through one Exit Node, assigning every candidate its verdict.
 struct IndexerSurvey {
     pools: std::sync::Arc<crate::correspondent::pool::Pools>,
     acquirer: std::sync::Arc<dyn crate::mixnet::acquire::TransportAcquirable>,
     order: Vec<Uri>,
-    chain: String,
-    pin: Option<Uri>,
     timeout: Duration,
     history: crate::lightclient::indexer_history::IndexerHistoryHandle,
 }
@@ -202,8 +198,11 @@ impl crate::mixnet::speed::SpeedPrioritized for IndexerSurvey {
         }
     }
 
-    fn settled(&self, outcomes: &[SurveyResult]) -> bool {
-        sweep::first_healthy_verdict(outcomes, &self.chain, self.pin.as_ref()).is_some()
+    fn settled(&self, _outcomes: &[SurveyResult]) -> bool {
+        // The IndexerSweep probes and assigns every indexer (ruled
+        // 2026-08-14): no answer ends the wave early, so the whole census
+        // earns its verdicts and every healthy indexer is draw-eligible.
+        false
     }
 
     fn answered(&self, outcomes: &[SurveyResult]) -> bool {
@@ -326,6 +325,36 @@ async fn probe_one(
 mod tests {
     use super::*;
     use crate::mixnet::MixnetMode;
+
+    /// HYPOTHESIS: the survey never settles early — every indexer must be
+    /// probed and assigned — so a healthy answer does not end the wave.
+    /// Falsified if one healthy outcome settles the survey.
+    #[test]
+    fn a_healthy_answer_does_not_settle_the_survey() {
+        let survey = IndexerSurvey {
+            pools: crate::correspondent::pool::Pools::new(),
+            acquirer: std::sync::Arc::new(crate::mixnet::acquire::SpawnedBinary::at(
+                std::path::PathBuf::from("/nonexistent/nym-proxy"),
+            )),
+            order: Vec::new(),
+            timeout: zingo_netutils::time::PROBE_LEG_TIMEOUT,
+            history: crate::lightclient::indexer_history::IndexerHistoryHandle::default(),
+        };
+        let healthy = crate::mixnet::sweep::SurveyResult {
+            uri: "https://a.example:443"
+                .parse()
+                .expect("the static uri parses"),
+            reported: Some(crate::mixnet::probe::ProbeSuccess {
+                chain: "main".to_string(),
+                height: 100,
+            }),
+            refusal: None,
+        };
+        assert!(
+            !crate::mixnet::speed::SpeedPrioritized::settled(&survey, &[healthy]),
+            "one healthy answer must not end the survey"
+        );
+    }
 
     /// HYPOTHESIS: revoking consent aborts the detached health sweep — the
     /// held task is cancelled and the slot empties — so no probe outlives

--- a/zingolib/src/mixnet/sweep.rs
+++ b/zingolib/src/mixnet/sweep.rs
@@ -220,39 +220,39 @@ fn healthy(result: &SurveyResult, chain: &str) -> bool {
         .is_some_and(|info| info.chain == chain)
 }
 
-/// The first-healthy verdict over the results seen so far: the pin the
-/// moment it answers on `chain`, any healthy candidate once the pin has
-/// refused or no pin exists, and `None` while the decision still awaits the
-/// pin or a first healthy answer.
-pub fn first_healthy_verdict(
+/// The verdict over the assigned survey (ruled 2026-08-14): a healthy pin
+/// wins outright, otherwise the sync indexer is drawn among every healthy
+/// answer because all of them are draw-eligible, and `None` awaits the pin
+/// or any healthy answer.
+pub fn healthy_draw_verdict(
     results: &[SurveyResult],
     chain: &str,
     pin: Option<&Uri>,
+    rng: &mut impl rand::Rng,
 ) -> Option<Uri> {
-    let first_healthy = || {
-        results
+    use rand::seq::SliceRandom as _;
+    let drawn = |rng: &mut _| {
+        let healthy_set: Vec<&Uri> = results
             .iter()
-            .find(|result| healthy(result, chain))
-            .map(|result| result.uri.clone())
+            .filter(|result| healthy(result, chain))
+            .map(|result| &result.uri)
+            .collect();
+        healthy_set.choose(rng).map(|uri| (*uri).clone())
     };
     match pin {
         Some(pin) => match results.iter().find(|result| &result.uri == pin) {
             Some(of_pin) if healthy(of_pin, chain) => Some(pin.clone()),
-            Some(_refused) => first_healthy(),
+            Some(_refused) => drawn(rng),
             None => None,
         },
-        None => first_healthy(),
+        None => drawn(rng),
     }
 }
 
-/// The [`Selection`] a first-healthy verdict yields: the verdict as the
-/// sync indexer, every healthy answer seen so far as the height-descending
-/// cohort, and the transmit candidates that exclude the verdict's operator.
-pub fn first_healthy_selection(
-    results: &[SurveyResult],
-    chain: &str,
-    sync_indexer: Uri,
-) -> Selection {
+/// The [`Selection`] a verdict yields: the verdict as the sync indexer,
+/// every healthy answer as the height-descending cohort, and the transmit
+/// candidates that exclude the verdict's operator.
+pub fn assigned_selection(results: &[SurveyResult], chain: &str, sync_indexer: Uri) -> Selection {
     let mut cohort: Vec<LiveCandidate> = results
         .iter()
         .filter(|result| healthy(result, chain))
@@ -564,19 +564,54 @@ mod tests {
         assert_eq!(RefusalTally::of(&[]).to_string(), "");
     }
 
-    /// HYPOTHESIS: without a pin, the first healthy answer is the verdict
-    /// the moment it exists, and a wrong-chain answer is not healthy.
-    /// Falsified if silence or a wrong-chain answer forms the verdict.
+    /// Trials enough that a find-first verdict's repetition is unmistakable.
+    const DRAW_SPREAD_TRIALS: usize = 12;
+
+    /// HYPOTHESIS: every healthy indexer is draw-eligible, so repeated
+    /// unpinned verdicts over one three-healthy survey reach more than one
+    /// distinct sync indexer. Falsified if the verdict binds the same
+    /// indexer every time.
     #[test]
-    fn the_first_healthy_answer_is_the_unpinned_verdict() {
+    fn every_healthy_indexer_is_draw_eligible() {
+        let seen = vec![
+            answered("https://a.example:443", "main", 100),
+            answered("https://b.example:443", "main", 100),
+            silent("https://c.example:443"),
+            answered("https://d.example:443", "main", 100),
+        ];
+        let mut distinct = std::collections::HashSet::new();
+        for trial in 0..DRAW_SPREAD_TRIALS {
+            distinct.insert(
+                healthy_draw_verdict(
+                    &seen,
+                    "main",
+                    None,
+                    &mut StdRng::seed_from_u64(trial as u64),
+                )
+                .expect("healthy answers exist"),
+            );
+        }
+        assert!(
+            distinct.len() > 1,
+            "the verdict bound one indexer every time: healthy answers \
+             are not draw-eligible"
+        );
+    }
+
+    /// HYPOTHESIS: without a pin, a sole healthy answer is the verdict the
+    /// moment it exists, and a wrong-chain answer is not healthy. Falsified
+    /// if silence or a wrong-chain answer forms the verdict.
+    #[test]
+    fn a_sole_healthy_answer_is_the_unpinned_verdict() {
         let mut seen = vec![
             silent("https://a.example:443"),
             answered("https://test.example:443", "test", 100),
         ];
-        assert_eq!(first_healthy_verdict(&seen, "main", None), None);
+        let mut rng = StdRng::seed_from_u64(0);
+        assert_eq!(healthy_draw_verdict(&seen, "main", None, &mut rng), None);
         seen.push(answered("https://b.example:443", "main", 100));
         assert_eq!(
-            first_healthy_verdict(&seen, "main", None),
+            healthy_draw_verdict(&seen, "main", None, &mut rng),
             Some(uri("https://b.example:443"))
         );
     }
@@ -587,38 +622,45 @@ mod tests {
     #[test]
     fn the_pin_preempts_earlier_answers_when_it_answers() {
         let pin = uri("https://pin.example:443");
+        let mut rng = StdRng::seed_from_u64(0);
         let mut seen = vec![answered("https://fast.example:443", "main", 100)];
-        assert_eq!(first_healthy_verdict(&seen, "main", Some(&pin)), None);
+        assert_eq!(
+            healthy_draw_verdict(&seen, "main", Some(&pin), &mut rng),
+            None
+        );
         seen.push(answered("https://pin.example:443", "main", 100));
-        assert_eq!(first_healthy_verdict(&seen, "main", Some(&pin)), Some(pin));
+        assert_eq!(
+            healthy_draw_verdict(&seen, "main", Some(&pin), &mut rng),
+            Some(pin)
+        );
     }
 
-    /// HYPOTHESIS: once the pin has refused, the verdict is the first
-    /// healthy answer already seen. Falsified if the refusal blocks it.
+    /// HYPOTHESIS: once the pin has refused, the verdict is drawn among the
+    /// healthy answers already seen. Falsified if the refusal blocks it.
     #[test]
-    fn a_refused_pin_yields_to_the_first_healthy_answer() {
+    fn a_refused_pin_yields_to_the_drawn_healthy_answer() {
         let pin = uri("https://pin.example:443");
         let seen = vec![
             answered("https://fast.example:443", "main", 100),
             silent("https://pin.example:443"),
         ];
         assert_eq!(
-            first_healthy_verdict(&seen, "main", Some(&pin)),
+            healthy_draw_verdict(&seen, "main", Some(&pin), &mut StdRng::seed_from_u64(0)),
             Some(uri("https://fast.example:443"))
         );
     }
 
-    /// HYPOTHESIS: the first-healthy selection carries every healthy answer
+    /// HYPOTHESIS: the assigned selection carries every healthy answer
     /// as its height-descending cohort and excludes the verdict's operator
     /// from the transmit candidates. Falsified if either property drifts.
     #[test]
-    fn the_first_healthy_selection_reports_its_evidence() {
+    fn the_assigned_selection_reports_its_evidence() {
         let results = vec![
             answered("https://na.zec.rocks:443", "main", 101),
             answered("https://other.example:443", "main", 102),
             silent("https://dead.example:443"),
         ];
-        let selection = first_healthy_selection(&results, "main", uri("https://na.zec.rocks:443"));
+        let selection = assigned_selection(&results, "main", uri("https://na.zec.rocks:443"));
         assert_eq!(
             selection
                 .cohort


### PR DESCRIPTION
The Server-Selection Sweep settled at the first healthy answer. The wave
cancelled every other probe. A session could open with one assigned indexer.

The user ruled three clauses on 2026-08-14. The sweep must probe and assign
every indexer. Every healthy indexer must be draw-eligible. Different
operations must select different indexers.

This change implements all three. The survey wave now runs the whole census.
Every candidate earns a verdict. The full survey costs about half a minute.
That cost sits inside the 285 second acquisition deadline. The verdict is
`healthy_draw_verdict`. A healthy pinned server wins outright. Otherwise the
sync indexer is drawn among the whole healthy set. `assigned_selection`
carries the healthy set as the cohort. The transmit candidates exclude the
sync operator. The send path is therefore disjoint from the sync indexer by
construction. The price fetch stays on its price sources by the same ruling.

Two falsifiers were observed red. One healthy answer settled the survey. All
twelve verdicts bound the same indexer. Both now pass, with the existing
sweep and select suites (38 tests) green, clippy clean, and a CHANGELOG
entry recording the behavior change.

Note for the auto-redraw work in flight: recovery now redraws from the
assigned healthy set, which this change makes available session-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
