### PR TITLE
repro: sync error recovery classification is inconsistent across wrappers and causes

### DIFF
--- a/pepper-sync/src/error.rs
+++ b/pepper-sync/src/error.rs
@@ -751,4 +751,124 @@ mod tests {
             }
         }
     }
+
+    /// REPRO: recovery classification disagrees with itself and with the
+    /// failure cause (claim slug `error-classification-mismatches`). Each
+    /// test encodes the proposed classification, so each fails on the
+    /// current code.
+    mod classification_mismatches {
+        use super::*;
+
+        /// REPRO (1): `FetcherDropped` is raised when the local fetch task
+        /// or its channel is gone (`client.rs` `map_err(|_| FetcherDropped)`),
+        /// so the server is not implicated and retrying it cannot help.
+        #[test]
+        fn fetcher_dropped_is_a_local_failure_and_aborts() {
+            assert_eq!(
+                ServerError::FetcherDropped.recovery_recommendation(),
+                SyncRecoveryObservables::Abort
+            );
+        }
+
+        /// REPRO (1): the boolean view agrees with the enum view.
+        #[test]
+        fn fetcher_dropped_does_not_recommend_the_same_server() {
+            assert!(!ServerError::FetcherDropped.recommend_same_server());
+        }
+
+        /// REPRO (2): a deadline that expired is transient, so the same
+        /// server is worth retrying.
+        #[test]
+        fn request_failed_deadline_exceeded_retries_the_same_server() {
+            let e = ServerError::RequestFailed(tonic::Status::deadline_exceeded("timeout"));
+            assert_eq!(
+                e.recovery_recommendation(),
+                SyncRecoveryObservables::MaybeRecoverableServer
+            );
+        }
+
+        /// REPRO (2): `Unavailable` is the canonical transient status.
+        #[test]
+        fn request_failed_unavailable_retries_the_same_server() {
+            let e = ServerError::RequestFailed(tonic::Status::unavailable("busy"));
+            assert_eq!(
+                e.recovery_recommendation(),
+                SyncRecoveryObservables::MaybeRecoverableServer
+            );
+        }
+
+        /// REPRO (2): an authentication refusal is not an availability
+        /// problem, so switching servers is not the recovery.
+        #[test]
+        fn request_failed_unauthenticated_is_not_server_unavailable() {
+            let e = ServerError::RequestFailed(tonic::Status::unauthenticated("no token"));
+            assert_ne!(
+                e.recovery_recommendation(),
+                SyncRecoveryObservables::ServerUnavailable
+            );
+        }
+
+        /// REPRO (3): a tree size the chain reports that the scanner cannot
+        /// reproduce is server misbehaviour, so another server is the recovery.
+        #[test]
+        fn scan_error_incorrect_tree_size_tries_another_server() {
+            let e: TestSyncError = ScanError::IncorrectTreeSize {
+                shielded_protocol: PoolType::IRONWOOD,
+                height: BlockHeight::from_u32(100),
+                block_metadata_size: 999,
+                calculated_size: 7,
+            }
+            .into();
+            assert_eq!(
+                e.recovery_recommendation(),
+                SyncRecoveryObservables::ServerUnavailable
+            );
+        }
+
+        /// REPRO (3): a transaction returned under the wrong txid is server
+        /// misbehaviour, so another server is the recovery.
+        #[test]
+        fn scan_error_incorrect_txid_tries_another_server() {
+            let e: TestSyncError = ScanError::IncorrectTxid {
+                txid_requested: TxId::from_bytes([1u8; 32]),
+                txid_returned: TxId::from_bytes([2u8; 32]),
+            }
+            .into();
+            assert_eq!(
+                e.recovery_recommendation(),
+                SyncRecoveryObservables::ServerUnavailable
+            );
+        }
+
+        /// REPRO (4): the same failed request must classify the same way
+        /// whether it arrives through `MempoolError` or directly.
+        #[test]
+        fn mempool_wrapped_request_failed_matches_direct_request_failed() {
+            let wrapped: TestSyncError = MempoolError::ServerError(ServerError::RequestFailed(
+                tonic::Status::unavailable("down"),
+            ))
+            .into();
+            let direct: TestSyncError =
+                ServerError::RequestFailed(tonic::Status::unavailable("down")).into();
+            assert_eq!(
+                wrapped.recovery_recommendation(),
+                direct.recovery_recommendation()
+            );
+        }
+
+        /// REPRO (4): the boolean view has the same wrapper inconsistency.
+        #[test]
+        fn mempool_wrapped_request_failed_matches_direct_recommend_same_server() {
+            let wrapped: TestSyncError = MempoolError::ServerError(ServerError::RequestFailed(
+                tonic::Status::unavailable("down"),
+            ))
+            .into();
+            let direct: TestSyncError =
+                ServerError::RequestFailed(tonic::Status::unavailable("down")).into();
+            assert_eq!(
+                wrapped.recommend_same_server(),
+                direct.recommend_same_server()
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR reproduces the claim `error-classification-mismatches`. It adds nine unit tests to the existing `#[cfg(test)]` module in `pepper-sync/src/error.rs` (new submodule `classification_mismatches`). Each test encodes the proposed classification, and every one fails on the current code. This is a reproduction and not a fix. No non-test code is changed.

The sync-bench A/B rule was not run because the commit adds tests only.

## Claims and code cites

1. `ServerError::FetcherDropped` is classified `recommend_same_server() == true` (`pepper-sync/src/error.rs:129`) and `MaybeRecoverableServer` (`pepper-sync/src/error.rs:199`). Every site that raises it is `map_err(|_| ServerError::FetcherDropped)` on a local channel send or a dropped oneshot (`pepper-sync/src/client.rs:107`, `111`, and the same pattern at every other request helper). The server is not involved, so retrying the same server cannot help. Defect of fact.
2. `ServerError::RequestFailed(_)` is `false` (`error.rs:133`) and `ServerUnavailable` (`error.rs:201`) for every `tonic::Status`. `DeadlineExceeded` and `Unavailable` are transient and retry worthy on the same server, while `Unauthenticated`, `InvalidArgument`, and `Unimplemented` are not availability problems. The `tonic::Code` is carried in the variant and is never inspected. The granularity is a design judgement, and the tests encode one proposed mapping.
3. `SyncError::ScanError(_)` maps to `Abort` (`error.rs:174`) even for `ScanError::IncorrectTreeSize` (`error.rs:272`) and `ScanError::IncorrectTxid` (`error.rs:286`), both of which describe data the server returned. Design judgement, though the existing `ScanError::ServerError` arm at `error.rs:173` already treats server caused scan failures as server problems.
4. `SyncError::MempoolError(_)` is `true` (`error.rs:101`) and `MaybeRecoverableServer` (`error.rs:171`), while the unwrapped `ServerError::RequestFailed(_)` it may contain is `false` and `ServerUnavailable` (`error.rs:133`, `201`). `client.rs:406` constructs exactly `MempoolError::ServerError(ServerError::RequestFailed(e))`. The same failure gets the opposite verdict depending on the wrapper. Defect of fact.
5. Not covered by tests. `client.rs:215` and `client.rs:352` gate stream retries on `e.message().contains("Unexpected EOF decoding stream.")`, and the retry loop exists only for `get_subtree_roots` and `get_transparent_address_transactions`. Noted for context.

## Tests

All nine are in `pepper-sync/src/error.rs`, module `tests::classification_mismatches`. Each assertion has its own `#[test]` so the run shows which parts fail.

| Test | Claim | Asserts |
| --- | --- | --- |
| `fetcher_dropped_is_a_local_failure_and_aborts` | 1 | `FetcherDropped.recovery_recommendation() == Abort` |
| `fetcher_dropped_does_not_recommend_the_same_server` | 1 | `!FetcherDropped.recommend_same_server()` |
| `request_failed_deadline_exceeded_retries_the_same_server` | 2 | `RequestFailed(deadline_exceeded)` is `MaybeRecoverableServer` |
| `request_failed_unavailable_retries_the_same_server` | 2 | `RequestFailed(unavailable)` is `MaybeRecoverableServer` |
| `request_failed_unauthenticated_is_not_server_unavailable` | 2 | `RequestFailed(unauthenticated)` is not `ServerUnavailable` |
| `scan_error_incorrect_tree_size_tries_another_server` | 3 | `SyncError::ScanError(IncorrectTreeSize)` is `ServerUnavailable` |
| `scan_error_incorrect_txid_tries_another_server` | 3 | `SyncError::ScanError(IncorrectTxid)` is `ServerUnavailable` |
| `mempool_wrapped_request_failed_matches_direct_request_failed` | 4 | wrapped and direct `RequestFailed` give the same `recovery_recommendation()` |
| `mempool_wrapped_request_failed_matches_direct_recommend_same_server` | 4 | wrapped and direct `RequestFailed` give the same `recommend_same_server()` |

## Observed output

Command: `cargo test -p pepper-sync --lib error::tests::classification_mismatches`

```
---- fetcher_dropped_is_a_local_failure_and_aborts ----
assertion `left == right` failed
  left: MaybeRecoverableServer
 right: Abort
---- fetcher_dropped_does_not_recommend_the_same_server ----
assertion failed: !ServerError::FetcherDropped.recommend_same_server()
---- request_failed_deadline_exceeded_retries_the_same_server ----
  left: ServerUnavailable
 right: MaybeRecoverableServer
---- request_failed_unavailable_retries_the_same_server ----
  left: ServerUnavailable
 right: MaybeRecoverableServer
---- request_failed_unauthenticated_is_not_server_unavailable ----
assertion `left != right` failed
  left: ServerUnavailable
 right: ServerUnavailable
---- scan_error_incorrect_tree_size_tries_another_server ----
  left: Abort
 right: ServerUnavailable
---- scan_error_incorrect_txid_tries_another_server ----
  left: Abort
 right: ServerUnavailable
---- mempool_wrapped_request_failed_matches_direct_request_failed ----
  left: MaybeRecoverableServer
 right: ServerUnavailable
---- mempool_wrapped_request_failed_matches_direct_recommend_same_server ----
  left: true
 right: false

test result: FAILED. 0 passed; 9 failed; 0 ignored; 0 measured; 111 filtered out
```

## Note on existing tests

The existing tests `recovery_recommendation::retry_same_server::fetcher_dropped` and `recovery_recommendation::try_different_server::request_failed` assert the current behaviour, so a fix that adopts the proposed classification would need to update them as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
