### PR TITLE
repro: a panicked scan worker leaves the scanner busy forever

### DIFF
--- a/pepper-sync/src/scan/task.rs
+++ b/pepper-sync/src/scan/task.rs
@@ -843,3 +843,59 @@ impl ScanTask {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // REPRO: `ScanWorker::run` never observes the `JoinHandle` of its spawned task and only clears
+    // `is_scanning` at the end of the loop body. If `scan` panics (reachable from server data via the
+    // `panic!("compact blocks do not match scan range!")` check in `scan.rs`), the worker stays
+    // "scanning" forever, no result or error is ever reported, and `Scanner::idle_worker` never returns
+    // it. Intended invariant: a panicked worker must be reported (error on the result channel or
+    // through the handle) or must go idle.
+    #[tokio::test]
+    async fn panicked_scan_worker_is_reported_or_idle() {
+        let (scan_results_sender, mut scan_results_receiver) = mpsc::unbounded_channel();
+        let (fetch_request_sender, _fetch_request_receiver) =
+            mpsc::unbounded_channel::<FetchRequest>();
+
+        let mut worker = ScanWorker::new(
+            0,
+            consensus::MainNetwork,
+            scan_results_sender,
+            fetch_request_sender,
+            HashMap::new(),
+        );
+        worker.run(1024);
+
+        // Scan range 10..20 with no compact blocks: `scan` panics before producing any result.
+        let scan_task = ScanTask::from_parts(
+            ScanRange::from_parts(
+                BlockHeight::from_u32(10)..BlockHeight::from_u32(20),
+                ScanPriority::Historic,
+            ),
+            None,
+            None,
+            BTreeSet::new(),
+            HashMap::new(),
+        );
+        worker.add_scan_task(scan_task);
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let handle = worker.handle.as_ref().expect("worker should be running");
+        assert!(
+            handle.is_finished(),
+            "worker task should have panicked and finished"
+        );
+
+        let reported = matches!(scan_results_receiver.try_recv(), Ok((_, Err(_))));
+
+        assert!(
+            reported || !worker.is_scanning(),
+            "a panicked scan worker must be reported or marked idle, but is_scanning={} and no result was sent",
+            worker.is_scanning()
+        );
+    }
+}


### PR DESCRIPTION
## Claim

A panic inside `scan(..)` leaves a `ScanWorker` busy forever, so the scanner ticks without progress and without an error.

- `pepper-sync/src/scan/task.rs:660-690`: `ScanWorker::run` spawns a tokio task and stores the `JoinHandle` in `self.handle`, but nothing ever polls it. `is_scanning` is stored `false` only at the end of the loop body, after `scan(..)` returns.
- `pepper-sync/src/scan/task.rs:585`: `Loader::check_error` shows the pattern that is missing for workers.
- `pepper-sync/src/scan/task.rs:169`: `Scanner::idle_worker` only returns workers with `is_scanning == false`.
- `pepper-sync/src/scan/task.rs:252`: `ScannerState::Shutdown` only drains idle workers.
- `pepper-sync/src/scan.rs:142-154`: `scan` panics on `.expect("compacts blocks should not be empty")` and on `panic!("compact blocks do not match scan range!")`, which are reachable from server data.

## What the test does

`scan::task::tests::panicked_scan_worker_is_reported_or_idle` builds a `ScanWorker` with `MainNetwork` params, empty ufvks, and an unbounded results channel, calls `run(1024)`, and sends a `ScanTask` for range `10..20` with no compact blocks. After 500 ms it asserts the invariant that a panicked worker is either reported (an `Err` on the results channel) or marked idle.

## Observed output on current `dev`

```
thread '...' panicked at pepper-sync/src/scan.rs:144:10:
compacts blocks should not be empty

thread '...' panicked at pepper-sync/src/scan/task.rs:895:9:
a panicked scan worker must be reported or marked idle, but is_scanning=true and no result was sent

test result: FAILED. 0 passed; 1 failed
```

The worker task is finished (`handle.is_finished() == true`), the `JoinError` is never observed, `is_scanning` stays `true`, and nothing is sent on the results channel.

## Notes

This PR is a reproduction only and does not contain a fix. The sync-bench A/B rule was not run because the commit adds a test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
