### PR TITLE
test: speed up send_shield_cycle from 58s to 44s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,7 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.7.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b228c06ae82365f306ff364e164da#537f84d3d81b228c06ae82365f306ff364e164da"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=89cf104a2416144d1bbbae30aca02bec062d1492#89cf104a2416144d1bbbae30aca02bec062d1492"
 dependencies = [
  "hex",
  "reqwest",
@@ -4553,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "zingo-consensus"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b228c06ae82365f306ff364e164da#537f84d3d81b228c06ae82365f306ff364e164da"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=89cf104a2416144d1bbbae30aca02bec062d1492#89cf104a2416144d1bbbae30aca02bec062d1492"
 
 [[package]]
 name = "zingo-memo"
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=537f84d3d81b228c06ae82365f306ff364e164da#537f84d3d81b228c06ae82365f306ff364e164da"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=89cf104a2416144d1bbbae30aca02bec062d1492#89cf104a2416144d1bbbae30aca02bec062d1492"
 
 [[package]]
 name = "zingolib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ portpicker = "0.1"
 # migration proptests consume it, so the merge restores it.
 proptest = "1.6.0"
 tempfile = "3"
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "537f84d3d81b228c06ae82365f306ff364e164da" }
-zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "537f84d3d81b228c06ae82365f306ff364e164da" }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "89cf104a2416144d1bbbae30aca02bec062d1492" }
+zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "89cf104a2416144d1bbbae30aca02bec062d1492" }
 
 ### Documentation
 indoc = "2"

--- a/libtonode-tests/src/chain_generics.rs
+++ b/libtonode-tests/src/chain_generics.rs
@@ -8,6 +8,7 @@ use zingolib::lightclient::LightClient;
 use zingolib::testutils::chain_generics::conduct_chain::ConductChain;
 use zingolib::testutils::default_test_wallet_settings;
 use zingolib::testutils::port_to_localhost_uri;
+use zingolib::testutils::timed;
 use zingolib::testutils::timestamped_test_log;
 
 use zingolib_testutils::scenarios::ClientBuilder;
@@ -27,7 +28,11 @@ pub struct LibtonodeEnvironment {
 impl ConductChain for LibtonodeEnvironment {
     async fn setup() -> Self {
         timestamped_test_log("starting mock libtonode network");
-        let (local_net, client_builder) = custom_clients_default().await;
+        let (local_net, client_builder) = timed(
+            "libtonode_setup::custom_clients_default",
+            custom_clients_default(),
+        )
+        .await;
 
         LibtonodeEnvironment {
             local_net,
@@ -49,14 +54,23 @@ impl ConductChain for LibtonodeEnvironment {
     }
 
     async fn increase_chain_height(&mut self) {
-        let start_height = self.local_net.validator().get_chain_height().await;
-        self.local_net
-            .validator()
-            .generate_blocks(1)
-            .await
-            .expect("Called for side effect, failed!");
+        let start_height = timed(
+            "increase_chain_height::get_chain_height[before]",
+            self.local_net.validator().get_chain_height(),
+        )
+        .await;
+        timed(
+            "increase_chain_height::generate_blocks",
+            self.local_net.validator().generate_blocks(1),
+        )
+        .await
+        .expect("Called for side effect, failed!");
         assert_eq!(
-            self.local_net.validator().get_chain_height().await,
+            timed(
+                "increase_chain_height::get_chain_height[after]",
+                self.local_net.validator().get_chain_height(),
+            )
+            .await,
             start_height + 1
         );
     }

--- a/libtonode-tests/tests/chain_generics.rs
+++ b/libtonode-tests/tests/chain_generics.rs
@@ -17,6 +17,7 @@ mod chain_generics {
     }
     #[tokio::test]
     async fn send_shield_cycle() {
+        tracing_subscriber::fmt().init();
         fixtures::send_shield_cycle::<LibtonodeEnvironment>(1).await;
     }
 }

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -548,6 +548,17 @@ pub fn timestamped_test_log(text: &str) {
     tracing::info!("{}: {}", crate::utils::now(), text);
 }
 
+/// Builds and caches the post-NU6.3 Orchard proving key ahead of the first send, so a fixture that awaits this during environment setup hides the multi-second build.
+pub async fn warm_orchard_proving_key() {
+    use orchard::circuit::OrchardCircuitVersion;
+    use zcash_primitives::transaction::builder;
+    tokio::task::spawn_blocking(|| {
+        builder::cached_orchard_proving_key(OrchardCircuitVersion::PostNu6_3);
+    })
+    .await
+    .expect("proving-key warmup task must not panic");
+}
+
 #[allow(unused_macros)]
 macro_rules! build_method {
     ($name:ident, $localtype:ty) => {

--- a/zingolib/src/testutils.rs
+++ b/zingolib/src/testutils.rs
@@ -559,6 +559,25 @@ pub async fn warm_orchard_proving_key() {
     .expect("proving-key warmup task must not panic");
 }
 
+/// Decimal places phase timers use when they report elapsed seconds.
+const PHASE_SECONDS_PRECISION: usize = 3;
+
+/// Awaits `fut` while logging the phase's start and its elapsed wall-clock seconds under `label`.
+pub async fn timed<T>(label: &str, fut: impl std::future::Future<Output = T>) -> T {
+    let start = std::time::Instant::now();
+    timestamped_test_log(format!("[phase] {label} started.").as_str());
+    let output = fut.await;
+    timestamped_test_log(
+        format!(
+            "[phase] {label} finished in {:.precision$}s.",
+            start.elapsed().as_secs_f64(),
+            precision = PHASE_SECONDS_PRECISION
+        )
+        .as_str(),
+    );
+    output
+}
+
 #[allow(unused_macros)]
 macro_rules! build_method {
     ($name:ident, $localtype:ty) => {

--- a/zingolib/src/testutils/chain_generics/conduct_chain.rs
+++ b/zingolib/src/testutils/chain_generics/conduct_chain.rs
@@ -7,6 +7,7 @@ use crate::config::{ClientConfig, WalletConfig};
 use crate::get_base_address_macro;
 use crate::lightclient::LightClient;
 use crate::testutils::lightclient::from_inputs;
+use crate::testutils::timed;
 use crate::wallet::keys::unified::ReceiverSelection;
 
 #[allow(async_fn_in_trait)]
@@ -31,15 +32,23 @@ pub trait ConductChain {
 
     /// builds an empty client
     async fn create_client(&mut self) -> LightClient {
-        let config = self.zingo_config().await;
+        let config = timed("create_client::zingo_config", self.zingo_config()).await;
         assert!(!matches!(config.wallet_config(), WalletConfig::Read));
-        let mut lightclient = LightClient::new_clearnet_consented(config, false)
-            .await
-            .unwrap();
-        lightclient
-            .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
-            .await
-            .unwrap();
+        let mut lightclient = timed(
+            "create_client::new_clearnet_consented",
+            LightClient::new_clearnet_consented(config, false),
+        )
+        .await
+        .unwrap();
+        timed(
+            "create_client::generate_unified_address",
+            lightclient.generate_unified_address(
+                ReceiverSelection::sapling_only(),
+                zip32::AccountId::ZERO,
+            ),
+        )
+        .await
+        .unwrap();
 
         lightclient
     }
@@ -69,26 +78,46 @@ pub trait ConductChain {
 
     /// builds a client and funds it in orchard and syncs it
     async fn fund_client_orchard(&mut self, value: u64) -> LightClient {
-        let mut faucet = self.create_faucet().await;
-        let mut recipient = self.create_client().await;
+        let mut faucet = timed("fund_client_orchard::create_faucet", self.create_faucet()).await;
+        let mut recipient = timed("fund_client_orchard::create_client", self.create_client()).await;
 
-        self.increase_chain_height().await;
-        self.sync_client_to_tip(&mut faucet).await;
+        timed(
+            "fund_client_orchard::increase_chain_height[pre-send]",
+            self.increase_chain_height(),
+        )
+        .await;
+        timed(
+            "fund_client_orchard::sync_faucet_to_tip",
+            self.sync_client_to_tip(&mut faucet),
+        )
+        .await;
 
-        from_inputs::quick_send(
-            &mut faucet,
-            vec![(
-                (get_base_address_macro!(recipient, "unified")).as_str(),
-                value,
-                None,
-            )],
+        let recipient_unified_address =
+            timed("fund_client_orchard::get_recipient_address", async {
+                get_base_address_macro!(recipient, "unified")
+            })
+            .await;
+        timed(
+            "fund_client_orchard::quick_send",
+            from_inputs::quick_send(
+                &mut faucet,
+                vec![(recipient_unified_address.as_str(), value, None)],
+            ),
         )
         .await
         .unwrap();
 
-        self.increase_chain_height().await;
+        timed(
+            "fund_client_orchard::increase_chain_height[post-send]",
+            self.increase_chain_height(),
+        )
+        .await;
 
-        self.sync_client_to_tip(&mut recipient).await;
+        timed(
+            "fund_client_orchard::sync_recipient_to_tip",
+            self.sync_client_to_tip(&mut recipient),
+        )
+        .await;
 
         recipient
     }

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -123,7 +123,10 @@ pub async fn send_shield_cycle<CC>(n: u64)
 where
     CC: ConductChain,
 {
-    let mut environment = CC::setup().await;
+    let (mut environment, ()) = tokio::join!(
+        CC::setup(),
+        crate::testutils::warm_orchard_proving_key(),
+    );
     let primary_fund = 1_000_000;
     let mut primary = environment.fund_client_orchard(primary_fund).await;
 

--- a/zingolib/src/testutils/chain_generics/fixtures.rs
+++ b/zingolib/src/testutils/chain_generics/fixtures.rs
@@ -12,6 +12,7 @@ use crate::testutils::chain_generics::conduct_chain::ConductChain;
 use crate::testutils::chain_generics::with_assertions;
 use crate::testutils::fee_tables;
 use crate::testutils::lightclient::get_base_address;
+use crate::testutils::timed;
 use crate::testutils::timestamped_test_log;
 
 /// Fixture for testing various vt transactions
@@ -124,75 +125,104 @@ where
     CC: ConductChain,
 {
     let (mut environment, ()) = tokio::join!(
-        CC::setup(),
-        crate::testutils::warm_orchard_proving_key(),
+        timed("send_shield_cycle::setup", CC::setup()),
+        timed(
+            "send_shield_cycle::warm_orchard_proving_key",
+            crate::testutils::warm_orchard_proving_key(),
+        ),
     );
     let primary_fund = 1_000_000;
-    let mut primary = environment.fund_client_orchard(primary_fund).await;
+    let mut primary = timed(
+        "send_shield_cycle::fund_client_orchard",
+        environment.fund_client_orchard(primary_fund),
+    )
+    .await;
 
-    let mut secondary = environment.create_client().await;
-    let secondary_taddr = get_base_address(&secondary, PoolType::Transparent).await;
+    let mut secondary = timed(
+        "send_shield_cycle::create_secondary_client",
+        environment.create_client(),
+    )
+    .await;
+    let secondary_taddr = timed(
+        "send_shield_cycle::get_secondary_taddr",
+        get_base_address(&secondary, PoolType::Transparent),
+    )
+    .await;
 
-    for _ in 0..n {
-        let (recorded_fee, recorded_value, recorded_change) =
-            with_assertions::assure_propose_send_bump_sync_all_recipients(
-                &mut environment,
-                &mut primary,
-                vec![
-                    (&secondary_taddr, 100_000, None),
-                    (&secondary_taddr, 4_000, None),
-                ],
-                vec![&mut secondary],
-                false,
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            (recorded_fee, recorded_value, recorded_change),
-            (
-                Option::unwrap(MARGINAL_FEE * 4_u64),
-                recorded_value,
-                recorded_change
-            )
-        );
+    for cycle in 0..n {
+        timed(
+            format!("send_shield_cycle::cycle[{cycle}]").as_str(),
+            async {
+                let (recorded_fee, recorded_value, recorded_change) = timed(
+                    format!("send_shield_cycle::cycle[{cycle}]::send_to_transparent").as_str(),
+                    with_assertions::assure_propose_send_bump_sync_all_recipients(
+                        &mut environment,
+                        &mut primary,
+                        vec![
+                            (&secondary_taddr, 100_000, None),
+                            (&secondary_taddr, 4_000, None),
+                        ],
+                        vec![&mut secondary],
+                        false,
+                    ),
+                )
+                .await
+                .unwrap();
+                assert_eq!(
+                    (recorded_fee, recorded_value, recorded_change),
+                    (
+                        Option::unwrap(MARGINAL_FEE * 4_u64),
+                        recorded_value,
+                        recorded_change
+                    )
+                );
 
-        let (recorded_fee, recorded_value) = with_assertions::assure_propose_shield_bump_sync(
-            &mut environment,
-            &mut secondary,
-            false,
+                let (recorded_fee, recorded_value) = timed(
+                    format!("send_shield_cycle::cycle[{cycle}]::shield").as_str(),
+                    with_assertions::assure_propose_shield_bump_sync(
+                        &mut environment,
+                        &mut secondary,
+                        false,
+                    ),
+                )
+                .await
+                .unwrap();
+                assert_eq!(
+                    (recorded_fee, recorded_value),
+                    (
+                        Option::unwrap(MARGINAL_FEE * 3_u64),
+                        Option::unwrap(Zatoshis::from_u64(100_000).unwrap() - recorded_fee)
+                    )
+                );
+
+                let primary_orchard_addr = timed(
+                    format!("send_shield_cycle::cycle[{cycle}]::get_primary_orchard_addr").as_str(),
+                    get_base_address(&primary, PoolType::Shielded(ShieldedPool::Orchard)),
+                )
+                .await;
+                let (recorded_fee, recorded_value, recorded_change) = timed(
+                    format!("send_shield_cycle::cycle[{cycle}]::send_back_to_orchard").as_str(),
+                    with_assertions::assure_propose_send_bump_sync_all_recipients(
+                        &mut environment,
+                        &mut secondary,
+                        vec![(&primary_orchard_addr, 50_000, None)],
+                        vec![&mut primary],
+                        false,
+                    ),
+                )
+                .await
+                .unwrap();
+                assert_eq!(
+                    (recorded_fee, recorded_value, recorded_change),
+                    (
+                        Option::unwrap(MARGINAL_FEE * 2_u64),
+                        Zatoshis::from_u64(50_000).unwrap(),
+                        recorded_change
+                    )
+                );
+            },
         )
-        .await
-        .unwrap();
-        assert_eq!(
-            (recorded_fee, recorded_value),
-            (
-                Option::unwrap(MARGINAL_FEE * 3_u64),
-                Option::unwrap(Zatoshis::from_u64(100_000).unwrap() - recorded_fee)
-            )
-        );
-
-        let (recorded_fee, recorded_value, recorded_change) =
-            with_assertions::assure_propose_send_bump_sync_all_recipients(
-                &mut environment,
-                &mut secondary,
-                vec![(
-                    &get_base_address(&primary, PoolType::Shielded(ShieldedPool::Orchard)).await,
-                    50_000,
-                    None,
-                )],
-                vec![&mut primary],
-                false,
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            (recorded_fee, recorded_value, recorded_change),
-            (
-                Option::unwrap(MARGINAL_FEE * 2_u64),
-                Zatoshis::from_u64(50_000).unwrap(),
-                recorded_change
-            )
-        );
+        .await;
     }
 }
 

--- a/zingolib/src/testutils/chain_generics/with_assertions.rs
+++ b/zingolib/src/testutils/chain_generics/with_assertions.rs
@@ -298,7 +298,7 @@ where
         environment.increase_chain_height().await;
         timestamped_test_log("syncking transaction confirmation.");
         // chain scan shows the same
-        sender.sync_and_await().await.unwrap();
+        environment.sync_client_to_tip(sender).await;
         let last_known_chain_height = sender
             .wallet()
             .read()

--- a/zingolib/src/testutils/chain_generics/with_assertions.rs
+++ b/zingolib/src/testutils/chain_generics/with_assertions.rs
@@ -19,6 +19,7 @@ use crate::testutils::assertions::for_each_proposed_transaction;
 use crate::testutils::chain_generics::conduct_chain::ConductChain;
 use crate::testutils::lightclient::from_inputs;
 use crate::testutils::lightclient::get_base_address;
+use crate::testutils::timed;
 use crate::testutils::timestamped_test_log;
 use crate::wallet::output::OutputRef;
 
@@ -66,23 +67,42 @@ where
     // adjacent to the height-5 NU6.1/6.2 co-activation (a wrong consensus
     // branch id from a stale wallet view); syncing to the true tip keeps
     // the builder on the post-activation branch.
-    environment.increase_chain_height().await;
-    environment.sync_client_to_tip(sender).await;
+    timed(
+        "assure_send::increase_chain_height",
+        environment.increase_chain_height(),
+    )
+    .await;
+    timed(
+        "assure_send::sync_sender_to_tip",
+        environment.sync_client_to_tip(sender),
+    )
+    .await;
     timestamped_test_log("syncked.");
-    let proposal = from_inputs::propose(sender, payments.clone())
-        .await
-        .unwrap();
+    let proposal = timed(
+        "assure_send::propose",
+        from_inputs::propose(sender, payments.clone()),
+    )
+    .await
+    .unwrap();
     timestamped_test_log(format!("proposed the following payments: {payments:?}").as_str());
-    let txids = sender.send_stored_proposal(true).await.unwrap();
+    let txids = timed(
+        "assure_send::send_stored_proposal",
+        sender.send_stored_proposal(true),
+    )
+    .await
+    .unwrap();
     timestamped_test_log("Transmitted send.");
 
-    follow_proposal(
-        environment,
-        sender,
-        recipients,
-        &proposal,
-        txids,
-        test_mempool,
+    timed(
+        "assure_send::follow_proposal",
+        follow_proposal(
+            environment,
+            sender,
+            recipients,
+            &proposal,
+            txids,
+            test_mempool,
+        ),
     )
     .await
 }
@@ -101,20 +121,38 @@ where
 {
     timestamped_test_log("started integration-test shield.");
     // The same tip-separation as assure_propose_send_bump_sync_all_recipients.
-    environment.increase_chain_height().await;
-    environment.sync_client_to_tip(client).await;
+    timed(
+        "assure_shield::increase_chain_height",
+        environment.increase_chain_height(),
+    )
+    .await;
+    timed(
+        "assure_shield::sync_client_to_tip",
+        environment.sync_client_to_tip(client),
+    )
+    .await;
     timestamped_test_log("syncked.");
-    let proposal = client
-        .propose_shield(zip32::AccountId::ZERO)
-        .await
-        .map_err(|e| e.to_string())?;
+    let proposal = timed(
+        "assure_shield::propose_shield",
+        client.propose_shield(zip32::AccountId::ZERO),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     timestamped_test_log(format!("proposed a shield: {proposal:#?}").as_str());
 
-    let txids = client.send_stored_proposal(true).await.unwrap();
+    let txids = timed(
+        "assure_shield::send_stored_proposal",
+        client.send_stored_proposal(true),
+    )
+    .await
+    .unwrap();
     timestamped_test_log("Transmitted shield.");
 
-    let (total_fee, _, s_shielded) =
-        follow_proposal(environment, client, vec![], &proposal, txids, test_mempool).await?;
+    let (total_fee, _, s_shielded) = timed(
+        "assure_shield::follow_proposal",
+        follow_proposal(environment, client, vec![], &proposal, txids, test_mempool),
+    )
+    .await?;
     Ok((total_fee, s_shielded))
 }
 
@@ -135,38 +173,49 @@ where
 
     timestamped_test_log("following proposal, preparing to unwind if an assertion fails.");
 
-    let mut indexer = zingo_netutils::GrpcIndexer::new(environment.lightserver_uri().unwrap())
-        .await
-        .unwrap();
+    let mut indexer = timed(
+        "follow_proposal::grpc_indexer_connect",
+        zingo_netutils::GrpcIndexer::new(environment.lightserver_uri().unwrap()),
+    )
+    .await
+    .unwrap();
     let server_height_at_send = BlockHeight::from(
-        indexer
-            .get_latest_block(DEFAULT_REQUEST_TIMEOUT)
-            .await
-            .unwrap()
-            .height as u32,
-    );
-    let last_known_chain_height = sender
-        .wallet()
-        .read()
+        timed(
+            "follow_proposal::get_latest_block",
+            indexer.get_latest_block(DEFAULT_REQUEST_TIMEOUT),
+        )
         .await
-        .sync_state
-        .last_known_chain_height()
-        .unwrap();
+        .unwrap()
+        .height as u32,
+    );
+    let last_known_chain_height = timed("follow_proposal::read_wallet_height", async {
+        sender
+            .wallet()
+            .read()
+            .await
+            .sync_state
+            .last_known_chain_height()
+            .unwrap()
+    })
+    .await;
     timestamped_test_log(format!("wallet height at send {last_known_chain_height}").as_str());
 
     // check that each record has the expected fee and status, returning the fee
     let (sender_recorded_fees, (sender_recorded_outputs, sender_recorded_statuses)): (
         Vec<Zatoshis>,
         (Vec<Zatoshis>, Vec<ConfirmationStatus>),
-    ) = for_each_proposed_transaction(sender, proposal, &txids, |wallet, transaction, step| {
-        (
-            compare_fee(wallet, transaction, step),
+    ) = timed(
+        "follow_proposal::check_recorded_records",
+        for_each_proposed_transaction(sender, proposal, &txids, |wallet, transaction, step| {
             (
-                Zatoshis::from_u64(transaction.total_value_received()),
-                transaction.status(),
-            ),
-        )
-    })
+                compare_fee(wallet, transaction, step),
+                (
+                    Zatoshis::from_u64(transaction.total_value_received()),
+                    transaction.status(),
+                ),
+            )
+        }),
+    )
     .await
     .into_iter()
     .map(|stepwise_result| {
@@ -193,7 +242,12 @@ where
     let option_recipient_mempool_outputs = if test_mempool {
         timestamped_test_log("syncking transaction from mempool.");
         // mempool scan shows the same
-        sender.sync_and_await().await.unwrap();
+        timed(
+            "follow_proposal::mempool_sender_sync",
+            sender.sync_and_await(),
+        )
+        .await
+        .unwrap();
         timestamped_test_log("cross-checking mempool records.");
 
         // Wait for the mempool monitor to observe every transaction, polling
@@ -256,8 +310,13 @@ where
         }
 
         let mut recipients_mempool_outputs: Vec<Vec<Zatoshis>> = vec![];
-        for recipient in &mut recipients {
-            recipient.sync_and_await().await.unwrap();
+        for (recipient_index, recipient) in recipients.iter_mut().enumerate() {
+            timed(
+                format!("follow_proposal::mempool_recipient[{recipient_index}]_sync").as_str(),
+                recipient.sync_and_await(),
+            )
+            .await
+            .unwrap();
 
             // check that each record has the status, returning the output value
             let (recipient_mempool_outputs, recipient_mempool_statuses): (
@@ -295,10 +354,18 @@ where
 
     let mut attempts = 0;
     loop {
-        environment.increase_chain_height().await;
+        timed(
+            format!("follow_proposal::confirm[{attempts}]::increase_chain_height").as_str(),
+            environment.increase_chain_height(),
+        )
+        .await;
         timestamped_test_log("syncking transaction confirmation.");
         // chain scan shows the same
-        environment.sync_client_to_tip(sender).await;
+        timed(
+            format!("follow_proposal::confirm[{attempts}]::sender_sync_to_tip").as_str(),
+            environment.sync_client_to_tip(sender),
+        )
+        .await;
         let last_known_chain_height = sender
             .wallet()
             .read()
@@ -313,15 +380,18 @@ where
         let (sender_confirmed_fees, (sender_confirmed_outputs, sender_confirmed_statuses)): (
             Vec<Zatoshis>,
             (Vec<Zatoshis>, Vec<ConfirmationStatus>),
-        ) = for_each_proposed_transaction(sender, proposal, &txids, |wallet, transaction, step| {
-            (
-                compare_fee(wallet, transaction, step),
+        ) = timed(
+            format!("follow_proposal::confirm[{attempts}]::check_confirmed_records").as_str(),
+            for_each_proposed_transaction(sender, proposal, &txids, |wallet, transaction, step| {
                 (
-                    Zatoshis::from_u64(transaction.total_value_received()),
-                    transaction.status(),
-                ),
-            )
-        })
+                    compare_fee(wallet, transaction, step),
+                    (
+                        Zatoshis::from_u64(transaction.total_value_received()),
+                        transaction.status(),
+                    ),
+                )
+            }),
+        )
         .await
         .into_iter()
         .map(|stepwise_result| {
@@ -375,8 +445,13 @@ where
     }
 
     let mut recipients_confirmed_outputs = vec![];
-    for recipient in &mut recipients {
-        recipient.sync_and_await().await.unwrap();
+    for (recipient_index, recipient) in recipients.iter_mut().enumerate() {
+        timed(
+            format!("follow_proposal::confirmed_recipient[{recipient_index}]_sync").as_str(),
+            recipient.sync_and_await(),
+        )
+        .await
+        .unwrap();
 
         // check that each record has the status, returning the output value
         let (recipient_confirmed_outputs, recipient_confirmed_statuses): (

--- a/zingolib_testutils/src/scenarios.rs
+++ b/zingolib_testutils/src/scenarios.rs
@@ -47,6 +47,7 @@ use zingolib::testutils::lightclient::from_inputs::{self, quick_send};
 use zingolib::testutils::lightclient::get_base_address;
 use zingolib::testutils::port_to_localhost_uri;
 use zingolib::testutils::sync_to_target_height;
+use zingolib::testutils::timed;
 use zingolib::wallet::keys::unified::ReceiverSelection;
 
 /// Default regtest network processes for testing and zingo-cli regtest mode:
@@ -272,9 +273,22 @@ pub async fn sync_client_to_validator_tip<V, I>(
     <V as Process>::Config: Send,
     LocalNet<V, I>: IndexerConvergence,
 {
-    let tip = local_net.validator().get_chain_height().await;
-    local_net.converge(tip).await;
-    sync_to_target_height(client, tip).await.unwrap();
+    let tip = timed(
+        "sync_to_validator_tip::get_chain_height",
+        local_net.validator().get_chain_height(),
+    )
+    .await;
+    timed(
+        "sync_to_validator_tip::indexer_converge",
+        local_net.converge(tip),
+    )
+    .await;
+    timed(
+        "sync_to_validator_tip::wallet_sync",
+        sync_to_target_height(client, tip),
+    )
+    .await
+    .unwrap();
 }
 
 /// Zebra's mempool rejection text for a spend of, or anchored at, the tip
@@ -525,13 +539,21 @@ impl ClientBuilder {
         overwrite: bool,
     ) -> LightClient {
         let config = self.make_unique_data_dir_and_create_config(wallet_config);
-        let mut lightclient = LightClient::new_clearnet_consented(config, overwrite)
-            .await
-            .unwrap();
-        lightclient
-            .generate_unified_address(ReceiverSelection::sapling_only(), zip32::AccountId::ZERO)
-            .await
-            .unwrap();
+        let mut lightclient = timed(
+            "build_client::new_clearnet_consented",
+            LightClient::new_clearnet_consented(config, overwrite),
+        )
+        .await
+        .unwrap();
+        timed(
+            "build_client::generate_unified_address",
+            lightclient.generate_unified_address(
+                ReceiverSelection::sapling_only(),
+                zip32::AccountId::ZERO,
+            ),
+        )
+        .await
+        .unwrap();
 
         lightclient
     }
@@ -962,20 +984,38 @@ async fn custom_clients_raw(
     replay_from: Option<PathBuf>,
 ) -> (MeteredNet, ClientBuilder) {
     let setup_started = std::time::Instant::now();
-    let (local_net, zebrad_front, zainod_front) =
-        launch_observed(mine_to_pool, configured_activation_heights).await;
+    let (local_net, zebrad_front, zainod_front) = timed(
+        "custom_clients_raw::launch_observed",
+        launch_observed(mine_to_pool, configured_activation_heights),
+    )
+    .await;
     let mut local_net = MeteredNet::new(local_net, zebrad_front, zainod_front, setup_started);
 
     match replay_from {
         Some(blocks_file) => {
-            let tip = chain_cache::replay(&local_net, &blocks_file).await;
+            let tip = timed(
+                "custom_clients_raw::chain_cache_replay",
+                chain_cache::replay(&local_net, &blocks_file),
+            )
+            .await;
             // The replay reorgs the launch block away; the Indexer may
             // have already ingested it (it starts syncing within
             // milliseconds of launch). Barrier on convergence to the
             // replayed tip so no wallet ever syncs the orphaned branch.
-            local_net.converge(tip).await;
+            timed(
+                "custom_clients_raw::replay_converge",
+                local_net.converge(tip),
+            )
+            .await;
         }
-        None => local_net.validator().generate_blocks(2).await.unwrap(),
+        None => {
+            timed(
+                "custom_clients_raw::generate_initial_blocks",
+                local_net.validator().generate_blocks(2),
+            )
+            .await
+            .unwrap();
+        }
     }
 
     let client_builder = ClientBuilder::new(
@@ -986,7 +1026,13 @@ async fn custom_clients_raw(
         // The validator is the sole source of activation-height truth
         // (infras ADR 0003): wallets take their schedule from the running
         // validator, never from a caller-supplied vector.
-        wallet_activation_heights(&local_net.validator().get_activation_heights().await),
+        wallet_activation_heights(
+            &timed(
+                "custom_clients_raw::get_activation_heights",
+                local_net.validator().get_activation_heights(),
+            )
+            .await,
+        ),
     );
 
     local_net.mark_setup_complete("custom_clients");


### PR DESCRIPTION
Profiling showed that zebra's getblocktemplate dominates this test. Each template builds a fresh shielded coinbase with a proof. An empty template costs about 2.2 seconds. A transaction-bearing template costs about 4.5 seconds.

This branch lands three speed-ups and the instrumentation that found them.

1. **Infrastructure pin bump.** The pin moves to 89cf104a2, the merge of zingolabs/infrastructure#284. `Zebrad::generate_blocks` now parks a long-poll getblocktemplate after each mined block. Zebrad precomputes the next coinbase during harness work. Mining drops from 28.3 to 23.2 seconds mean.
2. **Converge before the confirmation sync.** `follow_proposal` raced the indexer with a bare `sync_and_await`. The wasted confirm round cost about nine seconds. `sync_client_to_tip` barriers on indexer convergence first.
3. **Proving-key warmup.** The PostNu6_3 Orchard proving key now builds during environment setup, in parallel with the network launch. This removes over a second from the measured send path.
4. **Phase timers.** A `timed` helper logs each phase's label and elapsed seconds across the whole call graph. These timers produced the measurements above.

The measured mean run time falls from 58.4 seconds to about 44 seconds. A run through the merged pin confirmed 45.6 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)