### PR TITLE
refactor(`pepper-sync`): read a version byte only through its gate

### DIFF
--- a/pepper-sync/src/config.rs
+++ b/pepper-sync/src/config.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Write};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 
 #[cfg(feature = "wallet_essentials")]
-use crate::wallet::serialization::reject_unknown_version;
+use crate::wallet::serialization::read_version;
 
 /// Performance level.
 ///
@@ -40,8 +40,7 @@ impl PerformanceLevel {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("PerformanceLevel", version, Self::serialized_version())?;
+        read_version(&mut reader, "PerformanceLevel", Self::serialized_version())?;
 
         Ok(match reader.read_u8()? {
             0 => Self::Low,
@@ -100,8 +99,7 @@ impl SyncConfig {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("SyncConfig", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "SyncConfig", Self::serialized_version())?;
 
         let gap_limit = reader.read_u8()?;
         let scopes = reader.read_u8()?;

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -47,11 +47,7 @@ use super::{
 };
 
 /// Returns `InvalidData` when `version` is newer than the latest layout this build can read.
-pub(crate) fn reject_unknown_version(
-    type_name: &str,
-    version: u8,
-    latest: u8,
-) -> std::io::Result<()> {
+fn reject_unknown_version(type_name: &str, version: u8, latest: u8) -> std::io::Result<()> {
     if version > latest {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -61,6 +57,17 @@ pub(crate) fn reject_unknown_version(
         ));
     }
     Ok(())
+}
+
+/// Reads one layout version byte, rejecting any version newer than the latest this build can read.
+pub(crate) fn read_version<R: Read>(
+    mut reader: R,
+    type_name: &str,
+    latest: u8,
+) -> std::io::Result<u8> {
+    let version = reader.read_u8()?;
+    reject_unknown_version(type_name, version, latest)?;
+    Ok(version)
 }
 
 fn read_string<R: Read>(mut reader: R) -> std::io::Result<String> {
@@ -84,8 +91,7 @@ impl ScanTarget {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("ScanTarget", version, Self::serialized_version())?;
+        read_version(&mut reader, "ScanTarget", Self::serialized_version())?;
         let block_height = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
         let txid = TxId::read(&mut reader)?;
         let narrow_scan_area = reader.read_u8()? != 0;
@@ -114,8 +120,7 @@ impl SyncState {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("SyncState", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "SyncState", Self::serialized_version())?;
         let scan_ranges = Vector::read(&mut reader, |r| {
             let start = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
             let end = BlockHeight::from_u32(r.read_u32::<LittleEndian>()?);
@@ -255,8 +260,7 @@ impl TreeBounds {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("TreeBounds", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "TreeBounds", Self::serialized_version())?;
         let sapling_initial_tree_size = reader.read_u32::<LittleEndian>()?;
         let sapling_final_tree_size = reader.read_u32::<LittleEndian>()?;
         let orchard_initial_tree_size = reader.read_u32::<LittleEndian>()?;
@@ -300,8 +304,7 @@ impl NullifierMap {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("NullifierMap", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "NullifierMap", Self::serialized_version())?;
         let sapling = Vector::read(&mut reader, |r| {
             let mut nullifier_bytes = [0u8; 32];
             r.read_exact(&mut nullifier_bytes)?;
@@ -413,8 +416,7 @@ impl WalletBlock {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("WalletBlock", version, Self::serialized_version())?;
+        read_version(&mut reader, "WalletBlock", Self::serialized_version())?;
         let block_height = BlockHeight::from_u32(reader.read_u32::<LittleEndian>()?);
         let mut block_hash = BlockHash([0u8; 32]);
         reader.read_exact(&mut block_hash.0)?;
@@ -457,8 +459,7 @@ impl WalletTransaction {
         mut reader: R,
         consensus_parameters: &impl consensus::Parameters,
     ) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("WalletTransaction", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "WalletTransaction", Self::serialized_version())?;
         let txid = TxId::read(&mut reader)?;
         let status = ConfirmationStatus::read(&mut reader)?;
         let transaction = Transaction::read(
@@ -543,8 +544,7 @@ impl TransparentCoin {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("TransparentCoin", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "TransparentCoin", Self::serialized_version())?;
 
         let txid = TxId::read(&mut reader)?;
         let output_index = if version >= 1 {
@@ -635,8 +635,7 @@ fn write_refetch_nullifier_ranges(
 impl SaplingNote {
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("SaplingNote", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "SaplingNote", Self::serialized_version())?;
 
         let txid = TxId::read(&mut reader)?;
         let output_index = if version >= 2 {
@@ -772,10 +771,9 @@ fn read_orchard_protocol_note<R: Read, P>(
     mut reader: R,
     note_version: orchard::note::NoteVersion,
 ) -> std::io::Result<WalletNote<orchard::Note, orchard::note::Nullifier, P>> {
-    let version = reader.read_u8()?;
-    reject_unknown_version(
+    let version = read_version(
+        &mut reader,
         "OrchardNote",
-        version,
         WalletNote::<orchard::Note, orchard::note::Nullifier, P>::serialized_version(),
     )?;
 
@@ -920,8 +918,11 @@ impl OutgoingSaplingNote {
         mut reader: R,
         consensus_parameters: &impl consensus::Parameters,
     ) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("OutgoingSaplingNote", version, Self::serialized_version())?;
+        let version = read_version(
+            &mut reader,
+            "OutgoingSaplingNote",
+            Self::serialized_version(),
+        )?;
 
         let txid = TxId::read(&mut reader)?;
         let output_index = if version >= 1 {
@@ -1043,10 +1044,9 @@ fn read_orchard_protocol_outgoing_note<R: Read, P>(
     consensus_parameters: &impl consensus::Parameters,
     note_version: orchard::note::NoteVersion,
 ) -> std::io::Result<OutgoingNote<orchard::Note, P>> {
-    let version = reader.read_u8()?;
-    reject_unknown_version(
+    let version = read_version(
+        &mut reader,
         "OutgoingOrchardNote",
-        version,
         OutgoingNote::<orchard::Note, P>::serialized_version(),
     )?;
 
@@ -1195,8 +1195,7 @@ impl ShardTrees {
 
     /// Deserialize into `reader`
     pub fn read<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let version = reader.read_u8()?;
-        reject_unknown_version("ShardTrees", version, Self::serialized_version())?;
+        let version = read_version(&mut reader, "ShardTrees", Self::serialized_version())?;
         let sapling = Self::read_shardtree(&mut reader)?;
         let orchard = Self::read_shardtree(&mut reader)?;
         let ironwood = if version >= 1 {


### PR DESCRIPTION
Stacked on #2735.

## What this changes

PR #2735 gives every wallet reader a version guard. Each reader calls
`read_u8` and then calls `reject_unknown_version` on the next line. The
two statements stay separable. Nothing stops a new reader from taking
the byte and skipping the check.

This PR folds both steps into one function, `read_version`. It reads
one byte. It rejects any version newer than the latest this build can
read. It returns the byte to the caller. After the change, only
`read_version` itself calls `read_u8` for a version.

## Why the byte is returned

The version byte does two jobs. As a compatibility gate it is the same
for every type, so `read_version` owns it. As a layout discriminator it
is local to each reader. Eleven of the fourteen readers branch on the
value to decide whether a later field is present. `ShardTrees` reads an
Ironwood tree only at version 1. `NullifierMap` reads one only at
version 2. The function therefore hands the byte back.

Three readers never branch on it. `ScanTarget`, `WalletBlock`, and
`PerformanceLevel` call `read_version` as a statement.

## What stays the same

`reject_unknown_version` keeps its signature and its error text. It
remains pure and testable without a reader. It loses only its
visibility, because `read_version` is now its one caller.

The type name stays a literal argument. A trait constant would remove
it. However, `WalletNote` and `OutgoingNote` are each one generic impl
that serves both Sapling and Orchard. One associated name would report
`WalletNote` where the reader says `SaplingNote` or `OrchardNote`.

## Verification

`cargo clippy --all-features --all-targets` and `cargo fmt` are clean
for `pepper-sync`. The reproduction tests from #2735 are unchanged.
