### PR TITLE
test: grant immediate_migration_chunks_a_fragmented_wallet the heavy timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,6 +25,7 @@ test(mempool_spend_balance_and_note_status_accounting)
 | test(send_shield_cycle)
 | test(generate_a_range_of_value_transfers)
 | test(drain_chunks_a_fragmented_wallet)
+| test(immediate_migration_chunks_a_fragmented_wallet)
 | test(from_t_z_o_tz_to_zo_tzo_to_orchard)
 '''
 slow-timeout = { period = "60s", terminate-after = 20, grace-period = "30s" }
@@ -57,6 +58,7 @@ test(mempool_spend_balance_and_note_status_accounting)
 | test(send_shield_cycle)
 | test(generate_a_range_of_value_transfers)
 | test(drain_chunks_a_fragmented_wallet)
+| test(immediate_migration_chunks_a_fragmented_wallet)
 | test(from_t_z_o_tz_to_zo_tzo_to_orchard)
 '''
 slow-timeout = { period = "60s", terminate-after = 20, grace-period = "30s" }


### PR DESCRIPTION
## What

This PR adds `immediate_migration_chunks_a_fragmented_wallet` to the long-chain heavies override in `.config/nextest.toml`. The override raises the kill limit from 600 to 1200 seconds. Both the default and the ci profile get the entry.

## Why

The test proves more Orchard spends than fit one split transaction. It has always run near the 600-second default ceiling. The suite speedups in #2741 reshuffled the schedule, so the test now overlaps the other long-chain heavies. The last green dev run passed it at 571.8 seconds. Every dev CI run since 2026-08-26 kills it at 600 seconds. The sibling test `drain_chunks_a_fragmented_wallet` already sits in this override.

This timeout also fails CI on unrelated PRs, such as #2750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)