### PR TITLE
remove the unnecessary IP correlation warning

### DIFF
--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -1382,13 +1382,20 @@ fn render_status(
     }
 }
 
-/// The complete `network status` output: the Mixnet Mode line followed by the
-/// IP-correlation disclaimer. The disclaimer always accompanies the status
-/// (ZIP-0318), because Mixnet Mode obfuscates only send and price-fetch while
-/// synchronization stays on the ordinary connector, so a bare "ready" must
-/// never be read as end-to-end IP protection. The canonical text lives in
-/// [`zingolib::mixnet::IP_CORRELATION_DISCLAIMER`] so every frontend shows the same
-/// wording.
+/// The IP-correlation disclaimer this frontend shows alongside every Mixnet
+/// Mode status.
+#[cfg(feature = "nym")]
+const IP_CORRELATION_DISCLAIMER: &str = "\
+IP-correlation risk: Mixnet Mode covers only transaction transmission and \
+price-fetch. Wallet synchronization always uses the ordinary connection, so \
+the sync indexer (and any network operator on that path) sees your IP \
+address and can correlate it with the transactions you transmit; reusing the \
+same IP across sessions can reveal your wallet's total balance to that \
+operator. To hide your IP during synchronization as well, route the wallet \
+through a system-level VPN or NymVPN. See ZIP-0318.";
+
+/// Render the Mixnet Mode status line followed by the IP-correlation
+/// disclaimer.
 #[cfg(feature = "nym")]
 fn render_status_with_disclaimer(
     mode: zingolib::mixnet::MixnetMode,
@@ -1398,7 +1405,7 @@ fn render_status_with_disclaimer(
     format!(
         "{}\n\n{}",
         render_status(mode, socks5_addr, bootstrap_detail),
-        zingolib::mixnet::IP_CORRELATION_DISCLAIMER,
+        IP_CORRELATION_DISCLAIMER,
     )
 }
 

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -464,6 +464,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a prefix-only salvage read so `recovery_info` still works.
 
 ### Removed
+- `mixnet::IP_CORRELATION_DISCLAIMER` - the frontend-facing disclaimer text. A
+  library does not own the wording an application shows its user, so the text
+  moved into `zingo-cli` as a private constant. A frontend that shows the
+  IP-correlation risk now carries its own wording.
 - The `mixnet` re-export of `zingo_netutils::responsiveness::{PrioritisePrivacy,
   PrioritiseSpeed, Responsiveness}` - the responsiveness partition retired with
   ADR 0044's single hedged acquisition policy, and no class reaches the API.

--- a/zingolib/src/mixnet.rs
+++ b/zingolib/src/mixnet.rs
@@ -139,11 +139,11 @@ pub use driver::{MixnetStartPolicy, MixnetStatus, ProvisionStrategy};
 #[cfg(feature = "nym")]
 pub(crate) use driver::{StatusPublisher, status_publisher};
 #[cfg(feature = "nym")]
+pub use mode::MixnetMode;
+#[cfg(feature = "nym")]
 pub(crate) use mode::MixnetSlot;
 #[cfg(feature = "nym")]
 pub(crate) use mode::StandingClient;
-#[cfg(feature = "nym")]
-pub use mode::{IP_CORRELATION_DISCLAIMER, MixnetMode};
 #[cfg(feature = "nym")]
 pub use route::{MixnetNotReady, MixnetRoute, SlotTunnel, resolve_route};
 #[cfg(feature = "nym")]

--- a/zingolib/src/mixnet/mode.rs
+++ b/zingolib/src/mixnet/mode.rs
@@ -368,27 +368,6 @@ impl MixnetSlot {
     }
 }
 
-/// The IP-correlation disclaimer a frontend must show alongside Mixnet Mode
-/// status, satisfying ZIP-0318's requirement that the wallet explain the
-/// IP-correlation risk.
-///
-/// Mixnet Mode obfuscates only the Transmission and price-fetch surfaces, and
-/// synchronization stays on the ordinary connector (ADR 0011, "Per-surface
-/// transport tiers"). A bare "ready" status would let a user believe sync is
-/// protected too, so this text names the residual exposure: the sync indexer
-/// still learns the client IP and can correlate it with the wallet's on-chain
-/// activity, and a reused IP can leak the wallet's total balance. It is kept
-/// here as one canonical string so every frontend renders the same disclaimer
-/// rather than each paraphrasing the risk.
-pub const IP_CORRELATION_DISCLAIMER: &str = "\
-IP-correlation risk: Mixnet Mode covers only transaction transmission and \
-price-fetch. Wallet synchronization always uses the ordinary connection, so \
-the sync indexer (and any network operator on that path) sees your IP \
-address and can correlate it with the transactions you transmit; reusing the \
-same IP across sessions can reveal your wallet's total balance to that \
-operator. To hide your IP during synchronization as well, route the wallet \
-through a system-level VPN or NymVPN. See ZIP-0318.";
-
 #[cfg(test)]
 mod wire_contract {
     use std::str::FromStr as _;


### PR DESCRIPTION
Fixes:  https://github.com/zingolabs/zingolib/issues/2696

Please run:

`makers run-cli --online` to see if it works for you.