### PR TITLE
repro: one malformed mempool transaction aborts the sync session

### DIFF
--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -3747,4 +3747,60 @@ mod test {
             ));
         }
     }
+
+    /// REPRO (mempool-parse-failure-aborts-sync): a mempool transaction the
+    /// server streams that does not parse must be skipped, not turned into a
+    /// session abort. `process_mempool_transaction` currently maps the parse
+    /// failure to `ServerError::InvalidTransaction` and returns it, and the
+    /// main loop arm (`Some(raw_transaction) = mempool_transaction_receiver
+    /// .recv()`) applies `?` to that result, so one garbage transaction ends
+    /// the whole sync session.
+    mod mempool_parse_failure {
+        use std::collections::HashMap;
+
+        use zcash_protocol::consensus::{BlockHeight, MAIN_NETWORK};
+        use zingo_netutils::lightwallet_protocol::RawTransaction;
+
+        use crate::mocks::{MockWallet, MockWalletBuilder};
+        use crate::sync::{ScanPriority, ScanRange, process_mempool_transaction};
+        use crate::wallet::{SyncState, traits::SyncTransactions};
+
+        /// A wallet synced through `chain_height` with no transactions.
+        fn synced_wallet(chain_height: u32) -> MockWallet {
+            let sync_state = SyncState::new_for_test(vec![ScanRange::from_parts(
+                BlockHeight::from_u32(1)..BlockHeight::from_u32(chain_height + 1),
+                ScanPriority::Scanned,
+            )]);
+            MockWalletBuilder::new()
+                .sync_state(sync_state)
+                .create_mock_wallet()
+        }
+
+        /// Intended behaviour: an unparseable mempool transaction is
+        /// tolerated. The call returns `Ok` and the wallet is unchanged, so
+        /// the sync loop keeps running.
+        #[tokio::test]
+        async fn malformed_mempool_transaction_is_skipped_not_fatal() {
+            let mut wallet = synced_wallet(2_000_000);
+            let raw_transaction = RawTransaction {
+                data: vec![0xde, 0xad, 0xbe, 0xef],
+                height: 0,
+            };
+
+            let result = process_mempool_transaction(
+                &MAIN_NETWORK,
+                &HashMap::new(),
+                &mut wallet,
+                raw_transaction,
+            )
+            .await;
+
+            assert!(
+                result.is_ok(),
+                "a malformed mempool transaction must be skipped, got: {:?}",
+                result.err()
+            );
+            assert!(wallet.get_wallet_transactions().unwrap().is_empty());
+        }
+    }
 }


### PR DESCRIPTION
## Claim

`process_mempool_transaction` in `pepper-sync/src/sync.rs` (lines 1755-1817) parses the raw mempool transaction with `Transaction::read(&raw_transaction.data[..], BranchId::for_height(params, last_known_chain_height + 1))` (lines 1771-1776) and returns `Err(ServerError::InvalidTransaction)` when parsing fails. The main sync loop arm at lines 537-548 calls `process_mempool_transaction(..).await?`, so a single unparseable mempool transaction from the server aborts the entire sync session instead of being logged and skipped.

## What the test does

`sync::test::mempool_parse_failure::malformed_mempool_transaction_is_skipped_not_fatal` builds a `MockWallet` synced through height 2,000,000, feeds `process_mempool_transaction` a `RawTransaction { data: [0xde, 0xad, 0xbe, 0xef], height: 0 }` on mainnet parameters with an empty key map, and asserts the intended tolerant behaviour. The call should return `Ok` and leave the wallet transactions empty.

## Observed failing output

```
thread 'sync::test::mempool_parse_failure::malformed_mempool_transaction_is_skipped_not_fatal' panicked at pepper-sync/src/sync.rs:3798:13:
a malformed mempool transaction must be skipped, got: Some(ServerError(InvalidTransaction(Error { kind: UnexpectedEof, message: "failed to fill whole buffer" })))
test result: FAILED. 0 passed; 1 failed
```

The error propagates through the `?` at line 545 and terminates the sync task.

## Notes

This PR is a reproduction only and does not contain a fix. The secondary claim about the branch id being derived from `last_known_chain_height + 1` near a network upgrade boundary is not covered by a test here because exercising it requires a real v5 transaction built for a different branch, which is too speculative for a minimal repro. The sync-bench A/B rule was not run because the commit adds a test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
