### PR TITLE
fix(`pepper-sync`): add height-0 checkpoint when a loaded shard tree is empty

### DIFF
--- a/pepper-sync/src/sync.rs
+++ b/pepper-sync/src/sync.rs
@@ -2776,6 +2776,60 @@ mod test {
             // The wallet was cleared for rescan.
             assert!(wallet.get_wallet_block(BlockHeight::from_u32(6)).is_err());
         }
+
+        /// The balance path reads the newest sapling checkpoint as the anchor.
+        fn assert_every_tree_holds_a_checkpoint(wallet: &mut crate::mocks::MockWallet) {
+            use crate::wallet::traits::SyncShardTrees;
+            use shardtree::store::ShardStore as _;
+
+            let shard_trees = wallet.get_shard_trees_mut().unwrap();
+            let sapling = shard_trees.sapling.store().max_checkpoint_id().unwrap();
+            let orchard = shard_trees.orchard.store().max_checkpoint_id().unwrap();
+            let ironwood = shard_trees.ironwood.store().max_checkpoint_id().unwrap();
+            assert!(
+                sapling.is_some() && orchard.is_some() && ironwood.is_some(),
+                "a shard tree lost its last checkpoint: sapling {sapling:?}, orchard {orchard:?}, ironwood {ironwood:?}"
+            );
+        }
+
+        /// A target below the birthday clears every store but keeps a checkpoint.
+        #[test]
+        fn clear_all_truncation_leaves_a_checkpoint_in_every_tree() {
+            let mut shard_trees = ShardTrees::new();
+            for height in 6..=10u32 {
+                shard_trees
+                    .sapling
+                    .append_checkpoint(BlockHeight::from_u32(height))
+                    .unwrap();
+            }
+            let mut wallet = synced_wallet(shard_trees);
+
+            truncate_wallet_data(&mut wallet, BlockHeight::from_u32(3)).unwrap();
+
+            assert!(wallet.get_wallet_block(BlockHeight::from_u32(6)).is_err());
+            assert_every_tree_holds_a_checkpoint(&mut wallet);
+        }
+
+        /// The rescan recovery must also leave a checkpoint in every tree.
+        #[test]
+        fn rescan_recovery_leaves_a_checkpoint_in_every_tree() {
+            let mut shard_trees = ShardTrees::new();
+            for height in 9..=10u32 {
+                shard_trees
+                    .orchard
+                    .append_checkpoint(BlockHeight::from_u32(height))
+                    .unwrap();
+            }
+            let mut wallet = synced_wallet(shard_trees);
+
+            let result = truncate_wallet_data(&mut wallet, BlockHeight::from_u32(8));
+
+            assert!(matches!(
+                result,
+                Err(crate::error::SyncError::TruncationError(_, _))
+            ));
+            assert_every_tree_holds_a_checkpoint(&mut wallet);
+        }
     }
 
     /// The pool-accounting contract of [`crate::sync::sync_status`]:

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -1233,6 +1233,11 @@ impl ShardTrees {
                 Checkpoint::from_parts(tree_state, marks_removed.into_iter().collect()),
             ))
         })?;
+        if checkpoints.is_empty() {
+            store
+                .add_checkpoint(C::from(0), Checkpoint::tree_empty())
+                .expect("Infallible");
+        }
         for (checkpoint_id, checkpoint) in checkpoints {
             store
                 .add_checkpoint(checkpoint_id, checkpoint)

--- a/pepper-sync/src/wallet/serialization.rs
+++ b/pepper-sync/src/wallet/serialization.rs
@@ -1630,6 +1630,53 @@ mod tests {
         assert_window(orchard_store, oldest_kept);
     }
 
+    /// A blob with no checkpoint reads back with the height-zero checkpoint.
+    #[test]
+    fn shardtree_read_adds_initialization_checkpoint_when_blob_has_none() {
+        fn checkpoint_less<H, const DEPTH: u8, const SHARD_HEIGHT: u8>()
+        -> ShardTree<MemoryShardStore<H, BlockHeight>, DEPTH, SHARD_HEIGHT>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
+            ShardTree::new(
+                MemoryShardStore::empty(),
+                SHARDTREE_CHECKPOINT_ROLLING_WINDOW_SIZE as usize,
+            )
+        }
+
+        let mut shard_trees = ShardTrees {
+            sapling: checkpoint_less(),
+            orchard: checkpoint_less(),
+            ironwood: checkpoint_less(),
+        };
+        assert_eq!(
+            shard_trees
+                .sapling
+                .store()
+                .max_checkpoint_id()
+                .expect("infallible"),
+            None
+        );
+
+        let mut bytes = Vec::new();
+        shard_trees.write(&mut bytes).expect("write should succeed");
+        let roundtripped = ShardTrees::read(bytes.as_slice()).expect("read should succeed");
+
+        fn assert_initialization_checkpoint<S>(store: &S)
+        where
+            S: ShardStore<CheckpointId = BlockHeight, Error = std::convert::Infallible>,
+        {
+            assert_eq!(store.checkpoint_count().expect("infallible"), 1);
+            assert_eq!(
+                store.max_checkpoint_id().expect("infallible"),
+                Some(BlockHeight::from_u32(0))
+            );
+        }
+        assert_initialization_checkpoint(roundtripped.sapling.store());
+        assert_initialization_checkpoint(roundtripped.orchard.store());
+        assert_initialization_checkpoint(roundtripped.ironwood.store());
+    }
+
     /// A pinned anchor checkpoint survives serialization even once it has aged out of the
     /// rolling window. The pinned set itself is not persisted, being re-derived at the start of
     /// every sync.

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -205,13 +205,15 @@ impl WalletRead for LightWallet {
             return Ok(None);
         };
 
-        let max_checkpoint_height = self
+        let Some(max_checkpoint_height) = self
             .shard_trees
             .sapling
             .store()
             .max_checkpoint_id()
             .expect("infallible")
-            .expect("should be at least 1 checkpoint");
+        else {
+            return Ok(None);
+        };
 
         let anchor_height = std::cmp::min(
             max_checkpoint_height,

--- a/zingolib/src/wallet/zcb_traits.rs
+++ b/zingolib/src/wallet/zcb_traits.rs
@@ -1430,6 +1430,63 @@ mod tests {
         )
     }
 
+    /// A funded wallet whose sapling shard tree holds no checkpoint.
+    fn wallet_without_sapling_checkpoint() -> LightWallet {
+        use pepper_sync::sync::SHARDTREE_CHECKPOINT_ROLLING_WINDOW_SIZE;
+        use shardtree::store::memory::MemoryShardStore;
+
+        let mut wallet = funded_wallet();
+        wallet.shard_trees.sapling = ShardTree::new(
+            MemoryShardStore::empty(),
+            SHARDTREE_CHECKPOINT_ROLLING_WINDOW_SIZE as usize,
+        );
+        assert!(wallet.sync_state.last_known_chain_height().is_some());
+        wallet
+    }
+
+    #[test]
+    fn missing_sapling_checkpoint_means_no_anchor_and_zero_balance() {
+        let wallet = wallet_without_sapling_checkpoint();
+
+        assert_eq!(
+            wallet
+                .get_target_and_anchor_heights(wallet.wallet_settings.min_confirmations)
+                .expect("infallible"),
+            None
+        );
+        assert_eq!(
+            wallet
+                .shielded_spendable_balance(zip32::AccountId::ZERO, false)
+                .expect("a missing anchor is a zero balance, not an error"),
+            Zatoshis::ZERO
+        );
+    }
+
+    #[test]
+    fn reload_restores_missing_sapling_checkpoint() {
+        let mut wallet = wallet_without_sapling_checkpoint();
+
+        wallet.save_required = true;
+        let bytes = wallet.save().unwrap().expect("save required");
+        let reloaded = LightWallet::read(bytes.as_slice(), wallet.chain_type()).unwrap();
+
+        assert_eq!(
+            reloaded
+                .shard_trees
+                .sapling
+                .store()
+                .max_checkpoint_id()
+                .expect("infallible"),
+            Some(BlockHeight::from_u32(0))
+        );
+        assert!(
+            reloaded
+                .get_target_and_anchor_heights(wallet.wallet_settings.min_confirmations)
+                .expect("infallible")
+                .is_some()
+        );
+    }
+
     #[test]
     fn all_funds_max_spendable_selects_every_spend_worthy_note() {
         let notes = select_all_funds(&funded_wallet(), MaxSpendMode::MaxSpendable)


### PR DESCRIPTION
This PR solves an issue where wallets with checkpoint-less shard trees abort at launch.
