### PR TITLE
repro: a failed spending-transaction fetch loses the detected spend

### DIFF
--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -3363,6 +3363,64 @@ mod test {
             );
         }
 
+        /// REPRO: `update_shielded_spends` consumes the nullifier-map entry in
+        /// `detect_shielded_spends` before `scan_spending_transactions` awaits the
+        /// network. When the spending transaction is not in the wallet and the fetch
+        /// fails, the function returns before `update_spent_notes`, so the note is
+        /// never marked spent and the map entry that could re-detect it is gone.
+        ///
+        /// The invariant: after a failed detection pass the spend is still recoverable,
+        /// either the note carries the spending txid or the nullifier is still mapped.
+        #[tokio::test]
+        async fn failed_spending_transaction_fetch_must_not_lose_the_detected_spend() {
+            let mut wallet_transactions = HashMap::new();
+            wallet_transactions.insert(FUNDING_TXID, funding_transaction(None));
+            // The spending transaction evaded trial decryption: it is absent from the
+            // wallet, so `scan_spending_transactions` must fetch it.
+            let mut nullifier_map = NullifierMap::new();
+            nullifier_map.sapling.insert(
+                NOTE_NULLIFIER,
+                ScanTarget {
+                    block_height: SPEND_HEIGHT,
+                    txid: SPENDING_TXID,
+                    narrow_scan_area: true,
+                },
+            );
+            let mut wallet = MockWalletBuilder::new()
+                .wallet_transactions(wallet_transactions)
+                .nullifier_map(nullifier_map)
+                .create_mock_wallet();
+
+            // The fetcher is gone: every network request fails with `FetcherDropped`.
+            let (fetch_request_sender, fetch_request_receiver) =
+                tokio::sync::mpsc::unbounded_channel::<crate::client::FetchRequest>();
+            drop(fetch_request_receiver);
+
+            let result = spend::update_shielded_spends(
+                &zcash_protocol::consensus::MAIN_NETWORK,
+                &mut wallet,
+                fetch_request_sender,
+                &HashMap::new(),
+                &std::collections::BTreeMap::new(),
+                None,
+            )
+            .await;
+            assert!(result.is_err(), "the fetch was expected to fail");
+
+            let note_marked_spent = get_spending_txid(&wallet) == Some(SPENDING_TXID);
+            let nullifier_still_mapped = wallet
+                .get_nullifiers()
+                .unwrap()
+                .sapling
+                .contains_key(&NOTE_NULLIFIER);
+            assert!(
+                note_marked_spent || nullifier_still_mapped,
+                "the spend observation was lost: the note is unspent \
+                 (spending_transaction = {:?}) and the nullifier is no longer mapped",
+                get_spending_txid(&wallet)
+            );
+        }
+
         /// A scanned transaction record replaces an existing `Failed` record
         /// wholesale, because `extend_wallet_transactions` merges via `HashMap::extend`.
         /// This is why the reset-before-scan sequence heals completely.


### PR DESCRIPTION
## Claim

`update_shielded_spends` in `pepper-sync/src/sync/spend.rs` (lines 42 to 135) consumes the matching nullifier from the wallet's live `NullifierMap` inside `detect_shielded_spends` (`remove_entry`, lines 256 to 267, called at lines 65 to 72) before `scan_spending_transactions` (line 112, body at lines 146 to 215) awaits the network (`client::get_compact_block` at line 189 and `scan_transactions` at line 201). When that fetch returns `Err`, the function returns at line 123 before `update_spent_notes` (line 126) runs. The nullifier is gone from the map and the note is never marked spent, so the wallet reports a spent note as spendable and a later sync cannot re-detect it from the map.

## What the test does

`sync::test::spend_reset_lifecycle::failed_spending_transaction_fetch_must_not_lose_the_detected_spend` in `pepper-sync/src/sync.rs` builds a `MockWallet` with one confirmed funding transaction holding a sapling note with a known nullifier, and a nullifier map entry mapping that nullifier to a `ScanTarget` for a spending txid that is not in the wallet. It drops the `FetchRequest` receiver so every fetch fails with `FetcherDropped`, calls `update_shielded_spends` with an empty `scanned_blocks` map, asserts the call returns `Err`, and then asserts that the spend is still recoverable: either the note carries the spending txid or the nullifier is still mapped.

## Observed failing output

```
test sync::test::spend_reset_lifecycle::failed_spending_transaction_fetch_must_not_lose_the_detected_spend ... FAILED

thread '...' panicked at pepper-sync/src/sync.rs:3416:13:
the spend observation was lost: the note is unspent (spending_transaction = None) and the nullifier is no longer mapped
```

This PR is a reproduction and not a fix. The sync-bench A/B rule was not run because the commit adds a test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
