### PR TITLE
repro: a hash discontinuity inside a non-verify load aborts the sync session

### DIFF
--- a/pepper-sync/src/mocks.rs
+++ b/pepper-sync/src/mocks.rs
@@ -16,8 +16,8 @@ pub(super) enum MockWalletError {
     AnErrorVariant(String),
 }
 
-type SyncStatePatch = Box<dyn Fn(&SyncState) -> Result<&SyncState, MockWalletError>>;
-type GetBirthdayPatch = Box<dyn Fn(&BlockHeight) -> Result<BlockHeight, MockWalletError>>;
+type SyncStatePatch = Box<dyn Fn(&SyncState) -> Result<&SyncState, MockWalletError> + Send>;
+type GetBirthdayPatch = Box<dyn Fn(&BlockHeight) -> Result<BlockHeight, MockWalletError> + Send>;
 pub(super) struct MockWallet {
     birthday: BlockHeight,
     sync_state: SyncState,

--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -3747,4 +3747,146 @@ mod test {
             ));
         }
     }
+
+    /// Continuity failures reported for a load that is not a `Verify` range
+    /// or whose load range was split by the loader.
+    mod load_continuity_failure {
+        use std::collections::HashMap;
+
+        use tokio::sync::mpsc;
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::consensus::BlockHeight;
+        use zcash_protocol::local_consensus::LocalNetwork;
+
+        use crate::config::PerformanceLevel;
+        use crate::error::{ContinuityError, ScanError};
+        use crate::mocks::{MockWallet, MockWalletBuilder};
+        use crate::sync::{ScanPriority, ScanRange, process_scan_results};
+        use crate::wallet::{SyncState, traits::SyncWallet};
+
+        const LOCAL_NETWORK: LocalNetwork = LocalNetwork {
+            overwinter: Some(BlockHeight::from_u32(1)),
+            sapling: Some(BlockHeight::from_u32(1)),
+            blossom: Some(BlockHeight::from_u32(1)),
+            heartwood: Some(BlockHeight::from_u32(1)),
+            canopy: Some(BlockHeight::from_u32(1)),
+            nu5: Some(BlockHeight::from_u32(1)),
+            nu6: Some(BlockHeight::from_u32(1)),
+            nu6_1: Some(BlockHeight::from_u32(1)),
+            nu6_2: Some(BlockHeight::from_u32(1)),
+            nu6_3: Some(BlockHeight::from_u32(1)),
+        };
+
+        fn range(start: u32, end: u32, priority: ScanPriority) -> ScanRange {
+            ScanRange::from_parts(
+                BlockHeight::from_u32(start)..BlockHeight::from_u32(end),
+                priority,
+            )
+        }
+
+        fn wallet(scan_ranges: Vec<ScanRange>) -> MockWallet {
+            MockWalletBuilder::new()
+                .birthday(BlockHeight::from_u32(90))
+                .sync_state(SyncState::new_for_test(scan_ranges))
+                .create_mock_wallet()
+        }
+
+        fn hash_discontinuity(height: u32) -> ScanError {
+            ScanError::ContinuityError(ContinuityError::HashDiscontinuity {
+                height: BlockHeight::from_u32(height),
+                prev_hash: BlockHash([1; 32]),
+                previous_block_hash: BlockHash([2; 32]),
+            })
+        }
+
+        // REPRO: claim `mid-load-reorg-aborts-sync`. A hash discontinuity reported in the
+        // middle of a `ChainTip` load (the chain re-organised while the load was streamed)
+        // falls through to `scan_results?` in `process_scan_results` and aborts the sync
+        // session instead of re-prioritising the affected blocks to `Verify`.
+        #[tokio::test]
+        async fn discontinuity_inside_chain_tip_load_is_treated_as_reorg() {
+            // the loader selected 100..200 so the wallet holds it as `Scanning`, while the
+            // load carries its original `ChainTip` priority.
+            let mut wallet = wallet(vec![
+                range(90, 100, ScanPriority::Scanned),
+                range(100, 200, ScanPriority::Scanning),
+            ]);
+            let (fetch_request_sender, _fetch_request_receiver) = mpsc::unbounded_channel();
+            let ufvks = HashMap::new();
+            let mut nullifier_map_limit_exceeded = false;
+
+            let result = process_scan_results(
+                &LOCAL_NETWORK,
+                &mut wallet,
+                fetch_request_sender,
+                &ufvks,
+                range(100, 200, ScanPriority::ChainTip),
+                Err(hash_discontinuity(150)),
+                BlockHeight::from_u32(100),
+                PerformanceLevel::High,
+                &mut nullifier_map_limit_exceeded,
+            )
+            .await;
+
+            assert!(
+                result.is_ok(),
+                "a discontinuity inside a chain tip load aborted the sync session: {result:?}"
+            );
+            let sync_state = wallet.get_sync_state().unwrap();
+            assert!(
+                sync_state.scan_ranges().iter().any(|scan_range| {
+                    scan_range.priority() == ScanPriority::Verify
+                        && scan_range
+                            .block_range()
+                            .contains(&BlockHeight::from_u32(149))
+                }),
+                "the blocks around the discontinuity were not re-prioritised to Verify: {:?}",
+                sync_state.scan_ranges()
+            );
+        }
+
+        // REPRO: claim `mid-load-reorg-aborts-sync` (secondary). When the loader split the
+        // `Verify` range by output budget, the failing load is a sub-range of the wallet's
+        // scan range. The re-org path calls `state::set_scan_priority` with the load's range
+        // and that function panics when no wallet scan range matches exactly.
+        #[tokio::test]
+        async fn reorg_in_split_verify_load_does_not_panic() {
+            // the wallet holds the full verify range as `Scanning`, the load is its lower half.
+            let mut wallet = wallet(vec![
+                range(90, 100, ScanPriority::Scanned),
+                range(100, 110, ScanPriority::Scanning),
+            ]);
+            let (fetch_request_sender, _fetch_request_receiver) = mpsc::unbounded_channel();
+            let ufvks = HashMap::new();
+            let mut nullifier_map_limit_exceeded = false;
+
+            // on current code this call panics inside `set_scan_priority`, which fails the test.
+            let result = process_scan_results(
+                &LOCAL_NETWORK,
+                &mut wallet,
+                fetch_request_sender,
+                &ufvks,
+                range(100, 105, ScanPriority::Verify),
+                Err(hash_discontinuity(100)),
+                BlockHeight::from_u32(100),
+                PerformanceLevel::High,
+                &mut nullifier_map_limit_exceeded,
+            )
+            .await;
+
+            assert!(
+                result.is_ok(),
+                "a re-org detected by a split verify load failed: {result:?}"
+            );
+            let sync_state = wallet.get_sync_state().unwrap();
+            assert!(
+                sync_state
+                    .scan_ranges()
+                    .iter()
+                    .any(|scan_range| scan_range.priority() == ScanPriority::Verify),
+                "no Verify range after re-org: {:?}",
+                sync_state.scan_ranges()
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Claim (`mid-load-reorg-aborts-sync`)

`process_scan_results` in `pepper-sync/src/sync.rs:1536-1585` treats a `ScanError::ContinuityError(HashDiscontinuity { height, .. })` as a re-org only when `height` equals the start of the load's range and the load's priority is `Verify`. Every other hash discontinuity falls through to `scan_results?` at `pepper-sync/src/sync.rs:1584`, which returns the error from `process_scan_results` and therefore from the `sync` loop at `pepper-sync/src/sync.rs:520-531`, so the sync session aborts instead of marking the affected blocks `Verify` and re-scanning.

Secondary: on the re-org path, `state::set_scan_priority` is called with the load's block range (`pepper-sync/src/sync.rs:1550-1554`). That function panics when no wallet scan range has exactly that block range (`pepper-sync/src/sync/state.rs:436-447`). The loader splits a load by output budget (`pepper-sync/src/scan/task.rs:504-531`), and `ScanTask::split` truncates the load's `scan_range` (`pepper-sync/src/scan/task.rs:822-838`), so a `Verify` load can arrive as a sub-range of the wallet's scan range and the panic is reachable.

## What the tests do

Both tests live in `pepper-sync/src/sync.rs` under `mod test::load_continuity_failure` and call `process_scan_results` directly on a `MockWallet`.

- `discontinuity_inside_chain_tip_load_is_treated_as_reorg`: the wallet holds `90..100 Scanned` and `100..200 Scanning`. The load `100..200 ChainTip` reports `HashDiscontinuity { height: 150 }`. The test asserts `Ok(())` and a `Verify` range covering the discontinuity.
- `reorg_in_split_verify_load_does_not_panic`: the wallet holds `100..110 Scanning` (the verify range selected by the loader). The load `100..105 Verify` reports `HashDiscontinuity { height: 100 }`. The test asserts the call does not panic and leaves a `Verify` range.

The commit also adds `Send` to the two closure type aliases in the test-only `pepper-sync/src/mocks.rs` so that `MockWallet` satisfies the `W: Send` bound of `process_scan_results`.

## Observed output on `dev`

```
test sync::test::load_continuity_failure::discontinuity_inside_chain_tip_load_is_treated_as_reorg ... FAILED
  a discontinuity inside a chain tip load aborted the sync session: Err(ScanError(ContinuityError(HashDiscontinuity { height: BlockHeight(150), .. })))
test sync::test::load_continuity_failure::reorg_in_split_verify_load_does_not_panic ... FAILED
  panicked at pepper-sync/src/sync/state.rs:446:9: scan range with block range BlockHeight(100)..BlockHeight(105) not found!
```

## Notes

This PR is a reproduction and not a fix. Both tests are expected to fail on `dev`.

The abort in the first case is recoverable on the next sync session, because `update_scan_ranges` places a fresh `Verify` range above the highest scanned height. The session itself still ends with an error.

The sync-bench A/B rule was not run because the commit adds tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
