### PR TITLE
fix!: restore clearnet price fetch when Mixnet Mode is switched off

### DIFF
--- a/docs/adr/0011-nym-mixnet-transmission.md
+++ b/docs/adr/0011-nym-mixnet-transmission.md
@@ -490,3 +490,28 @@ workspace and generates its own bindings (zingo-mobile PR #1251). The
 UniFFI, and the runtime-boundary generalization remains in force; only
 the shim's hosting repository changes. This workspace keeps the desktop
 `nym-proxy` binary and its `bundle-nym-proxy` workbench tool.
+
+## Amendment (2026-08-26): the switched-off consent covers the price fetch
+
+The 2026-07-28 ruling above, that the switched-off consent covers
+Transmission and never the price fetch, is reversed. The deliberate
+SwitchedOff now consents to a clearnet price fetch exactly as it consents
+to a clearnet send. The mobile sessions supplied the deciding evidence. A
+user who declines the mixnet starts every session SwitchedOff, and the
+price display never works for that user, in any session, by design. The
+refusal was meant to prevent an unconsented leak, but the state it fires
+in is the one state the user reached by an explicit choice. The same
+session's sends already travel clearnet to an indexer that knows the
+wallet's address set, and a price API learns less than that indexer
+already holds.
+
+The amended rule: `update_current_price` follows the one route resolver.
+Ready races the sources through the tunnel as before. SwitchedOff races
+the same sources over untunneled HTTP, and the documentation disclosure
+from the 2026-07-27 amendment applies to that route again. The
+transitional states (Unattached, Bootstrapping, Died) keep their typed
+refusals, so absence is still not consent. The success value attests the
+route as a two-variant enum, mixnet with its SOCKS5 endpoint or clearnet,
+replacing the tunnel-endpoint string, and `PriceFetchRequiresMixnet`
+leaves the error surface as unreachable. `probe_destinations` remains
+mixnet-only, since its subject is the mixnet transport itself.

--- a/zingo-cli/CHANGELOG.md
+++ b/zingo-cli/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operation a second time to decide where log output goes.
 
 ### Changed
+- `current_price` works while Mixnet Mode is switched off, fetching over
+  clearnet as the toggle-off consents to (ADR 0011, amendment
+  2026-08-26), and its output names the route the fetch traveled.
 - `help` lists `info`, `change_server`, and `current_price` among the
   commands that need no wallet, where it had listed them as wallet
   commands. None of the three reads wallet state: the first two reach the

--- a/zingo-cli/src/commands.rs
+++ b/zingo-cli/src/commands.rs
@@ -304,13 +304,21 @@ async fn confirm(lightclient: &mut LightClient) -> Result<String, CommandError> 
 #[cfg(feature = "nym")]
 async fn current_price(lightclient: &mut LightClient) -> Result<String, CommandError> {
     match lightclient.update_current_price().await {
-        Ok(fetch) => Ok(format!(
-            "current price: {} USD (source: {}, rtt: {} ms, fetched over the mixnet via {})",
-            fetch.usd,
-            fetch.source.name(),
-            fetch.round_trip.as_millis(),
-            fetch.via_socks5
-        )),
+        Ok(fetch) => {
+            let route = match &fetch.route {
+                zingolib::lightclient::PriceFetchRoute::Mixnet { via_socks5 } => {
+                    format!("over the mixnet via {via_socks5}")
+                }
+                zingolib::lightclient::PriceFetchRoute::Clearnet => "over clearnet".to_string(),
+            };
+            Ok(format!(
+                "current price: {} USD (source: {}, rtt: {} ms, fetched {})",
+                fetch.usd,
+                fetch.source.name(),
+                fetch.round_trip.as_millis(),
+                route
+            ))
+        }
         Err(e) => Err(not_yet_typed(e)),
     }
 }

--- a/zingo-netutils/CHANGELOG.md
+++ b/zingo-netutils/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a superseded conduit permanently short of `Retired`.
 
 ### Changed
+- `socks5_fetch::fetch_text_untunneled` no longer sits behind the
+  `testutils` feature. It carries the clearnet price fetch a switched-off
+  Mixnet Mode consents to (ADR 0011, amendment 2026-08-26), where it used
+  to serve tests alone.
 - The `socks5-fetch` feature enables neither reqwest's `cookies` nor its
   `json`. A price leg is a single stateless GET against a public quote
   endpoint, so there is no session for a cookie jar to carry, and the fetch

--- a/zingo-netutils/src/socks5_fetch.rs
+++ b/zingo-netutils/src/socks5_fetch.rs
@@ -151,8 +151,9 @@ impl ConduitDial {
     }
 }
 
-/// The body at `url`, fetched without a conduit, for tests alone.
-#[cfg(feature = "testutils")]
+/// The body at `url`, fetched untunneled, disclosing the client IP: the
+/// clearnet leg of the price fetch a switched-off Mixnet Mode consents
+/// to.
 pub async fn fetch_text_untunneled(
     url: &str,
     request_timeout: Duration,

--- a/zingo-price/CHANGELOG.md
+++ b/zingo-price/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `get_source_price_untunneled`, the untunneled counterpart of
+  `get_source_price`, so the wallet can race the same sources over
+  clearnet when a switched-off Mixnet Mode consents to it (ADR 0011,
+  amendment 2026-08-26). It was previously a test-only helper.
+
 ### Changed
 - BREAKING: `PriceError::RequestFailed` carries a
   `zingo_netutils::socks5_fetch::Socks5FetchError` where it carried a

--- a/zingo-price/Cargo.toml
+++ b/zingo-price/Cargo.toml
@@ -40,6 +40,4 @@ zingo-netutils = { version = "5.0.1", path = "../zingo-netutils", optional = tru
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util"] }
-# `testutils` exposes the untunneled fetch leg, which the crate's own
-# tests use where production always dials through a conduit.
-zingo-netutils = { path = "../zingo-netutils", features = ["socks5-fetch", "testutils"] }
+zingo-netutils = { path = "../zingo-netutils", features = ["socks5-fetch"] }

--- a/zingo-price/src/lib.rs
+++ b/zingo-price/src/lib.rs
@@ -2,17 +2,16 @@
 
 //! Crate for ZEC price types, storage, and fetching.
 //!
-//! Currently only supports USD. The fetch defaults to clearnet; a caller that
-//! wants to hide the client IP from the price source passes a local SOCKS5
-//! proxy address (the Nym mixnet transport, ADR 0011) and the request is
-//! routed through it instead.
+//! Currently only supports USD. The routing policy lives in the caller:
+//! `get_source_price` dials through a local SOCKS5 tunnel endpoint (the
+//! Nym mixnet transport), and `get_source_price_untunneled` takes the
+//! clearnet leg a switched-off Mixnet Mode consents to.
 //!
 //! The whole fetch surface — and every dependency it needs — sits behind
 //! the `socks5-fetch` feature (on by default for this crate alone).
 //! Without it the crate is the storage-only data model: [`Price`] and
-//! [`PriceList`] with their wallet-file serialization. This is the
-//! dependency half of the mixnet-only price rule (ADR 0011, amendment
-//! 2026-07-28): a wallet build without the mixnet compiles no fetch.
+//! [`PriceList`] with their wallet-file serialization. A wallet build
+//! without the mixnet stack compiles no fetch.
 
 #[cfg(feature = "socks5-fetch")]
 use std::time::Duration;
@@ -774,6 +773,25 @@ pub async fn get_source_price(
     source.parse(&body)
 }
 
+/// One source's price over an untunneled clearnet leg, which discloses
+/// the client IP: the route a switched-off Mixnet Mode consents to.
+#[cfg(feature = "socks5-fetch")]
+pub async fn get_source_price_untunneled(
+    source: PriceSource,
+    url: &str,
+    request_timeout: Duration,
+    connect_timeout: Duration,
+) -> Result<Price, PriceError> {
+    let body =
+        zingo_netutils::socks5_fetch::fetch_text_untunneled(url, request_timeout, connect_timeout)
+            .await
+            .map_err(|error| PriceError::RequestFailed {
+                failure: error.net_op_failure(),
+                source: Box::new(error),
+            })?;
+    source.parse(&body)
+}
+
 #[cfg(all(test, feature = "socks5-fetch"))]
 mod tests {
     use super::*;
@@ -783,26 +801,6 @@ mod tests {
 
     /// Generous bounds for tests whose subject is not the timeout.
     const TEST_TIMEOUT: Duration = Duration::from_secs(10);
-
-    /// One source's price off an untunneled leg, which tests alone may take.
-    async fn fetch_untunneled(
-        source: PriceSource,
-        url: &str,
-        request_timeout: Duration,
-        connect_timeout: Duration,
-    ) -> Result<Price, PriceError> {
-        let body = zingo_netutils::socks5_fetch::fetch_text_untunneled(
-            url,
-            request_timeout,
-            connect_timeout,
-        )
-        .await
-        .map_err(|error| PriceError::RequestFailed {
-            failure: error.net_op_failure(),
-            source: Box::new(error),
-        })?;
-        source.parse(&body)
-    }
 
     /// One source's price through a conduit over `socks5`, for the tests
     /// whose subject is the proxy leg itself.
@@ -888,9 +886,10 @@ mod tests {
         ]"#;
         let url = spawn_trades_server(body).await;
 
-        let price = fetch_untunneled(PriceSource::Gemini, &url, TEST_TIMEOUT, TEST_TIMEOUT)
-            .await
-            .expect("the clearnet fetch parses a valid trades response");
+        let price =
+            get_source_price_untunneled(PriceSource::Gemini, &url, TEST_TIMEOUT, TEST_TIMEOUT)
+                .await
+                .expect("the clearnet fetch parses a valid trades response");
 
         assert_eq!(
             price.price_usd, 105.0,
@@ -907,9 +906,10 @@ mod tests {
     #[ignore = "hits a live price-source API over clearnet"]
     async fn live_clearnet_price_fetch_smoke() {
         let source = PriceSource::Kraken;
-        let price = fetch_untunneled(source, source.url(), REQUEST_TIMEOUT, CONNECT_TIMEOUT)
-            .await
-            .expect("the live price fetch succeeds");
+        let price =
+            get_source_price_untunneled(source, source.url(), REQUEST_TIMEOUT, CONNECT_TIMEOUT)
+                .await
+                .expect("the live price fetch succeeds");
         assert!(
             price.price_usd > 0.0 && price.price_usd.is_finite(),
             "a live ZEC/USD price is positive and finite, got {}",
@@ -928,7 +928,7 @@ mod tests {
         });
 
         let short = Duration::from_millis(300);
-        let error = fetch_untunneled(PriceSource::Gemini, &url, short, short)
+        let error = get_source_price_untunneled(PriceSource::Gemini, &url, short, short)
             .await
             .expect_err("a silent server cannot serve a price");
         match &error {
@@ -1005,9 +1005,10 @@ mod tests {
         ]"#;
         let url = spawn_trades_server(body).await;
 
-        let error = fetch_untunneled(PriceSource::Gemini, &url, TEST_TIMEOUT, TEST_TIMEOUT)
-            .await
-            .expect_err("two trades cannot yield the median of eleven");
+        let error =
+            get_source_price_untunneled(PriceSource::Gemini, &url, TEST_TIMEOUT, TEST_TIMEOUT)
+                .await
+                .expect_err("two trades cannot yield the median of eleven");
         assert!(
             matches!(error, PriceError::InsufficientTrades { received: 2 }),
             "the refusal must be typed with the received count: {error}"
@@ -1123,8 +1124,10 @@ mod tests {
         let kraken = spawn_answering_server(KRAKEN_ELEVEN_TRADES).await;
         let short = Duration::from_millis(500);
 
-        let refused = fetch_untunneled(PriceSource::Gemini, &garbage, short, short).await;
-        let answered = fetch_untunneled(PriceSource::Kraken, &kraken, short, short).await;
+        let refused =
+            get_source_price_untunneled(PriceSource::Gemini, &garbage, short, short).await;
+        let answered =
+            get_source_price_untunneled(PriceSource::Kraken, &kraken, short, short).await;
         let won = first_quote(vec![
             (PriceSource::Gemini, refused),
             (PriceSource::Kraken, answered),
@@ -1151,7 +1154,10 @@ mod tests {
             (PriceSource::Kraken, garbage_two),
             (PriceSource::CoinGecko, silent),
         ] {
-            outcomes.push((source, fetch_untunneled(source, &url, short, short).await));
+            outcomes.push((
+                source,
+                get_source_price_untunneled(source, &url, short, short).await,
+            ));
         }
         let failure = first_quote(outcomes).expect_err("no source answered with a price");
         let named: Vec<&str> = failure

--- a/zingolib/CHANGELOG.md
+++ b/zingolib/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- BREAKING: `LightClient::update_current_price` follows the route
+  resolver instead of refusing while Mixnet Mode is switched off
+  (ADR 0011, amendment 2026-08-26). A switched-off session races the
+  same price sources over untunneled clearnet HTTP, so the deliberate
+  toggle-off consents to the price fetch as it consents to Transmission.
+  The transitional states (`Unattached`, `Bootstrapping`, `Died`) keep
+  their typed `MixnetNotReady` refusals. `MixnetPriceFetch` carries
+  `route: PriceFetchRoute` (a two-variant enum, mixnet with its SOCKS5
+  endpoint or clearnet) where it carried `via_socks5: String`, and
+  `LightClientError::PriceFetchRequiresMixnet` is removed as
+  unreachable. `probe_destinations` remains mixnet-only.
 - BREAKING: `mixnet::resolve_route` takes the session's
   `MixnetConduit` rather than a `SocketAddr`, and `LightClient::mixnet_route`
   reads it from the new `LightClient::mixnet_conduit`. The resolver used to

--- a/zingolib/src/lightclient.rs
+++ b/zingolib/src/lightclient.rs
@@ -104,28 +104,36 @@ impl WalletMeta {
     }
 }
 
-/// A successfully fetched ZEC price, attested with the route it traveled,
-/// the source that answered, and the time the answer took.
-///
-/// The route attestation is the mixnet tunnel's local SOCKS5 endpoint the
-/// fetch went through. It rides the success value — not a log — so every
-/// consumer of [`LightClient::update_current_price`] holds per-fetch
-/// evidence that this fetch ran over the mixnet (ADR 0011). The source and
-/// round trip ride beside it: the fetch races all three price sources and
-/// reports the one whose answer arrived first.
+/// A successfully fetched ZEC price with the route it traveled, the
+/// source whose answer won the race, and the time the answer took. The
+/// route rides the success value so every consumer of
+/// [`LightClient::update_current_price`] holds per-fetch evidence of it.
 #[cfg(feature = "nym")]
 #[derive(Clone, Debug, PartialEq)]
 pub struct MixnetPriceFetch {
     /// The current ZEC price in USD.
     pub usd: f32,
-    /// The price source whose answer won the three-source race.
+    /// The price source whose answer won the race.
     pub source: zingo_price::PriceSource,
     /// Wall-clock time from dispatching the race to the winning answer,
-    /// tunnel traversal included.
+    /// tunnel traversal included on the mixnet route.
     pub round_trip: std::time::Duration,
-    /// The local SOCKS5 endpoint of the mixnet tunnel this fetch traveled
-    /// through.
-    pub via_socks5: String,
+    /// The route this fetch traveled.
+    pub route: PriceFetchRoute,
+}
+
+/// The route one price fetch traveled.
+#[cfg(feature = "nym")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PriceFetchRoute {
+    /// Untunneled HTTP straight to the price sources: the route a
+    /// switched-off Mixnet Mode consents to.
+    Clearnet,
+    /// The mixnet tunnel, reached through its local SOCKS5 endpoint.
+    Mixnet {
+        /// The local SOCKS5 endpoint the fetch traveled through.
+        via_socks5: String,
+    },
 }
 
 /// Struct which owns and manages the [`crate::wallet::LightWallet`]. Responsible for network operations such as

--- a/zingolib/src/lightclient/error.rs
+++ b/zingolib/src/lightclient/error.rs
@@ -49,21 +49,11 @@ pub enum LightClientError {
     /// No indexer configured. Call set_indexer_uri() to connect before calling network operations.
     #[error("Offline: no indexer configured. Call set_indexer_uri() to connect.")]
     Offline,
-    /// Price fetch error. Exists only in nym builds: the mixnet-only price
-    /// rule leaves other builds with no fetch to fail.
+    /// Price fetch error. Exists only in nym builds: the fetch compiles
+    /// only with the mixnet stack, so other builds have no fetch to fail.
     #[cfg(feature = "nym")]
     #[error("Price fetch error.")]
     PriceError(#[from] PriceError),
-    /// The mixnet-routed price fetch was requested while Mixnet Mode is toggled
-    /// off. The opt-in route fails closed rather than falling back to clearnet
-    /// (ADR 0011); use the clearnet default `update_current_price` instead, or
-    /// enable Mixnet Mode (`network on`).
-    #[cfg(feature = "nym")]
-    #[error(
-        "the mixnet-routed price fetch requires Mixnet Mode, which is off; \
-         enable Mixnet Mode, or use the clearnet price fetch"
-    )]
-    PriceFetchRequiresMixnet,
     /// A mixnet-only surface was attempted while the mixnet was bootstrapping.
     #[cfg(feature = "nym")]
     #[error(transparent)]

--- a/zingolib/src/lightclient/mixnet.rs
+++ b/zingolib/src/lightclient/mixnet.rs
@@ -1090,94 +1090,104 @@ impl LightClient {
         Ok(probes)
     }
 
-    /// Update and return the current ZEC price in USD by racing the three
-    /// price sources (Gemini, Kraken, CoinGecko) through the mixnet tunnel —
-    /// hiding the client IP, taking the first answer, erroring only when
-    /// every source fails and then naming each source's typed failure, and
-    /// returning the tunnel endpoint, the winning source, and the round-trip
-    /// time as per-fetch route evidence — while failing closed in every
-    /// other state: a typed [`MixnetNotReady`](crate::mixnet::MixnetNotReady)
-    /// refusal while unattached, bootstrapping, or died, and
-    /// [`LightClientError::PriceFetchRequiresMixnet`] while switched off,
-    /// because the switched-off consent covers Transmission and never a
-    /// third-party price API outside the Zcash ecosystem.
+    /// Update and return the current ZEC price in USD by racing the price
+    /// sources and taking the first answer. The race follows the Mixnet
+    /// Mode route: a ready mixnet carries it through the tunnel,
+    /// SwitchedOff carries it over clearnet as informed consent, and the
+    /// transitional states refuse with a typed
+    /// [`MixnetNotReady`](crate::mixnet::MixnetNotReady).
     pub async fn update_current_price(&self) -> Result<MixnetPriceFetch, LightClientError> {
-        // Held for the whole race, so the conduit knows the fetch is still
-        // running even while every source is in flight.
-        let dial = match self.mixnet_route()? {
-            crate::mixnet::MixnetRoute::Mixnet(conduit) => conduit.dial(),
-            crate::mixnet::MixnetRoute::Clearnet => {
-                return Err(LightClientError::PriceFetchRequiresMixnet);
-            }
-        };
-        let socks5_addr = dial.socks5();
-
-        // A spawned session births a per-run Proven Client — one fresh
-        // Shared exit per run, never the standing client's — while an
-        // attached session's single mobile-platform endpoint carries it as
-        // before. The per-run client is stopped whatever the outcome, and
-        // its lease recycles into the Exit Pool.
-        // The run is the one speed-priority operation shape: it acquires a
-        // transport, races its sources through that exit in a wave a
-        // Sentinel rides, and redraws whenever an exit proves to carry
-        // nothing. Acquisition, disposal, and the redraw bound are the
-        // shared loop's; this call site owns only the quote.
         let dispatched = std::time::Instant::now();
-        let run = PriceRun {
-            pools: self.destination_pools.clone(),
-        };
-        // A spawned session draws its own transport per run, so a dead exit
-        // costs a redraw. An attached session has one endpoint its platform
-        // host owns: there is nothing to redraw, so the run rides that tunnel
-        // for one wave, and a dead exit ends it.
-        let (outcomes, via_socks5) = if self.destination_pools.acquirer().is_some() {
-            let (outcomes, spent) = crate::mixnet::speed::run_speed_prioritized(&run)
-                .await
-                .map_err(crate::wallet::error::PriceError::Speed)?;
-            let dial = spent
-                .addr()
-                .map(|addr| addr.to_string())
-                .unwrap_or_default();
-            crate::mixnet::speed::SpeedPrioritized::dispose(&run, spent);
-            (outcomes, dial)
-        } else {
-            let conduit = zingo_netutils::conduit::MixnetConduit::over(socks5_addr);
-            match crate::mixnet::speed::run_wave(&run, &conduit).await {
-                crate::mixnet::speed::WaveEnd::Settled(outcomes)
-                | crate::mixnet::speed::WaveEnd::Exhausted(outcomes) => {
-                    (outcomes, socks5_addr.to_string())
-                }
+        let (outcomes, route) = match self.mixnet_route()? {
+            crate::mixnet::MixnetRoute::Clearnet => (
+                clearnet_price_race().await,
+                crate::lightclient::PriceFetchRoute::Clearnet,
+            ),
+            crate::mixnet::MixnetRoute::Mixnet(conduit) => {
+                let dial = conduit.dial();
+                let socks5_addr = dial.socks5();
+
+                let run = PriceRun {
+                    pools: self.destination_pools.clone(),
+                };
+
+                let (outcomes, via_socks5) = if self.destination_pools.acquirer().is_some() {
+                    let (outcomes, spent) = crate::mixnet::speed::run_speed_prioritized(&run)
+                        .await
+                        .map_err(crate::wallet::error::PriceError::Speed)?;
+                    let dial = spent
+                        .addr()
+                        .map(|addr| addr.to_string())
+                        .unwrap_or_default();
+                    crate::mixnet::speed::SpeedPrioritized::dispose(&run, spent);
+                    (outcomes, dial)
+                } else {
+                    let conduit = zingo_netutils::conduit::MixnetConduit::over(socks5_addr);
+                    match crate::mixnet::speed::run_wave(&run, &conduit).await {
+                        crate::mixnet::speed::WaveEnd::Settled(outcomes)
+                        | crate::mixnet::speed::WaveEnd::Exhausted(outcomes) => {
+                            (outcomes, socks5_addr.to_string())
+                        }
+                    }
+                };
+                (
+                    outcomes,
+                    crate::lightclient::PriceFetchRoute::Mixnet { via_socks5 },
+                )
             }
         };
         let raced =
             zingo_price::first_quote(outcomes).map_err(crate::wallet::error::PriceError::from)?;
-        let round_trip = dispatched.elapsed();
         Ok(MixnetPriceFetch {
             usd: raced.price.price_usd,
             source: raced.source,
-            round_trip,
-            via_socks5: via_socks5.to_string(),
+            round_trip: dispatched.elapsed(),
+            route,
         })
     }
+}
+
+/// Races every price source over untunneled clearnet HTTP, the route a
+/// switched-off Mixnet Mode consents to. Settles on the first quote,
+/// keeping earlier failures for the report.
+#[cfg(feature = "nym")]
+async fn clearnet_price_race() -> Vec<(
+    zingo_price::PriceSource,
+    Result<zingo_price::Price, zingo_price::PriceError>,
+)> {
+    use futures::StreamExt;
+    let mut in_flight = zingo_price::RACED_SOURCES
+        .iter()
+        .map(|&source| async move {
+            let quote = zingo_price::get_source_price_untunneled(
+                source,
+                source.url(),
+                zingo_price::REQUEST_TIMEOUT,
+                zingo_price::CONNECT_TIMEOUT,
+            )
+            .await;
+            (source, quote)
+        })
+        .collect::<futures::stream::FuturesUnordered<_>>();
+    let mut outcomes = Vec::new();
+    while let Some(outcome) = in_flight.next().await {
+        let settled = outcome.1.is_ok();
+        outcomes.push(outcome);
+        if settled {
+            break;
+        }
+    }
+    outcomes
 }
 
 #[cfg(test)]
 mod tests {
 
     mod price_fetch_contract {
-        //! The price-fetch error contract for the mixnet route (ADR 0011,
-        //! amendments 2026-07-23 and 2026-07-27).
-        //!
-        //! Every way the opt-in mixnet price fetch can fail must arrive at
-        //! the API surface as a typed [`LightClientError`] variant with its
-        //! source chain intact: never prose in the data channel, never a
-        //! silent clearnet fallback. The route pre-flight variants
-        //! (`PriceFetchRequiresMixnet`, `MixnetNotReady::{Unattached,
-        //! Bootstrapping, Died}`) pair with `mixnet::route`'s own
-        //! `resolve_route` tests; the tests here pin the surface wiring. The
-        //! transport-leg contract (typed connect and timeout failures with
-        //! their cause chains) is pinned in `zingo-price`'s own tests,
-        //! beside the mechanism.
+        //! The price-fetch error contract: every failure reaches the API
+        //! as a typed [`LightClientError`], and a clearnet leg runs only
+        //! with consent. Route refusals pair with `mixnet::route`'s tests;
+        //! transport-leg failures are pinned in `zingo-price`.
         use crate::lightclient::LightClient;
         use crate::lightclient::error::LightClientError;
         use crate::testutils::synthetic_wallet::SyntheticWalletBuilder;
@@ -1208,23 +1218,26 @@ mod tests {
             );
         }
 
-        /// Mixnet Mode switched off is equally a typed refusal for the
-        /// opt-in mixnet fetch: the caller demanded the private route, so a
-        /// consented-clearnet mode answers `PriceFetchRequiresMixnet` rather
-        /// than quietly fetching over clearnet.
+        /// Switched off consents to a clearnet fetch; only `Unattached`,
+        /// `Bootstrapping`, and `Died` refuse. A failed race is accepted,
+        /// a route refusal is not.
         #[tokio::test]
-        async fn switched_off_mode_is_a_typed_refusal() {
+        async fn switched_off_mode_consents_to_a_clearnet_fetch() {
             let mut client = LightClient::new_for_test(wallet()).await;
             client.disable_mixnet().await;
 
-            let error = client
-                .update_current_price()
-                .await
-                .expect_err("switched off consents to clearnet, not to a mixnet fetch");
-            assert!(
-                matches!(error, LightClientError::PriceFetchRequiresMixnet),
-                "the refusal must be typed, not prose: {error}"
-            );
+            match client.update_current_price().await {
+                Ok(fetch) => assert_eq!(
+                    fetch.route,
+                    crate::lightclient::PriceFetchRoute::Clearnet,
+                    "a switched-off fetch must attest the clearnet route"
+                ),
+
+                Err(LightClientError::PriceError(_)) => {}
+                Err(refusal) => {
+                    panic!("switched off must consent to a clearnet fetch, not refuse: {refusal}")
+                }
+            }
         }
 
         /// The startup opt-out is the explicit act (ADR 0024, consent at

--- a/zingolib/src/wallet/error.rs
+++ b/zingolib/src/wallet/error.rs
@@ -141,9 +141,9 @@ pub enum WalletError {
     WalletAlreadyCreated,
 }
 
-/// Price error. Exists only in nym builds: the mixnet-only price rule
-/// (ADR 0011, amendment 2026-07-28) leaves other builds with no fetch and
-/// therefore no fetch failures.
+/// Price error. Exists only in nym builds: the fetch compiles only with
+/// the mixnet stack, so other builds have no fetch and therefore no
+/// fetch failures.
 #[cfg(feature = "nym")]
 #[derive(Debug, thiserror::Error)]
 pub enum PriceError {


### PR DESCRIPTION
This PR restores the price fetch when nym is switched off, which was not working.