### PR TITLE
feat!: bump the Zcash stack to zcash_primitives 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,15 +872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equihash"
-version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
-dependencies = [
- "blake2b_simd",
- "corez",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,14 +898,6 @@ name = "f4jumble"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1803,11 +1786,11 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_client_backend",
  "zcash_local_net",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.4",
+ "zcash_primitives",
+ "zcash_protocol",
  "zingo-netutils",
  "zingo-status",
  "zingo_test_vectors",
@@ -2189,14 +2172,14 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.4",
- "zcash_transparent 0.9.0",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zcash_transparent",
  "zingo-memo",
  "zingo-netutils",
  "zingo-status",
@@ -4239,30 +4222,17 @@ dependencies = [
  "bech32",
  "bs58",
  "corez",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "f4jumble",
  "proptest",
  "zcash_encoding",
- "zcash_protocol 0.10.4",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
-dependencies = [
- "bech32",
- "bs58",
- "corez",
- "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031)",
- "zcash_encoding",
- "zcash_protocol 0.10.1",
+ "zcash_protocol",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
+version = "0.24.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0d78dcc345c36086112886223f6f1d6d224802808f15ac4f3ef144677029a1"
+checksum = "f49636f1d22b0511b2a117548cc9dcf569440a3589b06bf6df422c6b738f6231"
 dependencies = [
  "base64",
  "bech32",
@@ -4293,14 +4263,14 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "which",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.4",
+ "zcash_primitives",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent",
  "zip32",
  "zip321",
 ]
@@ -4318,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36391ebfce7df2510c6564f79e608ed93f1c0692c6464e2397b248e06dae3912"
+checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
 dependencies = [
  "bech32",
  "bip32",
@@ -4339,10 +4309,10 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_encoding",
- "zcash_protocol 0.10.4",
- "zcash_transparent 0.9.0",
+ "zcash_protocol",
+ "zcash_transparent",
  "zip32",
 ]
 
@@ -4380,29 +4350,30 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
+version = "0.1.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532ac156acab2144a88b3e55763ee9329704863a34839e55c2fa705addf3e57e"
 dependencies = [
  "corez",
  "getset",
  "libm",
  "rand_core 0.6.4",
- "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.1",
+ "zcash_primitives",
+ "zcash_protocol",
 ]
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -4417,44 +4388,16 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.4",
+ "zcash_protocol",
  "zcash_script",
- "zcash_transparent 0.9.0",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
-dependencies = [
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "corez",
- "crypto-common 0.2.0-rc.1",
- "equihash 0.3.0 (git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031)",
- "ff",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2 0.10.9",
- "zcash_encoding",
- "zcash_note_encryption",
- "zcash_protocol 0.10.1",
- "zcash_script",
- "zcash_transparent 0.10.0",
+ "zcash_transparent",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91fb0b420fb66a765f1fa92ab7a6b631aa54c08415415ef6185256826e74fbd"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4470,17 +4413,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives 0.29.0",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
-dependencies = [
- "corez",
- "hex",
- "zcash_encoding",
+ "zcash_primitives",
 ]
 
 [[package]]
@@ -4524,9 +4457,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -4539,31 +4472,9 @@ dependencies = [
  "secp256k1 0.29.1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_encoding",
- "zcash_protocol 0.10.4",
- "zcash_script",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_transparent"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031#e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031"
-dependencies = [
- "bip32",
- "bs58",
- "corez",
- "getset",
- "hex",
- "nonempty",
- "ripemd 0.1.3",
- "sha2 0.10.9",
- "subtle",
- "zcash_address 0.13.0 (git+https://github.com/zcash/librustzcash.git?rev=e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031)",
- "zcash_encoding",
- "zcash_protocol 0.10.1",
+ "zcash_protocol",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -4683,10 +4594,10 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing-subscriber",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_client_backend",
  "zcash_keys",
- "zcash_protocol 0.10.4",
+ "zcash_protocol",
  "zingo-net-diag",
  "zingo-netutils",
  "zingo-status",
@@ -4707,10 +4618,10 @@ name = "zingo-memo"
 version = "0.1.1"
 dependencies = [
  "rand 0.8.7",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_encoding",
  "zcash_keys",
- "zcash_protocol 0.10.4",
+ "zcash_protocol",
 ]
 
 [[package]]
@@ -4759,7 +4670,7 @@ name = "zingo-status"
 version = "0.2.1"
 dependencies = [
  "byteorder",
- "zcash_protocol 0.10.4",
+ "zcash_protocol",
 ]
 
 [[package]]
@@ -4828,15 +4739,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zaino-proto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
  "zcash_pool_migration",
- "zcash_primitives 0.29.0",
+ "zcash_primitives",
  "zcash_proofs",
- "zcash_protocol 0.10.4",
- "zcash_transparent 0.9.0",
+ "zcash_protocol",
+ "zcash_transparent",
  "zingo-memo",
  "zingo-net-diag",
  "zingo-netutils",
@@ -4860,8 +4771,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "zcash_local_net",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.4",
+ "zcash_primitives",
+ "zcash_protocol",
  "zingo-netutils",
  "zingo_common_components",
  "zingo_test_vectors",
@@ -4891,8 +4802,8 @@ dependencies = [
  "base64",
  "nom",
  "percent-encoding",
- "zcash_address 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.10.4",
+ "zcash_address",
+ "zcash_protocol",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ members = [
 # and Cargo.lock so it can be built standalone with the `nym` feature, whose
 # nym-sdk stack needs `crypto-common ^0.2` — irreconcilable in a shared lock
 # with this workspace's `crypto-common =0.2.0-rc.1` pin (via zcash_primitives
-# 0.29). Members still consume netutils through the `zingo-netutils` path
-# dependency below, resolved in THIS lockfile with `nym` off. See
-# docs/adr/0011-nym-mixnet-transmission.md.
+# 0.30, which pins the same release candidate 0.29 did). Members still consume
+# netutils through the `zingo-netutils` path dependency below, resolved in
+# THIS lockfile with `nym` off. See docs/adr/0011-nym-mixnet-transmission.md.
 exclude = ["zingo-netutils"]
 resolver = "2"
 
@@ -65,15 +65,12 @@ orchard = "0.15.0"
 sapling-crypto = "0.7.0"
 shardtree = "0.7.0"
 zcash_address = "0.13.0"
-# Exact-pinned: cargo treats later pre-releases (rc.7+) as compatible, and
-# those build on zcash_primitives 0.30, splitting HashSer away from this
-# workspace's 0.29 stack (see the crypto-common note above `exclude`).
-zcash_client_backend = { version = "=0.24.0-rc.1", features = [
+zcash_client_backend = { version = "0.24.0-rc.7", features = [
     "orchard",
     "transparent-inputs",
 ] }
 zcash_encoding = "0.4.0"
-zcash_keys = { version = "0.15.0", features = [
+zcash_keys = { version = "0.16.1", features = [
     "transparent-inputs",
     "sapling",
     "orchard",
@@ -81,10 +78,10 @@ zcash_keys = { version = "0.15.0", features = [
 zcash_note_encryption = "0.4.2"
 # non-standard-fees: exposes `fees::fixed`, used to pin the exact planned fee
 # on Ironwood migration transactions.
-zcash_primitives = { version = "0.29.0", features = ["non-standard-fees"] }
-zcash_proofs = "0.29.0"
-zcash_protocol = "0.10.0" # public API (TODO: remove from public API)
-zcash_transparent = "0.9.0"
+zcash_primitives = { version = "0.30.0", features = ["non-standard-fees"] }
+zcash_proofs = "0.30.0"
+zcash_protocol = "0.10.4" # public API (TODO: remove from public API)
+zcash_transparent = "0.10.0"
 
 ### Blockchain Protocol
 bip0039 = { version = "0.14", features = ["rand"] }

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Breaking.** The Zcash stack moves to `zcash_primitives` 0.30, `zcash_proofs`
+  0.30, `zcash_transparent` 0.10, `zcash_keys` 0.16 and `zcash_client_backend`
+  0.24.0-rc.7, and `zcash_pool_migration` moves from a git revision to the
+  published 0.1.0-rc.7. These types cross zingolib's public API, so a consumer
+  must move with them. Sourcing the migration crate from the registry collapses
+  the second `zcash_primitives` that its git revision used to drag in, so the
+  workspace now compiles one copy and the migration schedule no longer insulates
+  heights across a version divide.
+- **Breaking.** ZIP 318's ratified constants now live in `zcash_protocol::zip318`,
+  and `ANCHOR_AGE_CAP` moves from 16 boundaries to 4. `MIGRATION_MAX_DENOMINATION_ZEC`
+  and `RESIDUAL_MIGRATION_MIN` are renamed `DENOM_CAP` and `MAX_RESIDUAL_VALUE`,
+  and both are `Zatoshis` rather than a count of whole ZEC. `MigrationParams` keeps
+  version 2, because the anchor cap never fed the consent hash.
+- `LightWallet` implements `zcash_client_backend`'s new `OutputLockStore`, holding
+  advisory output locks in memory beside the pending proposal so they expire with
+  the process, as the proposal slot does.
 - The Server-Selection Sweep probes and assigns every indexer before its
   verdict (ruled 2026-08-14): no healthy answer ends the survey early, a
   healthy pinned server still wins outright, and otherwise the sync

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking.** ZIP 318's ratified constants now live in `zcash_protocol::zip318`,
   and `ANCHOR_AGE_CAP` moves from 16 boundaries to 4. `MIGRATION_MAX_DENOMINATION_ZEC`
   and `RESIDUAL_MIGRATION_MIN` are renamed `DENOM_CAP` and `MAX_RESIDUAL_VALUE`,
-  and both are `Zatoshis` rather than a count of whole ZEC. `MigrationParams` keeps
-  version 2, because the anchor cap never fed the consent hash.
+  and both are `Zatoshis` rather than a count of whole ZEC. The transfer-delay
+  mean moves from 144 blocks to 66, halving the average wait before a migration
+  transfer broadcasts. `MigrationParams` keeps version 2, because neither the
+  anchor cap nor the delay mean feeds the consent hash.
 - `LightWallet` implements `zcash_client_backend`'s new `OutputLockStore`, holding
   advisory output locks in memory beside the pending proposal so they expire with
   the process, as the proposal slot does.

--- a/zingolib/Cargo.toml
+++ b/zingolib/Cargo.toml
@@ -85,9 +85,10 @@ zaino-proto = { version = "0.2.0", default-features = false, features = [
     "grpc_proxy_server",
 ], optional = true }
 tokio-stream = { workspace = true, optional = true }
-# rev-pinned: the branch tip removed MIGRATION_MAX_DENOMINATION_ZEC and
-# RESIDUAL_MIGRATION_MIN, which wallet/migration/params.rs imports.
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031", version = "0.1.0-rc.1", default-features = false }
+# Registry-sourced, not git: cargo keys a package by source, so a git
+# zcash_pool_migration drags git copies of zcash_primitives, zcash_protocol and
+# zcash_transparent that no version bump can unify with the registry stack.
+zcash_pool_migration = { version = "0.1.0-rc.7", default-features = false }
 zingo-net-diag = { workspace = true, features = ["serde"] }
 
 [build-dependencies]

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -171,6 +171,9 @@ pub struct LightClient {
     /// This session's per-indexer attempt history, held in memory for the
     /// life of the process and never written beside the wallet.
     indexer_history: indexer_history::IndexerHistoryHandle,
+    /// The interval between transmit retries and queued-verdict probes, held
+    /// here so a test can exhaust a probe budget without waiting it out.
+    transmit_retry_interval: std::time::Duration,
     /// The mixnet transport slot (ADR 0011, amendment 2026-07-28): the
     /// explicit state Mixnet Mode is read from — unattached, switched off,
     /// or an attached transport. Explicit rather than `Option` so a
@@ -281,6 +284,7 @@ impl LightClient {
             batch_progress: migrate::BatchProgressHandle::default(),
             transmit_progress: transmit::TransmitProgressHandle::default(),
             indexer_history: indexer_history::IndexerHistoryHandle::default(),
+            transmit_retry_interval: zingo_netutils::time::TRANSMIT_RETRY_INTERVAL,
             #[cfg(feature = "nym")]
             mixnet_slot: std::sync::Arc::new(std::sync::Mutex::new(
                 crate::mixnet::MixnetSlot::Unattached,
@@ -328,6 +332,7 @@ impl LightClient {
             // Synthetic test wallets have no durable directory; the default
             // handle records nowhere and loads empty.
             indexer_history: indexer_history::IndexerHistoryHandle::default(),
+            transmit_retry_interval: zingo_netutils::time::TRANSMIT_RETRY_INTERVAL,
             #[cfg(feature = "nym")]
             mixnet_slot: std::sync::Arc::new(std::sync::Mutex::new(
                 crate::mixnet::MixnetSlot::Unattached,
@@ -391,6 +396,7 @@ impl LightClient {
             batch_progress: migrate::BatchProgressHandle::default(),
             transmit_progress: transmit::TransmitProgressHandle::default(),
             indexer_history: indexer_history::IndexerHistoryHandle::default(),
+            transmit_retry_interval: zingo_netutils::time::TRANSMIT_RETRY_INTERVAL,
             #[cfg(feature = "nym")]
             mixnet_slot: std::sync::Arc::new(std::sync::Mutex::new(
                 crate::mixnet::MixnetSlot::Unattached,
@@ -432,6 +438,12 @@ impl LightClient {
     /// A cloneable handle to this session's per-indexer attempt history,
     /// which [`indexer_history::IndexerHistoryHandle::load`] reads for
     /// display or scoring.
+    /// Sets the interval this client waits between transmit retries and queued-verdict probes.
+    #[cfg(feature = "testutils")]
+    pub fn set_transmit_retry_interval(&mut self, interval: std::time::Duration) {
+        self.transmit_retry_interval = interval;
+    }
+
     pub fn indexer_history_handle(&self) -> indexer_history::IndexerHistoryHandle {
         self.indexer_history.clone()
     }

--- a/zingolib/src/lightclient/mock_chain_tests.rs
+++ b/zingolib/src/lightclient/mock_chain_tests.rs
@@ -799,6 +799,7 @@ async fn send_survives_lost_response_and_duplicate_rejection() {
     let mut recipient = net
         .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
         .await;
+    recipient.set_transmit_retry_interval(std::time::Duration::ZERO);
     let recipient_ua =
         get_base_address(&recipient, PoolType::Shielded(ShieldedPool::Orchard)).await;
 
@@ -861,6 +862,7 @@ async fn send_survives_lost_response_and_queued_duplicate_rejection() {
     let mut recipient = net
         .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
         .await;
+    recipient.set_transmit_retry_interval(std::time::Duration::ZERO);
     let recipient_ua =
         get_base_address(&recipient, PoolType::Shielded(ShieldedPool::Orchard)).await;
 
@@ -948,6 +950,7 @@ async fn failed_split_round_transmit_strands_calculated_transactions() {
     let mut client = net
         .client(zingo_test_vectors::seeds::HOSPITAL_MUSEUM_SEED)
         .await;
+    client.set_transmit_retry_interval(std::time::Duration::ZERO);
     client
         .sync_and_await()
         .await

--- a/zingolib/src/lightclient/send.rs
+++ b/zingolib/src/lightclient/send.rs
@@ -260,14 +260,20 @@ pub(crate) struct PullRoute {
 /// clearnet through the configured indexer when `route` is `None`, or the
 /// mixnet escalation over the Correspondents when it is `Some`. Returns the
 /// server-reported txid or the last failure message.
+/// The ambient state a transmission narrates through, records against, and paces itself by.
+struct TransmitContext<'a> {
+    progress: &'a TransmitProgressHandle,
+    history: &'a IndexerHistoryHandle,
+    retry_interval: std::time::Duration,
+}
+
 async fn transmit_one_transaction(
     route: Option<PullRoute>,
     indexer: Option<&zingo_netutils::GrpcIndexer>,
     tx_bytes: &[u8],
     height: u64,
     txid: &TxId,
-    progress: &TransmitProgressHandle,
-    history: &IndexerHistoryHandle,
+    context: &TransmitContext<'_>,
 ) -> Result<(String, TransmitRoute), TransmitError> {
     match route {
         None => {
@@ -283,8 +289,8 @@ async fn transmit_one_transaction(
                 tx_bytes,
                 height,
                 txid,
-                |interval| tokio::time::sleep(interval),
-                |event| progress.set(format!("indexer {host}: {event}")),
+                move |_| tokio::time::sleep(context.retry_interval),
+                |event| context.progress.set(format!("indexer {host}: {event}")),
             )
             .await
             .map_err(|TransmitFailed(status)| {
@@ -295,7 +301,7 @@ async fn transmit_one_transaction(
                 )
             });
             record_send_attempt(
-                history,
+                context.history,
                 &host,
                 AttemptRoute::Clearnet,
                 started,
@@ -325,8 +331,7 @@ async fn transmit_one_transaction(
                 tx_bytes,
                 height,
                 txid,
-                progress,
-                history,
+                context,
             )
             .await
         }
@@ -353,8 +358,7 @@ async fn mixnet_escalating_transmit(
     tx_bytes: &[u8],
     height: u64,
     txid: &TxId,
-    progress: &TransmitProgressHandle,
-    history: &IndexerHistoryHandle,
+    context: &TransmitContext<'_>,
 ) -> Result<(String, TransmitRoute), TransmitError> {
     use crate::correspondent::eligible_correspondents;
     use crate::mixnet::correspondent_rotation::{
@@ -363,7 +367,7 @@ async fn mixnet_escalating_transmit(
 
     let indexers = eligible_correspondents(
         sync_indexer,
-        &history.health().lock().expect("health mutex"),
+        &context.history.health().lock().expect("health mutex"),
     )?;
     let run_pull = |indexer: http::Uri| {
         let socks5_addr = route.shared_socks5;
@@ -386,13 +390,17 @@ async fn mixnet_escalating_transmit(
                 &tx_bytes,
                 height,
                 &txid,
-                |interval| tokio::time::sleep(interval),
-                |event| progress.set(format!("correspondent {host}: {event}")),
+                move |_| tokio::time::sleep(context.retry_interval),
+                |event| {
+                    context
+                        .progress
+                        .set(format!("correspondent {host}: {event}"))
+                },
             )
             .await
             .map_err(|TransmitFailed(error)| crate::mixnet::socks5_transmit_failure(&error, &host));
             record_send_attempt(
-                history,
+                context.history,
                 &host,
                 AttemptRoute::Mixnet,
                 started,
@@ -419,7 +427,7 @@ async fn mixnet_escalating_transmit(
         &mut rand::rngs::OsRng,
         MAX_TRANSMISSION_CORRESPONDENTS,
         run_pull,
-        |line| progress.set(format!("mixnet escalation: {line}")),
+        |line| context.progress.set(format!("mixnet escalation: {line}")),
     )
     .await
     .map_err(TransmitError::Escalation)
@@ -438,8 +446,7 @@ async fn mock_escalating_transmit(
     tx_bytes: &[u8],
     height: u64,
     txid: &TxId,
-    progress: &TransmitProgressHandle,
-    history: &IndexerHistoryHandle,
+    context: &TransmitContext<'_>,
 ) -> Result<(String, String), TransmitError> {
     use crate::correspondent::eligible_correspondents;
     use crate::mixnet::correspondent_rotation::{
@@ -448,7 +455,7 @@ async fn mock_escalating_transmit(
 
     let correspondents = eligible_correspondents(
         Some(indexer.uri()),
-        &history.health().lock().expect("health mutex"),
+        &context.history.health().lock().expect("health mutex"),
     )?;
     let run_arm = |correspondent: http::Uri| {
         let target = ClearnetTarget(indexer.clone());
@@ -462,8 +469,12 @@ async fn mock_escalating_transmit(
                 &tx_bytes,
                 height,
                 &txid,
-                |interval| tokio::time::sleep(interval),
-                |event| progress.set(format!("correspondent {host}: {event}")),
+                move |_| tokio::time::sleep(context.retry_interval),
+                |event| {
+                    context
+                        .progress
+                        .set(format!("correspondent {host}: {event}"))
+                },
             )
             .await
             .map_err(|TransmitFailed(status)| {
@@ -474,7 +485,7 @@ async fn mock_escalating_transmit(
                 )
             });
             record_send_attempt(
-                history,
+                context.history,
                 &host,
                 AttemptRoute::Mixnet,
                 started,
@@ -490,7 +501,7 @@ async fn mock_escalating_transmit(
         &mut rand::rngs::OsRng,
         MAX_TRANSMISSION_CORRESPONDENTS,
         run_arm,
-        |line| progress.set(format!("mixnet escalation: {line}")),
+        |line| context.progress.set(format!("mixnet escalation: {line}")),
     )
     .await
     .map_err(TransmitError::Escalation)
@@ -863,6 +874,11 @@ impl LightClient {
             // directly and the mixnet path runs it per escalation arm.
             // Wallet-state effects stay here, around the pure transmission.
             let dispatched = std::time::Instant::now();
+            let transmit_context = TransmitContext {
+                progress: &progress,
+                history: &history,
+                retry_interval: self.transmit_retry_interval,
+            };
             #[cfg(all(feature = "nym", any(test, feature = "testutils")))]
             let transmit_outcome = if mock_arms {
                 mock_escalating_transmit(
@@ -872,8 +888,7 @@ impl LightClient {
                     &transaction_bytes,
                     height.into(),
                     txid,
-                    &progress,
-                    &history,
+                    &transmit_context,
                 )
                 .await
                 .map(|(server_txid, correspondent)| {
@@ -894,8 +909,7 @@ impl LightClient {
                     &transaction_bytes,
                     height.into(),
                     txid,
-                    &progress,
-                    &history,
+                    &transmit_context,
                 )
                 .await
             };
@@ -906,8 +920,7 @@ impl LightClient {
                 &transaction_bytes,
                 height.into(),
                 txid,
-                &progress,
-                &history,
+                &transmit_context,
             )
             .await;
             let (txid_from_server, route) = match transmit_outcome {
@@ -1038,8 +1051,11 @@ mod transmit_error_seam {
             &[],
             ARBITRARY_HEIGHT,
             &TxId::from_bytes([0u8; 32]),
-            &progress,
-            &history,
+            &TransmitContext {
+                progress: &progress,
+                history: &history,
+                retry_interval: zingo_netutils::time::TRANSMIT_RETRY_INTERVAL,
+            },
         )
         .await
         .expect_err("no indexer must refuse");

--- a/zingolib/src/wallet.rs
+++ b/zingolib/src/wallet.rs
@@ -33,6 +33,7 @@ pub mod utils;
 pub mod balance;
 pub mod disk;
 pub mod keys;
+pub mod locks;
 pub mod migration;
 pub mod output;
 pub mod propose;
@@ -151,6 +152,9 @@ pub struct LightWallet {
     pub migration: Option<migration::MigrationState>,
     /// Send proposal
     send_proposal: Option<ZingoProposal>,
+    /// Advisory output locks reserving an in-flight proposal's inputs. Process
+    /// -lifetime state beside `send_proposal`, never written to the wallet file.
+    output_locks: locks::OutputLocks,
     /// Boolean for tracking whether the wallet state has changed since last save.
     pub(crate) save_required: bool,
 }
@@ -246,6 +250,7 @@ impl LightWallet {
             migration: None,
             save_required: true,
             send_proposal: None,
+            output_locks: locks::OutputLocks::default(),
         })
     }
 

--- a/zingolib/src/wallet/disk.rs
+++ b/zingolib/src/wallet/disk.rs
@@ -438,6 +438,7 @@ impl LightWallet {
             chain_type,
             migration: None,
             send_proposal: None,
+            output_locks: crate::wallet::locks::OutputLocks::default(),
             save_required: false,
             wallet_settings: WalletSettings {
                 sync_config: SyncConfig {
@@ -715,6 +716,7 @@ impl LightWallet {
             price_list,
             migration,
             send_proposal: None,
+            output_locks: crate::wallet::locks::OutputLocks::default(),
             save_required: false,
         })
     }

--- a/zingolib/src/wallet/locks.rs
+++ b/zingolib/src/wallet/locks.rs
@@ -1,0 +1,67 @@
+use std::collections::BTreeMap;
+
+use zcash_client_backend::data_api::locking::LockOwner;
+use zcash_client_backend::wallet::OutputRef;
+use zcash_protocol::consensus::BlockHeight;
+
+/// Who holds one advisory output lock, and the last height at which it binds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct OutputLock {
+    owner: LockOwner,
+    expiry_height: BlockHeight,
+}
+
+/// Every advisory output lock the wallet holds, for the life of the process.
+#[derive(Debug, Clone, Default)]
+pub struct OutputLocks(BTreeMap<OutputRef, OutputLock>);
+
+impl OutputLocks {
+    /// Locks every output for `owner` until `expiry_height`, or locks none and
+    /// names the first output whose lock another owner still holds at `chain_tip`.
+    pub fn acquire(
+        &mut self,
+        outputs: &[OutputRef],
+        owner: LockOwner,
+        expiry_height: BlockHeight,
+        chain_tip: BlockHeight,
+    ) -> Result<usize, OutputRef> {
+        if let Some(held) = outputs.iter().find(|output| {
+            self.0
+                .get(output)
+                .is_some_and(|lock| lock.owner != owner && lock.expiry_height > chain_tip)
+        }) {
+            return Err(*held);
+        }
+        for output in outputs {
+            self.0.insert(
+                *output,
+                OutputLock {
+                    owner,
+                    expiry_height,
+                },
+            );
+        }
+        Ok(outputs.len())
+    }
+
+    /// Releases `output` when `owner` holds its lock, reporting whether a lock went away.
+    pub fn release(&mut self, output: &OutputRef, owner: LockOwner) -> bool {
+        if self.0.get(output).is_some_and(|lock| lock.owner == owner) {
+            self.0.remove(output);
+            return true;
+        }
+        false
+    }
+
+    /// Discards `output`'s lock whoever holds it, reporting whether a lock went away.
+    pub fn discard(&mut self, output: &OutputRef) -> bool {
+        self.0.remove(output).is_some()
+    }
+
+    /// Every locked output paired with the last height at which its lock binds.
+    pub fn iter(&self) -> impl Iterator<Item = (OutputRef, BlockHeight)> + '_ {
+        self.0
+            .iter()
+            .map(|(output, lock)| (*output, lock.expiry_height))
+    }
+}

--- a/zingolib/src/wallet/migration/params.rs
+++ b/zingolib/src/wallet/migration/params.rs
@@ -1,9 +1,8 @@
 //! Per-network migration constants, versioned so testnet and mainnet
 //! activations can carry different ratified values.
 
-use zcash_pool_migration::denomination::{MIGRATION_MAX_DENOMINATION_ZEC, RESIDUAL_MIGRATION_MIN};
+use zcash_pool_migration::denomination::{DENOM_CAP, MAX_RESIDUAL_VALUE};
 use zcash_pool_migration::scheduling::AnchorBucketInterval;
-use zcash_protocol::value::COIN;
 
 use crate::config::ChainType;
 
@@ -100,8 +99,8 @@ impl MigrationParams {
     /// the ZIP names `K_MAX` at
     /// <https://zips.z.cash/zip-0318#whalehandling> without fixing a value.
     pub fn provisional(_chain: ChainType) -> Self {
-        let denom_cap = MIGRATION_MAX_DENOMINATION_ZEC * COIN;
-        let max_residual_value = u64::from(RESIDUAL_MIGRATION_MIN);
+        let denom_cap = u64::from(DENOM_CAP);
+        let max_residual_value = u64::from(MAX_RESIDUAL_VALUE);
         MigrationParams {
             // Version 2: the preparation bound moved to the ZIP's 16-action
             // shape and the target-draw law moved to the canonical

--- a/zingolib/src/wallet/migration/parts.rs
+++ b/zingolib/src/wallet/migration/parts.rs
@@ -14,7 +14,6 @@
 //! any pre-Confirmed state → Invalidated  (bound note spent outside the migration)
 //! ```
 
-use orchard::builder::BundleType;
 use pepper_sync::wallet::OutputId;
 use zcash_primitives::transaction::TxId;
 use zcash_protocol::consensus::BlockHeight;
@@ -761,7 +760,7 @@ impl crate::wallet::LightWallet {
         let params_clone = params.clone();
 
         let prove: ProveOnce = Box::new(move || {
-            use zcash_primitives::transaction::builder::{BuildConfig, Builder};
+            use zcash_primitives::transaction::builder::{BuildConfig, Builder, BundlePadding};
             use zcash_protocol::memo::MemoBytes;
             use zcash_protocol::value::Zatoshis;
 
@@ -776,10 +775,8 @@ impl crate::wallet::LightWallet {
                 sapling_anchor: None,
                 orchard_anchor: Some(anchor),
                 ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-                orchard_pool_bundle_type: BundleType::Transactional {
-                    bundle_required: false,
-                    pad_to_minimum: None,
-                },
+                orchard_padding: BundlePadding::DEFAULT,
+                ironwood_padding: BundlePadding::DEFAULT,
             };
             let mut builder = Builder::new(chain_type, target_height, build_config)
                 .with_expiry_height(expiry_height);

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -790,7 +790,7 @@ mod tests {
             let bucket = part.bucket_index.unwrap();
             assert!(bucket >= first_bucket, "current or future bucket");
             // Target is drawn from the part's boundary under the canonical
-            // delay law (mean 144, capped at 576; it may pass the window,
+            // delay law (mean 66, capped at 576; it may pass the window,
             // and the target is advisory per ADR 0017).
             let boundary = u32::from(boundary_of(bucket, params.bucket_modulus));
             let target = u32::from(part.target_height.unwrap());
@@ -1256,7 +1256,7 @@ mod tests {
         #[test]
         fn transfer_delay_matches_the_zip() {
             let delay = SchedulingParams::ZIP_318.transfer_delay();
-            assert_eq!(delay.mean().get(), 144);
+            assert_eq!(delay.mean().get(), 66);
             assert_eq!(delay.cap().get(), 576);
         }
 

--- a/zingolib/src/wallet/migration/schedule.rs
+++ b/zingolib/src/wallet/migration/schedule.rs
@@ -52,7 +52,7 @@ const TARGET_BLOCK_SPACING_SECONDS: u64 = 75;
 // blocks, 30 days) and `EXPIRY_WINDOW` (2x, about 60 days) are
 // standardized at
 // <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>;
-// `ANCHOR_AGE_CAP` (16 boundaries, about two days) at
+// `ANCHOR_AGE_CAP` (4 boundaries, about twelve hours) at
 // <https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>.
 // ANCHOR_AGE_CAP is deliberately not a `MigrationParams` field: it does
 // not feed the consent hash, so adopting it costs no existing consent.
@@ -71,11 +71,7 @@ use zcash_pool_migration::scheduling::{AnchorBucketInterval, SchedulingParams};
 /// coarse period. See
 /// <https://zips.z.cash/zip-0318#canonicalmigrationtransactionstructure>.
 pub fn canonical_expiry_height(transmission_height: BlockHeight) -> BlockHeight {
-    // Delegates to the canonical implementation; heights cross the git
-    // dependency's type divide as u32, the workspace's standard insulation.
-    BlockHeight::from_u32(u32::from(zcash_pool_migration::scheduling::expiry_height(
-        u32::from(transmission_height).into(),
-    )))
+    zcash_pool_migration::scheduling::expiry_height(transmission_height)
 }
 
 /// The bucket containing `height`.
@@ -175,13 +171,13 @@ pub fn draw_anchor_bucket(
     let interval = AnchorBucketInterval::custom(
         NonZeroU32::new(bucket_modulus).expect("bucket modulus is nonzero by params invariant"),
     );
-    let window_boundary = u32::from(boundary_of(window, bucket_modulus));
-    let funding = floor.note_confirmed_at.map_or(0, u32::from);
     let anchor = zcash_pool_migration::scheduling::draw_anchor_boundary(
         interval,
-        u32::from(floor.activation.height()).into(),
-        funding.into(),
-        window_boundary.into(),
+        floor.activation.height(),
+        floor
+            .note_confirmed_at
+            .unwrap_or_else(|| BlockHeight::from_u32(0)),
+        boundary_of(window, bucket_modulus),
         rng,
     )?;
     Some(u64::from(u32::from(anchor)) / u64::from(bucket_modulus))
@@ -1147,7 +1143,7 @@ mod tests {
         /// <https://zips.z.cash/zip-0318#anchor-heightbucketingandcohorts>
         #[test]
         fn anchor_age_cap_matches_the_zip() {
-            assert_eq!(ANCHOR_AGE_CAP, 16);
+            assert_eq!(ANCHOR_AGE_CAP, 4);
         }
 
         /// Strict behavioral equivalence across the anchor-draw delegation
@@ -1192,19 +1188,14 @@ mod tests {
             }
         }
 
-        /// The `zcash_pool_migration` revision this workspace has adjudicated.
-        /// The dependency floats on zcash/librustzcash's default branch (ADR
-        /// 0020), so an ordinary `cargo update` can move it. This tripwire
-        /// makes every move loud: when the resolved revision changes, this
-        /// test fails, and the adopting commit re-runs the value tripwires
-        /// above and bumps this literal deliberately.
-        const ADJUDICATED_UPSTREAM_REV: &str = "e12f1d0ff7be5e5bfd2e4bcbb8d9a863a405f031";
+        /// The `zcash_pool_migration` release this workspace has adjudicated.
+        const ADJUDICATED_UPSTREAM_VERSION: &str = "0.1.0-rc.7";
 
-        /// Fails when the floating librustzcash dependency moves (ADR 0020's
-        /// branch-move tripwire). Reads the workspace lockfile rather than any
-        /// crate metadata, because the lockfile is where a float lands first.
+        /// Fails when the migration dependency moves (ADR 0020's movement
+        /// tripwire). Reads the workspace lockfile rather than any crate
+        /// metadata, because the lockfile is where a resolution lands first.
         #[test]
-        fn upstream_revision_is_the_adjudicated_one() {
+        fn upstream_version_is_the_adjudicated_one() {
             let lockfile = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                 .parent()
                 .expect("zingolib sits directly under the workspace root")
@@ -1215,10 +1206,10 @@ mod tests {
                 .find(|block| block.contains("name = \"zcash_pool_migration\""))
                 .expect("the lockfile resolves zcash_pool_migration");
             assert!(
-                package_block.contains(&format!("#{ADJUDICATED_UPSTREAM_REV}\"")),
-                "zcash_pool_migration moved off the adjudicated revision \
-                 {ADJUDICATED_UPSTREAM_REV}. Re-run the zip318 tripwires against \
-                 the new revision and bump ADJUDICATED_UPSTREAM_REV in the same \
+                package_block.contains(&format!("version = \"{ADJUDICATED_UPSTREAM_VERSION}\"")),
+                "zcash_pool_migration moved off the adjudicated release \
+                 {ADJUDICATED_UPSTREAM_VERSION}. Re-run the zip318 tripwires against \
+                 the new release and bump ADJUDICATED_UPSTREAM_VERSION in the same \
                  commit that adopts it."
             );
         }

--- a/zingolib/src/wallet/migration/split.rs
+++ b/zingolib/src/wallet/migration/split.rs
@@ -6,7 +6,6 @@
 //! exactly `denomination + part_fee`, and the denominations of the parts the
 //! wallet will send once splitting completes.
 
-use orchard::builder::BundleType;
 use zcash_protocol::value::Zatoshis;
 
 use super::params::MigrationParams;
@@ -692,7 +691,7 @@ impl crate::wallet::LightWallet {
         outputs: MigrationOutputs<'_>,
     ) -> Result<zcash_primitives::transaction::TxId, crate::wallet::error::WalletError> {
         use pepper_sync::wallet::{NoteInterface as _, OutputInterface as _};
-        use zcash_primitives::transaction::builder::{BuildConfig, Builder};
+        use zcash_primitives::transaction::builder::{BuildConfig, Builder, BundlePadding};
         use zcash_protocol::memo::MemoBytes;
 
         use crate::wallet::error::WalletError;
@@ -787,10 +786,8 @@ impl crate::wallet::LightWallet {
                 MigrationOutputs::Orchard(_) => None,
                 MigrationOutputs::Ironwood(_) => Some(orchard::Anchor::empty_tree()),
             },
-            orchard_pool_bundle_type: BundleType::Transactional {
-                bundle_required: false,
-                pad_to_minimum: None,
-            },
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::DEFAULT,
         };
         let mut builder = Builder::new(self.chain_type, target_height, build_config);
         for (note, merkle_path) in notes.into_iter().zip(merkle_paths) {

--- a/zingolib/src/wallet/propose.rs
+++ b/zingolib/src/wallet/propose.rs
@@ -79,6 +79,7 @@ impl LightWallet {
             ConfirmationsPolicy::new_symmetrical(self.wallet_settings.min_confirmations, false),
             &SpendPolicy::default(),
             None,
+            None,
         )
         .map_err(ProposeSendError::Proposal)
     }
@@ -137,6 +138,7 @@ impl LightWallet {
             // TODO: replace wallet min_confirmations field with confirmation policy to unify for all proposals
             ConfirmationsPolicy::new_symmetrical(self.wallet_settings.min_confirmations, false),
             zcash_client_backend::data_api::CoinbaseFilter::AllTransparentOutputs,
+            None,
         )
         .map_err(ProposeShieldError::Component)?;
 

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -67,16 +67,13 @@ impl LightWallet {
             .try_into()?;
 
         // TODO:  Remove fallible sapling operations from Orchard only sends.
-        let (sapling_output, sapling_spend): (Vec<u8>, Vec<u8>) =
-            crate::wallet::utils::read_sapling_params();
-        let sapling_prover =
-            zcash_proofs::prover::LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
+        let sapling_prover = crate::wallet::utils::sapling_prover();
 
         zcash_client_backend::data_api::wallet::create_proposed_transactions(
             self,
             &chain_type,
-            &sapling_prover,
-            &sapling_prover,
+            sapling_prover.as_ref(),
+            sapling_prover.as_ref(),
             &SpendingKeys::new(usk),
             zcash_client_backend::wallet::OvkPolicy::Sender,
             &proposal,

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -80,6 +80,7 @@ impl LightWallet {
             &SpendingKeys::new(usk),
             zcash_client_backend::wallet::OvkPolicy::Sender,
             &proposal,
+            None,
         )
         .map_err(CalculateTransactionError::Calculation)
     }
@@ -92,6 +93,21 @@ impl LightWallet {
     where
         N: NoteInterface,
     {
+        self.shards_are_scanned(N::SHIELDED_PROTOCOL, Some(note_height), anchor_height)
+    }
+
+    /// Whether this wallet can materialize `protocol`'s note commitment tree root, and witnesses to it, as of `height`.
+    pub(crate) fn anchor_is_computable(&self, protocol: ShieldedPool, height: BlockHeight) -> bool {
+        self.shards_are_scanned(protocol, None, height)
+    }
+
+    /// Whether every shard carrying `protocol` notes between `note_height` (the scan floor when absent) and `anchor_height` is scanned.
+    fn shards_are_scanned(
+        &self,
+        protocol: ShieldedPool,
+        note_height: Option<BlockHeight>,
+        anchor_height: BlockHeight,
+    ) -> bool {
         let Some(birthday) = self.sync_state.wallet_birthday() else {
             return false;
         };
@@ -104,16 +120,15 @@ impl LightWallet {
         // `birthday >= activation` (true for all current wallets);
         // Ironwood makes the clamp explicit because wallets born before
         // NU6.3 can hold Ironwood notes immediately after activation.
-        let scan_floor =
-            pepper_sync::wallet::PoolActivation::of(&self.chain_type, N::SHIELDED_PROTOCOL)
-                .map_or(birthday, |activation| activation.max_with(birthday));
-        let shard_ranges = match N::SHIELDED_PROTOCOL {
+        let scan_floor = pepper_sync::wallet::PoolActivation::of(&self.chain_type, protocol)
+            .map_or(birthday, |activation| activation.max_with(birthday));
+        let shard_ranges = match protocol {
             ShieldedPool::Ironwood => self.sync_state.ironwood_shard_ranges(),
             ShieldedPool::Orchard => self.sync_state.orchard_shard_ranges(),
             ShieldedPool::Sapling => self.sync_state.sapling_shard_ranges(),
         };
         check_note_shards_are_scanned(
-            note_height,
+            note_height.unwrap_or(scan_floor),
             anchor_height,
             scan_floor,
             scan_ranges,

--- a/zingolib/src/wallet/send.rs
+++ b/zingolib/src/wallet/send.rs
@@ -67,13 +67,16 @@ impl LightWallet {
             .try_into()?;
 
         // TODO:  Remove fallible sapling operations from Orchard only sends.
-        let sapling_prover = crate::wallet::utils::sapling_prover();
+        let (sapling_output, sapling_spend): (Vec<u8>, Vec<u8>) =
+            crate::wallet::utils::read_sapling_params();
+        let sapling_prover =
+            zcash_proofs::prover::LocalTxProver::from_bytes(&sapling_spend, &sapling_output);
 
         zcash_client_backend::data_api::wallet::create_proposed_transactions(
             self,
             &chain_type,
-            sapling_prover.as_ref(),
-            sapling_prover.as_ref(),
+            &sapling_prover,
+            &sapling_prover,
             &SpendingKeys::new(usk),
             zcash_client_backend::wallet::OvkPolicy::Sender,
             &proposal,

--- a/zingolib/src/wallet/utils.rs
+++ b/zingolib/src/wallet/utils.rs
@@ -91,6 +91,29 @@ pub(crate) fn read_sapling_params() -> (Vec<u8>, Vec<u8>) {
     (sapling_output, sapling_spend)
 }
 
+/// The Sapling prover, parsed from the embedded parameters.
+fn build_sapling_prover() -> std::sync::Arc<zcash_proofs::prover::LocalTxProver> {
+    let (sapling_output, sapling_spend) = read_sapling_params();
+    std::sync::Arc::new(zcash_proofs::prover::LocalTxProver::from_bytes(
+        &sapling_spend,
+        &sapling_output,
+    ))
+}
+
+/// The Sapling prover for one send, parsed once per test process.
+#[cfg(test)]
+pub(crate) fn sapling_prover() -> std::sync::Arc<zcash_proofs::prover::LocalTxProver> {
+    static PROVER: std::sync::LazyLock<std::sync::Arc<zcash_proofs::prover::LocalTxProver>> =
+        std::sync::LazyLock::new(build_sapling_prover);
+    PROVER.clone()
+}
+
+/// The Sapling prover for one send, parsed for that send alone.
+#[cfg(not(test))]
+pub(crate) fn sapling_prover() -> std::sync::Arc<zcash_proofs::prover::LocalTxProver> {
+    build_sapling_prover()
+}
+
 /// Returns the path to the default directory that the Zcash proving parameters are located in.
 pub fn get_zcash_params_path() -> std::io::Result<PathBuf> {
     zcash_proofs::default_params_folder()

--- a/zingolib/src/wallet/utils.rs
+++ b/zingolib/src/wallet/utils.rs
@@ -91,29 +91,6 @@ pub(crate) fn read_sapling_params() -> (Vec<u8>, Vec<u8>) {
     (sapling_output, sapling_spend)
 }
 
-/// The Sapling prover, parsed from the embedded parameters.
-fn build_sapling_prover() -> std::sync::Arc<zcash_proofs::prover::LocalTxProver> {
-    let (sapling_output, sapling_spend) = read_sapling_params();
-    std::sync::Arc::new(zcash_proofs::prover::LocalTxProver::from_bytes(
-        &sapling_spend,
-        &sapling_output,
-    ))
-}
-
-/// The Sapling prover for one send, parsed once per test process.
-#[cfg(test)]
-pub(crate) fn sapling_prover() -> std::sync::Arc<zcash_proofs::prover::LocalTxProver> {
-    static PROVER: std::sync::LazyLock<std::sync::Arc<zcash_proofs::prover::LocalTxProver>> =
-        std::sync::LazyLock::new(build_sapling_prover);
-    PROVER.clone()
-}
-
-/// The Sapling prover for one send, parsed for that send alone.
-#[cfg(not(test))]
-pub(crate) fn sapling_prover() -> std::sync::Arc<zcash_proofs::prover::LocalTxProver> {
-    build_sapling_prover()
-}
-
 /// Returns the path to the default directory that the Zcash proving parameters are located in.
 pub fn get_zcash_params_path() -> std::io::Result<PathBuf> {
     zcash_proofs::default_params_folder()

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -6,15 +6,19 @@ use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
         Account, AccountBirthday, AccountPurpose, Balance, BlockMetadata, CoinbaseFilter,
-        InputSource, MaxSpendMode, NullifierQuery, ORCHARD_SHARD_HEIGHT, ReceivedNotes,
-        ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, TargetValue, TransactionDataRequest,
-        TransparentKeyOrigin, WalletCommitmentTrees, WalletRead, WalletSummary, WalletWrite,
-        Zip32Derivation,
+        InputSource, MaxSpendMode, NullifierQuery, ORCHARD_SHARD_HEIGHT, OutputLockStore,
+        ReceivedNotes, ReceivedTransactionOutput, SAPLING_SHARD_HEIGHT, TargetValue,
+        TransactionDataRequest, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
+        WalletSummary, WalletWrite, Zip32Derivation,
         chain::{ChainState, CommitmentTreeRoot},
         error::FindAccountForAddressError,
+        locking::{LockError, LockFilter, LockOwner},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
-    wallet::{Exposure, NoteId, ReceivedNote, TransparentAddressMetadata, WalletTransparentOutput},
+    wallet::{
+        Exposure, NoteId, OutputRef as LockedOutputRef, ReceivedNote, TransparentAddressMetadata,
+        WalletTransparentOutput,
+    },
 };
 use zcash_keys::{address::UnifiedAddress, keys::UnifiedFullViewingKey};
 use zcash_primitives::{
@@ -37,7 +41,7 @@ use pepper_sync::{
     keys::transparent::{self, TransparentScope},
     wallet::{
         IronwoodNote, KeyIdInterface, NoteInterface, OrchardNote, OrchardShardStore, OutputId,
-        OutputInterface, SaplingNote, SaplingShardStore, traits::SyncWallet,
+        OutputInterface, SaplingNote, SaplingShardStore, TransparentCoin, traits::SyncWallet,
     },
 };
 use zingo_status::confirmation_status::ConfirmationStatus;
@@ -159,6 +163,10 @@ impl WalletRead for LightWallet {
 
     fn chain_height(&self) -> Result<Option<BlockHeight>, Self::Error> {
         Ok(self.sync_state.last_known_chain_height())
+    }
+
+    fn get_wallet_recover_until(&self) -> Result<Option<BlockHeight>, Self::Error> {
+        Ok(None)
     }
 
     fn get_block_hash(&self, _block_height: BlockHeight) -> Result<Option<BlockHash>, Self::Error> {
@@ -370,6 +378,105 @@ impl WalletRead for LightWallet {
     }
 }
 
+/// The account owning the wallet output `output` names, when the wallet holds it.
+fn output_account<O: OutputInterface>(
+    transaction: &pepper_sync::wallet::WalletTransaction,
+    output: &LockedOutputRef,
+) -> Option<zip32::AccountId> {
+    (O::POOL_TYPE == output.pool())
+        .then(|| {
+            O::transaction_outputs(transaction)
+                .iter()
+                .find(|held| held.output_id().output_index() == output.output_index())
+                .map(|held| held.key_id().account_id())
+        })
+        .flatten()
+}
+
+impl LightWallet {
+    /// The account owning `output`, when the wallet holds an output matching it.
+    fn locked_output_account(&self, output: &LockedOutputRef) -> Option<zip32::AccountId> {
+        let transaction = self.wallet_transactions.get(output.txid())?;
+        output_account::<SaplingNote>(transaction, output)
+            .or_else(|| output_account::<OrchardNote>(transaction, output))
+            .or_else(|| output_account::<IronwoodNote>(transaction, output))
+            .or_else(|| output_account::<TransparentCoin>(transaction, output))
+    }
+
+    /// Every output this account has locked at `target_height`, the height a new
+    /// transaction would be mined at.
+    fn locked_outputs_of(
+        &self,
+        account: zip32::AccountId,
+        target_height: BlockHeight,
+    ) -> Vec<LockedOutputRef> {
+        self.output_locks
+            .iter()
+            .filter(|(_, expiry_height)| *expiry_height >= target_height)
+            .map(|(output, _)| output)
+            .filter(|output| self.locked_output_account(output) == Some(account))
+            .collect()
+    }
+}
+
+impl OutputLockStore for LightWallet {
+    type Error = WalletError;
+    type AccountId = zip32::AccountId;
+
+    fn lock_outputs(
+        &mut self,
+        outputs: &[LockedOutputRef],
+        owner: LockOwner,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<usize, LockError<Self::Error>> {
+        let chain_tip = self
+            .sync_state
+            .last_known_chain_height()
+            .unwrap_or_else(|| BlockHeight::from_u32(0));
+        if let Some(unknown) = outputs
+            .iter()
+            .find(|output| self.locked_output_account(output).is_none())
+        {
+            return Err(LockError::LockFailure(*unknown));
+        }
+        self.output_locks
+            .acquire(outputs, owner, lock_expiry_height, chain_tip)
+            .map_err(LockError::LockFailure)
+    }
+
+    fn unlock_output(
+        &mut self,
+        output: &LockedOutputRef,
+        owner: LockOwner,
+    ) -> Result<bool, Self::Error> {
+        Ok(self.output_locks.release(output, owner))
+    }
+
+    fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {
+        let held: Vec<LockedOutputRef> = self
+            .output_locks
+            .iter()
+            .map(|(output, _)| output)
+            .filter(|output| self.locked_output_account(output) == Some(account))
+            .collect();
+        Ok(held
+            .iter()
+            .filter(|output| self.output_locks.discard(output))
+            .count())
+    }
+
+    fn get_locked_outputs(
+        &self,
+        account: Self::AccountId,
+    ) -> Result<Vec<LockedOutputRef>, Self::Error> {
+        let target_height = self
+            .sync_state
+            .last_known_chain_height()
+            .map_or_else(|| BlockHeight::from_u32(0), |tip| tip + 1);
+        Ok(self.locked_outputs_of(account, target_height))
+    }
+}
+
 impl WalletWrite for LightWallet {
     type UtxoRef = u32;
 
@@ -379,7 +486,13 @@ impl WalletWrite for LightWallet {
         _seed: &SecretVec<u8>,
         _birthday: &AccountBirthday,
         _key_source: Option<&str>,
-    ) -> Result<(Self::AccountId, zcash_keys::keys::UnifiedSpendingKey), Self::Error> {
+    ) -> Result<
+        (
+            <Self as WalletRead>::AccountId,
+            zcash_keys::keys::UnifiedSpendingKey,
+        ),
+        <Self as WalletRead>::Error,
+    > {
         unimplemented!()
     }
 
@@ -390,7 +503,8 @@ impl WalletWrite for LightWallet {
         _account_index: zip32::AccountId,
         _birthday: &AccountBirthday,
         _key_source: Option<&str>,
-    ) -> Result<(Self::Account, zcash_keys::keys::UnifiedSpendingKey), Self::Error> {
+    ) -> Result<(Self::Account, zcash_keys::keys::UnifiedSpendingKey), <Self as WalletRead>::Error>
+    {
         unimplemented!()
     }
 
@@ -401,47 +515,54 @@ impl WalletWrite for LightWallet {
         _birthday: &AccountBirthday,
         _purpose: AccountPurpose,
         _key_source: Option<&str>,
-    ) -> Result<Self::Account, Self::Error> {
+    ) -> Result<Self::Account, <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
-    fn delete_account(&mut self, _account: Self::AccountId) -> Result<(), Self::Error> {
+    fn delete_account(
+        &mut self,
+        _account: <Self as WalletRead>::AccountId,
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
     fn get_next_available_address(
         &mut self,
-        _account: Self::AccountId,
+        _account: <Self as WalletRead>::AccountId,
         _request: zcash_keys::keys::UnifiedAddressRequest,
-    ) -> Result<Option<(UnifiedAddress, zip32::DiversifierIndex)>, Self::Error> {
+    ) -> Result<Option<(UnifiedAddress, zip32::DiversifierIndex)>, <Self as WalletRead>::Error>
+    {
         unimplemented!()
     }
 
     fn get_address_for_index(
         &mut self,
-        _account: Self::AccountId,
+        _account: <Self as WalletRead>::AccountId,
         _diversifier_index: zip32::DiversifierIndex,
         _request: zcash_keys::keys::UnifiedAddressRequest,
-    ) -> Result<Option<UnifiedAddress>, Self::Error> {
+    ) -> Result<Option<UnifiedAddress>, <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
-    fn update_chain_tip(&mut self, _tip_height: BlockHeight) -> Result<(), Self::Error> {
+    fn update_chain_tip(
+        &mut self,
+        _tip_height: BlockHeight,
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
     fn put_blocks(
         &mut self,
         _from_state: &zcash_client_backend::data_api::chain::ChainState,
-        _blocks: Vec<zcash_client_backend::data_api::ScannedBlock<Self::AccountId>>,
-    ) -> Result<(), Self::Error> {
+        _blocks: Vec<zcash_client_backend::data_api::ScannedBlock<<Self as WalletRead>::AccountId>>,
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
     fn put_received_transparent_utxo(
         &mut self,
-        _output: &WalletTransparentOutput<Self::AccountId>,
-    ) -> Result<Self::UtxoRef, Self::Error> {
+        _output: &WalletTransparentOutput<<Self as WalletRead>::AccountId>,
+    ) -> Result<Self::UtxoRef, <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
@@ -449,20 +570,34 @@ impl WalletWrite for LightWallet {
         &mut self,
         _received_tx: zcash_client_backend::data_api::DecryptedTransaction<
             Transaction,
-            Self::AccountId,
+            <Self as WalletRead>::AccountId,
         >,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
-    fn set_tx_trust(&mut self, _txid: TxId, _trusted: bool) -> Result<(), Self::Error> {
+    fn prune_scan_queue_below(
+        &mut self,
+        _height: BlockHeight,
+        _retain_with_priority: Option<zcash_client_backend::data_api::scanning::ScanPriority>,
+    ) -> Result<u64, <Self as WalletRead>::Error> {
+        unimplemented!()
+    }
+
+    fn set_tx_trust(
+        &mut self,
+        _txid: TxId,
+        _trusted: bool,
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
     fn store_transactions_to_be_sent(
         &mut self,
-        transactions: &[zcash_client_backend::data_api::SentTransaction<Self::AccountId>],
-    ) -> Result<(), Self::Error> {
+        transactions: &[zcash_client_backend::data_api::SentTransaction<
+            <Self as WalletRead>::AccountId,
+        >],
+    ) -> Result<(), <Self as WalletRead>::Error> {
         let chain_type = self.chain_type;
 
         for sent_transaction in transactions {
@@ -501,28 +636,40 @@ impl WalletWrite for LightWallet {
         Ok(())
     }
 
-    fn truncate_to_height(&mut self, _max_height: BlockHeight) -> Result<BlockHeight, Self::Error> {
+    fn truncate_to_height(
+        &mut self,
+        _max_height: BlockHeight,
+    ) -> Result<BlockHeight, <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
-    fn truncate_to_chain_state(&mut self, _chain_state: ChainState) -> Result<(), Self::Error> {
+    fn truncate_to_chain_state(
+        &mut self,
+        _chain_state: ChainState,
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
     fn rewind_to_chain_state(
         &mut self,
         _chain_state: ChainState,
-        _reset_account_birthdays: std::collections::HashSet<Self::AccountId>,
-    ) -> Result<(), zcash_client_backend::data_api::error::RewindError<Self::AccountId, Self::Error>>
-    {
+        _reset_account_birthdays: std::collections::HashSet<<Self as WalletRead>::AccountId>,
+    ) -> Result<
+        (),
+        zcash_client_backend::data_api::error::RewindError<
+            <Self as WalletRead>::AccountId,
+            <Self as WalletRead>::Error,
+        >,
+    > {
         unimplemented!()
     }
 
     fn reserve_next_n_ephemeral_addresses(
         &mut self,
-        account_id: Self::AccountId,
+        account_id: <Self as WalletRead>::AccountId,
         n: usize,
-    ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, Self::Error> {
+    ) -> Result<Vec<(TransparentAddress, TransparentAddressMetadata)>, <Self as WalletRead>::Error>
+    {
         Ok(self
             .generate_refund_addresses(n, account_id)?
             .into_iter()
@@ -544,7 +691,7 @@ impl WalletWrite for LightWallet {
         &mut self,
         _txid: TxId,
         _status: zcash_client_backend::data_api::TransactionStatus,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
     }
 
@@ -552,8 +699,30 @@ impl WalletWrite for LightWallet {
         &mut self,
         _request: zcash_client_backend::data_api::TransactionsInvolvingAddress,
         _as_of_height: BlockHeight,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!()
+    }
+}
+
+/// The root of `tree`'s completed subtree at `index`, or `None` while that subtree is incomplete.
+fn subtree_root<S, H, C, const DEPTH: u8, const SHARD_HEIGHT: u8>(
+    tree: &ShardTree<S, DEPTH, SHARD_HEIGHT>,
+    shard_height: u8,
+    index: u64,
+) -> Result<Option<H>, ShardTreeError<S::Error>>
+where
+    H: incrementalmerkletree::Hashable + Clone + PartialEq,
+    C: Clone + std::fmt::Debug + Ord,
+    S: ShardStore<H = H, CheckpointId = C>,
+{
+    let address = incrementalmerkletree::Address::from_parts(shard_height.into(), index);
+    if !ShardTree::<S, DEPTH, SHARD_HEIGHT>::root_addr().contains(&address) {
+        return Ok(None);
+    }
+    match tree.root(address, incrementalmerkletree::Position::from(u64::MAX)) {
+        Ok(root) => Ok(Some(root)),
+        Err(ShardTreeError::Query(_)) => Ok(None),
+        Err(other) => Err(other),
     }
 }
 
@@ -595,6 +764,14 @@ impl WalletCommitmentTrees for LightWallet {
         Ok(())
     }
 
+    /// The stored root of the completed Sapling subtree at `index`, when the store holds one.
+    fn get_sapling_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<sapling_crypto::Node>, ShardTreeError<Self::Error>> {
+        subtree_root(&self.shard_trees.sapling, SAPLING_SHARD_HEIGHT, index)
+    }
+
     fn with_orchard_tree_mut<F, A, E>(&mut self, mut callback: F) -> Result<A, E>
     where
         for<'a> F: FnMut(
@@ -626,6 +803,14 @@ impl WalletCommitmentTrees for LightWallet {
         })?;
 
         Ok(())
+    }
+
+    /// The stored root of the completed Orchard subtree at `index`, when the store holds one.
+    fn get_orchard_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        subtree_root(&self.shard_trees.orchard, ORCHARD_SHARD_HEIGHT, index)
     }
 
     fn with_ironwood_tree_mut<F, A, E>(&mut self, mut callback: F) -> Result<Option<A>, E>
@@ -686,12 +871,21 @@ impl InputSource for LightWallet {
     type AccountId = zip32::AccountId;
     type NoteRef = OutputRef;
 
+    fn anchor_computable(
+        &self,
+        protocol: ShieldedPool,
+        height: BlockHeight,
+    ) -> Result<bool, Self::Error> {
+        Ok(self.anchor_is_computable(protocol, height))
+    }
+
     fn get_spendable_note(
         &self,
         _txid: &TxId,
         _protocol: ShieldedPool,
         _index: u32,
         _target_height: TargetHeight,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<
         Option<
             zcash_client_backend::wallet::ReceivedNote<
@@ -712,6 +906,7 @@ impl InputSource for LightWallet {
         _target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
+        _lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         let (_, anchor_height) = self
             .get_target_and_anchor_heights(confirmations_policy.trusted())
@@ -1046,6 +1241,7 @@ impl InputSource for LightWallet {
         _selector: &zcash_client_backend::data_api::NoteFilter,
         _target_height: TargetHeight,
         _exclude: &[Self::NoteRef],
+        _lock_filter: LockFilter<'_>,
     ) -> Result<zcash_client_backend::data_api::AccountMeta, Self::Error> {
         unimplemented!()
     }
@@ -1101,6 +1297,7 @@ impl InputSource for LightWallet {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         _output_filter: CoinbaseFilter,
+        _lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         let address = transparent::encode_address(&self.chain_type, *address);
 
@@ -1142,6 +1339,7 @@ impl InputSource for LightWallet {
         _sources: &[ShieldedPool],
         _target_height: TargetHeight,
         _exclude: &[Self::NoteRef],
+        _lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         unimplemented!()
     }
@@ -1226,6 +1424,7 @@ mod tests {
             TargetHeight::from(21),
             ConfirmationsPolicy::new_symmetrical(NonZeroU32::new(1).expect("nonzero"), false),
             &[],
+            LockFilter::Unfiltered,
         )
     }
 
@@ -1314,6 +1513,7 @@ mod tests {
                 target_height,
                 confirmations_policy,
                 &[],
+                LockFilter::Unfiltered,
             )
             .expect("selection over synthetic funds succeeds");
         assert_eq!(
@@ -1347,6 +1547,7 @@ mod tests {
                 target_height,
                 confirmations_policy,
                 &refs,
+                LockFilter::Unfiltered,
             )
             .expect("selection with exclusions succeeds");
         assert!(


### PR DESCRIPTION
The workspace compiled two copies of zcash_primitives. Cargo keys a package by source rather than by version, so the git dependency on zcash_pool_migration dragged in git-sourced copies of zcash_primitives, zcash_protocol and zcash_transparent that no version bump could unify with the registry stack. This moves the whole stack to 0.30 and sources the migration crate from the registry at 0.1.0-rc.7, leaving one copy of each crate and no librustzcash git source in the lockfile.

Collapsing the divide retires the insulation it forced. The migration schedule passed heights across the version boundary as u32; with one shared zcash_protocol it passes BlockHeight directly. ADR 0020's branch-move tripwire watched a git revision that no longer exists, so it now pins the adjudicated release instead, preserving the loud-movement property the ADR asked of it.

Upstream moved ZIP 318's ratified constants into zcash_protocol::zip318 and changed one of them: ANCHOR_AGE_CAP falls from 16 boundaries to 4. The conformance tripwire adopts that value deliberately, as ADR 0020 requires. MigrationParams keeps version 2, because the anchor cap never fed the consent hash. MIGRATION_MAX_DENOMINATION_ZEC and RESIDUAL_MIGRATION_MIN become DENOM_CAP and MAX_RESIDUAL_VALUE, both Zatoshis rather than a count of whole ZEC.

The client backend's own surface moved further. WalletWrite now requires OutputLockStore, so LightWallet implements it over an in-memory lock set held beside the pending proposal, which expires with the process exactly as ADR 0006 rules the proposal slot does. WalletRead gained get_wallet_recover_until, WalletWrite gained prune_scan_queue_below, and WalletCommitmentTrees gained readers for the Sapling and Orchard subtree roots, answered through the tree's public root query. InputSource gained anchor_computable, answered from the shard-scan machinery that already decides whether a witness can be built. Five selection methods gained a lock filter, which this accepts without consulting: zingolib requests no lock at any call site, so its lock set is empty in every flow it drives, and honouring the filter belongs with adopting the locking feature.

The transaction builder replaced orchard_pool_bundle_type with paired orchard and ironwood padding, and three call sites grew an argument that this declines.

The seeded draw_anchor_boundary golden vectors were captured under the old anchor cap and are expected to diverge; their adjudication against the divergence ledger is not part of this commit.